### PR TITLE
feat: 本番環境でEntity V2を有効化

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -188,7 +188,7 @@ jobs:
             --platform managed \
             --allow-unauthenticated \
             --service-account="cloud-run-nextjs@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
-            --set-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }},NEXTAUTH_URL=https://suzumina.click,AUTH_TRUST_HOST=true,NEXT_PUBLIC_GA_MEASUREMENT_ID=G-9SYZ48LBPH,NEXT_PUBLIC_GTM_ID=GTM-W7QT5PCR,NEXT_PUBLIC_ADSENSE_CLIENT_ID=ca-pub-8077945848616354" \
+            --set-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }},NEXTAUTH_URL=https://suzumina.click,AUTH_TRUST_HOST=true,NEXT_PUBLIC_GA_MEASUREMENT_ID=G-9SYZ48LBPH,NEXT_PUBLIC_GTM_ID=GTM-W7QT5PCR,NEXT_PUBLIC_ADSENSE_CLIENT_ID=ca-pub-8077945848616354,ENABLE_ENTITY_V2=true" \
             --set-secrets="DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,NEXTAUTH_SECRET=NEXTAUTH_SECRET:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest,RESEND_API_KEY=RESEND_API_KEY:latest,CONTACT_EMAIL_RECIPIENTS=CONTACT_EMAIL_RECIPIENTS:latest" \
             --memory 2Gi \
             --cpu 1 \

--- a/scripts/enable-entity-v2.sh
+++ b/scripts/enable-entity-v2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Script to enable Entity V2 in production
+
+set -e
+
+# Configuration
+PROJECT_ID="suzumina-click"
+SERVICE_NAME="suzumina-click-web"
+REGION="asia-northeast1"
+
+echo "🚀 Enabling Entity V2 in production..."
+
+# Update Cloud Run environment variable
+echo "📝 Updating Cloud Run environment variable..."
+gcloud run services update $SERVICE_NAME \
+  --region=$REGION \
+  --project=$PROJECT_ID \
+  --update-env-vars="ENABLE_ENTITY_V2=true"
+
+echo "✅ Entity V2 has been enabled in production!"
+echo "🔍 Please verify the deployment at: https://suzumina.click"


### PR DESCRIPTION
## 概要

本番環境でEntity V2アーキテクチャを有効化します。

## 変更内容

- Cloud Runデプロイメントワークフローに  を追加

## 根拠

1. PR #114（Entity V2実使用開始）が完了し、全テスト合格
2. ローカル環境で  での動作確認済み
3. データ移行スクリプト（PR #19）実行済み
4. Firestoreデータバリデーションシステム実装済み
5. フィーチャーフラグによる緊急時のロールバック可能

## 関連PR

- #114: Entity V2実使用開始 - フィーチャーフラグ統合
- #113: Production Migration Scripts for Entity V2
- #112: Feature Flags Implementation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>