### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/apps/web/src/app/_components/VideoList.tsx
+++ b/apps/web/src/app/_components/VideoList.tsx
@@ -85,10 +85,14 @@ export default function VideoList({
 
   // フィルタの変更ハンドラ
   const handleFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newVideoType = e.target.value as VideoType;
-    setVideoType(newVideoType);
-    // フィルタ変更時に即座に動画を再読み込み
-    loadVideos(true);
+    const newVideoType = e.target.value;
+    if (["all", "archived", "upcoming"].includes(newVideoType)) {
+      setVideoType(newVideoType as VideoType);
+      // フィルタ変更時に即座に動画を再読み込み
+      loadVideos(true);
+    } else {
+      console.warn("Invalid video type:", newVideoType);
+    }
   };
 
   // 配信状態によって動画リストに表示するヘッダーテキストを変更


### PR DESCRIPTION
Potential fix for [https://github.com/nothink-jp/suzumina.click/security/code-scanning/1](https://github.com/nothink-jp/suzumina.click/security/code-scanning/1)

To fix the issue, we need to ensure that the `videoType` value is sanitized or validated before it is interpolated into the URL string. The best approach is to validate the `e.target.value` against the allowed `VideoType` values before updating the state. This ensures that only safe, expected values are used in the URL.

1. Add a validation step in the `handleFilterChange` function to check if `e.target.value` is a valid `VideoType`. If it is not valid, ignore the input or set a default value.
2. This change will ensure that `videoType` is always a safe, controlled value, preventing any malicious input from being used in the URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
