### PR TITLE
fix: 価格履歴と作品詳細画面のUI改善

### DIFF
--- a/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
+++ b/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
@@ -36,6 +36,7 @@ import { useMemo } from "react";
 import CharacteristicEvaluation from "@/components/content/characteristic-evaluation";
 import { PriceHistory } from "@/components/price-history/price-history";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
+import { formatJSTDateTime } from "@/utils/date-format";
 import { generateMockCharacteristicData } from "@/utils/mock-evaluation-data";
 import SampleImageGallery from "./SampleImageGallery";
 import { WorkEvaluation } from "./work-evaluation";
@@ -237,11 +238,6 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 										</Badge>
 									)}
 								</div>
-								{ageRatingCheck.isR18 && (
-									<p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
-										この作品は18歳以上の方を対象とした内容を含みます。
-									</p>
-								)}
 							</div>
 						)}
 
@@ -381,7 +377,9 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 													<Calendar className="h-5 w-5 text-muted-foreground" />
 													<div>
 														<div className="text-sm text-gray-700">販売日</div>
-														<div className="font-semibold text-gray-900">{work.releaseDate}</div>
+														<div className="font-semibold text-gray-900">
+															{formatJSTDateTime(work.releaseDate)}
+														</div>
 													</div>
 												</div>
 											)}
@@ -708,13 +706,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 
 						{/* 価格推移タブ */}
 						<TabsContent value="price-history" className="space-y-6">
-							<div className="space-y-4">
-								<div className="text-center mb-6">
-									<h3 className="text-xl font-semibold text-gray-900 mb-2">価格推移チャート</h3>
-									<p className="text-gray-600">この作品の価格変動やセール情報を確認できます</p>
-								</div>
-								<PriceHistory workId={work.productId} />
-							</div>
+							<PriceHistory workId={work.productId} />
 						</TabsContent>
 					</Tabs>
 				</div>

--- a/apps/web/src/components/price-history/price-history.tsx
+++ b/apps/web/src/components/price-history/price-history.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import type { PriceHistoryDocument } from "@suzumina.click/shared-types";
-import { useState, useTransition } from "react";
-import { toast } from "sonner";
+import { useState } from "react";
 import useSWR from "swr";
 import { getRecentPriceHistory } from "@/actions/price-history";
 import { error as logError } from "@/lib/logger";
@@ -36,48 +35,25 @@ async function fetchPriceHistory(workId: string): Promise<PriceHistoryDocument[]
 
 export function PriceHistory({ workId, className = "" }: PriceHistoryProps) {
 	const [selectedCurrency, setSelectedCurrency] = useState<CurrencyOption>("JPY");
-	const [showDiscountPrices, setShowDiscountPrices] = useState(true);
-	const [isPending, startTransition] = useTransition();
 
 	const {
 		data: priceHistory,
 		error,
 		isLoading,
-		mutate,
 	} = useSWR(workId ? `price-history-${workId}` : null, () => fetchPriceHistory(workId), {
 		revalidateOnFocus: false,
 		revalidateOnReconnect: false,
 		dedupingInterval: 5 * 60 * 1000, // 5分間は重複リクエストを防ぐ
 	});
 
-	const handleRefresh = () => {
-		startTransition(() => {
-			mutate()
-				.then(() => {
-					toast.success("価格履歴を更新しました");
-				})
-				.catch(() => {
-					toast.error("価格履歴の更新に失敗しました");
-				});
-		});
-	};
-
 	if (error) {
 		return (
 			<div className={`text-center ${className}`}>
 				<div className="rounded-lg bg-red-50 p-6">
 					<div className="text-red-800 font-medium mb-2">価格履歴の読み込みに失敗しました</div>
-					<div className="text-red-600 text-sm mb-4">
+					<div className="text-red-600 text-sm">
 						{error.message || "不明なエラーが発生しました"}
 					</div>
-					<button
-						type="button"
-						onClick={handleRefresh}
-						disabled={isPending}
-						className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
-					>
-						{isPending ? "更新中..." : "再試行"}
-					</button>
 				</div>
 			</div>
 		);
@@ -105,17 +81,9 @@ export function PriceHistory({ workId, className = "" }: PriceHistoryProps) {
 			<div className={`text-center ${className}`}>
 				<div className="rounded-lg bg-gray-50 p-6">
 					<div className="text-gray-600 font-medium mb-2">価格履歴データがありません</div>
-					<div className="text-gray-500 text-sm mb-4">
+					<div className="text-gray-500 text-sm">
 						この作品の価格履歴がまだ収集されていないか、データが存在しません
 					</div>
-					<button
-						type="button"
-						onClick={handleRefresh}
-						disabled={isPending}
-						className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-					>
-						{isPending ? "確認中..." : "データを確認"}
-					</button>
 				</div>
 			</div>
 		);
@@ -124,48 +92,22 @@ export function PriceHistory({ workId, className = "" }: PriceHistoryProps) {
 	return (
 		<div className={`space-y-6 ${className}`}>
 			{/* コントロールパネル */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div className="flex items-center gap-4">
-					{/* 通貨選択 */}
-					<div className="flex items-center gap-2">
-						<label htmlFor="currency-select" className="text-sm font-medium text-gray-700">
-							通貨:
-						</label>
-						<select
-							id="currency-select"
-							value={selectedCurrency}
-							onChange={(e) => setSelectedCurrency(e.target.value as CurrencyOption)}
-							className="rounded-md border border-gray-300 px-3 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						>
-							{CURRENCY_OPTIONS.map((option) => (
-								<option key={option.value} value={option.value}>
-									{option.label}
-								</option>
-							))}
-						</select>
-					</div>
-
-					{/* セール価格表示切り替え */}
-					<label className="flex items-center gap-2 text-sm">
-						<input
-							type="checkbox"
-							checked={showDiscountPrices}
-							onChange={(e) => setShowDiscountPrices(e.target.checked)}
-							className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-						/>
-						セール価格を表示
-					</label>
-				</div>
-
-				{/* 更新ボタン */}
-				<button
-					type="button"
-					onClick={handleRefresh}
-					disabled={isPending}
-					className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+			<div className="flex items-center gap-2">
+				<label htmlFor="currency-select" className="text-sm font-medium text-gray-700">
+					通貨:
+				</label>
+				<select
+					id="currency-select"
+					value={selectedCurrency}
+					onChange={(e) => setSelectedCurrency(e.target.value as CurrencyOption)}
+					className="rounded-md border border-gray-300 px-3 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 				>
-					{isPending ? "更新中..." : "最新データに更新"}
-				</button>
+					{CURRENCY_OPTIONS.map((option) => (
+						<option key={option.value} value={option.value}>
+							{option.label}
+						</option>
+					))}
+				</select>
 			</div>
 
 			{/* 価格チャート */}
@@ -174,7 +116,7 @@ export function PriceHistory({ workId, className = "" }: PriceHistoryProps) {
 				<PriceHistoryChart
 					priceHistory={priceHistory}
 					currency={selectedCurrency}
-					showDiscountPrices={showDiscountPrices}
+					showDiscountPrices={true}
 				/>
 			</div>
 

--- a/apps/web/src/components/price-history/price-statistics.tsx
+++ b/apps/web/src/components/price-history/price-statistics.tsx
@@ -56,7 +56,7 @@ export function PriceStatistics({
 
 	// 現在セール中かどうか
 	const currentRecord = priceHistory[priceHistory.length - 1];
-	const isCurrentlyOnSale = currentRecord?.discountRate && currentRecord.discountRate > 0;
+	const isCurrentlyOnSale = !!currentRecord?.discountRate && currentRecord.discountRate > 0;
 	const currentDiscountRate = currentRecord?.discountRate || 0;
 
 	// 通貨別の定価を取得

--- a/apps/web/src/utils/date-format.ts
+++ b/apps/web/src/utils/date-format.ts
@@ -1,0 +1,69 @@
+/**
+ * 日付を日本標準時でフォーマット
+ * @param dateString - ISO形式の日付文字列
+ * @returns "YYYY年 M月 D日 h時mm分" 形式の文字列
+ */
+export function formatJSTDateTime(dateString: string | Date): string {
+	const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+	// 無効な日付の場合は元の文字列を返す
+	if (Number.isNaN(date.getTime())) {
+		return typeof dateString === "string" ? dateString : "";
+	}
+
+	// 日本標準時のオプション
+	const options: Intl.DateTimeFormatOptions = {
+		year: "numeric",
+		month: "numeric",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		timeZone: "Asia/Tokyo",
+	};
+
+	// 日本語ロケールでフォーマット
+	const formatter = new Intl.DateTimeFormat("ja-JP", options);
+	const parts = formatter.formatToParts(date);
+
+	// パーツから各要素を取得
+	const year = parts.find((p) => p.type === "year")?.value || "";
+	const month = parts.find((p) => p.type === "month")?.value || "";
+	const day = parts.find((p) => p.type === "day")?.value || "";
+	const hour = parts.find((p) => p.type === "hour")?.value || "";
+	const minute = parts.find((p) => p.type === "minute")?.value || "";
+
+	return `${year}年 ${month}月 ${day}日 ${hour}時${minute}分`;
+}
+
+/**
+ * 日付を日本標準時の日付のみでフォーマット
+ * @param dateString - ISO形式の日付文字列
+ * @returns "YYYY年 M月 D日" 形式の文字列
+ */
+export function formatJSTDate(dateString: string | Date): string {
+	const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+	// 無効な日付の場合は元の文字列を返す
+	if (Number.isNaN(date.getTime())) {
+		return typeof dateString === "string" ? dateString : "";
+	}
+
+	// 日本標準時のオプション
+	const options: Intl.DateTimeFormatOptions = {
+		year: "numeric",
+		month: "numeric",
+		day: "numeric",
+		timeZone: "Asia/Tokyo",
+	};
+
+	// 日本語ロケールでフォーマット
+	const formatter = new Intl.DateTimeFormat("ja-JP", options);
+	const parts = formatter.formatToParts(date);
+
+	// パーツから各要素を取得
+	const year = parts.find((p) => p.type === "year")?.value || "";
+	const month = parts.find((p) => p.type === "month")?.value || "";
+	const day = parts.find((p) => p.type === "day")?.value || "";
+
+	return `${year}年 ${month}月 ${day}日`;
+}

--- a/apps/web/src/utils/date-format.ts
+++ b/apps/web/src/utils/date-format.ts
@@ -1,13 +1,40 @@
 /**
+ * 日付を検証して Date オブジェクトを返す
+ * @param dateString - ISO形式の日付文字列またはDateオブジェクト
+ * @returns 有効な Date オブジェクト、または無効な場合は null
+ */
+function validateAndParseDate(dateString: string | Date): Date | null {
+	const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+
+	// 無効な日付の場合
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+
+	return date;
+}
+
+/**
+ * 日本標準時でフォーマットした日付のパーツを取得
+ * @param date - Dateオブジェクト
+ * @param options - Intl.DateTimeFormatOptions
+ * @returns フォーマットされた日付のパーツ
+ */
+function getJSTFormattedParts(date: Date, options: Intl.DateTimeFormatOptions) {
+	const formatter = new Intl.DateTimeFormat("ja-JP", options);
+	return formatter.formatToParts(date);
+}
+
+/**
  * 日付を日本標準時でフォーマット
  * @param dateString - ISO形式の日付文字列
  * @returns "YYYY年 M月 D日 h時mm分" 形式の文字列
  */
 export function formatJSTDateTime(dateString: string | Date): string {
-	const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+	const date = validateAndParseDate(dateString);
 
 	// 無効な日付の場合は元の文字列を返す
-	if (Number.isNaN(date.getTime())) {
+	if (!date) {
 		return typeof dateString === "string" ? dateString : "";
 	}
 
@@ -22,8 +49,7 @@ export function formatJSTDateTime(dateString: string | Date): string {
 	};
 
 	// 日本語ロケールでフォーマット
-	const formatter = new Intl.DateTimeFormat("ja-JP", options);
-	const parts = formatter.formatToParts(date);
+	const parts = getJSTFormattedParts(date, options);
 
 	// パーツから各要素を取得
 	const year = parts.find((p) => p.type === "year")?.value || "";
@@ -41,10 +67,10 @@ export function formatJSTDateTime(dateString: string | Date): string {
  * @returns "YYYY年 M月 D日" 形式の文字列
  */
 export function formatJSTDate(dateString: string | Date): string {
-	const date = typeof dateString === "string" ? new Date(dateString) : dateString;
+	const date = validateAndParseDate(dateString);
 
 	// 無効な日付の場合は元の文字列を返す
-	if (Number.isNaN(date.getTime())) {
+	if (!date) {
 		return typeof dateString === "string" ? dateString : "";
 	}
 
@@ -57,8 +83,7 @@ export function formatJSTDate(dateString: string | Date): string {
 	};
 
 	// 日本語ロケールでフォーマット
-	const formatter = new Intl.DateTimeFormat("ja-JP", options);
-	const parts = formatter.formatToParts(date);
+	const parts = getJSTFormattedParts(date, options);
 
 	// パーツから各要素を取得
 	const year = parts.find((p) => p.type === "year")?.value || "";


### PR DESCRIPTION
## Summary
- 価格統計で余分な「0」が表示される問題を修正
- 価格推移タブのUIを簡略化
- 販売日表示を日本標準時形式に変更
- 不要な年齢確認警告メッセージを削除

## Details

### 1. 価格統計の「0」表示問題
- **問題**: React条件付きレンダリングで `isCurrentlyOnSale` が `0` の時、画面に「0」が表示されていた
- **修正**: `!!` を追加して boolean に変換

### 2. 価格推移タブの簡略化
- 「価格推移チャート」ヘッダーを削除（自明なため）
- 「セール価格を表示」チェックボックスを削除（常に表示）
- 「最新データに更新」ボタンを削除（自動更新のみ）

### 3. 販売日の表示形式改善
- ISO形式（2025-07-28T15:00:00.000Z）から
- 日本標準時形式（2025年 7月 29日 0時00分）へ変更
- `formatJSTDateTime` ユーティリティ関数を追加

### 4. 年齢確認警告の削除
- 「この作品は18歳以上の方を対象とした内容を含みます。」を削除
- 年齢確認済みユーザーのみアクセス可能なため不要

## Test plan
- [x] 価格統計に余分な「0」が表示されないことを確認
- [x] 価格推移タブのUIが簡略化されていることを確認
- [x] 販売日が日本標準時で表示されることを確認
- [x] 年齢確認警告が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)