### PR TITLE
feat: dlsiteWorksコレクションをworksに移行

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,8 @@ For detailed project documentation, see [Documentation Index](docs/README.md).
 - **Check DDD implementation criteria** before creating new entities - see `docs/decisions/architecture/ADR-001-ddd-implementation-guidelines.md`
 
 ### 8. CRITICAL NAMING CONVENTIONS
-- **Firestore collection for DLsite works is `dlsiteWorks`** - NOT `works`
-- This naming inconsistency is known but changing would require major migration
+- **Firestore collection for DLsite works is `works`** - NOT `dlsiteWorks` (renamed on 2025-07-31)
+- Previously named `dlsiteWorks`, but renamed to `works` for consistency
 - Always verify collection names when working with Firestore
 
 ### 9. DATA INTEGRITY
@@ -116,4 +116,4 @@ pnpm build
 ---
 
 **Last Updated**: 2025-07-31
-**Document Version**: 4.1 (Added data integrity checks)
+**Document Version**: 4.2 (Updated collection name from dlsiteWorks to works)

--- a/apps/admin/src/app/actions/work-actions.ts
+++ b/apps/admin/src/app/actions/work-actions.ts
@@ -30,7 +30,7 @@ export async function updateWork(workId: string, data: UpdateWorkData): Promise<
 		}
 
 		const firestore = getFirestore();
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 
 		// 作品の存在確認
 		const workDoc = await workRef.get();
@@ -90,7 +90,7 @@ export async function deleteWork(workId: string): Promise<ActionResult> {
 		const firestore = getFirestore();
 
 		// 作品の存在確認
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 		const workDoc = await workRef.get();
 		if (!workDoc.exists) {
 			return {

--- a/apps/admin/src/app/api/admin/works/[workId]/route.ts
+++ b/apps/admin/src/app/api/admin/works/[workId]/route.ts
@@ -15,7 +15,7 @@ export async function PUT(request: NextRequest, context: { params: Promise<{ wor
 		const body = await request.json();
 
 		const firestore = getFirestore();
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 
 		// 作品の存在確認
 		const workDoc = await workRef.get();
@@ -68,7 +68,7 @@ export async function DELETE(
 		const firestore = getFirestore();
 
 		// 作品の存在確認
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 		const workDoc = await workRef.get();
 		if (!workDoc.exists) {
 			return NextResponse.json({ error: "Work not found" }, { status: 404 });

--- a/apps/admin/src/app/page.tsx
+++ b/apps/admin/src/app/page.tsx
@@ -31,7 +31,7 @@ async function getAdminStats() {
 		const [usersSnap, videosSnap, worksSnap, buttonsSnap, contactsSnap] = await Promise.all([
 			firestore.collection("users").get(),
 			firestore.collection("videos").get(),
-			firestore.collection("dlsiteWorks").get(),
+			firestore.collection("works").get(),
 			firestore.collection("audioButtons").get(),
 			firestore.collection("contacts").get(),
 		]);

--- a/apps/admin/src/app/works/page.tsx
+++ b/apps/admin/src/app/works/page.tsx
@@ -68,7 +68,7 @@ async function getWorks(
 		const firestore = getFirestore();
 
 		// 総件数を取得
-		const totalSnap = await firestore.collection("dlsiteWorks").get();
+		const totalSnap = await firestore.collection("works").get();
 		const totalCount = totalSnap.size;
 
 		// ページング計算
@@ -80,11 +80,7 @@ async function getWorks(
 		const actualOffset = (currentPage - 1) * limit;
 
 		// データ取得（ソートなしで安全に取得）
-		const worksSnap = await firestore
-			.collection("dlsiteWorks")
-			.offset(actualOffset)
-			.limit(limit)
-			.get();
+		const worksSnap = await firestore.collection("works").offset(actualOffset).limit(limit).get();
 
 		const works = worksSnap.docs.map((doc) => {
 			const data = doc.data();
@@ -156,7 +152,7 @@ function formatPrice(price: {
 async function calculateStats() {
 	try {
 		const firestore = getFirestore();
-		const allWorksSnap = await firestore.collection("dlsiteWorks").get();
+		const allWorksSnap = await firestore.collection("works").get();
 
 		const allWorks = allWorksSnap.docs.map((doc) => {
 			const data = doc.data();

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
@@ -84,7 +84,7 @@ describe("checkDataIntegrity", () => {
 
 		// collection().get()のモック
 		mockCollection.mockImplementation((collName: string) => {
-			if (collName === "circles" || collName === "creators" || collName === "dlsiteWorks") {
+			if (collName === "circles" || collName === "creators" || collName === "works") {
 				return {
 					get: vi.fn().mockResolvedValue(emptySnapshot),
 					doc: mockDoc,
@@ -164,7 +164,7 @@ describe("checkDataIntegrity", () => {
 					doc: mockDoc,
 				};
 			}
-			if (collName === "creators" || collName === "dlsiteWorks") {
+			if (collName === "creators" || collName === "works") {
 				return {
 					get: vi.fn().mockResolvedValue(emptySnapshot),
 					doc: vi.fn(() => mockWorkDoc),
@@ -241,7 +241,7 @@ describe("checkDataIntegrity", () => {
 
 		// collection()のモック
 		mockCollection.mockImplementation((collName: string) => {
-			if (collName === "circles" || collName === "dlsiteWorks") {
+			if (collName === "circles" || collName === "works") {
 				return {
 					get: vi.fn().mockResolvedValue(emptySnapshot),
 					doc: mockDoc,
@@ -290,7 +290,7 @@ describe("checkDataIntegrity", () => {
 	});
 
 	it("削除されたCreator-Work関連を復元する", async () => {
-		// dlsiteWorksコレクションのモック
+		// worksコレクションのモック
 		const mockWorks = {
 			size: 1,
 			docs: [
@@ -332,7 +332,7 @@ describe("checkDataIntegrity", () => {
 
 		// collection()のモック
 		mockCollection.mockImplementation((collName: string) => {
-			if (collName === "dlsiteWorks") {
+			if (collName === "works") {
 				return {
 					get: vi.fn().mockResolvedValue(mockWorks),
 					doc: mockDoc,

--- a/apps/functions/src/endpoints/data-integrity-check.ts
+++ b/apps/functions/src/endpoints/data-integrity-check.ts
@@ -96,7 +96,7 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult): Promise<void
 		const existingWorkIds: string[] = [];
 		for (const workId of uniqueWorkIds) {
 			const workDoc = await firestore
-				.collection("dlsiteWorks")
+				.collection("works")
 				.doc(workId as string)
 				.get();
 			if (workDoc.exists) {
@@ -150,7 +150,7 @@ async function checkOrphanedCreators(result: IntegrityCheckResult): Promise<void
 
 		for (const workMapping of worksSnapshot.docs) {
 			const workId = workMapping.id;
-			const workDoc = await firestore.collection("dlsiteWorks").doc(workId).get();
+			const workDoc = await firestore.collection("works").doc(workId).get();
 
 			if (!workDoc.exists) {
 				logger.warn(`Creator ${creatorDoc.id}: 孤立したマッピング ${workId} を検出`);
@@ -292,7 +292,7 @@ async function commitBatchIfNeeded(
 async function restoreCreatorWorkRelations(result: IntegrityCheckResult): Promise<void> {
 	logger.info("Creator-Work関連の復元を開始");
 
-	const worksSnapshot = await firestore.collection("dlsiteWorks").get();
+	const worksSnapshot = await firestore.collection("works").get();
 	const batch = firestore.batch();
 	const processedCreators = new Set<string>();
 
@@ -366,7 +366,7 @@ async function restoreCreatorWorkRelations(result: IntegrityCheckResult): Promis
 async function checkWorkCircleConsistency(result: IntegrityCheckResult): Promise<void> {
 	logger.info("Work-Circle相互参照の整合性チェックを開始");
 
-	const worksSnapshot = await firestore.collection("dlsiteWorks").get();
+	const worksSnapshot = await firestore.collection("works").get();
 	const batch = firestore.batch();
 	let batchCount = 0;
 

--- a/apps/functions/src/services/dlsite/__tests__/circle-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/circle-firestore.test.ts
@@ -382,12 +382,12 @@ describe("circle-firestore", () => {
 				docs: actualWorks.map((work) => ({ id: work.id })),
 			};
 
-			// dlsiteWorksコレクションのクエリ
-			const dlsiteWorksQuery = {
+			// worksコレクションのクエリ
+			const worksQuery = {
 				get: vi.fn().mockResolvedValue(worksSnapshot),
 			};
 
-			mockWhere.mockReturnValueOnce(dlsiteWorksQuery);
+			mockWhere.mockReturnValueOnce(worksQuery);
 
 			// circlesコレクションのドキュメント取得
 			mockGet.mockResolvedValueOnce({
@@ -409,11 +409,11 @@ describe("circle-firestore", () => {
 				docs: [{ id: "RJ111111" }],
 			};
 
-			const dlsiteWorksQuery = {
+			const worksQuery = {
 				get: vi.fn().mockResolvedValue(worksSnapshot),
 			};
 
-			mockWhere.mockReturnValueOnce(dlsiteWorksQuery);
+			mockWhere.mockReturnValueOnce(worksQuery);
 			mockGet.mockResolvedValueOnce({ exists: false });
 
 			const result = await recalculateCircleWorkIds("RG99999");
@@ -438,11 +438,11 @@ describe("circle-firestore", () => {
 				docs: actualWorks.map((work) => ({ id: work.id })),
 			};
 
-			const dlsiteWorksQuery = {
+			const worksQuery = {
 				get: vi.fn().mockResolvedValue(worksSnapshot),
 			};
 
-			mockWhere.mockReturnValueOnce(dlsiteWorksQuery);
+			mockWhere.mockReturnValueOnce(worksQuery);
 			mockGet.mockResolvedValueOnce({
 				exists: true,
 				data: () => existingCircle,

--- a/apps/functions/src/services/dlsite/circle-firestore.ts
+++ b/apps/functions/src/services/dlsite/circle-firestore.ts
@@ -227,7 +227,7 @@ export async function recalculateCircleWorkIds(circleId: string): Promise<number
 	try {
 		// 実際の作品を検索
 		const worksSnapshot = await firestore
-			.collection("dlsiteWorks")
+			.collection("works")
 			.where("circleId", "==", circleId)
 			.get();
 

--- a/apps/functions/src/services/dlsite/dlsite-firestore.ts
+++ b/apps/functions/src/services/dlsite/dlsite-firestore.ts
@@ -14,7 +14,7 @@ import { FAILURE_REASONS, trackMultipleFailedWorks } from "./failure-tracker";
 // Note: 最適化構造では mapToFirestoreData, filterWorksForUpdate, validateWorkData は不要
 
 // Firestore関連の定数
-const DLSITE_WORKS_COLLECTION = "dlsiteWorks";
+const DLSITE_WORKS_COLLECTION = "works";
 
 /**
  * 単一チャンクのバッチ処理

--- a/apps/functions/src/services/price-history/price-history-saver.ts
+++ b/apps/functions/src/services/price-history/price-history-saver.ts
@@ -46,7 +46,7 @@ export async function savePriceHistory(
 
 		// サブコレクション参照
 		const priceHistoryRef = firestore
-			.collection("dlsiteWorks")
+			.collection("works")
 			.doc(workId)
 			.collection("priceHistory")
 			.doc(today as string);

--- a/apps/functions/src/tools/cleanup-dlsiteworks-collection.ts
+++ b/apps/functions/src/tools/cleanup-dlsiteworks-collection.ts
@@ -1,0 +1,114 @@
+/**
+ * dlsiteWorksコレクションの削除スクリプト
+ *
+ * 実行方法:
+ * pnpm --filter @suzumina.click/functions tsx src/tools/cleanup-dlsiteworks-collection.ts
+ *
+ * 注意事項:
+ * - worksコレクションへのマイグレーションが完了していることを確認してから実行すること
+ * - このスクリプトは元に戻すことができない破壊的な操作です
+ * - 実行前に必ずバックアップを確認すること
+ */
+
+import firestore from "../infrastructure/database/firestore";
+import * as logger from "../shared/logger";
+
+const COLLECTION_TO_DELETE = "dlsiteWorks";
+const BATCH_SIZE = 400; // Firestore batch limit
+
+async function deleteCollection(): Promise<void> {
+	logger.info(`コレクション削除開始: ${COLLECTION_TO_DELETE}`);
+
+	try {
+		// 1. コレクションのドキュメント総数を確認
+		const snapshot = await firestore.collection(COLLECTION_TO_DELETE).get();
+		const totalDocs = snapshot.size;
+		logger.info(`削除対象ドキュメント数: ${totalDocs}`);
+
+		if (totalDocs === 0) {
+			logger.info("削除対象のドキュメントが存在しません");
+			return;
+		}
+
+		// 2. 最終確認
+		logger.warn("⚠️  最終確認: このコレクションを削除してもよろしいですか？");
+		logger.warn("この操作は元に戻すことができません！");
+		logger.warn("10秒後に削除を開始します...");
+
+		await new Promise((resolve) => setTimeout(resolve, 10000));
+
+		// 3. バッチ処理でドキュメントを削除
+		let deletedDocs = 0;
+		let batch = firestore.batch();
+		let batchCount = 0;
+
+		for (const doc of snapshot.docs) {
+			// サブコレクションも含めて削除
+			const priceHistorySnapshot = await doc.ref.collection("priceHistory").get();
+			for (const priceDoc of priceHistorySnapshot.docs) {
+				batch.delete(priceDoc.ref);
+				batchCount++;
+
+				if (batchCount >= BATCH_SIZE) {
+					await batch.commit();
+					logger.info(`サブコレクション削除バッチコミット: ${batchCount}件`);
+					batch = firestore.batch();
+					batchCount = 0;
+				}
+			}
+
+			// メインドキュメントを削除
+			batch.delete(doc.ref);
+			batchCount++;
+
+			if (batchCount >= BATCH_SIZE) {
+				await batch.commit();
+				deletedDocs += batchCount;
+				logger.info(
+					`進捗: ${deletedDocs}件削除済み (${Math.round((deletedDocs / totalDocs) * 100)}%)`,
+				);
+
+				batch = firestore.batch();
+				batchCount = 0;
+			}
+		}
+
+		// 残りのドキュメントを削除
+		if (batchCount > 0) {
+			await batch.commit();
+			deletedDocs += batchCount;
+			logger.info(`進捗: ${deletedDocs}件削除済み (100%)`);
+		}
+
+		// 4. 検証: コレクションが空になったことを確認
+		const verifySnapshot = await firestore.collection(COLLECTION_TO_DELETE).get();
+		if (verifySnapshot.empty) {
+			logger.info("✅ コレクションが正常に削除されました");
+		} else {
+			logger.error(`❌ ${verifySnapshot.size}件のドキュメントが残っています`);
+		}
+	} catch (error) {
+		logger.error("削除中にエラーが発生しました:", error);
+		throw error;
+	}
+}
+
+// メイン処理
+async function main(): Promise<void> {
+	try {
+		await deleteCollection();
+		logger.info("🎉 削除処理が完了しました！");
+		process.exit(0);
+	} catch (error) {
+		logger.error("エラーが発生しました:", error);
+		process.exit(1);
+	}
+}
+
+// スクリプト実行
+if (require.main === module) {
+	main().catch((error) => {
+		logger.error("予期しないエラー:", error);
+		process.exit(1);
+	});
+}

--- a/apps/functions/src/tools/core/region-restriction-detector.ts
+++ b/apps/functions/src/tools/core/region-restriction-detector.ts
@@ -148,7 +148,7 @@ class RegionRestrictionDetector {
 		},
 	): Promise<void> {
 		try {
-			const workRef = firestore.collection("dlsiteWorks").doc(workId);
+			const workRef = firestore.collection("works").doc(workId);
 			await workRef.update(restrictionData);
 			// 作品フラグ更新ログは省略（ログ削減）
 		} catch (error) {
@@ -156,7 +156,7 @@ class RegionRestrictionDetector {
 				// ドキュメントが存在しない場合は作成
 				// 作品ドキュメント作成ログは省略（ログ削減）
 				await firestore
-					.collection("dlsiteWorks")
+					.collection("works")
 					.doc(workId)
 					.set({
 						productId: workId,

--- a/apps/functions/src/tools/migrate-dlsiteworks-to-works.ts
+++ b/apps/functions/src/tools/migrate-dlsiteworks-to-works.ts
@@ -1,0 +1,152 @@
+/**
+ * dlsiteWorksコレクションからworksコレクションへのマイグレーションスクリプト
+ *
+ * 実行方法:
+ * pnpm --filter @suzumina.click/functions tsx src/tools/migrate-dlsiteworks-to-works.ts
+ *
+ * 注意事項:
+ * - 本番環境で実行する前に必ずバックアップを取得すること
+ * - ダウンタイム中に実行することを推奨
+ * - 大量のFirestore読み書きオペレーションが発生するため、課金に注意
+ */
+
+import firestore from "../infrastructure/database/firestore";
+import * as logger from "../shared/logger";
+
+const SOURCE_COLLECTION = "dlsiteWorks";
+const TARGET_COLLECTION = "works";
+const BATCH_SIZE = 400; // Firestore batch limit
+const SUBCOLLECTION_NAME = "priceHistory";
+
+async function migrateSubcollections(sourceDocId: string, targetDocId: string): Promise<void> {
+	const sourceSubcollection = firestore
+		.collection(SOURCE_COLLECTION)
+		.doc(sourceDocId)
+		.collection(SUBCOLLECTION_NAME);
+
+	const targetSubcollection = firestore
+		.collection(TARGET_COLLECTION)
+		.doc(targetDocId)
+		.collection(SUBCOLLECTION_NAME);
+
+	const snapshot = await sourceSubcollection.get();
+
+	if (snapshot.empty) {
+		return;
+	}
+
+	const batch = firestore.batch();
+	let batchCount = 0;
+
+	for (const doc of snapshot.docs) {
+		const targetDocRef = targetSubcollection.doc(doc.id);
+		batch.set(targetDocRef, doc.data());
+		batchCount++;
+
+		if (batchCount >= BATCH_SIZE) {
+			await batch.commit();
+			logger.info(`サブコレクション ${SUBCOLLECTION_NAME} のバッチコミット完了: ${batchCount}件`);
+			batchCount = 0;
+		}
+	}
+
+	if (batchCount > 0) {
+		await batch.commit();
+		logger.info(`サブコレクション ${SUBCOLLECTION_NAME} の最終バッチコミット完了: ${batchCount}件`);
+	}
+}
+
+async function migrateCollection(): Promise<void> {
+	logger.info(`マイグレーション開始: ${SOURCE_COLLECTION} → ${TARGET_COLLECTION}`);
+
+	try {
+		// 1. ソースコレクションのドキュメント総数を確認
+		const sourceSnapshot = await firestore.collection(SOURCE_COLLECTION).get();
+		const totalDocs = sourceSnapshot.size;
+		logger.info(`総ドキュメント数: ${totalDocs}`);
+
+		if (totalDocs === 0) {
+			logger.warn("ソースコレクションにドキュメントが存在しません");
+			return;
+		}
+
+		// 2. バッチ処理でドキュメントをコピー
+		let processedDocs = 0;
+		let batch = firestore.batch();
+		let batchCount = 0;
+
+		for (const doc of sourceSnapshot.docs) {
+			const targetDocRef = firestore.collection(TARGET_COLLECTION).doc(doc.id);
+			batch.set(targetDocRef, doc.data());
+			batchCount++;
+
+			// サブコレクションのマイグレーション
+			await migrateSubcollections(doc.id, doc.id);
+
+			if (batchCount >= BATCH_SIZE) {
+				await batch.commit();
+				processedDocs += batchCount;
+				logger.info(
+					`進捗: ${processedDocs}/${totalDocs} (${Math.round((processedDocs / totalDocs) * 100)}%)`,
+				);
+
+				batch = firestore.batch();
+				batchCount = 0;
+			}
+		}
+
+		// 残りのドキュメントをコミット
+		if (batchCount > 0) {
+			await batch.commit();
+			processedDocs += batchCount;
+			logger.info(`進捗: ${processedDocs}/${totalDocs} (100%)`);
+		}
+
+		logger.info("マイグレーション完了！");
+		logger.info(`処理したドキュメント数: ${processedDocs}`);
+
+		// 3. 検証: ターゲットコレクションのドキュメント数を確認
+		const targetSnapshot = await firestore.collection(TARGET_COLLECTION).get();
+		logger.info(`ターゲットコレクションのドキュメント数: ${targetSnapshot.size}`);
+
+		if (sourceSnapshot.size === targetSnapshot.size) {
+			logger.info("✅ ドキュメント数が一致しました");
+		} else {
+			logger.error("❌ ドキュメント数が一致しません！");
+			logger.error(`ソース: ${sourceSnapshot.size}, ターゲット: ${targetSnapshot.size}`);
+		}
+	} catch (error) {
+		logger.error("マイグレーション中にエラーが発生しました:", error);
+		throw error;
+	}
+}
+
+// メイン処理
+async function main(): Promise<void> {
+	try {
+		// 確認プロンプト
+		logger.warn("⚠️  警告: このスクリプトは本番データを変更します！");
+		logger.warn(`ソース: ${SOURCE_COLLECTION}`);
+		logger.warn(`ターゲット: ${TARGET_COLLECTION}`);
+		logger.warn("続行しますか？ (5秒後に自動的に開始します...)");
+
+		// 5秒間の待機時間を設ける
+		await new Promise((resolve) => setTimeout(resolve, 5000));
+
+		await migrateCollection();
+
+		logger.info("🎉 すべての処理が完了しました！");
+		process.exit(0);
+	} catch (error) {
+		logger.error("エラーが発生しました:", error);
+		process.exit(1);
+	}
+}
+
+// スクリプト実行
+if (require.main === module) {
+	main().catch((error) => {
+		logger.error("予期しないエラー:", error);
+		process.exit(1);
+	});
+}

--- a/apps/web/src/actions/price-history.ts
+++ b/apps/web/src/actions/price-history.ts
@@ -24,7 +24,7 @@ export async function getPriceHistory(
 		// サブコレクション参照
 		const firestore = getFirestore();
 		let query = firestore
-			.collection("dlsiteWorks")
+			.collection("works")
 			.doc(workId)
 			.collection("priceHistory")
 			.orderBy("date", "desc");

--- a/apps/web/src/app/actions/work-actions.ts
+++ b/apps/web/src/app/actions/work-actions.ts
@@ -41,7 +41,7 @@ async function validateWorkExists(
 	workId: string,
 ): Promise<{ success: true } | { success: false; error: string }> {
 	const firestore = getFirestore();
-	const workRef = firestore.collection("dlsiteWorks").doc(workId);
+	const workRef = firestore.collection("works").doc(workId);
 	const workDoc = await workRef.get();
 
 	if (!workDoc.exists) {
@@ -118,7 +118,7 @@ export async function updateWork(
 
 		// Firestoreを更新
 		const firestore = getFirestore();
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 		await workRef.update(updateData);
 
 		// キャッシュの無効化
@@ -176,7 +176,7 @@ export async function deleteWork(
 		}
 
 		const firestore = getFirestore();
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 
 		// 作品の存在確認
 		const workDoc = await workRef.get();
@@ -270,7 +270,7 @@ async function applyPagination(
 	params: WorkPaginationParams,
 ) {
 	if (params.startAfter) {
-		const startAfterDoc = await firestore.collection("dlsiteWorks").doc(params.startAfter).get();
+		const startAfterDoc = await firestore.collection("works").doc(params.startAfter).get();
 		if (startAfterDoc.exists) {
 			return query.startAfter(startAfterDoc);
 		}
@@ -312,7 +312,7 @@ async function getTotalWorksCount(
 	firestore: FirebaseFirestore.Firestore,
 ): Promise<number | undefined> {
 	try {
-		const countSnapshot = await firestore.collection("dlsiteWorks").get();
+		const countSnapshot = await firestore.collection("works").get();
 		return countSnapshot.size;
 	} catch (countError) {
 		logger.warn("総件数取得エラー", {
@@ -346,7 +346,7 @@ export async function getWorksForAdmin(
 
 		const validatedParams = validationResult.data;
 		const firestore = getFirestore();
-		const worksRef = firestore.collection("dlsiteWorks");
+		const worksRef = firestore.collection("works");
 
 		// クエリ構築
 		let query = buildWorksQuery(worksRef, validatedParams);
@@ -423,7 +423,7 @@ export async function refreshWorkData(
 		}
 
 		const firestore = getFirestore();
-		const workRef = firestore.collection("dlsiteWorks").doc(workId);
+		const workRef = firestore.collection("works").doc(workId);
 
 		// 作品の存在確認
 		const workDoc = await workRef.get();

--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -358,7 +358,7 @@ describe("Circle page server actions", () => {
 						}),
 					};
 				}
-				if (collectionName === "dlsiteWorks") {
+				if (collectionName === "works") {
 					return {
 						get: vi.fn().mockResolvedValue({
 							empty: false,
@@ -404,7 +404,7 @@ describe("Circle page server actions", () => {
 						}),
 					};
 				}
-				if (collectionName === "dlsiteWorks") {
+				if (collectionName === "works") {
 					return {
 						get: vi.fn().mockResolvedValue({
 							empty: true,
@@ -463,7 +463,7 @@ describe("Circle page server actions", () => {
 						}),
 					};
 				}
-				if (collectionName === "dlsiteWorks") {
+				if (collectionName === "works") {
 					return {
 						get: vi.fn().mockRejectedValue(new Error("Firestore error")),
 					};
@@ -580,7 +580,7 @@ describe("Circle page server actions", () => {
 						}),
 					};
 				}
-				if (collectionName === "dlsiteWorks") {
+				if (collectionName === "works") {
 					return {
 						get: vi.fn().mockResolvedValue({
 							empty: false,
@@ -682,7 +682,7 @@ describe("Circle page server actions", () => {
 						}),
 					};
 				}
-				if (collectionName === "dlsiteWorks") {
+				if (collectionName === "works") {
 					return {
 						get: vi.fn().mockResolvedValue({
 							empty: false,

--- a/apps/web/src/app/circles/[circleId]/actions.ts
+++ b/apps/web/src/app/circles/[circleId]/actions.ts
@@ -117,7 +117,7 @@ export async function getCircleWorks(circleId: string): Promise<WorkPlainObject[
 
 		// 全作品を取得してクライアント側でフィルタリング
 		// circleId が設定されていない作品もサークル名で検索
-		const allWorksSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allWorksSnapshot = await firestore.collection("works").get();
 
 		const allMatchingWorks = allWorksSnapshot.docs
 			.map((doc) => {
@@ -183,7 +183,7 @@ export async function getCircleWorksWithPagination(
 		const circleName = circleData.name;
 
 		// 全作品を取得してクライアント側でフィルタリング
-		const allWorksSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allWorksSnapshot = await firestore.collection("works").get();
 
 		const allMatchingWorks = allWorksSnapshot.docs
 			.map((doc) => {

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -120,7 +120,7 @@ describe("Creator page server actions", () => {
 					doc: mockDoc,
 				};
 			}
-			if (collectionName === "dlsiteWorks") {
+			if (collectionName === "works") {
 				return {
 					doc: vi.fn((id) => ({
 						id,

--- a/apps/web/src/app/creators/[creatorId]/actions.ts
+++ b/apps/web/src/app/creators/[creatorId]/actions.ts
@@ -152,7 +152,7 @@ export async function getCreatorWorks(creatorId: string): Promise<WorkPlainObjec
 		// Firestoreの whereIn 制限により、一度に10件まで
 		for (let i = 0; i < workIds.length; i += 10) {
 			const batch = workIds.slice(i, i + 10);
-			const workRefs = batch.map((id) => firestore.collection("dlsiteWorks").doc(id));
+			const workRefs = batch.map((id) => firestore.collection("works").doc(id));
 			const workDocs = await firestore.getAll(...workRefs);
 
 			for (const doc of workDocs) {
@@ -229,7 +229,7 @@ export async function getCreatorWorksWithPagination(
 		// Firestoreの whereIn 制限により、一度に10件まで
 		for (let i = 0; i < workIds.length; i += 10) {
 			const batch = workIds.slice(i, i + 10);
-			const workRefs = batch.map((id) => firestore.collection("dlsiteWorks").doc(id));
+			const workRefs = batch.map((id) => firestore.collection("works").doc(id));
 			const workDocs = await firestore.getAll(...workRefs);
 
 			for (const doc of workDocs) {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -73,7 +73,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		// 作品ページを追加
 		try {
 			const worksSnapshot = await firestore
-				.collection("dlsiteWorks")
+				.collection("works")
 				.where("isPublic", "==", true)
 				.limit(1000)
 				.get();

--- a/apps/web/src/app/works/__tests__/actions.test.ts
+++ b/apps/web/src/app/works/__tests__/actions.test.ts
@@ -373,7 +373,7 @@ describe("works actions", () => {
 			expect(result).toBeTruthy();
 			expect(result?.productId).toBe("RJ123456");
 			expect(result?.title).toBe("テスト作品");
-			expect(mockCollection).toHaveBeenCalledWith("dlsiteWorks");
+			expect(mockCollection).toHaveBeenCalledWith("works");
 			expect(mockDoc).toHaveBeenCalledWith("RJ123456");
 		});
 

--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -296,7 +296,7 @@ export async function getWorks(params: EnhancedSearchParams = {}): Promise<WorkL
 
 		// まず全てのデータを取得して、クライアント側で並び替え
 		// (DLsiteのIDフォーマットに対応するため)
-		const allSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allSnapshot = await firestore.collection("works").get();
 
 		// 全データを配列に変換
 		let allWorks = allSnapshot.docs.map((doc) => ({
@@ -381,7 +381,7 @@ export async function getWorks(params: EnhancedSearchParams = {}): Promise<WorkL
 export async function getWorkById(workId: string): Promise<WorkPlainObject | null> {
 	try {
 		const firestore = getFirestore();
-		const doc = await firestore.collection("dlsiteWorks").doc(workId).get();
+		const doc = await firestore.collection("works").doc(workId).get();
 
 		if (!doc.exists) {
 			return null;
@@ -422,12 +422,12 @@ export async function getRelatedWorks(
 		const firestore = getFirestore();
 
 		// 基準作品を取得
-		const baseDoc = await firestore.collection("dlsiteWorks").doc(workId).get();
+		const baseDoc = await firestore.collection("works").doc(workId).get();
 		if (!baseDoc.exists) return [];
 
 		const baseWork = { id: baseDoc.id, ...baseDoc.data() } as WorkDocument;
 
-		const allSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allSnapshot = await firestore.collection("works").get();
 
 		let allWorks = allSnapshot.docs.map((doc) => ({
 			...doc.data(),
@@ -483,7 +483,7 @@ export async function getWorksStats(
 ) {
 	try {
 		const firestore = getFirestore();
-		const allSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allSnapshot = await firestore.collection("works").get();
 
 		const allWorks = allSnapshot.docs.map((doc) => ({
 			...doc.data(),
@@ -678,7 +678,7 @@ function calculateQualityPercentages(stats: QualityStats) {
 export async function getDataQualityReport() {
 	try {
 		const firestore = getFirestore();
-		const allSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allSnapshot = await firestore.collection("works").get();
 
 		const allWorks = allSnapshot.docs.map((doc) => ({
 			...doc.data(),
@@ -781,7 +781,7 @@ export async function getPopularVoiceActors(limit = 20): Promise<
 > {
 	try {
 		const firestore = getFirestore();
-		const allSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allSnapshot = await firestore.collection("works").get();
 
 		const allWorks = allSnapshot.docs.map((doc) => ({
 			...doc.data(),
@@ -839,7 +839,7 @@ export async function getPopularGenres(limit = 30): Promise<
 > {
 	try {
 		const firestore = getFirestore();
-		const allSnapshot = await firestore.collection("dlsiteWorks").get();
+		const allSnapshot = await firestore.collection("works").get();
 
 		const allWorks = allSnapshot.docs.map((doc) => ({
 			...doc.data(),

--- a/apps/web/src/lib/__tests__/firestore-safety.test.ts
+++ b/apps/web/src/lib/__tests__/firestore-safety.test.ts
@@ -141,7 +141,7 @@ describe("firestore-safety", () => {
 				workUrl: "https://www.dlsite.com/maniax/work/=/product_id/RJ123456.html",
 			};
 
-			const result = validateFirestoreData("dlsiteWorks", validWork);
+			const result = validateFirestoreData("works", validWork);
 			expect(result.valid).toBe(true);
 			expect(result.errors).toHaveLength(0);
 		});

--- a/apps/web/src/lib/firestore-safety.ts
+++ b/apps/web/src/lib/firestore-safety.ts
@@ -236,7 +236,7 @@ export function validateFirestoreData(
 			break;
 		}
 
-		case "dlsiteWorks": {
+		case "works": {
 			// thumbnailUrlの検証
 			if (data.thumbnailUrl && typeof data.thumbnailUrl === "string") {
 				const urlValidation = validateUrl(data.thumbnailUrl, "thumbnailUrl", [

--- a/docs/operations/migration-dlsiteworks-to-works.md
+++ b/docs/operations/migration-dlsiteworks-to-works.md
@@ -1,0 +1,133 @@
+# dlsiteWorks → works コレクション名マイグレーション手順
+
+## 概要
+Firestoreコレクション名を `dlsiteWorks` から `works` に変更するマイグレーション手順書です。
+
+## 背景
+- 現在のコレクション名 `dlsiteWorks` は他のコレクション（`videos`, `users`, `circles` など）の命名規則と一致していない
+- 一貫性のある命名規則に統一するため `works` に変更する
+
+## 影響範囲
+- **コード**: 約20ファイル、60箇所以上の参照
+- **インフラ**: Terraformのセキュリティルール、インデックス定義
+- **データ**: 約1,500件の作品ドキュメント + 価格履歴サブコレクション
+
+## 前提条件
+- 本番環境へのアクセス権限
+- Firestore Admin権限
+- ダウンタイム: 30分-1時間を確保
+
+## マイグレーション手順
+
+### 1. 事前準備（必須）
+```bash
+# バックアップの作成（推奨）
+gcloud firestore export gs://your-backup-bucket/dlsiteworks-backup-$(date +%Y%m%d)
+```
+
+### 2. アプリケーションの停止
+```bash
+# Cloud Functionsの一時停止
+gcloud functions disable dlsiteUnifiedDataCollection
+gcloud functions disable checkDataIntegrity
+```
+
+### 3. データマイグレーション実行
+```bash
+# マイグレーションスクリプトの実行
+cd apps/functions
+pnpm tsx src/tools/migrate-dlsiteworks-to-works.ts
+
+# 実行ログ例:
+# マイグレーション開始: dlsiteWorks → works
+# 総ドキュメント数: 1487
+# 進捗: 400/1487 (27%)
+# 進捗: 800/1487 (54%)
+# ...
+# ✅ ドキュメント数が一致しました
+```
+
+### 4. インフラ更新
+```bash
+# Terraformで新しいインデックスを作成
+cd terraform
+terraform apply -target=google_firestore_index.works_circleid_registdate_desc
+
+# セキュリティルールの更新
+terraform apply -target=google_firestore_document.firestore_rules
+```
+
+### 5. コードのデプロイ
+```bash
+# mainブランチにマージ後、GitHub Actionsで自動デプロイ
+# または手動デプロイ:
+gcloud functions deploy dlsiteUnifiedDataCollection --source . --runtime nodejs22
+gcloud functions deploy checkDataIntegrity --source . --runtime nodejs22
+```
+
+### 6. 動作確認
+```bash
+# 新しいコレクションでのデータ取得確認
+firebase firestore:get works/RJ123456
+
+# Webアプリケーションでの動作確認
+# - 作品一覧ページ
+# - 作品詳細ページ
+# - サークルページ
+# - クリエイターページ
+```
+
+### 7. 旧コレクションの削除（確認後）
+```bash
+# 削除前の最終確認
+firebase firestore:get dlsiteWorks --limit 5
+
+# 削除スクリプトの実行
+pnpm tsx src/tools/cleanup-dlsiteworks-collection.ts
+```
+
+### 8. Cloud Functionsの再有効化
+```bash
+gcloud functions enable dlsiteUnifiedDataCollection
+gcloud functions enable checkDataIntegrity
+```
+
+## ロールバック手順
+
+問題が発生した場合:
+
+1. コードを前のバージョンに戻す
+```bash
+git checkout main
+```
+
+2. データを逆マイグレーション（必要に応じて）
+```bash
+# worksからdlsiteWorksへの逆マイグレーションスクリプトを実行
+# （別途作成が必要）
+```
+
+3. バックアップからの復元
+```bash
+gcloud firestore import gs://your-backup-bucket/dlsiteworks-backup-YYYYMMDD
+```
+
+## 注意事項
+- **キャッシュ**: CDNやブラウザキャッシュのクリアが必要な場合がある
+- **インデックス**: 新しいコレクションでインデックスの構築に時間がかかる可能性
+- **並行処理**: マイグレーション中の書き込みは失われる可能性があるため、必ずアプリケーションを停止する
+
+## 完了チェックリスト
+- [ ] バックアップ作成完了
+- [ ] Cloud Functions停止確認
+- [ ] データマイグレーション成功
+- [ ] インデックス作成完了
+- [ ] セキュリティルール更新完了
+- [ ] アプリケーションデプロイ完了
+- [ ] 動作確認完了
+- [ ] 旧コレクション削除完了
+- [ ] Cloud Functions再有効化完了
+
+## 問題発生時の連絡先
+- 技術責任者: [連絡先]
+- インフラチーム: [連絡先]

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -80,7 +80,7 @@
 }
 ```
 
-### 2. `dlsiteWorks` コレクション ✅ 実装完了・v0.3.0統合データ構造対応完了
+### 2. `works` コレクション ✅ 実装完了・v0.3.0統合データ構造対応完了
 
 **目的**: 涼花みなせ様の関連DLsite作品情報を保存（統合データ構造実装済み）
 
@@ -647,7 +647,7 @@
 
 **データ保持期間**: 永続保存（長期分析用）
 
-#### サブコレクション: `dlsiteWorks/{workId}/priceHistory` ✅ v0.3.4価格履歴実装完了
+#### サブコレクション: `works/{workId}/priceHistory` ✅ v0.3.4価格履歴実装完了
 
 **目的**: DLsite作品の詳細価格履歴データ（サブコレクション方式・全履歴保持）
 
@@ -817,12 +817,12 @@ type CreatorType = "voice" | "illustration" | "scenario" | "music" | "other";
 | `isPublicProfile + createdAt (DESC)` | [`isPublicProfile`, `createdAt`, `__name__`] | ✅ **使用中** | 管理者ユーザー一覧 |
 | `isPublicProfile + role + lastLoginAt (DESC)` | [`isPublicProfile`, `role`, `lastLoginAt`, `__name__`] | ✅ **使用中** | 管理者フィルター機能 |
 
-#### ⚠️ **dlsiteWorks コレクション** (0個 - 全件取得方式)
+#### ⚠️ **works コレクション** (0個 - 全件取得方式)
 
 **実装方式**: 全件取得 + クライアントサイドフィルタリング
 ```typescript
 // 作品一覧は複合インデックスを使用しない
-const allSnapshot = await firestore.collection("dlsiteWorks").get();
+const allSnapshot = await firestore.collection("works").get();
 ```
 
 **フィルタリング**: カテゴリ・価格・評価・検索 全てクライアントサイド実行
@@ -861,7 +861,7 @@ const allSnapshot = await firestore.collection("dlsiteWorks").get();
 - **audioButtons**: マイページ用（現在無効化中だが保持）
 
 #### **ℹ️ 対象外**
-- **dlsiteWorks**: 全件取得方式のため複合インデックス不要
+- **works**: 全件取得方式のため複合インデックス不要
 - **時系列データ**: 外部管理インデックス使用
 
 #### 🔍 **2025-07-19 総合分析結果** - 全21個の複合インデックス要件特定
@@ -1000,7 +1000,7 @@ try {
 - **videos 削除対象**: videoType(1個) + liveStreamingDetails関連(6個) = 7個
 - **audioButtons 削除対象**: startTime未使用(1個) = 1個  
 - **videos 保持**: liveBroadcastContent(2個) + categoryId(2個) = 4個 ✅ **実際に使用中**
-- **サークル・クリエイター新規追加**: circles(2個) + creatorWorkMappings(3個) + dlsiteWorks(1個) = 6個
+- **サークル・クリエイター新規追加**: circles(2個) + creatorWorkMappings(3個) + works(1個) = 6個
 
 ### 🎯 **実装優先度マトリックス**
 
@@ -1052,7 +1052,7 @@ try {
 | `creatorId + types (ARRAY_CONTAINS)` | [`creatorId`, `types`, `__name__`] | ⚠️ **未設定** | クリエイタータイプ別検索 |
 | `workId + types (ARRAY_CONTAINS)` | [`workId`, `types`, `__name__`] | ⚠️ **未設定** | 作品からクリエイター検索 |
 
-#### ✅ **dlsiteWorks コレクション** (1個) - v11.6新規追加必要
+#### ✅ **works コレクション** (1個) - v11.6新規追加必要
 
 | インデックス | フィールド | 使用状況 | 使用箇所 |
 |-------------|------------|----------|----------|
@@ -1184,8 +1184,8 @@ terraform apply -target=google_firestore_index.videos_publishedat_range_desc
 
 ## アクセスパターン
 
-- **パブリック読み取り**: `videos`、`dlsiteWorks`、公開`audioButtons`
-- **管理者書き込み**: `videos`と`dlsiteWorks`はCloud Functionsのみが書き込み可能
+- **パブリック読み取り**: `videos`、`works`、公開`audioButtons`
+- **管理者書き込み**: `videos`と`works`はCloud Functionsのみが書き込み可能
 - **ユーザー制御**: `audioButtons`はServer Actionsで作成・更新・削除（実装完了、運用準備完了）
 - **認証制御**: `audioButtons`、`users`、`favorites`コレクション（実装完了）
 - **お気に入り機能**: `users/{userId}/favorites`サブコレクション（実装完了）
@@ -1323,7 +1323,7 @@ gcloud firestore indexes composite delete projects/suzumina-click/databases/\(de
 
 **実行した操作**:
 - ✅ **Entity/Value Objectアーキテクチャ移行**: DLsiteWorkエンティティとValue Object分離完了
-- ✅ **レガシーフィールド削除**: 以下のフィールドをdlsiteWorksコレクションから完全削除:
+- ✅ **レガシーフィールド削除**: 以下のフィールドをworksコレクションから完全削除:
   - `totalDownloadCount`: 総DL数（未使用）
   - `bonusContent`: 特典情報（低頻度アクセス）
   - `isExclusive`: 独占配信フラグ（未使用）
@@ -1345,7 +1345,7 @@ gcloud firestore indexes composite delete projects/suzumina-click/databases/\(de
 
 **実行した操作**:
 - ✅ **サークル・クリエイター情報収集**: `circles`・`creatorWorkMappings`コレクション新規追加
-- ✅ **dlsiteWorks拡張**: `circleId`フィールド統合・サークル情報参照対応
+- ✅ **works拡張**: `circleId`フィールド統合・サークル情報参照対応
 - ✅ **Individual Info API統合**: maker_id/maker_name/creaters自動抽出・バッチ処理対応
 - ✅ **Fire-and-Forget実装**: メイン処理に影響しないサークル・クリエイター情報更新
 - ✅ **非正規化データ設計**: 効率的クエリのためのcreatorWorkMappings最適化
@@ -1368,16 +1368,16 @@ gcloud firestore indexes composite delete projects/suzumina-click/databases/\(de
 ### 2025-07-19 v11.4 完全実装状況調査・Terraformインデックス管理統合・正確なコスト最適化完了
 
 **実行した操作**:
-- ✅ **全コレクション実装状況調査**: videos/dlsiteWorks/audioButtons/contacts/favorites 全機能実装状況確認
+- ✅ **全コレクション実装状況調査**: videos/works/audioButtons/contacts/favorites 全機能実装状況確認
 - ✅ **Terraform管理統合**: 複合インデックス定義の過不足分析・未使用11個特定・必要3個追加
 - ✅ **正確なコスト最適化**: 年間$120削減（当初$24から修正）・削除8個/追加3個の詳細計画
 - ✅ **動画フィルター機能確認**: liveBroadcastContent・categoryIdインデックスが実際に使用中と判明
-- ✅ **作品一覧設計思想確認**: dlsiteWorksは全件取得+クライアントサイドフィルタリング方式
+- ✅ **作品一覧設計思想確認**: worksは全件取得+クライアントサイドフィルタリング方式
 - ✅ **実装状況ドキュメント化**: 各コレクションの実際のクエリパターンと使用状況を正確に記録
 
 **重要な発見・修正**:
 - ✅ **videos インデックス見直し**: 当初「削除推奨」とした4個が実際には使用中（重大な誤分析修正）
-- ✅ **dlsiteWorks インデックス不要**: 複合クエリを使用せず全件取得方式のため既存インデックス未使用
+- ✅ **works インデックス不要**: 複合クエリを使用せず全件取得方式のため既存インデックス未使用
 - ✅ **audioButtons 最適化済み**: 8個が適切に使用中・フォールバック戦略で障害耐性確保
 - ✅ **コスト試算修正**: $24/年 → $120/年削減（5倍の効果）・詳細内訳提供
 - ✅ **Terraform設定完備**: 即座適用可能な追加・削除コマンド・管理方針策定

--- a/docs/reference/infrastructure-architecture.md
+++ b/docs/reference/infrastructure-architecture.md
@@ -519,7 +519,7 @@ service cloud.firestore {
     
     // 動画・作品データ - 読み取りのみ
     match /{collection}/{document} {
-      allow read: if collection in ['videos', 'dlsiteWorks'];
+      allow read: if collection in ['videos', 'works'];
       allow write: if false;
     }
   }

--- a/docs/reference/ubiquitous-language.md
+++ b/docs/reference/ubiquitous-language.md
@@ -129,8 +129,8 @@
 
 | 用語 | 定義 | 英語表記 | 技術的詳細 |
 |------|------|----------|----------|
-| **価格履歴** | 作品価格の日別変動記録 | Price History | `dlsiteWorks/{workId}/priceHistory` サブコレクション |
-| **dlsiteWorksコレクション** | DLsite作品データを格納するFirestoreコレクション | dlsiteWorks Collection | **注意: "works"ではなく"dlsiteWorks"** |
+| **価格履歴** | 作品価格の日別変動記録 | Price History | `works/{workId}/priceHistory` サブコレクション |
+| **worksコレクション** | DLsite作品データを格納するFirestoreコレクション | works Collection | **注意: 以前は"dlsiteWorks"だったが"works"に移行** |
 | **価格推移チャート** | 価格変動をグラフィカルに表示する機能 | Price Trend Chart | Recharts統合・インタラクティブ表示 |
 | **定価** | 作品の通常販売価格 | Regular Price | キャンペーン適用前価格 |
 | **セール価格** | 割引キャンペーン適用後の価格 | Discount Price | `discount_rate` 適用後価格 |

--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -322,7 +322,7 @@ resource "google_firestore_index" "videos_categoryid_publishedat_asc" {
 # ℹ️  NOTES - 自動作成・外部管理インデックス
 # ===================================================================
 # 
-# dlsiteWorks コレクション:
+# works コレクション:
 # - category×releaseDateISO: 既存インデックス使用 (Terraform外管理)
 # - price.current, rating.stars: Single-field自動作成
 # 
@@ -390,7 +390,7 @@ resource "google_firestore_index" "contacts_priority_createdat_desc" {
 # 📈 PRICE HISTORY INDEXES - 価格履歴サブコレクション用
 # ===================================================================
 
-# dlsiteWorks/{workId}/priceHistory サブコレクション
+# works/{workId}/priceHistory サブコレクション
 # price-history.ts の getPriceHistory() で使用
 # 
 # ⚠️ 注意: dateフィールドのみのインデックスは不要
@@ -472,11 +472,11 @@ resource "google_firestore_index" "creators_works_collection_group_circleid" {
   }
 }
 
-# dlsiteWorks コレクション - サークル別作品一覧用
+# works コレクション - サークル別作品一覧用
 # サークルIDと登録日の複合インデックス
-resource "google_firestore_index" "dlsiteworks_circleid_registdate_desc" {
+resource "google_firestore_index" "works_circleid_registdate_desc" {
   project    = var.gcp_project_id
-  collection = "dlsiteWorks"
+  collection = "works"
   
   fields {
     field_path = "circleId"
@@ -494,7 +494,7 @@ resource "google_firestore_index" "dlsiteworks_circleid_registdate_desc" {
 # ===================================================================
 # 
 # 【現在の構成】
-# ✅ 実装済み (使用中):          15個 (audioButtons: 8, users: 2, contacts: 2, favorites: 1, circles: 1, creatorMappings: 2, dlsiteWorks: 1)
+# ✅ 実装済み (使用中):          15個 (audioButtons: 8, users: 2, contacts: 2, favorites: 1, circles: 1, creatorMappings: 2, works: 1)
 # 🔴 削除推奨 (未使用):          10個 (videos関連、audioButtons startTime 1個)
 # 🔶 無効化中 (フォールバック):   4個 (createdBy関連、マイページ用)
 # ℹ️ 自動インデックス対応:        priceHistory (single-fieldで十分)

--- a/terraform/firestore_rules.tf
+++ b/terraform/firestore_rules.tf
@@ -34,7 +34,7 @@ resource "google_firestore_document" "firestore_rules" {
             }
             
             // DLsite作品コレクション
-            match /dlsiteWorks/{workId} {
+            match /works/{workId} {
               // 誰でも読み取り可能、書き込みは管理者のみ
               allow read;
               allow write: if false; // 管理者APIのみ書き込み可能


### PR DESCRIPTION
## 概要
Firestoreコレクション名を`dlsiteWorks`から`works`に統一するマイグレーション。

## 変更理由
- 他のコレクション（`videos`, `users`, `circles`等）との命名規則統一
- 技術的負債の解消

## 変更内容
- ✅ 全コード（約20ファイル、60箇所以上）の参照を更新
- ✅ Terraformのセキュリティルールとインデックス定義を更新
- ✅ データマイグレーションスクリプトを追加
- ✅ ドキュメントを更新

## マイグレーション計画
- 詳細手順: `docs/operations/migration-dlsiteworks-to-works.md`
- 推定作業時間: 1.5-2営業日
- 推定ダウンタイム: 30分-1時間

## 破壊的変更
⚠️ **BREAKING CHANGE**: Firestoreコレクション名の変更により、本番環境でのデータマイグレーションが必要です。

## チェックリスト
- [x] コード変更完了
- [x] テスト更新・動作確認
- [x] ドキュメント更新
- [x] マイグレーション手順書作成
- [ ] 本番環境でのマイグレーション実行（マージ後）

## 関連Issue
#141 (コレクション名の不整合)

🤖 Generated with [Claude Code](https://claude.ai/code)