### PR TITLE
fix: deploy-web.yml のヘルスチェックロジックを改善

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -183,15 +183,33 @@ jobs:
           
           echo "New revision URL: $NEW_REVISION_URL"
           
-          # Wait for revision to be ready
-          echo "Waiting for revision to be ready..."
-          sleep 20
-          
-          # Health check on new revision
-          for i in {1..5}; do
-            echo "Health check attempt $i/5..."
+          # Wait for Cloud Run service to become ready
+          echo "Waiting for Cloud Run service to become ready..."
+          for i in {1..6}; do
+            echo "Checking service readiness (attempt $i/6)..."
+            SERVICE_STATUS=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
+              --region ${{ env.REGION }} \
+              --format 'value(status.conditions[0].status)')
             
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$NEW_REVISION_URL/api/health" || echo "000")
+            if [ "$SERVICE_STATUS" = "True" ]; then
+              echo "✅ Service is ready"
+              break
+            else
+              echo "⏳ Service not ready yet (status: $SERVICE_STATUS)"
+              sleep 10
+            fi
+          done
+          
+          # Additional wait for container startup
+          echo "Waiting for container to fully start..."
+          sleep 30
+          
+          # Health check on new revision with increased attempts and timeout
+          for i in {1..10}; do
+            echo "Health check attempt $i/10..."
+            
+            # Use longer timeout for curl (10 seconds)
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$NEW_REVISION_URL/api/health" || echo "000")
             
             if [ "$HTTP_CODE" = "200" ]; then
               echo "✅ Health check passed on new revision"
@@ -204,25 +222,45 @@ jobs:
               
               echo "✅ Traffic migrated successfully"
               
-              # Final check on production URL
-              sleep 10
-              PROD_CHECK=$(curl -s -o /dev/null -w "%{http_code}" "https://suzumina.click/api/health" || echo "000")
-              if [ "$PROD_CHECK" = "200" ]; then
-                echo "✅ Production health check passed"
-                exit 0
-              else
-                echo "❌ Production health check failed with HTTP code $PROD_CHECK"
-                echo "⚠️ Warning: Traffic has been migrated but production health check failed"
-                echo "Manual intervention may be required to rollback if necessary"
-                exit 1
-              fi
+              # Final check on production URL with retries
+              echo "Verifying production deployment..."
+              sleep 15
+              
+              for j in {1..3}; do
+                PROD_CHECK=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "https://suzumina.click/api/health" || echo "000")
+                if [ "$PROD_CHECK" = "200" ]; then
+                  echo "✅ Production health check passed"
+                  exit 0
+                else
+                  echo "⚠️ Production check attempt $j/3 failed (HTTP $PROD_CHECK)"
+                  sleep 5
+                fi
+              done
+              
+              echo "❌ Production health check failed after 3 attempts"
+              echo "⚠️ Warning: Traffic has been migrated but production health check failed"
+              echo "Manual intervention may be required to rollback if necessary"
+              exit 1
             else
               echo "❌ Health check failed (HTTP $HTTP_CODE)"
-              sleep 10
+              
+              # Check if the revision exists and is serving
+              REVISION_STATUS=$(gcloud run revisions describe $(basename $NEW_REVISION_URL) \
+                --region ${{ env.REGION }} \
+                --format 'value(status.conditions[0].message)' 2>/dev/null || echo "Revision not found")
+              echo "Revision status: $REVISION_STATUS"
+              
+              # Exponential backoff for retries
+              if [ $i -le 5 ]; then
+                sleep 15
+              else
+                sleep 30
+              fi
             fi
           done
           
-          echo "❌ Health check failed after 5 attempts"
+          echo "❌ Health check failed after 10 attempts"
+          echo "Please check Cloud Run logs for more details"
           exit 1
       
       # Parallel cleanup


### PR DESCRIPTION
## 概要
WebアプリのCloud Runデプロイ時にヘルスチェックが失敗する問題を修正

## 問題
- デプロイ自体は成功しているが、ヘルスチェックが5回全て失敗してワークフローがエラーになる
- 新しいリビジョンの起動に時間がかかっている可能性

## 変更内容
1. **サービス準備状態の確認**: Cloud Runサービス自体の準備完了を待つ処理を追加
2. **待機時間の延長**: コンテナ起動待機時間を20秒→30秒に増加
3. **リトライ回数の増加**: ヘルスチェックを5回→10回に増加
4. **タイムアウト設定**: curlコマンドに10秒のタイムアウトを設定
5. **エクスポネンシャルバックオフ**: 失敗時の待機時間を段階的に増加（15秒→30秒）
6. **デバッグ情報の追加**: リビジョンのステータス情報を出力
7. **プロダクションチェックの改善**: 本番URLのヘルスチェックにもリトライロジックを追加

## 影響範囲
- デプロイワークフローの実行時間が若干増加する可能性があります（最大で数分）
- しかし、デプロイの成功率が向上し、手動での再実行が不要になります

🤖 Generated with [Claude Code](https://claude.ai/code)