### PR TITLE
fix: checkDataIntegrity関数のIAM権限不足を修正

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -263,6 +263,7 @@ jobs:
             --timeout 540s \
             --max-instances 1 \
             --service-account data-integrity-check-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
+            --ingress-settings internal-only \
             --quiet &
           deploy_pids["checkDataIntegrity"]=$!
           


### PR DESCRIPTION
## 概要
`checkDataIntegrity` 関数が頻繁にHTTP 403エラーを受けている問題を修正

## 問題
- 週1回実行されるはずの関数が、数分間隔でHTTP POSTリクエスト（403エラー）を受けていた
- 他のPub/Subトリガー関数（fetchYouTubeVideos、fetchDLsiteUnifiedData）では発生していない

## 原因
`checkDataIntegrity` 関数には他の関数にある重要なIAM権限が不足していた：
1. Pub/Sub Service AgentのToken Creator権限
2. Cloud Run Invoker権限  
3. Eventarcの権限設定

これらがないため、Pub/SubがOIDCトークンを作成できず、認証なしでの呼び出しになっていた。

## 修正内容

### 1. Terraformに必要なIAM権限を追加
- `serviceAccountTokenCreator`: Pub/SubがOIDCトークンを作成
- `run.invoker`: Cloud Functions Gen2の実行権限
- `eventarc.eventReceiver`: Eventarcのイベント受信権限

### 2. GitHub Actionsに`--ingress-settings internal-only`を追加
- 外部からの直接HTTPアクセスを完全にブロック
- Pub/Sub経由のみでの実行を強制

## 期待される効果
- 不正なHTTP 403エラーが解消
- Pub/Sub経由での正しい認証付き呼び出しが可能に
- 週1回の正常な実行のみになる

## デプロイ手順
1. Terraformを適用してIAM権限を更新
2. GitHub Actionsで関数を再デプロイ

🤖 Generated with [Claude Code](https://claude.ai/code)