### PR TITLE
fix: Cloud Functions fetchDLsiteUnifiedData のメモリ制限を増加

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -242,7 +242,7 @@ jobs:
             --region asia-northeast1 \
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --set-env-vars NODE_ENV=production,FUNCTION_SIGNATURE_TYPE=cloudevent,FUNCTION_TARGET=fetchDLsiteUnifiedData,INDIVIDUAL_INFO_API_ENABLED=true,API_ONLY_MODE=true,MAX_CONCURRENT_API_REQUESTS=5,API_REQUEST_DELAY_MS=500,ENABLE_DATA_VALIDATION=true,MINIMUM_QUALITY_SCORE=80,ENABLE_TIMESERIES_INTEGRATION=true,LOG_LEVEL=info \
-            --memory 256Mi \
+            --memory 512Mi \
             --timeout 300s \
             --max-instances 1 \
             --service-account fetch-dlsite-individual-api-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \

--- a/terraform/function_dlsite_individual_info_api.tf
+++ b/terraform/function_dlsite_individual_info_api.tf
@@ -10,7 +10,7 @@ locals {
   dlsite_individual_api_function_name = "fetchDLsiteUnifiedData"
   dlsite_individual_api_runtime       = "nodejs22"
   dlsite_individual_api_entry_point   = "fetchDLsiteUnifiedData"
-  dlsite_individual_api_memory        = "256Mi"  # さらなるコスト最適化（512Mi→256Mi）
+  dlsite_individual_api_memory        = "512Mi"  # Memory increased due to 260 MiB usage
   dlsite_individual_api_timeout       = 300    # 5分タイムアウト（API集約処理最適化）
 }
 


### PR DESCRIPTION
## 概要
`fetchDLsiteUnifiedData` Cloud Function がメモリ不足エラーで失敗していた問題を修正

## エラー内容
```
Memory limit of 256 MiB exceeded with 260 MiB used
```

## 変更内容
- GitHub Actions `deploy-functions.yml`: メモリ制限を 256Mi → 512Mi に増加
- Terraform `function_dlsite_individual_info_api.tf`: メモリ制限を 256Mi → 512Mi に増加

## テスト方法
1. PR マージ後、GitHub Actions で Cloud Functions が自動デプロイされます
2. Cloud Console でメモリ使用状況を確認できます

🤖 Generated with [Claude Code](https://claude.ai/code)