### PR TITLE
PR #22 - 旧コード非推奨化

### DIFF
--- a/apps/functions/src/services/youtube/youtube-firestore.ts
+++ b/apps/functions/src/services/youtube/youtube-firestore.ts
@@ -1,3 +1,17 @@
+/**
+ * YouTube Firestore Service V1
+ *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use ./youtube-firestore-v2.ts instead.
+ *
+ * Migration guide:
+ * 1. Import from './youtube-firestore-v2' instead of './youtube-firestore'
+ * 2. Use saveVideosToFirestoreV2() instead of saveVideosToFirestore()
+ * 3. Use updateVideoWithV2() instead of updateVideoWithDetails()
+ * 4. Entity V2 is already enabled in production with feature flags
+ *
+ * Note: The V2 service automatically adds _v2Migration flag to all new data
+ */
+
 import type { FirestoreServerVideoData, LiveBroadcastContent } from "@suzumina.click/shared-types";
 import type { youtube_v3 } from "googleapis";
 import firestore, { Timestamp } from "../../infrastructure/database/firestore";
@@ -344,6 +358,7 @@ function createVideoData(
 /**
  * Firestoreに動画データを保存
  *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use saveVideosToFirestoreV2() from './youtube-firestore-v2' instead.
  * @param videoDetails - 保存する動画詳細情報
  * @param playlistMappings - 動画ID → プレイリストタイトル配列のマップ（オプション）
  * @returns Promise<number> - 保存した動画数
@@ -430,6 +445,7 @@ export async function saveVideosToFirestore(
 /**
  * 単一の動画データをFirestore用のデータ形式に変換（外部公開用）
  *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use VideoMapperV2.fromYouTubeAPI() from '../mappers/video-mapper-v2' instead.
  * @param videoData - YouTube APIから返される動画データ
  * @param playlistTags - 該当動画のプレイリストタグ（オプション）
  * @returns Firestore用の動画データ

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -2,6 +2,22 @@
 
 /**
  * Server Actions for fetching video data from Firestore (ユーザー向け)
+ *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use ./actions-v2.ts instead.
+ *
+ * Migration guide:
+ * 1. Import from './actions-v2' instead of './actions'
+ * 2. The API is identical, just the import path changes
+ * 3. Entity V2 is already enabled in production, so the data format is compatible
+ *
+ * Example:
+ * ```typescript
+ * // Before:
+ * import { fetchVideos } from './actions';
+ *
+ * // After:
+ * import { fetchVideos } from './actions-v2';
+ * ```
  */
 
 import {
@@ -454,6 +470,8 @@ function processRegularResults(
 
 /**
  * Firestoreからビデオタイトル一覧を取得するServer Action（ユーザー向けページネーション対応）
+ *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use getVideoTitles from './actions-v2' instead.
  */
 export async function getVideoTitles(params?: {
 	page?: number;
@@ -519,6 +537,8 @@ export async function getVideoTitles(params?: {
 /**
  * 総動画数を取得するServer Action
  * Note: count()クエリは権限問題があるため、通常のクエリで代替
+ *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use getTotalVideoCount from './actions-v2' instead.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 3層タグ検索条件の複合処理が必要
 export async function getTotalVideoCount(params?: {
@@ -606,6 +626,8 @@ export async function getTotalVideoCount(params?: {
 
 /**
  * 特定の動画IDで動画データを取得するServer Action
+ *
+ * @deprecated Will be removed in v3.0.0 (target: August 31, 2025). Use getVideoById from './actions-v2' instead.
  * @param videoId - 動画ID
  * @returns 動画データまたはnull
  */

--- a/docs/DEPRECATED_APIS.md
+++ b/docs/DEPRECATED_APIS.md
@@ -1,0 +1,74 @@
+# Deprecated APIs
+
+This document tracks deprecated APIs in the suzumina.click codebase that will be removed in future versions.
+
+## Deprecation Timeline
+
+### Target: v3.0.0 (August 31, 2025)
+
+The following APIs are deprecated and will be removed in v3.0.0:
+
+#### Web Application
+
+##### `/apps/web/src/app/videos/actions.ts`
+- **Status**: Deprecated
+- **Replacement**: Use `/apps/web/src/app/videos/actions-v2.ts`
+- **Affected Functions**:
+  - `getVideoTitles()` → Use from `actions-v2`
+  - `getTotalVideoCount()` → Use from `actions-v2`
+  - `getVideoById()` → Use from `actions-v2`
+
+**Migration Example**:
+```typescript
+// Before:
+import { fetchVideos } from './actions';
+
+// After:
+import { fetchVideos } from './actions-v2';
+```
+
+#### Cloud Functions
+
+##### `/apps/functions/src/services/youtube/youtube-firestore.ts`
+- **Status**: Deprecated
+- **Replacement**: Use `/apps/functions/src/services/youtube/youtube-firestore-v2.ts`
+- **Affected Functions**:
+  - `saveVideosToFirestore()` → Use `saveVideosToFirestoreV2()`
+  - `convertVideoDataForFirestore()` → Use `VideoMapperV2.fromYouTubeAPI()`
+
+**Migration Example**:
+```typescript
+// Before:
+import { saveVideosToFirestore } from './youtube-firestore';
+
+// After:
+import { saveVideosToFirestoreV2 } from './youtube-firestore-v2';
+```
+
+## Background
+
+These APIs are being deprecated as part of the Entity/Value Object architecture migration (Entity V2). The new architecture provides:
+
+- Better type safety with domain models
+- Cleaner separation of concerns
+- Improved maintainability
+- Automatic _v2Migration flag for data tracking
+
+## Production Status
+
+Entity V2 is already enabled in production through feature flags:
+- Web Application: `ENABLE_ENTITY_V2=true`
+- Cloud Functions: `ENABLE_ENTITY_V2=true`
+
+## Removal Schedule
+
+1. **Now - August 2025**: Deprecated APIs remain functional with deprecation warnings
+2. **August 31, 2025**: V1 APIs will be removed (PR #23)
+3. **October 2025**: V2 suffixes and feature flags will be removed (PR #24)
+4. **January 2026**: Compatibility code (fromLegacy/toLegacy) will be removed (Phase 8)
+
+## Questions?
+
+If you have questions about migrating to the new APIs, please refer to:
+- `docs/DOMAIN_MODEL.md` - Domain model architecture
+- `docs/DOMAIN_OBJECT_CATALOG.md` - Domain object specifications


### PR DESCRIPTION
## 概要
Entity V2移行に伴い、旧コード（V1）を非推奨化します。

## 変更内容
### Web Application
- `/apps/web/src/app/videos/actions.ts`
  - ファイル全体に`@deprecated`タグを追加
  - 各関数（`getVideoTitles`, `getTotalVideoCount`, `getVideoById`）に個別の`@deprecated`タグを追加
  - 移行ガイドをコメントに記載

### Cloud Functions
- `/apps/functions/src/services/youtube/youtube-firestore.ts`
  - ファイル全体に`@deprecated`タグを追加
  - 主要関数（`saveVideosToFirestore`, `convertVideoDataForFirestore`）に個別の`@deprecated`タグを追加
  - 移行ガイドをコメントに記載

### Documentation
- `/docs/DEPRECATED_APIS.md`を作成
  - 非推奨APIの一覧と移行ガイド
  - 削除スケジュールの明記

## 削除予定
- **削除予定日**: 2025年8月31日 (v3.0.0)
- **理由**: Entity V2アーキテクチャへの移行完了

## 現在の状況
- Entity V2は本番環境で有効化済み
- 新規データには`_v2Migration`フラグが自動付与
- V1とV2は互換性があり、並行稼働中

## テスト
- ✅ 全テスト合格（644件）
- ✅ TypeScript型チェック合格
- ✅ Linting合格

## 次のステップ
- PR #23: 旧コード削除（2025年8月31日）
- PR #24: V2サフィックス削除と環境変数削除
- Phase 8: オーバーヘッドコード削除（2025年10月）

🤖 Generated with [Claude Code](https://claude.ai/code)