### PR TITLE
fix: 動画の日付表示が現在時刻になる問題を修正

### DIFF
--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -33,6 +33,7 @@ import {
 	type VideoListResult,
 } from "@suzumina.click/shared-types";
 import { getFirestore } from "@/lib/firestore";
+import * as logger from "@/lib/logger";
 
 /**
  * ページネーション用のクエリを構築する関数（ユーザー向け）
@@ -99,9 +100,28 @@ function buildUserPaginationQuery(
  * Timestamp型をISO文字列に変換する関数
  */
 function convertTimestampToISO(timestamp: unknown): string {
-	return timestamp instanceof Timestamp
-		? timestamp.toDate().toISOString()
-		: new Date().toISOString();
+	// すでにISO文字列の場合（Firestoreでは文字列として保存されている）
+	if (typeof timestamp === "string") {
+		return timestamp;
+	}
+	// Timestampオブジェクトの場合
+	if (timestamp instanceof Timestamp) {
+		return timestamp.toDate().toISOString();
+	}
+	// Dateオブジェクトの場合
+	if (timestamp instanceof Date) {
+		return timestamp.toISOString();
+	}
+	// Firestore Timestampのプレーンオブジェクト形式（_secondsプロパティを持つ）
+	if (timestamp && typeof timestamp === "object" && "_seconds" in timestamp) {
+		const seconds = (timestamp as { _seconds: number })._seconds;
+		return new Date(seconds * 1000).toISOString();
+	}
+	// それ以外の場合はエラーログを出してデフォルト値を返す
+	logger.error("Invalid timestamp format", { timestamp, type: typeof timestamp });
+	// publishedAtとlastFetchedAtで異なるデフォルト値が必要だが、ここでは判断できないので
+	// 明らかに間違っているが害の少ない過去の日付を返す
+	return "1970-01-01T00:00:00.000Z";
 }
 
 /**


### PR DESCRIPTION
## 概要
すべての動画の日付表示が現在時刻（2025/07/26）になってしまう問題を修正しました。

## 問題の詳細
- すべての動画の公開日が現在の日付として表示される
- liveStreamingDetailsの日付もすべて現在時刻として表示される
- Firestore内のデータは正しいが、フロントエンドでの変換時に問題が発生

## 原因
1. **convertTimestampToISO関数の問題**
   - 文字列のタイムスタンプを認識せず、Date.now()にフォールバックしていた
   - Firestoreでは日付が文字列として保存されているのに対応していなかった

2. **convertLiveStreamingDetails関数の問題**
   - Timestampインスタンスのみを処理し、文字列を無視していた
   - 結果としてundefinedが返され、UIで問題が発生

3. **createdAt/updatedAtの処理**
   - 新規作成時以外でも現在時刻を使用していた

## 修正内容
1. **convertTimestampToISO関数の修正**
   - 文字列のタイムスタンプをそのまま返すように変更
   - 不適切なDate.now()へのフォールバックを削除
   - エラー時は1970-01-01を返すように変更（明らかに間違っているが害が少ない）

2. **convertLiveStreamingDetails関数の修正**
   - 包括的なタイムスタンプ変換関数を追加
   - 文字列、Timestamp、Date、_secondsオブジェクトなど全形式に対応

3. **createdAt/updatedAtの処理修正**
   - 実際のデータを使用するように変更
   - 新規作成時のみ現在時刻を使用

## テスト結果
- すべてのテストが成功
- 動画ID `yKwHLkRMEAo` で正しい日付（2020-05-24）が表示されることを確認
- TypeScript型チェックもすべて通過

## スクリーンショット
ユーザーから提供された問題のスクリーンショット：
- 動画詳細ページですべての日付が現在時刻として表示されていた

## 関連Issue
- Entity V2移行作業の一環で発見された問題

🤖 Generated with [Claude Code](https://claude.ai/code)