### PR TITLE
feat(shared-types): implement type aliasing system for cleaner naming conventions

### DIFF
--- a/docs/ENTITY_VALUE_OBJECT_PR_BREAKDOWN.md
+++ b/docs/ENTITY_VALUE_OBJECT_PR_BREAKDOWN.md
@@ -1,0 +1,457 @@
+# Entity/Value Object拡張 PR分割計画
+
+## 概要
+
+Entity/Value Objectアーキテクチャ拡張を、管理可能な単位のPRに分割し、リスクを最小化しながら段階的に実装します。
+
+## PR分割の原則
+
+1. **単一責任**: 各PRは1つの明確な目的を持つ
+2. **独立性**: PRは可能な限り独立してマージ可能
+3. **サイズ制限**: 各PR 500行以下（テスト含む）
+4. **後方互換性**: 各PRは既存機能を破壊しない
+5. **テスト必須**: 各PRには対応するテストを含む
+
+## Phase 1: 基盤整備（2 PRs）
+
+### PR #1: エイリアスシステムの導入
+**サイズ**: ~100行  
+**リスク**: 低  
+**依存**: なし
+
+```
+packages/shared-types/src/
+├── aliases/
+│   ├── index.ts         # 型エイリアス定義
+│   └── __tests__/
+│       └── aliases.test.ts  # 型等価性テスト
+└── index.ts             # エイリアスの再エクスポート
+```
+
+**内容**:
+- 簡潔な型名のエイリアス作成
+- 型の等価性を保証するテスト
+- ドキュメント更新
+
+### PR #2: Value Object基盤クラスの導入
+**サイズ**: ~200行  
+**リスク**: 低  
+**依存**: PR #1
+
+```
+packages/shared-types/src/
+└── value-objects/
+    ├── base/
+    │   ├── value-object.ts      # 基底インターフェース
+    │   ├── transforms.ts        # 共通変換関数
+    │   └── guards.ts           # 共通型ガード
+    └── __tests__/
+        └── base.test.ts
+```
+
+**内容**:
+- Value Object共通インターフェース
+- equals(), clone()等の共通メソッド
+- 共通バリデーション関数
+
+## Phase 2: Video Entity実装（5 PRs）
+
+### PR #3: Video Value Objects (Part 1)
+**サイズ**: ~300行  
+**リスク**: 低  
+**依存**: PR #2
+
+```
+packages/shared-types/src/value-objects/
+├── video-metadata.ts
+├── channel.ts
+└── __tests__/
+    ├── video-metadata.test.ts
+    └── channel.test.ts
+```
+
+**内容**:
+- VideoMetadata Value Object
+- Channel Value Object
+- ビジネスロジック実装
+- 単体テスト
+
+### PR #4: Video Value Objects (Part 2)
+**サイズ**: ~300行  
+**リスク**: 低  
+**依存**: PR #2
+
+```
+packages/shared-types/src/value-objects/
+├── video-statistics.ts
+├── video-content.ts
+└── __tests__/
+    ├── video-statistics.test.ts
+    └── video-content.test.ts
+```
+
+**内容**:
+- VideoStatistics Value Object
+- VideoContent Value Object
+- 統計計算ロジック
+- フォーマット関数
+
+### PR #5: Video Entity定義
+**サイズ**: ~200行  
+**リスク**: 中  
+**依存**: PR #3, #4
+
+```
+packages/shared-types/src/entities/
+├── video-v2.ts          # 新しいVideo Entity
+└── __tests__/
+    └── video-v2.test.ts
+```
+
+**内容**:
+- 新Video Entity定義
+- 既存Videoとの互換性維持
+- 統合テスト
+
+### PR #6: Video Mapper実装
+**サイズ**: ~400行  
+**リスク**: 中  
+**依存**: PR #5
+
+```
+apps/functions/src/services/mappers/
+├── video-mapper-v2.ts
+└── __tests__/
+    └── video-mapper-v2.test.ts
+```
+
+**内容**:
+- YouTube APIからのマッピング
+- エラーハンドリング
+- パフォーマンステスト
+
+### PR #7: Video移行ヘルパー
+**サイズ**: ~200行  
+**リスク**: 低  
+**依存**: PR #5, #6
+
+```
+packages/shared-types/src/migrations/
+├── video-migration.ts
+└── __tests__/
+    └── video-migration.test.ts
+```
+
+**内容**:
+- 旧Video → 新Video変換
+- 新Video → 旧Video変換
+- バッチ移行関数
+
+## Phase 3: AudioButton Entity実装（4 PRs）
+
+### PR #8: AudioButton Value Objects
+**サイズ**: ~400行  
+**リスク**: 低  
+**依存**: PR #2
+
+```
+packages/shared-types/src/value-objects/
+├── audio-reference.ts
+├── audio-content.ts
+├── button-statistics.ts
+└── __tests__/
+    ├── audio-reference.test.ts
+    ├── audio-content.test.ts
+    └── button-statistics.test.ts
+```
+
+**内容**:
+- 3つのValue Object実装
+- タイムスタンプ処理ロジック
+- 人気度スコア計算
+
+### PR #9: AudioButton Entity定義
+**サイズ**: ~200行  
+**リスク**: 中  
+**依存**: PR #8
+
+```
+packages/shared-types/src/entities/
+├── audio-button-v2.ts
+└── __tests__/
+    └── audio-button-v2.test.ts
+```
+
+**内容**:
+- 新AudioButton Entity
+- 既存との互換性
+- バリデーション
+
+### PR #10: AudioButton Mapper実装
+**サイズ**: ~300行  
+**リスク**: 中  
+**依存**: PR #9
+
+```
+apps/functions/src/services/mappers/
+├── audio-button-mapper-v2.ts
+└── __tests__/
+    └── audio-button-mapper-v2.test.ts
+```
+
+**内容**:
+- Firestoreからのマッピング
+- YouTube統合
+- エラーハンドリング
+
+### PR #11: AudioButton移行ヘルパー
+**サイズ**: ~200行  
+**リスク**: 低  
+**依存**: PR #9, #10
+
+```
+packages/shared-types/src/migrations/
+├── audio-button-migration.ts
+└── __tests__/
+    └── audio-button-migration.test.ts
+```
+
+## Phase 4: フロントエンド統合（3 PRs）
+
+### PR #12: コンポーネント更新 (Video)
+**サイズ**: ~300行  
+**リスク**: 中  
+**依存**: PR #5-7
+
+```
+apps/web/src/components/
+├── video/
+│   ├── video-card-v2.tsx
+│   ├── video-list-v2.tsx
+│   └── __tests__/
+└── hooks/
+    └── use-video-v2.ts
+```
+
+**内容**:
+- 新Video Entity対応コンポーネント
+- 既存コンポーネントとの共存
+- E2Eテスト
+
+### PR #13: コンポーネント更新 (AudioButton)
+**サイズ**: ~400行  
+**リスク**: 高（音声ボタンシステムのコア）  
+**依存**: PR #8-11
+
+```
+apps/web/src/components/audio/
+├── audio-button-v2.tsx
+├── audio-player-v2.tsx
+└── __tests__/
+```
+
+**内容**:
+- 新AudioButton対応
+- プレイヤープール統合
+- パフォーマンス最適化
+
+### PR #14: Server Actions更新
+**サイズ**: ~300行  
+**リスク**: 中  
+**依存**: PR #12, #13
+
+```
+apps/web/src/actions/
+├── video-actions-v2.ts
+├── audio-button-actions-v2.ts
+└── __tests__/
+```
+
+## Phase 5: バックエンド統合（3 PRs）
+
+### PR #15: Cloud Functions更新 (Video)
+**サイズ**: ~400行  
+**リスク**: 高  
+**依存**: PR #5-7
+
+```
+apps/functions/src/
+├── endpoints/
+│   └── youtube-sync-v2.ts
+└── services/
+    └── youtube/
+        └── youtube-service-v2.ts
+```
+
+**内容**:
+- YouTube同期の新Entity対応
+- データ収集最適化
+- エラーハンドリング
+
+### PR #16: Cloud Functions更新 (AudioButton)
+**サイズ**: ~300行  
+**リスク**: 中  
+**依存**: PR #8-11
+
+```
+apps/functions/src/
+├── endpoints/
+│   └── audio-button-sync-v2.ts
+└── services/
+    └── audio/
+        └── audio-button-service-v2.ts
+```
+
+### PR #17: バッチ移行スクリプト
+**サイズ**: ~400行  
+**リスク**: 高（データ移行）  
+**依存**: PR #15, #16
+
+```
+apps/functions/src/services/migration/
+├── entity-v2-migration.ts
+├── dry-run-report.ts
+└── __tests__/
+```
+
+## Phase 6: 切り替えと廃止（4 PRs）
+
+### PR #18: フィーチャーフラグ実装
+**サイズ**: ~200行  
+**リスク**: 低  
+**依存**: すべての実装PR
+
+```
+packages/shared-types/src/config/
+└── feature-flags.ts
+
+apps/web/src/lib/
+└── feature-flags.ts
+```
+
+**内容**:
+- Entity V2の段階的有効化
+- A/Bテスト準備
+- ロールバック機能
+
+### PR #19: 本番データ移行
+**サイズ**: ~100行（スクリプト実行）  
+**リスク**: 最高  
+**依存**: PR #17, #18
+
+**内容**:
+- バックアップ作成
+- 移行スクリプト実行
+- 検証とロールバック準備
+
+### PR #20: 旧コード非推奨化
+**サイズ**: ~500行  
+**リスク**: 低  
+**依存**: PR #19成功
+
+```
+各ファイルに@deprecatedマーク追加
+ESLintルール更新
+ドキュメント更新
+```
+
+### PR #21: 旧コード削除
+**サイズ**: ~1000行（削除）  
+**リスク**: 中  
+**依存**: 1ヶ月の安定稼働後
+
+**内容**:
+- 旧Entity定義削除
+- 旧Mapper削除
+- 移行ヘルパー削除
+
+## タイムライン
+
+```mermaid
+gantt
+    title Entity/Value Object拡張 実装タイムライン
+    dateFormat YYYY-MM-DD
+    section Phase 1
+    PR#1 エイリアス     :2025-08-01, 2d
+    PR#2 基盤クラス     :2025-08-03, 3d
+    
+    section Phase 2
+    PR#3 Video VO 1     :2025-08-06, 3d
+    PR#4 Video VO 2     :2025-08-09, 3d
+    PR#5 Video Entity   :2025-08-12, 2d
+    PR#6 Video Mapper   :2025-08-14, 4d
+    PR#7 Video移行      :2025-08-18, 2d
+    
+    section Phase 3
+    PR#8 Audio VO       :2025-08-20, 4d
+    PR#9 Audio Entity   :2025-08-24, 2d
+    PR#10 Audio Mapper  :2025-08-26, 3d
+    PR#11 Audio移行     :2025-08-29, 2d
+    
+    section Phase 4
+    PR#12 UI Video      :2025-09-01, 3d
+    PR#13 UI Audio      :2025-09-04, 4d
+    PR#14 Actions       :2025-09-08, 3d
+    
+    section Phase 5
+    PR#15 CF Video      :2025-09-11, 4d
+    PR#16 CF Audio      :2025-09-15, 3d
+    PR#17 バッチ移行    :2025-09-18, 4d
+    
+    section Phase 6
+    PR#18 フラグ        :2025-09-22, 2d
+    PR#19 本番移行      :2025-09-24, 1d
+    PR#20 非推奨化      :2025-09-25, 3d
+    PR#21 削除          :2025-10-25, 3d
+```
+
+## PR レビューチェックリスト
+
+### 各PRで確認すべき項目
+
+- [ ] TypeScript strict modeでエラーなし
+- [ ] 単体テストカバレッジ 90%以上
+- [ ] 既存テストがすべて合格
+- [ ] パフォーマンステスト合格（該当する場合）
+- [ ] 後方互換性の維持
+- [ ] ドキュメント更新
+- [ ] 変更ログ記載
+
+### マージ基準
+
+1. **通常PR**: 1人以上のレビュー承認
+2. **高リスクPR**: 2人以上のレビュー承認 + QAテスト
+3. **データ移行PR**: 3人以上のレビュー承認 + ステージング検証
+
+## リスク管理
+
+### 各フェーズのリスクと対策
+
+| Phase | 主なリスク | 対策 |
+|-------|-----------|------|
+| Phase 1 | 型定義の不整合 | 自動テストによる検証 |
+| Phase 2-3 | Value Object設計ミス | 段階的実装とレビュー |
+| Phase 4 | UI不具合 | E2Eテスト強化 |
+| Phase 5 | データ不整合 | ドライラン実施 |
+| Phase 6 | 本番障害 | フィーチャーフラグ |
+
+## 成功指標
+
+### 技術指標
+- 全PRのテスト合格率: 100%
+- コードカバレッジ: 90%以上維持
+- TypeScriptエラー: 0
+- パフォーマンス劣化: なし
+
+### プロジェクト指標
+- 計画通りのPR数: 21±3
+- スケジュール遵守率: 80%以上
+- 重大バグ: 0
+- ロールバック回数: 2回以下
+
+---
+
+**作成日**: 2025年7月24日  
+**バージョン**: 1.0  
+**総PR数**: 21  
+**推定期間**: 8-10週間

--- a/docs/PR_01_TYPE_ALIASES.md
+++ b/docs/PR_01_TYPE_ALIASES.md
@@ -1,0 +1,92 @@
+# PR #1: Type Aliases System Implementation
+
+## Overview
+
+This PR introduces a type aliasing system to provide cleaner, more concise naming conventions for commonly used types in the suzumina.click project. This is the first step in the Entity/Value Object architecture expansion.
+
+## Changes
+
+### New Files
+
+1. **`packages/shared-types/src/aliases/index.ts`**
+   - Defines simplified type aliases for existing verbose type names
+   - Provides type guards for runtime type checking
+   - Maps existing types to cleaner names (e.g., `OptimizedFirestoreDLsiteWorkData` → `Work`)
+
+2. **`packages/shared-types/src/aliases/__tests__/aliases.test.ts`**
+   - Type-level tests ensuring aliases correctly map to original types
+   - Runtime tests for type guard functions
+   - Currently 11 active tests, 8 skipped (for types to be implemented in future PRs)
+
+### Modified Files
+
+1. **`packages/shared-types/src/index.ts`**
+   - Added export for the new aliases module
+   - Maintains backward compatibility by keeping existing exports
+
+## Implementation Details
+
+### Currently Implemented Aliases
+
+| Original Type | New Alias | Status |
+|--------------|-----------|---------|
+| OptimizedFirestoreDLsiteWorkData | Work | ✅ Implemented |
+| FirestoreWorkEvaluation | WorkEvaluation | ✅ Implemented |
+| DLsiteRawApiResponse | DLsiteApiResponse | ✅ Implemented |
+
+### Placeholder Aliases (To Be Implemented)
+
+| Original Type | New Alias | Status |
+|--------------|-----------|---------|
+| FirestoreUserDocument | User | 🔜 Placeholder |
+| FirestoreVideoDocument | Video | 🔜 Placeholder |
+| OptimizedAudioButtonData | AudioButton | 🔜 Placeholder |
+| CircleCreatorInfoData | CircleCreator | 🔜 Placeholder |
+| UnifiedDataCollectionMetadata | CollectionMetadata | 🔜 Placeholder |
+| FirestoreFieldTimestamp | Timestamp | 🔜 Placeholder |
+| PriceHistoryEntryData | PriceHistory | 🔜 Placeholder |
+| VideoTagAssociationData | VideoTag | 🔜 Placeholder |
+
+## Type Guards
+
+Implemented type guards for runtime type checking:
+- `isWork(value: unknown): value is Work`
+- `isUser(value: unknown): value is User`
+- `isVideo(value: unknown): value is Video`
+- `isAudioButton(value: unknown): value is AudioButton`
+
+## Testing
+
+- All tests pass: ✅
+- TypeScript compilation: ✅
+- Test coverage: 373 passed, 8 skipped (total 381)
+
+## Migration Strategy
+
+This PR follows the planned approach:
+1. Introduce aliases without breaking existing code
+2. New code can start using cleaner names immediately
+3. Existing code continues to work with original names
+4. Future PRs will gradually migrate to use the new aliases
+
+## Next Steps
+
+After this PR is merged:
+- PR #2 will introduce Value Object base classes
+- PR #3-7 will implement Video entity with Value Objects
+- PR #8-11 will implement AudioButton entity with Value Objects
+
+## Checklist
+
+- [x] TypeScript strict mode with no errors
+- [x] Unit tests pass
+- [x] Backward compatibility maintained
+- [x] Documentation updated
+- [x] No performance impact (compile-time only changes)
+
+## Review Notes
+
+- This is a low-risk change that only adds type aliases
+- No runtime behavior is modified
+- All existing code continues to work unchanged
+- The placeholder types (marked with `any`) will be properly typed in future PRs

--- a/packages/shared-types/src/aliases/__tests__/aliases.test.ts
+++ b/packages/shared-types/src/aliases/__tests__/aliases.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import type { DLsiteRawApiResponse } from "../../api-schemas/dlsite-raw";
+
+import type { OptimizedFirestoreDLsiteWorkData } from "../../entities/work";
+import type { FirestoreWorkEvaluation } from "../../entities/work-evaluation";
+import type { DLsiteApiResponse, Work, WorkEvaluation } from "../index";
+
+// Note: These types will be imported once they are defined
+// For now, we'll use placeholders for testing the aliasing system
+
+import { isAudioButton, isUser, isVideo, isWork } from "../index";
+
+// Type-level tests to ensure aliases are correctly mapped
+type AssertEqual<T, U> = T extends U ? (U extends T ? true : false) : false;
+
+describe("Type Aliases", () => {
+	describe("Entity Aliases", () => {
+		it("should correctly alias Work type", () => {
+			type TestWork = AssertEqual<Work, OptimizedFirestoreDLsiteWorkData>;
+			const _test: TestWork = true;
+			expect(_test).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias User type", () => {
+			// TODO: Enable when FirestoreUserDocument is available
+			// type TestUser = AssertEqual<User, FirestoreUserDocument>;
+			// const _test: TestUser = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias Video type", () => {
+			// TODO: Enable when FirestoreVideoDocument is available
+			// type TestVideo = AssertEqual<Video, FirestoreVideoDocument>;
+			// const _test: TestVideo = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias AudioButton type", () => {
+			// TODO: Enable when OptimizedAudioButtonData is available
+			// type TestAudioButton = AssertEqual<AudioButton, OptimizedAudioButtonData>;
+			// const _test: TestAudioButton = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+
+		it("should correctly alias WorkEvaluation type", () => {
+			type TestWorkEvaluation = AssertEqual<WorkEvaluation, FirestoreWorkEvaluation>;
+			const _test: TestWorkEvaluation = true;
+			expect(_test).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias CircleCreator type", () => {
+			// TODO: Enable when CircleCreatorInfoData is available
+			// type TestCircleCreator = AssertEqual<CircleCreator, CircleCreatorInfoData>;
+			// const _test: TestCircleCreator = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+	});
+
+	describe("API Aliases", () => {
+		it("should correctly alias DLsiteApiResponse type", () => {
+			type TestApiResponse = AssertEqual<DLsiteApiResponse, DLsiteRawApiResponse>;
+			const _test: TestApiResponse = true;
+			expect(_test).toBe(true);
+		});
+	});
+
+	describe("Metadata Aliases", () => {
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias CollectionMetadata type", () => {
+			// TODO: Enable when UnifiedDataCollectionMetadata is available
+			// type TestMetadata = AssertEqual<CollectionMetadata, UnifiedDataCollectionMetadata>;
+			// const _test: TestMetadata = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias Timestamp type", () => {
+			// TODO: Enable when FirestoreFieldTimestamp is available
+			// type TestTimestamp = AssertEqual<Timestamp, FirestoreFieldTimestamp>;
+			// const _test: TestTimestamp = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias PriceHistory type", () => {
+			// TODO: Enable when PriceHistoryEntryData is available
+			// type TestPriceHistory = AssertEqual<PriceHistory, PriceHistoryEntryData>;
+			// const _test: TestPriceHistory = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+
+		// biome-ignore lint/suspicious/noSkippedTests: Types not yet implemented
+		it.skip("should correctly alias VideoTag type", () => {
+			// TODO: Enable when VideoTagAssociationData is available
+			// type TestVideoTag = AssertEqual<VideoTag, VideoTagAssociationData>;
+			// const _test: TestVideoTag = true;
+			// expect(_test).toBe(true);
+			expect(true).toBe(true);
+		});
+	});
+
+	describe("Type Guards", () => {
+		describe("isWork", () => {
+			it("should return true for valid Work objects", () => {
+				const validWork = {
+					id: "RJ123456",
+					title: "Test Work",
+					circleId: "RG12345",
+					// ... other required fields
+				};
+				expect(isWork(validWork)).toBe(true);
+			});
+
+			it("should return false for invalid objects", () => {
+				expect(isWork(null)).toBe(false);
+				expect(isWork(undefined)).toBe(false);
+				expect(isWork({})).toBe(false);
+				expect(isWork({ id: "test" })).toBe(false);
+				expect(isWork({ id: "test", title: "test" })).toBe(false);
+			});
+		});
+
+		describe("isUser", () => {
+			it("should return true for valid User objects", () => {
+				const validUser = {
+					id: "user123",
+					email: "test@example.com",
+					role: "user",
+					// ... other required fields
+				};
+				expect(isUser(validUser)).toBe(true);
+			});
+
+			it("should return false for invalid objects", () => {
+				expect(isUser(null)).toBe(false);
+				expect(isUser(undefined)).toBe(false);
+				expect(isUser({})).toBe(false);
+				expect(isUser({ id: "test" })).toBe(false);
+				expect(isUser({ id: "test", email: "test@example.com" })).toBe(false);
+			});
+		});
+
+		describe("isVideo", () => {
+			it("should return true for valid Video objects", () => {
+				const validVideo = {
+					id: "video123",
+					title: "Test Video",
+					channelId: "channel123",
+					// ... other required fields
+				};
+				expect(isVideo(validVideo)).toBe(true);
+			});
+
+			it("should return false for invalid objects", () => {
+				expect(isVideo(null)).toBe(false);
+				expect(isVideo(undefined)).toBe(false);
+				expect(isVideo({})).toBe(false);
+				expect(isVideo({ id: "test" })).toBe(false);
+				expect(isVideo({ id: "test", title: "test" })).toBe(false);
+			});
+		});
+
+		describe("isAudioButton", () => {
+			it("should return true for valid AudioButton objects", () => {
+				const validAudioButton = {
+					id: "button123",
+					videoId: "video123",
+					timestamp: 123,
+					// ... other required fields
+				};
+				expect(isAudioButton(validAudioButton)).toBe(true);
+			});
+
+			it("should return false for invalid objects", () => {
+				expect(isAudioButton(null)).toBe(false);
+				expect(isAudioButton(undefined)).toBe(false);
+				expect(isAudioButton({})).toBe(false);
+				expect(isAudioButton({ id: "test" })).toBe(false);
+				expect(isAudioButton({ id: "test", videoId: "video123" })).toBe(false);
+			});
+		});
+	});
+});

--- a/packages/shared-types/src/aliases/index.ts
+++ b/packages/shared-types/src/aliases/index.ts
@@ -1,0 +1,149 @@
+/**
+ * Type aliases for cleaner, more concise naming conventions
+ *
+ * This module provides simplified names for commonly used types
+ * while maintaining backward compatibility with existing code.
+ */
+
+import type { DLsiteRawApiResponse } from "../api-schemas/dlsite-raw";
+// Import existing types
+import type { OptimizedFirestoreDLsiteWorkData } from "../entities/work";
+import type { FirestoreWorkEvaluation } from "../entities/work-evaluation";
+
+// Note: Some types are not yet defined in the codebase
+// They will be added as part of the Entity/Value Object migration
+// For now, we'll create placeholder types to demonstrate the aliasing system
+
+// ===== Entity Aliases =====
+
+/**
+ * Simplified alias for DLsite work data
+ * @alias OptimizedFirestoreDLsiteWorkData
+ */
+export type Work = OptimizedFirestoreDLsiteWorkData;
+
+/**
+ * Simplified alias for user document
+ * @alias FirestoreUserDocument (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with FirestoreUserDocument in future PR
+export type User = any; // TODO: Replace with FirestoreUserDocument when available
+
+/**
+ * Simplified alias for video document
+ * @alias FirestoreVideoDocument (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with FirestoreVideoDocument in future PR
+export type Video = any; // TODO: Replace with FirestoreVideoDocument when available
+
+/**
+ * Simplified alias for audio button data
+ * @alias OptimizedAudioButtonData (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with OptimizedAudioButtonData in future PR
+export type AudioButton = any; // TODO: Replace with OptimizedAudioButtonData when available
+
+/**
+ * Simplified alias for work evaluation
+ * @alias FirestoreWorkEvaluation
+ */
+export type WorkEvaluation = FirestoreWorkEvaluation;
+
+/**
+ * Simplified alias for circle/creator info
+ * @alias CircleCreatorInfoData (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with CircleCreatorInfoData in future PR
+export type CircleCreator = any; // TODO: Replace with CircleCreatorInfoData when available
+
+// ===== API Aliases =====
+
+/**
+ * Simplified alias for DLsite API response
+ * @alias DLsiteRawApiResponse
+ */
+export type DLsiteApiResponse = DLsiteRawApiResponse;
+
+// ===== Metadata Aliases =====
+
+/**
+ * Simplified alias for collection metadata
+ * @alias UnifiedDataCollectionMetadata (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with UnifiedDataCollectionMetadata in future PR
+export type CollectionMetadata = any; // TODO: Replace with UnifiedDataCollectionMetadata when available
+
+/**
+ * Simplified alias for Firestore timestamp
+ * @alias FirestoreFieldTimestamp (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with FirestoreFieldTimestamp in future PR
+export type Timestamp = any; // TODO: Replace with FirestoreFieldTimestamp when available
+
+/**
+ * Simplified alias for price history entry
+ * @alias PriceHistoryEntryData (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with PriceHistoryEntryData in future PR
+export type PriceHistory = any; // TODO: Replace with PriceHistoryEntryData when available
+
+/**
+ * Simplified alias for video tag association
+ * @alias VideoTagAssociationData (to be implemented)
+ */
+// biome-ignore lint/suspicious/noExplicitAny: Placeholder type - will be replaced with VideoTagAssociationData in future PR
+export type VideoTag = any; // TODO: Replace with VideoTagAssociationData when available
+
+// ===== Type Guards =====
+
+/**
+ * Type guard to check if a value is a Work
+ */
+export function isWork(value: unknown): value is Work {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"id" in value &&
+		"title" in value &&
+		"circleId" in value
+	);
+}
+
+/**
+ * Type guard to check if a value is a User
+ */
+export function isUser(value: unknown): value is User {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"id" in value &&
+		"email" in value &&
+		"role" in value
+	);
+}
+
+/**
+ * Type guard to check if a value is a Video
+ */
+export function isVideo(value: unknown): value is Video {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"id" in value &&
+		"title" in value &&
+		"channelId" in value
+	);
+}
+
+/**
+ * Type guard to check if a value is an AudioButton
+ */
+export function isAudioButton(value: unknown): value is AudioButton {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"id" in value &&
+		"videoId" in value &&
+		"timestamp" in value
+	);
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -3,6 +3,9 @@
  * 涼花みなせウェブサイト用の共有型定義パッケージ
  */
 
+// === Type Aliases ===
+// Export type aliases for cleaner naming conventions
+export * from "./aliases";
 // === API Schemas ===
 export * from "./api-schemas/dlsite-raw";
 // === Entities ===


### PR DESCRIPTION
## Summary
- Introduce type aliasing system for cleaner, more concise naming conventions
- Map verbose type names to simplified aliases (e.g., `OptimizedFirestoreDLsiteWorkData` → `Work`)
- First step in Entity/Value Object architecture expansion (PR #1/21)

## Changes

### New Features
- **Type Aliases Module** (`packages/shared-types/src/aliases/`)
  - Simplified names for commonly used types
  - Type guards for runtime type checking
  - Placeholder types for future implementations

### Currently Implemented Aliases
| Original Type | New Alias | Status |
|--------------|-----------|---------|
| OptimizedFirestoreDLsiteWorkData | Work | ✅ Implemented |
| FirestoreWorkEvaluation | WorkEvaluation | ✅ Implemented |
| DLsiteRawApiResponse | DLsiteApiResponse | ✅ Implemented |

### Type Guards
- `isWork(value: unknown): value is Work`
- `isUser(value: unknown): value is User`
- `isVideo(value: unknown): value is Video`
- `isAudioButton(value: unknown): value is AudioButton`

## Test Plan
- [x] All existing tests pass (373 passed, 8 skipped)
- [x] TypeScript compilation successful
- [x] Linting passes
- [x] Type-level tests verify correct aliasing
- [x] Runtime tests verify type guards work correctly

## Migration Strategy
1. This PR introduces aliases without breaking existing code
2. New code can start using cleaner names immediately
3. Existing code continues to work with original names
4. Future PRs will gradually migrate to use new aliases

## Related Documentation
- [Entity/Value Object PR Breakdown](https://github.com/nothink-jp/suzumina.click/blob/feat/entity-v2-aliases/docs/ENTITY_VALUE_OBJECT_PR_BREAKDOWN.md)
- [Expansion Plan](https://github.com/nothink-jp/suzumina.click/blob/feat/entity-v2-aliases/docs/ENTITY_VALUE_OBJECT_EXPANSION_PLAN.md)

🤖 Generated with [Claude Code](https://claude.ai/code)