### PR TITLE
feat: Creator Entity と CreatorWorkMapping Entity の適用

### DIFF
--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -58,6 +58,22 @@ vi.mock("@suzumina.click/shared-types", () => ({
 		},
 	})),
 	isValidCreatorId: vi.fn((id) => id && id.length > 0),
+	CreatorEntity: {
+		create: vi.fn((creatorId, name, types, workCount) => ({
+			toPlainObject: vi.fn(() => ({
+				id: creatorId,
+				creatorId,
+				name,
+				types,
+				workCount,
+				registeredAt: new Date().toISOString(),
+				lastUpdated: new Date().toISOString(),
+			})),
+		})),
+	},
+	CreatorWorkMappingEntity: {
+		create: vi.fn(),
+	},
 }));
 
 // Firestore モック
@@ -125,19 +141,19 @@ describe("Creator page server actions", () => {
 		it("存在するクリエイター情報を正しく集約する", async () => {
 			const mockMappings = [
 				{
-					creatorId: "creator123",
+					creatorId: "123456",
 					creatorName: "テストクリエイター",
 					types: ["voice"],
 					workId: "RJ111111",
 				},
 				{
-					creatorId: "creator123",
+					creatorId: "123456",
 					creatorName: "テストクリエイター",
 					types: ["illustration"],
 					workId: "RJ222222",
 				},
 				{
-					creatorId: "creator123",
+					creatorId: "123456",
 					creatorName: "テストクリエイター",
 					types: ["voice", "scenario"],
 					workId: "RJ333333",
@@ -151,15 +167,18 @@ describe("Creator page server actions", () => {
 				})),
 			});
 
-			const result = await getCreatorInfo("creator123");
+			const result = await getCreatorInfo("123456");
 
-			expect(result).toEqual({
-				id: "creator123",
+			expect(result).toMatchObject({
+				id: "123456",
+				creatorId: "123456",
 				name: "テストクリエイター",
 				types: ["voice", "illustration", "scenario"], // 重複なし、ユニークな値
 				workCount: 3,
 			});
-			expect(mockWhere).toHaveBeenCalledWith("creatorId", "==", "creator123");
+			expect(result?.registeredAt).toBeDefined();
+			expect(result?.lastUpdated).toBeDefined();
+			expect(mockWhere).toHaveBeenCalledWith("creatorId", "==", "123456");
 		});
 
 		it("クリエイターが存在しない場合はnullを返す", async () => {

--- a/apps/web/src/app/creators/[creatorId]/components/CreatorPageClient.tsx
+++ b/apps/web/src/app/creators/[creatorId]/components/CreatorPageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CreatorPageInfo, WorkPlainObject } from "@suzumina.click/shared-types";
+import type { CreatorPlainObject, WorkPlainObject } from "@suzumina.click/shared-types";
 import { getCreatorTypeLabel } from "@suzumina.click/shared-types";
 import {
 	ListPageContent,
@@ -13,7 +13,7 @@ import WorkList from "@/app/works/components/WorkList";
 import { getCreatorWorksWithPagination } from "../actions";
 
 interface CreatorPageClientProps {
-	creator: CreatorPageInfo;
+	creator: CreatorPlainObject;
 	initialData: WorkPlainObject[];
 	initialTotalCount: number;
 	initialPage: number;

--- a/packages/shared-types/src/entities/__tests__/creator-entity.test.ts
+++ b/packages/shared-types/src/entities/__tests__/creator-entity.test.ts
@@ -417,16 +417,10 @@ describe("CreatorEntity", () => {
 				id: "12345",
 				creatorId: "12345",
 				name: "テスト声優",
-				roles: ["voice"],
-				rolesDisplay: "声優",
-				primaryRole: "voice",
+				types: ["voice"],
 				workCount: 10,
-				isNew: true,
-				isActive: true,
-				hasWorks: true,
-				isVoiceActor: true,
 			});
-			expect(plain.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+			expect(plain.registeredAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 			expect(plain.lastUpdated).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 		});
 	});

--- a/packages/shared-types/src/entities/__tests__/creator-work-mapping-entity.test.ts
+++ b/packages/shared-types/src/entities/__tests__/creator-work-mapping-entity.test.ts
@@ -374,17 +374,11 @@ describe("CreatorWorkMappingEntity", () => {
 
 			expect(plain).toMatchObject({
 				id: "12345_RJ01234567",
-				mappingId: "12345_RJ01234567",
 				creatorId: "12345",
 				workId: "RJ01234567",
 				creatorName: "テスト声優",
-				roles: ["voice"],
+				types: ["voice"],
 				circleId: "RG23954",
-				isVoiceActor: true,
-				isIllustrator: false,
-				isScenarioWriter: false,
-				hasMultipleRoles: false,
-				isRecent: true,
 			});
 			expect(plain.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
 		});

--- a/packages/shared-types/src/entities/creator-entity.ts
+++ b/packages/shared-types/src/entities/creator-entity.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod";
+import type { CreatorPlainObject } from "../plain-objects/creator-plain";
 import {
 	CREATOR_ROLE_LABELS,
 	CREATOR_ROLE_PRIORITY,
@@ -494,34 +495,14 @@ export class CreatorEntity
 	/**
 	 * Converts to plain object for serialization
 	 */
-	toPlainObject(): {
-		id: string;
-		creatorId: string;
-		name: string;
-		roles: CreatorRole[];
-		rolesDisplay: string;
-		primaryRole: CreatorRole;
-		workCount: number;
-		isNew: boolean;
-		isActive: boolean;
-		hasWorks: boolean;
-		isVoiceActor: boolean;
-		createdAt: string;
-		lastUpdated: string;
-	} {
+	toPlainObject(): CreatorPlainObject {
 		return {
 			id: this.creatorId,
 			creatorId: this.creatorId,
 			name: this.creatorName,
-			roles: this.creatorRoles,
-			rolesDisplay: this._roles.toDisplayString(),
-			primaryRole: this._roles.getPrimaryRole(),
+			types: this.creatorRoles,
 			workCount: this.workCount,
-			isNew: this.isNewCreator(),
-			isActive: this.isActive(),
-			hasWorks: this.hasWorks(),
-			isVoiceActor: this.isVoiceActor(),
-			createdAt: this._createdAt.toISOString(),
+			registeredAt: this._createdAt.toISOString(),
 			lastUpdated: this._lastUpdated.toISOString(),
 		};
 	}

--- a/packages/shared-types/src/entities/creator-work-mapping-entity.ts
+++ b/packages/shared-types/src/entities/creator-work-mapping-entity.ts
@@ -7,6 +7,7 @@
  */
 
 import { z } from "zod";
+import type { CreatorWorkMappingPlainObject } from "../plain-objects/creator-plain";
 import { CreatorRole } from "../value-objects/work/creator-type";
 import { WorkId } from "../value-objects/work/work-id";
 import { BaseEntity, type EntityValidatable } from "./base/entity";
@@ -481,34 +482,14 @@ export class CreatorWorkMappingEntity
 	/**
 	 * Converts to plain object for serialization
 	 */
-	toPlainObject(): {
-		id: string;
-		mappingId: string;
-		creatorId: string;
-		workId: string;
-		creatorName: string;
-		roles: CreatorRole[];
-		circleId: string;
-		isVoiceActor: boolean;
-		isIllustrator: boolean;
-		isScenarioWriter: boolean;
-		hasMultipleRoles: boolean;
-		isRecent: boolean;
-		createdAt: string;
-	} {
+	toPlainObject(): CreatorWorkMappingPlainObject {
 		return {
 			id: this.mappingId,
-			mappingId: this.mappingId,
 			creatorId: this.creatorIdString,
 			workId: this.workIdString,
 			creatorName: this.creatorNameString,
-			roles: this.rolesArray,
+			types: this.rolesArray,
 			circleId: this.circleIdString,
-			isVoiceActor: this.isVoiceActorInWork(),
-			isIllustrator: this.isIllustratorInWork(),
-			isScenarioWriter: this.isScenarioWriterInWork(),
-			hasMultipleRoles: this.hasMultipleRoles(),
-			isRecent: this.isRecentMapping(),
 			createdAt: this._createdAt.toISOString(),
 		};
 	}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -44,6 +44,7 @@ export * from "./migrations";
 // === Plain Objects ===
 export * from "./plain-objects/audio-button-plain";
 export * from "./plain-objects/circle-plain";
+export * from "./plain-objects/creator-plain";
 export * from "./plain-objects/work-plain";
 // === Firestore Types ===
 // FirestoreServerWorkData has been removed - use WorkDocument from entities/work instead

--- a/packages/shared-types/src/plain-objects/creator-plain.ts
+++ b/packages/shared-types/src/plain-objects/creator-plain.ts
@@ -1,0 +1,33 @@
+/**
+ * Creator Plain Object
+ *
+ * Serializable representation of Creator Entity for Server/Client boundary
+ */
+
+/**
+ * Creator Plain Object interface
+ * Used for passing creator data between Server and Client Components
+ */
+export interface CreatorPlainObject {
+	id: string;
+	creatorId: string;
+	name: string;
+	types: string[];
+	workCount: number;
+	registeredAt: string;
+	lastUpdated: string;
+}
+
+/**
+ * Creator Work Mapping Plain Object interface
+ * Used for passing mapping data between Server and Client Components
+ */
+export interface CreatorWorkMappingPlainObject {
+	id: string;
+	creatorId: string;
+	workId: string;
+	creatorName: string;
+	types: string[];
+	circleId: string;
+	createdAt: string;
+}


### PR DESCRIPTION
## 概要

Circle Entity と同じミニマルなDDDパターンを Creator Entity と CreatorWorkMapping Entity に適用しました。

## 変更内容

### 1. PlainObject 型の定義
- `CreatorPlainObject` - Server/Client Component 境界用の型
- `CreatorWorkMappingPlainObject` - マッピング情報のシリアライズ用型

### 2. Entity の拡張
- `CreatorEntity.toPlainObject()` - PlainObject への変換メソッド
- `CreatorWorkMappingEntity.toPlainObject()` - PlainObject への変換メソッド

### 3. Server Actions の更新
- `getCreatorInfo()` が `CreatorEntity.create()` と `toPlainObject()` を使用
- `CreatorPageInfo` 型から `CreatorPlainObject` 型への移行

### 4. Cloud Functions の更新
- `updateCreatorMappings()` が `CreatorWorkMappingEntity.create()` を使用
- Entity の `toFirestore()` メソッドで Firestore 形式に変換

### 5. テストの修正
- Creator ID が数値形式であることを反映（"creator123" → "123456"）
- 無効なサークルID テストの期待値を修正
- PlainObject 形式に合わせてアサーションを更新

## 設計方針

Circle Entity と同様のアプローチ：
- Repository パターンは採用せず、直接 Firestore 操作
- Entity-Value Object パターンによるドメインモデリング
- PlainObject による Server/Client 境界の型安全性確保

## テスト結果

- ✅ 全てのテストが成功
- ✅ TypeScript の型チェックが成功
- ✅ Linting が成功

## レビューポイント

1. Creator ID の数値制約が適切か
2. PlainObject の構造が使いやすいか
3. エラーハンドリングが適切か