### PR TITLE
feat: 汎用リストコンポーネント(GenericList)の実装とStorybook 9.1.0へのアップデート

### DIFF
--- a/docs/reference/common-list-component-design.md
+++ b/docs/reference/common-list-component-design.md
@@ -1,0 +1,277 @@
+# 共通リストコンポーネント設計
+
+## 概要
+
+suzumina.clickにおける共通リストコンポーネントの設計ドキュメント。
+パフォーマンス最適化と実装の統一性を目的として、各種リストページで使用される共通コンポーネントを設計する。
+
+## 適用対象ページ一覧
+
+### 1. メインコンテンツリスト
+
+| ページ | パス | 現在のコンポーネント | データ取得Action | 主な機能 |
+|--------|------|---------------------|------------------|----------|
+| トップページ | `/` | HomePage | getLatestAudioButtons, getLatestVideos, getLatestWorks | 各種コンテンツの新着表示 |
+| 作品一覧 | `/works` | WorksPageClient + WorkList | getWorks | 作品の検索・フィルタリング・ページネーション |
+| 動画一覧 | `/videos` | VideoList | getVideoTitles | 動画の検索・フィルタリング・ページネーション |
+| 音声ボタン一覧 | `/buttons` | AudioButtonsList | getAudioButtons | ボタンの検索・フィルタリング・ページネーション |
+| 検索結果 | `/search` | SearchPageContent | 複数Actions | 横断検索結果の表示 |
+
+### 2. 詳細ページ内のリスト
+
+| ページ | パス | 現在のコンポーネント | データ取得Action | 主な機能 |
+|--------|------|---------------------|------------------|----------|
+| サークル詳細 | `/circles/[circleId]` | CirclePageClient | getCircleWithWorksWithPagination | サークルの作品一覧 |
+| クリエイター詳細 | `/creators/[creatorId]` | CreatorPageClient | getCreatorWithWorksWithPagination | クリエイターの作品一覧 |
+| お気に入り | `/favorites` | (未確認) | (未確認) | ユーザーのお気に入りリスト |
+| ユーザー詳細 | `/users/[userId]` | (未確認) | (未確認) | ユーザーが作成したボタン一覧 |
+
+## 共通要件
+
+### 1. パフォーマンス要件
+- Firestoreクエリ最適化（サーバーサイドフィルタリング）
+- 必要最小限のドキュメント読み取り
+- 効率的なページネーション（offset/cursor-based）
+- Server Component優先での実装
+
+### 2. 機能要件
+- ページネーション（ページ番号表示、前後ナビゲーション）
+- ソート機能（新着順、古い順、価格順、評価順など）
+- フィルタリング（カテゴリ、タグ、年齢制限など）
+- 検索機能（テキスト検索）
+- 表示件数切り替え（12/24/48件）
+- レスポンシブデザイン
+
+### 3. UI/UX要件
+- 統一されたレイアウト
+- スケルトンローディング
+- エラーハンドリング
+- 空状態の表示
+- アクセシビリティ対応
+
+## 現状の問題点
+
+1. **実装の重複**
+   - 各リストページで同様のロジックが重複実装されている
+   - ページネーション、フィルタリング、ソートの実装が統一されていない
+
+2. **パフォーマンスの不均一**
+   - 一部のページではFirestoreクエリが最適化されていない
+   - クライアントサイドフィルタリングが残っている箇所がある
+
+3. **UIの不統一**
+   - ページによってレイアウトやスタイルが異なる
+   - ユーザー体験の一貫性が欠けている
+
+## 設計方針
+
+### 1. コンポーネント構成
+
+```
+GenericListLayout
+├── ListHeader
+│   ├── Title
+│   ├── Description
+│   └── ViewToggle (Grid/List)
+├── ListFilters
+│   ├── SearchInput
+│   ├── SortSelect
+│   ├── FilterDropdowns
+│   └── LimitSelect
+├── ListContent
+│   ├── LoadingState
+│   ├── EmptyState
+│   ├── ErrorState
+│   └── ItemGrid/ItemList
+└── ListPagination
+    ├── PageNumbers
+    ├── PrevNext
+    └── PageInfo
+```
+
+### 2. データフロー
+
+```typescript
+interface ListPageProps<T> {
+  // サーバーサイドで取得した初期データ
+  initialData: T[];
+  totalCount: number;
+  filteredCount?: number;
+  
+  // ページ設定
+  pageConfig: {
+    basePath: string;
+    itemsPerPage: number;
+    currentPage: number;
+  };
+  
+  // フィルター設定
+  filterConfig?: {
+    search?: boolean;
+    sort?: SortOption[];
+    filters?: FilterDefinition[];
+  };
+  
+  // レンダリング設定
+  renderConfig: {
+    itemComponent: React.ComponentType<{ item: T }>;
+    gridCols?: { mobile: number; tablet: number; desktop: number };
+    emptyMessage?: string;
+  };
+}
+```
+
+### 3. 実装戦略
+
+#### Phase 1: 基盤コンポーネントの作成
+1. `GenericListLayout`コンポーネントの実装
+2. 共通ユーティリティ関数の整備（URL生成、パラメータ処理）
+3. 共通型定義の整備
+
+#### Phase 2: 段階的移行
+1. 作品一覧ページから移行開始（最も複雑なケース）
+2. 動画一覧、音声ボタン一覧への展開
+3. 詳細ページ内のリストへの適用
+4. トップページ、検索結果ページへの適用
+
+#### Phase 3: 最適化と改善
+1. パフォーマンスモニタリング
+2. ユーザビリティテスト
+3. アクセシビリティ改善
+
+## 期待される効果
+
+1. **開発効率の向上**
+   - コードの重複削減（推定50-70%削減）
+   - 新機能追加の容易化
+   - バグ修正の一元化
+
+2. **パフォーマンスの改善**
+   - 全ページでFirestoreクエリ最適化
+   - 統一されたキャッシュ戦略
+   - Bundle size削減
+
+3. **ユーザー体験の向上**
+   - 一貫性のあるUI/UX
+   - 予測可能な操作性
+   - 高速なページ遷移
+
+## 既存コンポーネントの分析
+
+### packages/uiの既存コンポーネント
+
+#### 1. レイアウトコンポーネント（すでに汎用化済み）
+- `ListPageLayout` - ページ全体のレイアウト
+- `ListPageHeader` - ページヘッダー
+- `ListPageContent` - コンテンツエリア 
+- `ListPageGrid` - グリッド表示
+- `ListPageStats` - 統計情報
+- `ListPageEmptyState` - 空状態
+
+これらは**そのまま活用可能**。
+
+#### 2. 制御コンポーネント（部分的に汎用化済み）
+- `ListDisplayControls` - ソート・表示件数制御
+- `SearchFilterPanel` - 検索・フィルターUI
+- `Pagination` (shadcn/ui) - ページネーション
+
+これらは**統合・改善が必要**。
+
+### apps/webの実装
+
+- `WorkList`, `VideoList`, `AudioButtonsList` など
+- 各リストで同様のロジックを個別実装
+- URLパラメータ処理、フィルター状態管理が重複
+
+## 推奨アーキテクチャ
+
+### 1. コンポーネントの配置
+
+```
+packages/ui/
+├── components/
+│   ├── custom/
+│   │   ├── list-page-layout.tsx      (既存・維持)
+│   │   ├── generic-list/              (新規)
+│   │   │   ├── generic-list.tsx      
+│   │   │   ├── use-list-state.ts     
+│   │   │   ├── use-url-params.ts     
+│   │   │   └── types.ts              
+│   │   └── ...
+│   └── ui/                            (既存・維持)
+```
+
+### 2. 新しい汎用リストコンポーネント
+
+```typescript
+// packages/ui/src/components/custom/generic-list/generic-list.tsx
+interface GenericListProps<T> {
+  // データ
+  items: T[];
+  totalCount: number;
+  
+  // 設定
+  config: {
+    baseUrl: string;
+    itemsPerPageOptions?: number[];
+    sortOptions?: SortOption[];
+    filterDefinitions?: FilterDefinition[];
+  };
+  
+  // レンダリング
+  renderItem: (item: T) => React.ReactNode;
+  renderEmptyState?: () => React.ReactNode;
+  
+  // Server Actions
+  fetchData: (params: ListParams) => Promise<ListResult<T>>;
+}
+```
+
+### 3. 共通ロジックの抽出
+
+```typescript
+// packages/ui/src/components/custom/generic-list/use-list-state.ts
+export function useListState<T>(config: ListConfig) {
+  // URLパラメータとの同期
+  // フィルター状態管理
+  // ページネーション計算
+  // ソート・フィルター処理
+}
+```
+
+### 4. 段階的移行戦略
+
+#### Phase 1: 共通ロジックの抽出（packages/ui）
+1. `useListState` - 状態管理フック
+2. `useUrlParams` - URLパラメータ同期フック  
+3. 共通型定義
+
+#### Phase 2: 汎用コンポーネント実装（packages/ui）
+1. `GenericList` - 汎用リストコンポーネント
+2. 既存の`ListPageLayout`系と統合
+3. テスト・ドキュメント作成
+
+#### Phase 3: 既存リストの移行（apps/web）
+1. `WorkList` → `GenericList`を使用
+2. `VideoList` → `GenericList`を使用
+3. その他のリストも順次移行
+
+## 利点
+
+1. **コードの集約**
+   - 共通ロジックをpackages/uiに集約
+   - apps/webは業務ロジックに集中
+
+2. **保守性の向上**
+   - バグ修正・機能追加が一箇所で完結
+   - テストも集約化
+
+3. **再利用性**
+   - 新しいリストページの追加が容易
+   - 一貫性のあるUX
+
+## 次のステップ
+
+1. Phase 1の実装開始（共通フックの作成）
+2. 既存コンポーネントとの互換性確認
+3. 段階的移行の詳細計画作成

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { StorybookConfig } from "@storybook/react-vite";
 
 const config: StorybookConfig = {
@@ -19,6 +20,14 @@ const config: StorybookConfig = {
 		config.css.postcss = {
 			plugins: [postcssPlugin.default()],
 		};
+
+		// Next.js navigation モックを追加
+		config.resolve = config.resolve || {};
+		config.resolve.alias = {
+			...config.resolve.alias,
+			"next/navigation": resolve(__dirname, "./mocks/next-navigation.ts"),
+		};
+
 		return config;
 	},
 };

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -28,6 +28,12 @@ const config: StorybookConfig = {
 			"next/navigation": resolve(__dirname, "./mocks/next-navigation.ts"),
 		};
 
+		// Storybook環境変数を設定
+		config.define = {
+			...config.define,
+			"process.env.STORYBOOK": JSON.stringify("true"),
+		};
+
 		return config;
 	},
 };

--- a/packages/ui/.storybook/mocks/next-navigation.ts
+++ b/packages/ui/.storybook/mocks/next-navigation.ts
@@ -1,0 +1,52 @@
+/**
+ * Mock for Next.js navigation hooks in Storybook
+ */
+
+// Simple mock functions that log to console
+const mockFn =
+	(name: string) =>
+	(...args: any[]) => {
+		console.log(`[Next Navigation Mock] ${name}`, args);
+	};
+
+// Mock useRouter
+export const useRouter = () => ({
+	push: mockFn("router.push"),
+	replace: mockFn("router.replace"),
+	back: mockFn("router.back"),
+	forward: mockFn("router.forward"),
+	refresh: mockFn("router.refresh"),
+	prefetch: mockFn("router.prefetch"),
+});
+
+// Mock useSearchParams
+export const useSearchParams = () => {
+	const params = new URLSearchParams(window.location.search);
+	return params;
+};
+
+// Mock usePathname
+export const usePathname = () => {
+	return window.location.pathname || "/";
+};
+
+// Mock useParams
+export const useParams = () => {
+	return {};
+};
+
+// Mock notFound
+export const notFound = () => {
+	console.log("[Next Navigation Mock] notFound");
+	throw new Error("NEXT_NOT_FOUND");
+};
+
+// Mock redirect
+export const redirect = (url: string) => {
+	console.log("[Next Navigation Mock] redirect", url);
+};
+
+// Mock permanentRedirect
+export const permanentRedirect = (url: string) => {
+	console.log("[Next Navigation Mock] permanentRedirect", url);
+};

--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -9,6 +9,12 @@ const preview: Preview = {
 				date: /Date$/i,
 			},
 		},
+		a11y: {
+			// 'todo' - show a11y violations in the test UI only
+			// 'error' - fail CI on a11y violations
+			// 'off' - skip a11y checks entirely
+			test: "todo",
+		},
 	},
 };
 

--- a/packages/ui/.storybook/vitest.setup.ts
+++ b/packages/ui/.storybook/vitest.setup.ts
@@ -1,6 +1,7 @@
+import * as a11yAddonAnnotations from "@storybook/addon-a11y/preview";
 import { setProjectAnnotations } from "@storybook/react";
 import * as projectAnnotations from "./preview";
 
 // This is an important step to apply the right configuration when testing your stories.
 // More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-setProjectAnnotations([projectAnnotations]);
+setProjectAnnotations([a11yAddonAnnotations, projectAnnotations]);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -76,13 +76,12 @@
 		"zod": "^4.0.5"
 	},
 	"devDependencies": {
-		"@chromatic-com/storybook": "^4.0.1",
-		"@storybook/addon-a11y": "^9.0.17",
-		"@storybook/addon-docs": "^9.0.17",
-		"@storybook/addon-onboarding": "^9.0.17",
-		"@storybook/addon-vitest": "^9.0.17",
-		"@storybook/react-vite": "^9.0.17",
-		"@storybook/test": "9.0.0-alpha.2",
+		"@chromatic-com/storybook": "^4.1.0",
+		"@storybook/addon-a11y": "^9.1.0",
+		"@storybook/addon-docs": "^9.1.0",
+		"@storybook/addon-onboarding": "^9.1.0",
+		"@storybook/addon-vitest": "^9.1.0",
+		"@storybook/react-vite": "^9.1.0",
 		"@suzumina.click/typescript-config": "workspace:*",
 		"@tailwindcss/postcss": "^4.1.11",
 		"@testing-library/jest-dom": "^6.6.3",
@@ -94,7 +93,7 @@
 		"@vitest/coverage-v8": "^3.2.4",
 		"happy-dom": "^18.0.1",
 		"rimraf": "^6.0.1",
-		"storybook": "^9.0.17",
+		"storybook": "^9.1.0",
 		"tailwindcss": "^4.1.11",
 		"typescript": "^5.8.3",
 		"vitest": "^3.2.4"

--- a/packages/ui/src/components/custom/audio-button-preview.stories.tsx
+++ b/packages/ui/src/components/custom/audio-button-preview.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import type { FrontendAudioButtonData } from "@suzumina.click/shared-types";
+import { fn } from "storybook/test";
 import { AudioButtonPreview } from "./audio-button-preview";
 
 const meta = {

--- a/packages/ui/src/components/custom/audio-button.stories.tsx
+++ b/packages/ui/src/components/custom/audio-button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import type { FrontendAudioButtonData } from "@suzumina.click/shared-types";
+import { fn } from "storybook/test";
 import { AudioButton } from "./audio-button";
 
 const meta = {

--- a/packages/ui/src/components/custom/audio-player.stories.tsx
+++ b/packages/ui/src/components/custom/audio-player.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import type { FrontendAudioButtonData } from "@suzumina.click/shared-types";
 import { useRef } from "react";
+import { fn } from "storybook/test";
 import { type AudioControls, AudioPlayer } from "./audio-player";
 
 const meta = {

--- a/packages/ui/src/components/custom/generic-list/__tests__/types.test.ts
+++ b/packages/ui/src/components/custom/generic-list/__tests__/types.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "vitest";
+import type { FilterDefinition, ListConfig, ListState, SortDefinition } from "../types";
+
+describe("generic-list types", () => {
+	test("FilterDefinition型が正しく定義されている", () => {
+		const filter: FilterDefinition = {
+			key: "category",
+			type: "select",
+			label: "カテゴリ",
+			options: [
+				{ value: "all", label: "すべて" },
+				{ value: "audio", label: "音声" },
+			],
+			defaultValue: "all",
+		};
+
+		expect(filter.key).toBe("category");
+		expect(filter.type).toBe("select");
+		expect(filter.options).toHaveLength(2);
+	});
+
+	test("SortDefinition型が正しく定義されている", () => {
+		const sort: SortDefinition = {
+			key: "newest",
+			label: "新しい順",
+			fields: [{ field: "createdAt", direction: "desc" }],
+		};
+
+		expect(sort.key).toBe("newest");
+		expect(sort.fields[0].direction).toBe("desc");
+	});
+
+	test("ListState型が正しく定義されている", () => {
+		const state: ListState = {
+			counts: {
+				total: 100,
+				filtered: 50,
+				displayed: 12,
+			},
+			pagination: {
+				currentPage: 1,
+				itemsPerPage: 12,
+				totalPages: 5,
+			},
+			filters: {
+				category: "audio",
+			},
+			sort: "newest",
+			search: "",
+			isLoading: false,
+			error: null,
+		};
+
+		expect(state.counts.total).toBe(100);
+		expect(state.pagination.totalPages).toBe(5);
+		expect(state.filters.category).toBe("audio");
+	});
+
+	test("ListConfig型が複雑なフィルターをサポートする", () => {
+		const config: ListConfig = {
+			baseUrl: "/test",
+			filters: [
+				{
+					key: "tags",
+					type: "multiselect",
+					label: "タグ",
+				},
+				{
+					key: "dateRange",
+					type: "dateRange",
+					label: "期間",
+				},
+				{
+					key: "price",
+					type: "range",
+					label: "価格",
+				},
+			],
+			sortOptions: [
+				{
+					key: "popular",
+					label: "人気順",
+					fields: [
+						{ field: "viewCount", direction: "desc" },
+						{ field: "rating", direction: "desc" },
+					],
+				},
+			],
+		};
+
+		expect(config.filters).toHaveLength(3);
+		expect(config.filters?.[0].type).toBe("multiselect");
+		expect(config.filters?.[1].type).toBe("dateRange");
+		expect(config.filters?.[2].type).toBe("range");
+		expect(config.sortOptions?.[0].fields).toHaveLength(2);
+	});
+});

--- a/packages/ui/src/components/custom/generic-list/generic-list.stories.tsx
+++ b/packages/ui/src/components/custom/generic-list/generic-list.stories.tsx
@@ -1,0 +1,534 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { GenericList } from "./generic-list";
+import type { ListConfig, ListParams, ListResult } from "./types";
+
+// Sample data type
+interface SampleWork {
+	id: string;
+	title: string;
+	circle: string;
+	releaseDate: string;
+	tags: string[];
+	price: number;
+	category: string;
+	dlCount: number;
+	rating: number;
+}
+
+// Sample data
+const sampleWorks: SampleWork[] = Array.from({ length: 100 }, (_, i) => ({
+	id: `RJ${String(i + 1).padStart(6, "0")}`,
+	title: `作品タイトル ${i + 1}`,
+	circle: `サークル ${Math.floor(i / 10) + 1}`,
+	releaseDate: new Date(Date.now() - i * 86400000).toISOString(),
+	tags: [`タグ${(i % 5) + 1}`, `タグ${((i + 2) % 5) + 1}`],
+	price: 500 + (i % 10) * 100,
+	category: ["音声作品", "ゲーム", "CG・イラスト", "マンガ"][i % 4],
+	dlCount: Math.floor(Math.random() * 10000),
+	rating: 3 + Math.random() * 2,
+}));
+
+// Fetch function
+async function fetchWorks(params: ListParams): Promise<ListResult<SampleWork>> {
+	// Simulate API delay
+	await new Promise((resolve) => setTimeout(resolve, 500));
+
+	let filteredWorks = [...sampleWorks];
+
+	// Apply filters
+	if (params.filters.category && params.filters.category !== "all") {
+		filteredWorks = filteredWorks.filter((work) => work.category === params.filters.category);
+	}
+
+	if (params.filters.priceRange) {
+		const { min, max } = params.filters.priceRange;
+		filteredWorks = filteredWorks.filter((work) => {
+			if (min !== undefined && work.price < min) return false;
+			if (max !== undefined && work.price > max) return false;
+			return true;
+		});
+	}
+
+	// Apply search
+	if (params.search) {
+		const searchLower = params.search.toLowerCase();
+		filteredWorks = filteredWorks.filter(
+			(work) =>
+				work.title.toLowerCase().includes(searchLower) ||
+				work.circle.toLowerCase().includes(searchLower) ||
+				work.tags.some((tag) => tag.toLowerCase().includes(searchLower)),
+		);
+	}
+
+	// Apply sort
+	const sortMap: Record<string, (a: SampleWork, b: SampleWork) => number> = {
+		newest: (a, b) => new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
+		oldest: (a, b) => new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime(),
+		popular: (a, b) => b.dlCount - a.dlCount,
+		priceAsc: (a, b) => a.price - b.price,
+		priceDesc: (a, b) => b.price - a.price,
+	};
+
+	if (params.sort && sortMap[params.sort]) {
+		filteredWorks.sort(sortMap[params.sort]);
+	}
+
+	// Apply pagination
+	const start = (params.page - 1) * params.limit;
+	const paginatedWorks = filteredWorks.slice(start, start + params.limit);
+
+	return {
+		items: paginatedWorks,
+		totalCount: sampleWorks.length,
+		filteredCount: filteredWorks.length,
+	};
+}
+
+const meta = {
+	title: "Custom/List/GenericList",
+	component: GenericList,
+	tags: ["autodocs"],
+	parameters: {
+		layout: "fullscreen",
+		docs: {
+			description: {
+				component: `
+汎用的なリスト表示コンポーネント。フィルタリング、ソート、ページネーション、検索などの機能を統合し、
+様々なリスト表示に対応できる柔軟な設計になっています。
+
+## 主な機能
+
+- **URL同期**: フィルター、ソート、ページネーションの状態をURLパラメータと同期
+- **柔軟なフィルター**: select, multiselect, range, dateRange など多様なフィルタータイプに対応
+- **ソート機能**: 複数フィールドでのソート定義が可能
+- **ページネーション**: ページサイズ変更、ページ番号の妥当性チェック付き
+- **検索機能**: リアルタイム検索に対応
+- **カスタマイズ可能**: レンダリング関数、グリッドレイアウト、フィルターなどを柔軟にカスタマイズ
+
+## 使用方法
+
+\`\`\`tsx
+import { GenericList } from "@suzumina.click/ui";
+import type { ListConfig, ListParams, ListResult } from "@suzumina.click/ui";
+
+// 設定
+const config: ListConfig = {
+  title: "商品一覧",
+  baseUrl: "/products",
+  filters: [
+    {
+      key: "category",
+      type: "select",
+      label: "カテゴリー",
+      options: [
+        { value: "all", label: "すべて" },
+        { value: "electronics", label: "家電" },
+      ],
+      defaultValue: "all",
+    },
+  ],
+  sortOptions: [
+    {
+      key: "newest",
+      label: "新着順",
+      fields: [{ field: "createdAt", direction: "desc" }],
+    },
+  ],
+  defaultSort: "newest",
+};
+
+// データ取得関数
+async function fetchProducts(params: ListParams): Promise<ListResult<Product>> {
+  const response = await fetch(\`/api/products?\${new URLSearchParams(params)}\`);
+  return response.json();
+}
+
+// 使用
+<GenericList
+  config={config}
+  fetchData={fetchProducts}
+  renderItem={(product) => <ProductCard product={product} />}
+/>
+\`\`\`
+				`,
+			},
+		},
+	},
+} satisfies Meta<typeof GenericList>;
+
+export default meta;
+type Story = StoryObj<typeof GenericList>;
+
+// Basic configuration
+const basicConfig: ListConfig = {
+	title: "作品一覧",
+	baseUrl: "/works",
+	filters: [
+		{
+			key: "category",
+			type: "select",
+			label: "カテゴリー",
+			placeholder: "カテゴリーを選択",
+			options: [
+				{ value: "all", label: "すべて" },
+				{ value: "音声作品", label: "音声作品" },
+				{ value: "ゲーム", label: "ゲーム" },
+				{ value: "CG・イラスト", label: "CG・イラスト" },
+				{ value: "マンガ", label: "マンガ" },
+			],
+			defaultValue: "all",
+		},
+	],
+	sortOptions: [
+		{
+			key: "newest",
+			label: "新着順",
+			fields: [{ field: "releaseDate", direction: "desc" }],
+		},
+		{
+			key: "oldest",
+			label: "古い順",
+			fields: [{ field: "releaseDate", direction: "asc" }],
+		},
+		{
+			key: "popular",
+			label: "人気順",
+			fields: [{ field: "dlCount", direction: "desc" }],
+		},
+		{
+			key: "priceAsc",
+			label: "価格が安い順",
+			fields: [{ field: "price", direction: "asc" }],
+		},
+		{
+			key: "priceDesc",
+			label: "価格が高い順",
+			fields: [{ field: "price", direction: "desc" }],
+		},
+	],
+	defaultSort: "newest",
+	paginationConfig: {
+		itemsPerPage: 12,
+		itemsPerPageOptions: [12, 24, 48],
+	},
+};
+
+export const Default: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: "基本的な使用例。カテゴリーフィルターとソート機能を備えた作品リストを表示します。",
+			},
+		},
+	},
+	args: {
+		config: basicConfig,
+		fetchData: fetchWorks,
+		renderItem: (work: SampleWork) => (
+			<div key={work.id} className="p-4 border rounded-lg hover:shadow-md transition-shadow">
+				<h3 className="font-semibold text-lg mb-2">{work.title}</h3>
+				<p className="text-sm text-muted-foreground mb-1">{work.circle}</p>
+				<p className="text-sm text-muted-foreground mb-2">{work.id}</p>
+				<div className="flex flex-wrap gap-1 mb-2">
+					{work.tags.map((tag) => (
+						<span key={tag} className="px-2 py-1 bg-secondary text-xs rounded">
+							{tag}
+						</span>
+					))}
+				</div>
+				<div className="flex justify-between items-center text-sm">
+					<span className="font-medium">¥{work.price.toLocaleString()}</span>
+					<span className="text-muted-foreground">DL: {work.dlCount.toLocaleString()}</span>
+				</div>
+			</div>
+		),
+		gridColumns: {
+			default: 1,
+			md: 2,
+			lg: 3,
+			xl: 4,
+		},
+	},
+};
+
+export const WithMultipleFilters: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"複数のフィルタータイプの組み合わせ例。カスタムフィルター（価格帯）の実装方法を示します。",
+			},
+		},
+	},
+	args: {
+		config: {
+			...basicConfig,
+			filters: [
+				...basicConfig.filters,
+				{
+					key: "priceRange",
+					type: "custom",
+					label: "価格帯",
+					defaultValue: { min: undefined, max: undefined },
+				},
+			],
+		},
+		fetchData: fetchWorks,
+		renderItem: Default.args.renderItem,
+		renderCustomFilters: () => (
+			<div className="flex gap-2">
+				<input
+					type="number"
+					placeholder="最低価格"
+					className="px-3 py-1 border rounded text-sm"
+					onChange={(e) => {
+						// In real implementation, this would update the filter
+						console.log("Min price:", e.target.value);
+					}}
+				/>
+				<input
+					type="number"
+					placeholder="最高価格"
+					className="px-3 py-1 border rounded text-sm"
+					onChange={(e) => {
+						// In real implementation, this would update the filter
+						console.log("Max price:", e.target.value);
+					}}
+				/>
+			</div>
+		),
+		gridColumns: Default.args.gridColumns,
+	},
+};
+
+export const LoadingState: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: "ローディング状態の表示例。カスタムローディングスケルトンを定義できます。",
+			},
+		},
+	},
+	args: {
+		config: basicConfig,
+		fetchData: async () => {
+			// Never resolve to show loading state
+			await new Promise(() => {});
+			return { items: [], totalCount: 0, filteredCount: 0 };
+		},
+		renderItem: Default.args.renderItem,
+		renderLoadingSkeleton: () => (
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+				{Array.from({ length: 6 }).map((_, i) => (
+					<div key={i} className="p-4 border rounded-lg">
+						<div className="h-6 bg-gray-200 rounded mb-2 animate-pulse" />
+						<div className="h-4 bg-gray-200 rounded w-2/3 mb-1 animate-pulse" />
+						<div className="h-4 bg-gray-200 rounded w-1/2 mb-2 animate-pulse" />
+						<div className="flex gap-1 mb-2">
+							<div className="h-6 bg-gray-200 rounded w-16 animate-pulse" />
+							<div className="h-6 bg-gray-200 rounded w-16 animate-pulse" />
+						</div>
+						<div className="flex justify-between">
+							<div className="h-4 bg-gray-200 rounded w-20 animate-pulse" />
+							<div className="h-4 bg-gray-200 rounded w-16 animate-pulse" />
+						</div>
+					</div>
+				))}
+			</div>
+		),
+	},
+};
+
+export const EmptyState: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: "データが空の状態の表示例。カスタム空状態コンポーネントを定義できます。",
+			},
+		},
+	},
+	args: {
+		config: basicConfig,
+		fetchData: async () => ({
+			items: [],
+			totalCount: 100,
+			filteredCount: 0,
+		}),
+		renderItem: Default.args.renderItem,
+		renderEmptyState: () => (
+			<div className="text-center py-12">
+				<h3 className="text-lg font-semibold mb-2">検索結果がありません</h3>
+				<p className="text-muted-foreground mb-4">条件を変更して再度お試しください</p>
+				<button
+					type="button"
+					className="px-4 py-2 bg-primary text-primary-foreground rounded hover:bg-primary/90"
+				>
+					フィルターをリセット
+				</button>
+			</div>
+		),
+	},
+};
+
+export const ErrorState: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: "エラー状態の表示例。データ取得に失敗した場合の処理を示します。",
+			},
+		},
+	},
+	args: {
+		config: basicConfig,
+		fetchData: async () => {
+			throw new Error("データの取得に失敗しました");
+		},
+		renderItem: Default.args.renderItem,
+	},
+};
+
+export const MinimalConfiguration: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: "最小限の設定での使用例。フィルターやソートなしでシンプルなリストを表示します。",
+			},
+		},
+	},
+	args: {
+		config: {
+			baseUrl: "/items",
+		},
+		fetchData: async (params) => ({
+			items: sampleWorks.slice((params.page - 1) * params.limit, params.page * params.limit),
+			totalCount: sampleWorks.length,
+			filteredCount: sampleWorks.length,
+		}),
+		renderItem: (work: SampleWork) => (
+			<div key={work.id} className="p-3 border rounded">
+				<h4 className="font-medium">{work.title}</h4>
+			</div>
+		),
+	},
+};
+
+export const CustomGridLayout: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: "カスタムグリッドレイアウトの例。レスポンシブなグリッド列数を細かく制御できます。",
+			},
+		},
+	},
+	args: {
+		config: basicConfig,
+		fetchData: fetchWorks,
+		renderItem: (work: SampleWork) => (
+			<div key={work.id} className="p-2 border rounded text-sm">
+				<h4 className="font-medium truncate">{work.title}</h4>
+				<p className="text-xs text-muted-foreground">¥{work.price}</p>
+			</div>
+		),
+		gridColumns: {
+			default: 2,
+			sm: 3,
+			md: 4,
+			lg: 6,
+			xl: 8,
+		},
+	},
+};
+
+// Interactive example with state management
+function InteractiveExample() {
+	const [selectedTags, setSelectedTags] = useState<string[]>([]);
+
+	const interactiveConfig: ListConfig = {
+		...basicConfig,
+		filters: [
+			...basicConfig.filters,
+			{
+				key: "tags",
+				type: "custom",
+				label: "タグ",
+				defaultValue: [],
+			},
+		],
+	};
+
+	const interactiveFetchData = async (params: ListParams): Promise<ListResult<SampleWork>> => {
+		const result = await fetchWorks(params);
+
+		// Additional filtering by tags
+		if (selectedTags.length > 0) {
+			result.items = result.items.filter((work) =>
+				selectedTags.some((tag) => work.tags.includes(tag)),
+			);
+			result.filteredCount = result.items.length;
+		}
+
+		return result;
+	};
+
+	return (
+		<GenericList<SampleWork>
+			config={interactiveConfig}
+			fetchData={interactiveFetchData}
+			renderItem={(work) => (
+				<div key={work.id} className="p-4 border rounded-lg">
+					<h3 className="font-semibold">{work.title}</h3>
+					<div className="flex flex-wrap gap-1 mt-2">
+						{work.tags.map((tag) => (
+							<button
+								key={tag}
+								type="button"
+								onClick={() => {
+									setSelectedTags((prev) =>
+										prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+									);
+								}}
+								className={`px-2 py-1 text-xs rounded ${
+									selectedTags.includes(tag) ? "bg-primary text-primary-foreground" : "bg-secondary"
+								}`}
+							>
+								{tag}
+							</button>
+						))}
+					</div>
+				</div>
+			)}
+			renderCustomFilters={() => (
+				<div className="flex flex-wrap gap-1">
+					{selectedTags.map((tag) => (
+						<span
+							key={tag}
+							className="px-2 py-1 bg-primary text-primary-foreground text-xs rounded flex items-center gap-1"
+						>
+							{tag}
+							<button
+								type="button"
+								onClick={() => setSelectedTags((prev) => prev.filter((t) => t !== tag))}
+								className="hover:text-primary-foreground/80"
+							>
+								×
+							</button>
+						</span>
+					))}
+				</div>
+			)}
+		/>
+	);
+}
+
+export const Interactive: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"インタラクティブな使用例。タグによるフィルタリングなど、より複雑な状態管理の実装例を示します。",
+			},
+		},
+	},
+	render: () => <InteractiveExample />,
+};

--- a/packages/ui/src/components/custom/generic-list/generic-list.tsx
+++ b/packages/ui/src/components/custom/generic-list/generic-list.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import {
+	Pagination,
+	PaginationContent,
+	PaginationEllipsis,
+	PaginationItem,
+	PaginationLink,
+	PaginationNext,
+	PaginationPrevious,
+} from "../../ui/pagination";
+import { Skeleton } from "../../ui/skeleton";
+import { ListDisplayControls } from "../list-display-controls";
+import {
+	ListPageContent,
+	ListPageEmptyState,
+	ListPageGrid,
+	ListPageLayout,
+	ListPageStats,
+} from "../list-page-layout";
+import { FilterSelect, SearchFilterPanel } from "../search-filter-panel";
+import type { ListConfig, ListParams, ListResult } from "./types";
+import { useListState } from "./use-list-state";
+
+export interface GenericListProps<T> {
+	/**
+	 * リストの設定オブジェクト
+	 * タイトル、ベースURL、フィルター、ソートオプションなどを定義
+	 */
+	config: ListConfig;
+
+	/**
+	 * データ取得関数
+	 * ListParams を受け取り、Promise<ListResult<T>> を返す
+	 */
+	fetchData: (params: ListParams) => Promise<ListResult<T>>;
+
+	/**
+	 * 各アイテムのレンダリング関数
+	 * @param item - 表示するアイテム
+	 * @param index - アイテムのインデックス
+	 */
+	renderItem: (item: T, index: number) => ReactNode;
+
+	/**
+	 * 空状態時のカスタムレンダリング関数
+	 * @default デフォルトの空状態メッセージを表示
+	 */
+	renderEmptyState?: () => ReactNode;
+
+	/**
+	 * ローディング時のカスタムスケルトン
+	 * @default デフォルトのスケルトンを表示
+	 */
+	renderLoadingSkeleton?: () => ReactNode;
+
+	/**
+	 * レスポンシブグリッドレイアウトの設定
+	 * @default { default: 1, md: 2, lg: 3 }
+	 */
+	gridColumns?: {
+		default?: number;
+		sm?: number;
+		md?: number;
+		lg?: number;
+		xl?: number;
+	};
+
+	/**
+	 * カスタムフィルターコンポーネントのレンダリング関数
+	 * 標準のフィルターに加えて独自のフィルターUIを追加できる
+	 */
+	renderCustomFilters?: () => ReactNode;
+
+	/**
+	 * カスタムコンテナコンポーネント
+	 * アイテムをラップするコンテナをカスタマイズできる
+	 * @param children - レンダリングされたアイテムの配列
+	 * @default ListPageGrid を使用
+	 */
+	renderContainer?: (children: ReactNode[]) => ReactNode;
+
+	/**
+	 * 追加のCSSクラス名
+	 */
+	className?: string;
+}
+
+/**
+ * 汎用リストコンポーネント
+ */
+export function GenericList<T>({
+	config,
+	fetchData,
+	renderItem,
+	renderEmptyState,
+	renderLoadingSkeleton,
+	gridColumns = {
+		default: 1,
+		md: 2,
+		lg: 3,
+	},
+	renderCustomFilters,
+	renderContainer,
+	className,
+}: GenericListProps<T>) {
+	const {
+		state,
+		loadData,
+		setPage,
+		setItemsPerPage,
+		setSort,
+		setSearch,
+		setFilter,
+		hasActiveFilters,
+	} = useListState(config, fetchData);
+
+	// 初回データ取得
+	useEffect(() => {
+		loadData();
+	}, [loadData]);
+
+	// ページネーションリンクの生成
+	const renderPaginationItems = () => {
+		const { currentPage, totalPages } = state.pagination;
+		const items: ReactNode[] = [];
+
+		// 最大表示ページ数
+		const maxPages = 5;
+		const halfMax = Math.floor(maxPages / 2);
+
+		let start = Math.max(1, currentPage - halfMax);
+		const end = Math.min(totalPages, start + maxPages - 1);
+
+		if (end - start + 1 < maxPages) {
+			start = Math.max(1, end - maxPages + 1);
+		}
+
+		// 最初のページへのリンク
+		if (start > 1) {
+			items.push(
+				<PaginationItem key="1">
+					<PaginationLink onClick={() => setPage(1)}>1</PaginationLink>
+				</PaginationItem>,
+			);
+			if (start > 2) {
+				items.push(
+					<PaginationItem key="ellipsis-start">
+						<PaginationEllipsis />
+					</PaginationItem>,
+				);
+			}
+		}
+
+		// ページ番号
+		for (let i = start; i <= end; i++) {
+			items.push(
+				<PaginationItem key={i}>
+					<PaginationLink isActive={i === currentPage} onClick={() => setPage(i)}>
+						{i}
+					</PaginationLink>
+				</PaginationItem>,
+			);
+		}
+
+		// 最後のページへのリンク
+		if (end < totalPages) {
+			if (end < totalPages - 1) {
+				items.push(
+					<PaginationItem key="ellipsis-end">
+						<PaginationEllipsis />
+					</PaginationItem>,
+				);
+			}
+			items.push(
+				<PaginationItem key={totalPages}>
+					<PaginationLink onClick={() => setPage(totalPages)}>{totalPages}</PaginationLink>
+				</PaginationItem>,
+			);
+		}
+
+		return items;
+	};
+
+	// フィルターのレンダリング
+	const renderFilters = () => {
+		if (!config.filters || config.filters.length === 0) {
+			return renderCustomFilters?.();
+		}
+
+		return (
+			<>
+				{config.filters.map((filter) => {
+					switch (filter.type) {
+						case "select":
+							return (
+								<FilterSelect
+									key={filter.key}
+									value={state.filters[filter.key] || filter.defaultValue}
+									onValueChange={(value) => setFilter(filter.key, value)}
+									placeholder={filter.placeholder || filter.label}
+									options={filter.options || []}
+								/>
+							);
+						// 他のフィルタータイプは必要に応じて追加
+						default:
+							return null;
+					}
+				})}
+				{renderCustomFilters?.()}
+			</>
+		);
+	};
+
+	// ローディングスケルトン
+	const defaultLoadingSkeleton = () =>
+		renderContainer ? (
+			renderContainer(
+				Array.from({ length: state.pagination.itemsPerPage }).map((_, index) => (
+					<Skeleton key={index} className="h-32 w-full" />
+				)),
+			)
+		) : (
+			<ListPageGrid columns={gridColumns}>
+				{Array.from({ length: state.pagination.itemsPerPage }).map((_, index) => (
+					<Skeleton key={index} className="h-32 w-full" />
+				))}
+			</ListPageGrid>
+		);
+
+	// 空状態
+	const defaultEmptyState = () => (
+		<ListPageEmptyState
+			title="データが見つかりませんでした"
+			description="検索条件を変更してお試しください"
+		/>
+	);
+
+	return (
+		<ListPageLayout className={className}>
+			<ListPageContent>
+				{/* 検索・フィルター */}
+				<SearchFilterPanel
+					searchValue={state.search}
+					onSearchChange={setSearch}
+					onSearch={loadData}
+					searchPlaceholder="検索..."
+					filters={renderFilters()}
+				/>
+
+				{/* リスト制御 */}
+				<ListDisplayControls
+					title={config.title || "一覧"}
+					totalCount={state.counts.total}
+					filteredCount={hasActiveFilters ? state.counts.filtered : undefined}
+					currentPage={state.pagination.currentPage}
+					totalPages={state.pagination.totalPages}
+					sortValue={state.sort}
+					onSortChange={setSort}
+					sortOptions={config.sortOptions?.map((s) => ({ value: s.key, label: s.label })) || []}
+					itemsPerPageValue={state.pagination.itemsPerPage.toString()}
+					onItemsPerPageChange={(value) => setItemsPerPage(Number(value))}
+					itemsPerPageOptions={
+						config.paginationConfig?.itemsPerPageOptions?.map((n) => ({
+							value: n.toString(),
+							label: `${n}件/ページ`,
+						})) || [
+							{ value: "12", label: "12件/ページ" },
+							{ value: "24", label: "24件/ページ" },
+							{ value: "48", label: "48件/ページ" },
+						]
+					}
+				/>
+
+				{/* コンテンツ */}
+				{state.isLoading ? (
+					renderLoadingSkeleton?.() || defaultLoadingSkeleton()
+				) : state.error ? (
+					<div className="text-center py-12">
+						<p className="text-destructive">{state.error}</p>
+						<button type="button" onClick={loadData} className="mt-4 text-primary hover:underline">
+							再試行
+						</button>
+					</div>
+				) : state.counts.displayed === 0 ? (
+					renderEmptyState?.() || defaultEmptyState()
+				) : renderContainer ? (
+					renderContainer(state.items.map((item, index) => renderItem(item, index)))
+				) : (
+					<ListPageGrid columns={gridColumns}>
+						{state.items.map((item, index) => renderItem(item, index))}
+					</ListPageGrid>
+				)}
+
+				{/* ページネーション */}
+				{state.pagination.totalPages > 1 && (
+					<div className="mt-8">
+						<Pagination>
+							<PaginationContent>
+								<PaginationItem>
+									<PaginationPrevious
+										onClick={() => setPage(Math.max(1, state.pagination.currentPage - 1))}
+										className={
+											state.pagination.currentPage === 1
+												? "pointer-events-none opacity-50"
+												: "cursor-pointer"
+										}
+									/>
+								</PaginationItem>
+								{renderPaginationItems()}
+								<PaginationItem>
+									<PaginationNext
+										onClick={() =>
+											setPage(
+												Math.min(state.pagination.totalPages, state.pagination.currentPage + 1),
+											)
+										}
+										className={
+											state.pagination.currentPage === state.pagination.totalPages
+												? "pointer-events-none opacity-50"
+												: "cursor-pointer"
+										}
+									/>
+								</PaginationItem>
+							</PaginationContent>
+						</Pagination>
+					</div>
+				)}
+
+				{/* 統計情報 */}
+				{state.counts.displayed > 0 && (
+					<ListPageStats
+						currentPage={state.pagination.currentPage}
+						totalPages={state.pagination.totalPages}
+						totalCount={state.counts.filtered}
+						itemsPerPage={state.pagination.itemsPerPage}
+					/>
+				)}
+			</ListPageContent>
+		</ListPageLayout>
+	);
+}

--- a/packages/ui/src/components/custom/generic-list/index.ts
+++ b/packages/ui/src/components/custom/generic-list/index.ts
@@ -1,0 +1,7 @@
+/**
+ * 共通リストコンポーネント
+ */
+
+export * from "./types";
+export * from "./use-list-state";
+export * from "./use-url-params";

--- a/packages/ui/src/components/custom/generic-list/index.ts
+++ b/packages/ui/src/components/custom/generic-list/index.ts
@@ -2,6 +2,8 @@
  * 共通リストコンポーネント
  */
 
+export type { GenericListProps } from "./generic-list";
+export { GenericList } from "./generic-list";
 export * from "./types";
-export * from "./use-list-state";
-export * from "./use-url-params";
+export { useListState } from "./use-list-state";
+export { useUrlParams } from "./use-url-params";

--- a/packages/ui/src/components/custom/generic-list/types.ts
+++ b/packages/ui/src/components/custom/generic-list/types.ts
@@ -47,6 +47,7 @@ export interface PaginationConfig {
 
 // リスト設定
 export interface ListConfig {
+	title?: string;
 	baseUrl: string;
 	filters?: FilterDefinition[];
 	sortOptions?: SortDefinition[];
@@ -79,7 +80,9 @@ export interface ListResult<T> {
 }
 
 // リスト状態
-export interface ListState {
+export interface ListState<T = any> {
+	// データ
+	items: T[];
 	// 件数管理
 	counts: {
 		total: number;

--- a/packages/ui/src/components/custom/generic-list/types.ts
+++ b/packages/ui/src/components/custom/generic-list/types.ts
@@ -1,0 +1,118 @@
+/**
+ * 共通リストコンポーネントの型定義
+ */
+
+// フィルタータイプの定義
+export type FilterType =
+	| "select"
+	| "multiselect"
+	| "range"
+	| "dateRange"
+	| "search"
+	| "boolean"
+	| "custom";
+
+// フィルター定義
+export interface FilterDefinition {
+	key: string;
+	type: FilterType;
+	label: string;
+	placeholder?: string;
+	options?: Array<{ value: string; label: string }>;
+	defaultValue?: any;
+	validation?: (value: any) => boolean;
+	transform?: (value: any) => any;
+	// 依存関係
+	dependsOn?: string;
+	getDynamicOptions?: (parentValue: any) => Array<{ value: string; label: string }>;
+}
+
+// ソート定義
+export interface SortDefinition {
+	key: string;
+	label: string;
+	// 複数フィールドでのソートに対応
+	fields: Array<{
+		field: string;
+		direction: "asc" | "desc";
+	}>;
+}
+
+// ページネーション設定
+export interface PaginationConfig {
+	currentPage: number;
+	itemsPerPage: number;
+	itemsPerPageOptions?: number[];
+}
+
+// リスト設定
+export interface ListConfig {
+	baseUrl: string;
+	filters?: FilterDefinition[];
+	sortOptions?: SortDefinition[];
+	defaultSort?: string;
+	paginationConfig?: Partial<PaginationConfig>;
+	// URLパラメータのカスタマイズ
+	urlParamMapping?: {
+		page?: string;
+		limit?: string;
+		sort?: string;
+		search?: string;
+		[key: string]: string | undefined;
+	};
+}
+
+// リストパラメータ（URLやフィルターの値）
+export interface ListParams {
+	page: number;
+	limit: number;
+	sort?: string;
+	search?: string;
+	filters: Record<string, any>;
+}
+
+// リスト結果
+export interface ListResult<T> {
+	items: T[];
+	totalCount: number;
+	filteredCount: number;
+}
+
+// リスト状態
+export interface ListState {
+	// 件数管理
+	counts: {
+		total: number;
+		filtered: number;
+		displayed: number;
+	};
+	// ページネーション
+	pagination: {
+		currentPage: number;
+		itemsPerPage: number;
+		totalPages: number;
+	};
+	// フィルター
+	filters: Record<string, any>;
+	// ソート
+	sort: string;
+	// 検索
+	search: string;
+	// ローディング状態
+	isLoading: boolean;
+	// エラー状態
+	error: string | null;
+}
+
+// アクション型
+export type ListAction =
+	| { type: "SET_ITEMS"; payload: { items: any[]; totalCount: number; filteredCount: number } }
+	| { type: "SET_PAGE"; payload: number }
+	| { type: "SET_ITEMS_PER_PAGE"; payload: number }
+	| { type: "SET_FILTER"; payload: { key: string; value: any } }
+	| { type: "SET_FILTERS"; payload: Record<string, any> }
+	| { type: "RESET_FILTERS" }
+	| { type: "SET_SORT"; payload: string }
+	| { type: "SET_SEARCH"; payload: string }
+	| { type: "SET_LOADING"; payload: boolean }
+	| { type: "SET_ERROR"; payload: string | null };

--- a/packages/ui/src/components/custom/generic-list/use-list-state.ts
+++ b/packages/ui/src/components/custom/generic-list/use-list-state.ts
@@ -1,0 +1,280 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useReducer } from "react";
+import type { ListAction, ListConfig, ListParams, ListResult, ListState } from "./types";
+import { useUrlParams } from "./use-url-params";
+
+/**
+ * リスト状態を管理するリデューサー
+ */
+function listReducer(state: ListState, action: ListAction): ListState {
+	switch (action.type) {
+		case "SET_ITEMS": {
+			const { totalCount, filteredCount } = action.payload;
+			const totalPages = Math.ceil(filteredCount / state.pagination.itemsPerPage);
+
+			// ページ番号の妥当性チェック
+			const validPage = Math.min(
+				Math.max(1, state.pagination.currentPage),
+				Math.max(1, totalPages),
+			);
+
+			return {
+				...state,
+				counts: {
+					total: totalCount,
+					filtered: filteredCount,
+					displayed: action.payload.items.length,
+				},
+				pagination: {
+					...state.pagination,
+					totalPages,
+					currentPage: validPage,
+				},
+			};
+		}
+
+		case "SET_PAGE":
+			return {
+				...state,
+				pagination: {
+					...state.pagination,
+					currentPage: action.payload,
+				},
+			};
+
+		case "SET_ITEMS_PER_PAGE": {
+			const totalPages = Math.ceil(state.counts.filtered / action.payload);
+			return {
+				...state,
+				pagination: {
+					...state.pagination,
+					itemsPerPage: action.payload,
+					totalPages,
+					currentPage: 1, // ページサイズ変更時は1ページ目へ
+				},
+			};
+		}
+
+		case "SET_FILTER":
+			return {
+				...state,
+				filters: {
+					...state.filters,
+					[action.payload.key]: action.payload.value,
+				},
+				pagination: {
+					...state.pagination,
+					currentPage: 1, // フィルター変更時は1ページ目へ
+				},
+			};
+
+		case "SET_FILTERS":
+			return {
+				...state,
+				filters: action.payload,
+				pagination: {
+					...state.pagination,
+					currentPage: 1,
+				},
+			};
+
+		case "RESET_FILTERS": {
+			const defaultFilters: Record<string, any> = {};
+			// デフォルト値の復元はconfigから行う必要があるため、
+			// ここでは空オブジェクトにリセット
+			return {
+				...state,
+				filters: defaultFilters,
+				search: "",
+				pagination: {
+					...state.pagination,
+					currentPage: 1,
+				},
+			};
+		}
+
+		case "SET_SORT":
+			return {
+				...state,
+				sort: action.payload,
+				pagination: {
+					...state.pagination,
+					currentPage: 1,
+				},
+			};
+
+		case "SET_SEARCH":
+			return {
+				...state,
+				search: action.payload,
+				pagination: {
+					...state.pagination,
+					currentPage: 1,
+				},
+			};
+
+		case "SET_LOADING":
+			return {
+				...state,
+				isLoading: action.payload,
+			};
+
+		case "SET_ERROR":
+			return {
+				...state,
+				error: action.payload,
+				isLoading: false,
+			};
+
+		default:
+			return state;
+	}
+}
+
+/**
+ * リスト状態管理フック
+ */
+export function useListState<T>(
+	config: ListConfig,
+	fetchData: (params: ListParams) => Promise<ListResult<T>>,
+) {
+	const urlParams = useUrlParams(config);
+	const { params } = urlParams;
+
+	// 初期状態
+	const initialState = useMemo(
+		(): ListState => ({
+			counts: {
+				total: 0,
+				filtered: 0,
+				displayed: 0,
+			},
+			pagination: {
+				currentPage: params.page,
+				itemsPerPage: params.limit,
+				totalPages: 0,
+			},
+			filters: params.filters,
+			sort: params.sort,
+			search: params.search,
+			isLoading: false,
+			error: null,
+		}),
+		[params],
+	);
+
+	const [state, dispatch] = useReducer(listReducer, initialState);
+
+	// URLパラメータとの同期
+	useEffect(() => {
+		dispatch({ type: "SET_PAGE", payload: params.page });
+		dispatch({ type: "SET_ITEMS_PER_PAGE", payload: params.limit });
+		dispatch({ type: "SET_SORT", payload: params.sort });
+		dispatch({ type: "SET_SEARCH", payload: params.search });
+		dispatch({ type: "SET_FILTERS", payload: params.filters });
+	}, [params]);
+
+	// データ取得
+	const loadData = useCallback(async () => {
+		dispatch({ type: "SET_LOADING", payload: true });
+		dispatch({ type: "SET_ERROR", payload: null });
+
+		try {
+			const result = await fetchData(params);
+			dispatch({
+				type: "SET_ITEMS",
+				payload: {
+					items: result.items,
+					totalCount: result.totalCount,
+					filteredCount: result.filteredCount,
+				},
+			});
+			return result;
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : "データの取得に失敗しました";
+			dispatch({ type: "SET_ERROR", payload: errorMessage });
+			throw error;
+		} finally {
+			dispatch({ type: "SET_LOADING", payload: false });
+		}
+	}, [fetchData, params]);
+
+	// アクション関数
+	const setPage = useCallback(
+		(page: number) => {
+			urlParams.updatePage(page);
+		},
+		[urlParams],
+	);
+
+	const setItemsPerPage = useCallback(
+		(itemsPerPage: number) => {
+			urlParams.updateLimit(itemsPerPage);
+		},
+		[urlParams],
+	);
+
+	const setSort = useCallback(
+		(sort: string) => {
+			urlParams.updateSort(sort);
+		},
+		[urlParams],
+	);
+
+	const setSearch = useCallback(
+		(search: string) => {
+			urlParams.updateSearch(search);
+		},
+		[urlParams],
+	);
+
+	const setFilter = useCallback(
+		(key: string, value: any) => {
+			urlParams.updateFilter(key, value);
+		},
+		[urlParams],
+	);
+
+	const resetFilters = useCallback(() => {
+		urlParams.resetFilters();
+	}, [urlParams]);
+
+	// フィルターが適用されているかチェック
+	const hasActiveFilters = useMemo(() => {
+		if (state.search) return true;
+
+		if (!config.filters) return false;
+
+		return config.filters.some((filter) => {
+			const value = state.filters[filter.key];
+			const defaultValue = filter.defaultValue;
+
+			// 値が設定されており、デフォルト値と異なる場合
+			if (value === undefined || value === null) return false;
+			if (value === defaultValue) return false;
+
+			// 配列の場合
+			if (Array.isArray(value)) return value.length > 0;
+
+			// オブジェクトの場合（range など）
+			if (typeof value === "object") {
+				return Object.values(value).some((v) => v !== undefined && v !== null && v !== "");
+			}
+
+			return true;
+		});
+	}, [state.search, state.filters, config.filters]);
+
+	return {
+		state,
+		loadData,
+		setPage,
+		setItemsPerPage,
+		setSort,
+		setSearch,
+		setFilter,
+		resetFilters,
+		hasActiveFilters,
+	};
+}

--- a/packages/ui/src/components/custom/generic-list/use-url-params.ts
+++ b/packages/ui/src/components/custom/generic-list/use-url-params.ts
@@ -4,8 +4,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import type { ListConfig, ListParams } from "./types";
 
-// Storybook環境の検出
-const isStorybook = typeof window !== "undefined" && window.location.href.includes("iframe.html");
+// Storybook環境の検出（環境変数とURLの両方でチェック）
+const isStorybook =
+	process.env.STORYBOOK === "true" ||
+	(typeof window !== "undefined" && window.location.href.includes("iframe.html"));
 
 /**
  * URLパラメータとリスト状態を同期するフック

--- a/packages/ui/src/components/custom/generic-list/use-url-params.ts
+++ b/packages/ui/src/components/custom/generic-list/use-url-params.ts
@@ -4,6 +4,9 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo } from "react";
 import type { ListConfig, ListParams } from "./types";
 
+// Storybook環境の検出
+const isStorybook = typeof window !== "undefined" && window.location.href.includes("iframe.html");
+
 /**
  * URLパラメータとリスト状態を同期するフック
  */
@@ -139,9 +142,11 @@ export function useUrlParams(config: ListConfig) {
 				}
 			}
 
-			// URLを更新
-			const newUrl = `${config.baseUrl}?${params.toString()}`;
-			router.push(newUrl);
+			// URLを更新（Storybook環境ではスキップ）
+			if (!isStorybook) {
+				const newUrl = `${config.baseUrl}?${params.toString()}`;
+				router.push(newUrl);
+			}
 		},
 		[router, config, paramMapping],
 	);

--- a/packages/ui/src/components/custom/generic-list/use-url-params.ts
+++ b/packages/ui/src/components/custom/generic-list/use-url-params.ts
@@ -1,0 +1,213 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+import type { ListConfig, ListParams } from "./types";
+
+/**
+ * URLパラメータとリスト状態を同期するフック
+ */
+export function useUrlParams(config: ListConfig) {
+	const router = useRouter();
+	const searchParams = useSearchParams();
+
+	// URLパラメータのマッピング設定
+	const paramMapping = useMemo(
+		() => ({
+			page: "page",
+			limit: "limit",
+			sort: "sort",
+			search: "search",
+			...config.urlParamMapping,
+		}),
+		[config.urlParamMapping],
+	);
+
+	// 現在のURLパラメータを取得
+	const getParams = useCallback((): ListParams => {
+		const page = Number.parseInt(searchParams.get(paramMapping.page) || "1", 10) || 1;
+		const limit = Number.parseInt(
+			searchParams.get(paramMapping.limit) ||
+				config.paginationConfig?.itemsPerPage?.toString() ||
+				"12",
+			10,
+		);
+		const sort = searchParams.get(paramMapping.sort) || config.defaultSort || "";
+		const search = searchParams.get(paramMapping.search) || "";
+
+		// フィルターパラメータを収集
+		const filters: Record<string, any> = {};
+		if (config.filters) {
+			for (const filter of config.filters) {
+				const value = searchParams.get(filter.key);
+				if (value !== null) {
+					// 型に応じた変換
+					if (filter.type === "multiselect") {
+						filters[filter.key] = value.split(",").filter(Boolean);
+					} else if (filter.type === "boolean") {
+						filters[filter.key] = value === "true";
+					} else if (filter.type === "range" || filter.type === "dateRange") {
+						// rangeの場合は "min,max" 形式を想定
+						const [min, max] = value.split(",");
+						filters[filter.key] = { min, max };
+					} else {
+						filters[filter.key] = value;
+					}
+				} else if (filter.defaultValue !== undefined) {
+					filters[filter.key] = filter.defaultValue;
+				}
+			}
+		}
+
+		return { page, limit, sort, search, filters };
+	}, [searchParams, paramMapping, config]);
+
+	// URLパラメータを更新
+	const setParams = useCallback(
+		(updates: Partial<ListParams>, resetPage = true) => {
+			const currentUrl = new URL(window.location.href);
+			const params = new URLSearchParams(currentUrl.search);
+
+			// ページ番号をリセット（フィルター変更時など）
+			if (resetPage && !("page" in updates)) {
+				params.delete(paramMapping.page);
+			}
+
+			// 更新を適用
+			if (updates.page !== undefined) {
+				if (updates.page > 1) {
+					params.set(paramMapping.page, updates.page.toString());
+				} else {
+					params.delete(paramMapping.page);
+				}
+			}
+
+			if (updates.limit !== undefined) {
+				const defaultLimit = config.paginationConfig?.itemsPerPage || 12;
+				if (updates.limit !== defaultLimit) {
+					params.set(paramMapping.limit, updates.limit.toString());
+				} else {
+					params.delete(paramMapping.limit);
+				}
+			}
+
+			if (updates.sort !== undefined) {
+				if (updates.sort && updates.sort !== config.defaultSort) {
+					params.set(paramMapping.sort, updates.sort);
+				} else {
+					params.delete(paramMapping.sort);
+				}
+			}
+
+			if (updates.search !== undefined) {
+				if (updates.search) {
+					params.set(paramMapping.search, updates.search);
+				} else {
+					params.delete(paramMapping.search);
+				}
+			}
+
+			// フィルターの更新
+			if (updates.filters && config.filters) {
+				for (const filter of config.filters) {
+					const value = updates.filters[filter.key];
+					if (value !== undefined && value !== null && value !== filter.defaultValue) {
+						// 型に応じた文字列化
+						if (filter.type === "multiselect" && Array.isArray(value)) {
+							if (value.length > 0) {
+								params.set(filter.key, value.join(","));
+							} else {
+								params.delete(filter.key);
+							}
+						} else if (filter.type === "boolean") {
+							params.set(filter.key, value.toString());
+						} else if (
+							(filter.type === "range" || filter.type === "dateRange") &&
+							typeof value === "object" &&
+							value.min !== undefined &&
+							value.max !== undefined
+						) {
+							params.set(filter.key, `${value.min},${value.max}`);
+						} else if (value) {
+							params.set(filter.key, value.toString());
+						} else {
+							params.delete(filter.key);
+						}
+					} else {
+						params.delete(filter.key);
+					}
+				}
+			}
+
+			// URLを更新
+			const newUrl = `${config.baseUrl}?${params.toString()}`;
+			router.push(newUrl);
+		},
+		[router, config, paramMapping],
+	);
+
+	// 個別のパラメータ更新用ヘルパー
+	const updatePage = useCallback(
+		(page: number) => {
+			setParams({ page }, false);
+		},
+		[setParams],
+	);
+
+	const updateLimit = useCallback(
+		(limit: number) => {
+			setParams({ limit });
+		},
+		[setParams],
+	);
+
+	const updateSort = useCallback(
+		(sort: string) => {
+			setParams({ sort });
+		},
+		[setParams],
+	);
+
+	const updateSearch = useCallback(
+		(search: string) => {
+			setParams({ search });
+		},
+		[setParams],
+	);
+
+	const updateFilter = useCallback(
+		(key: string, value: any) => {
+			const currentParams = getParams();
+			setParams({
+				filters: {
+					...currentParams.filters,
+					[key]: value,
+				},
+			});
+		},
+		[getParams, setParams],
+	);
+
+	const resetFilters = useCallback(() => {
+		const defaultFilters: Record<string, any> = {};
+		if (config.filters) {
+			for (const filter of config.filters) {
+				if (filter.defaultValue !== undefined) {
+					defaultFilters[filter.key] = filter.defaultValue;
+				}
+			}
+		}
+		setParams({ filters: defaultFilters, search: "" });
+	}, [config.filters, setParams]);
+
+	return {
+		params: getParams(),
+		setParams,
+		updatePage,
+		updateLimit,
+		updateSort,
+		updateSearch,
+		updateFilter,
+		resetFilters,
+	};
+}

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -17,8 +17,20 @@ export { AutocompleteDropdown } from "./autocomplete-dropdown";
 export { DateRangeFilter } from "./date-range-filter";
 // Utility components
 export { GenericCarousel } from "./generic-carousel";
+export type {
+	FilterDefinition,
+	FilterType,
+	GenericListProps,
+	ListAction,
+	ListConfig,
+	ListParams,
+	ListResult,
+	ListState,
+	PaginationConfig,
+	SortDefinition,
+} from "./generic-list";
 // Generic list components
-export * from "./generic-list";
+export { GenericList, useListState, useUrlParams } from "./generic-list";
 export { HighlightTags, HighlightText, MultiFieldHighlight } from "./highlight-text";
 // Layout components
 export { ListDisplayControls } from "./list-display-controls";

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -17,6 +17,8 @@ export { AutocompleteDropdown } from "./autocomplete-dropdown";
 export { DateRangeFilter } from "./date-range-filter";
 // Utility components
 export { GenericCarousel } from "./generic-carousel";
+// Generic list components
+export * from "./generic-list";
 export { HighlightTags, HighlightText, MultiFieldHighlight } from "./highlight-text";
 // Layout components
 export { ListDisplayControls } from "./list-display-controls";

--- a/packages/ui/src/components/custom/progressive-audio-button-list.stories.tsx
+++ b/packages/ui/src/components/custom/progressive-audio-button-list.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import type { FrontendAudioButtonData } from "@suzumina.click/shared-types";
+import { fn } from "storybook/test";
 import { ProgressiveAudioButtonList } from "./progressive-audio-button-list";
 
 const meta: Meta<typeof ProgressiveAudioButtonList> = {

--- a/packages/ui/src/components/custom/search-and-filter-panel.stories.tsx
+++ b/packages/ui/src/components/custom/search-and-filter-panel.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { fn } from "storybook/test";
 import { SearchAndFilterPanel } from "./search-and-filter-panel";
 import { FilterSelect } from "./search-filter-panel";
 

--- a/packages/ui/src/components/custom/search-filter-panel.stories.tsx
+++ b/packages/ui/src/components/custom/search-filter-panel.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { fn } from "storybook/test";
 import { FilterSelect, SearchFilterPanel, SortSelect } from "./search-filter-panel";
 
 const meta: Meta<typeof SearchFilterPanel> = {

--- a/packages/ui/src/components/custom/tag-list.stories.tsx
+++ b/packages/ui/src/components/custom/tag-list.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { fn } from "storybook/test";
 import { TagList } from "./tag-list";
 
 const meta: Meta<typeof TagList> = {

--- a/packages/ui/src/components/custom/three-layer-tag-display.stories.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { fn } from "storybook/test";
 import { VideoTagDisplay } from "./three-layer-tag-display";
 
 const meta: Meta<typeof VideoTagDisplay> = {

--- a/packages/ui/src/components/custom/virtualized-audio-button-list.stories.tsx
+++ b/packages/ui/src/components/custom/virtualized-audio-button-list.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
 import type { FrontendAudioButtonData } from "@suzumina.click/shared-types";
+import { fn } from "storybook/test";
 import { VirtualizedAudioButtonList } from "./virtualized-audio-button-list";
 
 const meta: Meta<typeof VirtualizedAudioButtonList> = {

--- a/packages/ui/src/components/custom/youtube-player.stories.tsx
+++ b/packages/ui/src/components/custom/youtube-player.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { fn } from "storybook/test";
 import { YouTubePlayer } from "./youtube-player";
 
 const meta = {

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,4 +1,19 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+// Mock Next.js navigation
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		refresh: vi.fn(),
+		back: vi.fn(),
+		forward: vi.fn(),
+		prefetch: vi.fn(),
+	}),
+	useSearchParams: () => new URLSearchParams(),
+	usePathname: () => "/",
+}));
 
 // Mock for ResizeObserver
 global.ResizeObserver = class ResizeObserver {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 6.0.1
       typescript:
         specifier: ^5.8.3
-        version: 5.8.3
+        version: 5.9.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
@@ -65,7 +65,7 @@ importers:
         version: 4.20.3
       typescript:
         specifier: ^5.8.3
-        version: 5.8.3
+        version: 5.9.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
@@ -80,7 +80,7 @@ importers:
         version: 7.11.3
       '@hookform/resolvers':
         specifier: ^5.1.1
-        version: 5.2.1(react-hook-form@7.61.1(react@19.1.1))
+        version: 5.2.1(react-hook-form@7.62.0(react@19.1.1))
       '@suzumina.click/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
@@ -98,10 +98,10 @@ importers:
         version: 0.525.0(react@19.1.1)
       next:
         specifier: ^15.4.3
-        version: 15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       next-auth:
         specifier: ^5.0.0-beta.29
-        version: 5.0.0-beta.29(next@15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+        version: 5.0.0-beta.29(next@15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
       react:
         specifier: ^19.1.0
         version: 19.1.1
@@ -110,7 +110,7 @@ importers:
         version: 19.1.1(react@19.1.1)
       react-hook-form:
         specifier: ^7.60.0
-        version: 7.61.1(react@19.1.1)
+        version: 7.62.0(react@19.1.1)
       react-window:
         specifier: ^1.8.11
         version: 1.8.11(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -135,7 +135,7 @@ importers:
         version: 15.4.5
       '@playwright/test':
         specifier: ^1.53.2
-        version: 1.54.1
+        version: 1.54.2
       '@suzumina.click/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -147,10 +147,10 @@ importers:
         version: 6.6.4
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@10.4.0)
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.0.12
         version: 24.1.0
@@ -174,7 +174,7 @@ importers:
         version: 18.0.1
       playwright:
         specifier: ^1.53.2
-        version: 1.54.1
+        version: 1.54.2
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -183,7 +183,7 @@ importers:
         version: 4.1.11
       typescript:
         specifier: ^5.8.3
-        version: 5.8.3
+        version: 5.9.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
@@ -205,10 +205,10 @@ importers:
         version: 6.0.1
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)
+        version: 8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.2)
       typescript:
         specifier: ^5.8.3
-        version: 5.8.3
+        version: 5.9.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
@@ -219,7 +219,7 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: ^5.1.1
-        version: 5.2.1(react-hook-form@7.61.1(react@19.1.1))
+        version: 5.2.1(react-hook-form@7.62.0(react@19.1.1))
       '@radix-ui/react-accordion':
         specifier: 1.2.11
         version: 1.2.11(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -339,7 +339,7 @@ importers:
         version: 19.1.1(react@19.1.1)
       react-hook-form:
         specifier: ^7.60.0
-        version: 7.61.1(react@19.1.1)
+        version: 7.62.0(react@19.1.1)
       react-resizable-panels:
         specifier: ^3.0.3
         version: 3.0.4(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -366,26 +366,23 @@ importers:
         version: 4.0.14
     devDependencies:
       '@chromatic-com/storybook':
-        specifier: ^4.0.1
-        version: 4.0.1(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        specifier: ^4.1.0
+        version: 4.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       '@storybook/addon-a11y':
-        specifier: ^9.0.17
-        version: 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        specifier: ^9.1.0
+        version: 9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       '@storybook/addon-docs':
-        specifier: ^9.0.17
-        version: 9.0.18(@types/react@19.1.9)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        specifier: ^9.1.0
+        version: 9.1.0(@types/react@19.1.9)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       '@storybook/addon-onboarding':
-        specifier: ^9.0.17
-        version: 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        specifier: ^9.1.0
+        version: 9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       '@storybook/addon-vitest':
-        specifier: ^9.0.17
-        version: 9.0.18(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
+        specifier: ^9.1.0
+        version: 9.1.0(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(vitest@3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       '@storybook/react-vite':
-        specifier: ^9.0.17
-        version: 9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
-      '@storybook/test':
-        specifier: 9.0.0-alpha.2
-        version: 9.0.0-alpha.2(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+        specifier: ^9.1.0
+        version: 9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(typescript@5.9.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       '@suzumina.click/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -397,10 +394,10 @@ importers:
         version: 6.6.4
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@testing-library/user-event':
         specifier: ^14.6.1
-        version: 14.6.1(@testing-library/dom@10.4.0)
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.0.12
         version: 24.1.0
@@ -420,14 +417,14 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
       storybook:
-        specifier: ^9.0.17
-        version: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+        specifier: ^9.1.0
+        version: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
       typescript:
         specifier: ^5.8.3
-        version: 5.8.3
+        version: 5.9.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
@@ -603,14 +600,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@chromatic-com/storybook@4.0.1':
-    resolution: {integrity: sha512-GQXe5lyZl3yLewLJQyFXEpOp2h+mfN2bPrzYaOFNCJjO4Js9deKbRHTOSaiP2FRwZqDLdQwy2+SEGeXPZ94yYw==}
+  '@chromatic-com/storybook@4.1.0':
+    resolution: {integrity: sha512-B9XesFX5lQUdP81/QBTtkiYOFqEsJwQpzkZlcYPm2n/L1S/8ZabSPbz6NoY8hOJTXWZ2p7grygUlxyGy+gAvfQ==}
     engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
     peerDependencies:
-      storybook: ^0.0.0-0 || ^9.0.0 || ^9.1.0-0
+      storybook: ^0.0.0-0 || ^9.0.0 || ^9.1.0-0 || ^9.2.0-0
 
-  '@date-fns/tz@1.2.0':
-    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+  '@date-fns/tz@1.3.1':
+    resolution: {integrity: sha512-LnBOyuj+piItX/D5BWBSckBsuZyOt7Jg2obGNiObq7qjl1A2/8F+i4RS8/MmkSdnw6hOe6afrJLCWrUWZw5Mlw==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -1054,8 +1051,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.54.1':
-    resolution: {integrity: sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==}
+  '@playwright/test@1.54.2':
+    resolution: {integrity: sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1829,27 +1826,27 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@storybook/addon-a11y@9.0.18':
-    resolution: {integrity: sha512-msbsTI9TmePQ5ElVclLi7ns5WaAntouJFaj9ElNugFWME21k68RiyXnioDjDfEoi/+y8tthQNNqjsHoX/Ev0Og==}
+  '@storybook/addon-a11y@9.1.0':
+    resolution: {integrity: sha512-NCb5pJGL3b6/89L45MIL4yeqdGnvw6PlF4obFu2o8otz9TiVPf+Tl85uHDURY6bj9b+iTnCuu48u45E9SHuZfw==}
     peerDependencies:
-      storybook: ^9.0.18
+      storybook: ^9.1.0
 
-  '@storybook/addon-docs@9.0.18':
-    resolution: {integrity: sha512-1mLhaRDx8s1JAF51o56OmwMnIsg4BOQJ8cn+4wbMjh14pDFALrovlFl/BpAXnV1VaZqHjCB4ZWuP+y5CwXEpeQ==}
+  '@storybook/addon-docs@9.1.0':
+    resolution: {integrity: sha512-8pZ3/erLhvSn1dt4LSel3s3Gj76Lt6/siO9CoAYnPv0WW5KMbPhRoISkBLTAuy6OFMg4jyML+hE7y5qXEN1bSw==}
     peerDependencies:
-      storybook: ^9.0.18
+      storybook: ^9.1.0
 
-  '@storybook/addon-onboarding@9.0.18':
-    resolution: {integrity: sha512-A079BfJ3g3wYOtAuq9cPf2l6JHo+6UzEw1A2AbSNBBNP4hKfXpHcLadIVwuyOxuKjDUWzY5f4dJa3hCMurHXGQ==}
+  '@storybook/addon-onboarding@9.1.0':
+    resolution: {integrity: sha512-6TUcVTR8CFp4lqTm/79wa+rI5BUsw6XcX/xcxK/Ufo7AD1DPHx2xMEz3pp6KNNdzSajjBSU9Y/HqupginbjnfA==}
     peerDependencies:
-      storybook: ^9.0.18
+      storybook: ^9.1.0
 
-  '@storybook/addon-vitest@9.0.18':
-    resolution: {integrity: sha512-uPLh9H7kRho+raxyIBCm8Ymd3j0VPuWIQ1HSAkdx8itmNafNqs4HE67Z8Cfl259YzdWU/j5BhZqoiT62BCbIDw==}
+  '@storybook/addon-vitest@9.1.0':
+    resolution: {integrity: sha512-Z3UV5cYA1RMKFCW/XJCBIqiKc1eYwhEZwAtdw7B7dL7Ipa1I5S1VQZOdlTozE9NBhxkHy6aInyZwtNZRkhNV/w==}
     peerDependencies:
       '@vitest/browser': ^3.0.0
       '@vitest/runner': ^3.0.0
-      storybook: ^9.0.18
+      storybook: ^9.1.0
       vitest: ^3.0.0
     peerDependenciesMeta:
       '@vitest/browser':
@@ -1859,16 +1856,16 @@ packages:
       vitest:
         optional: true
 
-  '@storybook/builder-vite@9.0.18':
-    resolution: {integrity: sha512-lfbrozA6UPVizDrgbPEe04WMtxIraESwUkmwW3+Lxh8rKEUj5cXngcrJUW+meQNNaggdZZWEqeEtweuaLIR+Hg==}
+  '@storybook/builder-vite@9.1.0':
+    resolution: {integrity: sha512-qLQ9Kn8UxZk5bFdUVfka3BAk//i3nJH+EUq8h3VeSyOHDfoDAHxOe2usbMz3hEWZLJebAVY0TFO/P+fznBIA0g==}
     peerDependencies:
-      storybook: ^9.0.18
+      storybook: ^9.1.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/csf-plugin@9.0.18':
-    resolution: {integrity: sha512-MQ3WwXnMua5sX0uYyuO7dC5WOWuJCLqf8CsOn3zQ2ptNoH6hD7DFx5ZOa1uD6VxIuJ3LkA+YqfSRBncomJoRnA==}
+  '@storybook/csf-plugin@9.1.0':
+    resolution: {integrity: sha512-1lgYCfIE/j8Ae50QT6g7+wKe9CDi6ZYoSE3aukzdAdLoKAa6KqhMnsc5jdmGNqWbkpyOMVlmg+yT+CRJPaczeQ==}
     peerDependencies:
-      storybook: ^9.0.18
+      storybook: ^9.1.0
 
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
@@ -1880,38 +1877,33 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/react-dom-shim@9.0.18':
-    resolution: {integrity: sha512-qGR/d9x9qWRRxITaBVQkMnb73kwOm+N8fkbZRxc7U4lxupXRvkMIDh247nn71SYVBnvbh6//AL7P6ghiPWZYjA==}
+  '@storybook/react-dom-shim@9.1.0':
+    resolution: {integrity: sha512-/rxGDIpAwGWvUixsq2a70WuErJ75uxv1KTPAZNokAKR1P1GXSnD2O+ZWoUq1Xw6Fp/8y7ExMulFWgrCpQqfSag==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.0.18
+      storybook: ^9.1.0
 
-  '@storybook/react-vite@9.0.18':
-    resolution: {integrity: sha512-dHzUoeY0/S35TvSYxCkPuBlNQZx4Zj9QDhAZ0qdv+nSll++uPgqSe2y2vF+2p+XVYhjDn+YX5LORv00YtuQezg==}
+  '@storybook/react-vite@9.1.0':
+    resolution: {integrity: sha512-GhRnkW1KE2QZZOMkKZ52JcOmlaEvAAEazfPILwnYvSBsenpAwnnlAG/yY7bqUVUD9OLaEFqxCcMuDb9auaXSkw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.0.18
+      storybook: ^9.1.0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/react@9.0.18':
-    resolution: {integrity: sha512-CCH6Vj/O6I07PrhCHxc1pvCWYMfZhRzK7CVHAtrBP9xxnYA7OoXhM2wymuDogml5HW1BKtyVMeQ3oWZXFNgDXQ==}
+  '@storybook/react@9.1.0':
+    resolution: {integrity: sha512-4rMWxFSrp+/ypqZZps30h+op5urzZ4zhxzTyVtwK3xmUdg1SDxZ6hAGCFTur9Yav5MWfQDd9IkoBQ6nZS1So4A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^9.0.18
+      storybook: ^9.1.0
       typescript: '>= 4.9.x'
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@storybook/test@9.0.0-alpha.2':
-    resolution: {integrity: sha512-K2NPgyY8FoyRurijB6LKZmRUwb7fSZ2GbA8Hg1l18x2fSno467eRCm2IH/mmj5UpHTOQoaMIUXjRTY3XyNPdCQ==}
-    peerDependencies:
-      storybook: ^9.0.0-alpha.2
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2004,13 +1996,9 @@ packages:
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
 
-  '@testing-library/dom@10.4.0':
-    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
-
-  '@testing-library/jest-dom@6.5.0':
-    resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
-    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
   '@testing-library/jest-dom@6.6.4':
     resolution: {integrity: sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ==}
@@ -2030,12 +2018,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  '@testing-library/user-event@14.5.2':
-    resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
-    engines: {node: '>=12', npm: '>=6'}
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
 
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
@@ -2059,8 +2041,8 @@ packages:
   '@types/babel__template@7.4.4':
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
 
-  '@types/babel__traverse@7.20.7':
-    resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -2187,9 +2169,6 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@2.0.5':
-    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
-
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -2204,9 +2183,6 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.0.5':
-    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
-
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
@@ -2216,14 +2192,8 @@ packages:
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/spy@2.0.5':
-    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
-
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
-
-  '@vitest/utils@2.0.5':
-    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -2389,14 +2359,6 @@ packages:
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
-
-  chalk@3.0.0:
-    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
-    engines: {node: '>=8'}
-
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
 
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
@@ -2694,8 +2656,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.193:
-    resolution: {integrity: sha512-eePuBZXM9OVCwfYUhd2OzESeNGnWmLyeu0XAEjf7xjijNjHFdeJSzuRUGN4ueT2tEYo5YqjHramKEFxz67p3XA==}
+  electron-to-chromium@1.5.194:
+    resolution: {integrity: sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==}
 
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
@@ -3546,8 +3508,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  oauth4webapi@3.6.0:
-    resolution: {integrity: sha512-OwXPTXjKPOldTpAa19oksrX9TYHA0rt+VcUFTkJ7QKwgmevPpNm9Cn5vFZUtIo96FiU6AfPuUUGzoXqgOzibWg==}
+  oauth4webapi@3.6.1:
+    resolution: {integrity: sha512-b39+drVyA4aNUptFOhkkmGWnG/BE7dT29SW/8PVYElqp7j/DBqzm5SS1G+MUD07XlTcBOAG+6Cb/35Cx2kHIuQ==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3653,13 +3615,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.54.1:
-    resolution: {integrity: sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==}
+  playwright-core@1.54.2:
+    resolution: {integrity: sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.54.1:
-    resolution: {integrity: sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==}
+  playwright@1.54.2:
+    resolution: {integrity: sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3773,8 +3735,8 @@ packages:
     peerDependencies:
       react: ^19.1.1
 
-  react-hook-form@7.61.1:
-    resolution: {integrity: sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==}
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -4052,8 +4014,8 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
-  storybook@9.0.18:
-    resolution: {integrity: sha512-ruxpEpizwoYQTt1hBOrWyp9trPYWD9Apt1TJ37rs1rzmNQWpSNGJDMg91JV4mUhBChzRvnid/oRBFFCWJz/dfw==}
+  storybook@9.1.0:
+    resolution: {integrity: sha512-EXEmwMCcqwn0KOuc8brTZmFj4eEVImWgGFra6k3Nj8qrlnBXK551tmAjO5ihmL9gxRvv6FGdglnQKoyeYo/NRA==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -4181,16 +4143,8 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.3:
@@ -4264,8 +4218,8 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4565,7 +4519,7 @@ snapshots:
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.0.12
-      oauth4webapi: 3.6.0
+      oauth4webapi: 3.6.1
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
 
@@ -4720,19 +4674,19 @@ snapshots:
   '@biomejs/cli-win32-x64@2.1.1':
     optional: true
 
-  '@chromatic-com/storybook@4.0.1(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@chromatic-com/storybook@4.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 12.2.0
       filesize: 10.1.6
       jsonfile: 6.1.0
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       strip-ansi: 7.1.0
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
-  '@date-fns/tz@1.2.0': {}
+  '@date-fns/tz@1.3.1': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -4872,10 +4826,10 @@ snapshots:
       protobufjs: 7.5.3
       yargs: 17.7.2
 
-  '@hookform/resolvers@5.2.1(react-hook-form@7.61.1(react@19.1.1))':
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.1))':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.61.1(react@19.1.1)
+      react-hook-form: 7.62.0(react@19.1.1)
 
   '@img/sharp-darwin-arm64@0.34.3':
     optionalDependencies:
@@ -4984,14 +4938,14 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
-      react-docgen-typescript: 2.4.0(typescript@5.8.3)
+      react-docgen-typescript: 2.4.0(typescript@5.9.2)
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -5057,9 +5011,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.54.1':
+  '@playwright/test@1.54.2':
     dependencies:
-      playwright: 1.54.1
+      playwright: 1.54.2
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -5824,35 +5778,35 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/addon-a11y@9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
 
-  '@storybook/addon-docs@9.0.18(@types/react@19.1.9)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/addon-docs@9.1.0(@types/react@19.1.9)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.1.9)(react@19.1.1)
-      '@storybook/csf-plugin': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      '@storybook/csf-plugin': 9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@storybook/react-dom-shim': 9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      '@storybook/react-dom-shim': 9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-onboarding@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/addon-onboarding@9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))':
     dependencies:
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
 
-  '@storybook/addon-vitest@9.0.18(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
+  '@storybook/addon-vitest@9.1.0(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(vitest@3.2.4(@types/node@24.1.0)(happy-dom@18.0.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       prompts: 2.4.2
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       ts-dedent: 2.2.0
     optionalDependencies:
       '@vitest/runner': 3.2.4
@@ -5861,16 +5815,16 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
+  '@storybook/builder-vite@9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
     dependencies:
-      '@storybook/csf-plugin': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      '@storybook/csf-plugin': 9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       ts-dedent: 2.2.0
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
 
-  '@storybook/csf-plugin@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/csf-plugin@9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))':
     dependencies:
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -5880,25 +5834,25 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/react-dom-shim@9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
+  '@storybook/react-dom-shim@9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))':
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
 
-  '@storybook/react-vite@9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
+  '@storybook/react-vite@9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.46.2)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(typescript@5.9.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       '@rollup/pluginutils': 5.2.0(rollup@4.46.2)
-      '@storybook/builder-vite': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
-      '@storybook/react': 9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
+      '@storybook/builder-vite': 9.1.0(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
+      '@storybook/react': 9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(typescript@5.9.2)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 19.1.1
       react-docgen: 8.0.0
       react-dom: 19.1.1(react@19.1.1)
       resolve: 1.22.10
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       tsconfig-paths: 4.2.0
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
     transitivePeerDependencies:
@@ -5906,25 +5860,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)':
+  '@storybook/react@9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))(typescript@5.9.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.0.18(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
+      '@storybook/react-dom-shim': 9.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      storybook: 9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
     optionalDependencies:
-      typescript: 5.8.3
-
-  '@storybook/test@9.0.0-alpha.2(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@testing-library/dom': 10.4.0
-      '@testing-library/jest-dom': 6.5.0
-      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/expect': 2.0.5
-      '@vitest/spy': 2.0.5
-      storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
+      typescript: 5.9.2
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -6002,26 +5946,16 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.11
 
-  '@testing-library/dom@10.4.0':
+  '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/runtime': 7.28.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
-      chalk: 4.1.2
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
+      picocolors: 1.1.1
       pretty-format: 27.5.1
-
-  '@testing-library/jest-dom@6.5.0':
-    dependencies:
-      '@adobe/css-tools': 4.4.3
-      aria-query: 5.3.2
-      chalk: 3.0.0
-      css.escape: 1.5.1
-      dom-accessibility-api: 0.6.3
-      lodash: 4.17.21
-      redent: 3.0.0
 
   '@testing-library/jest-dom@6.6.4':
     dependencies:
@@ -6033,23 +5967,19 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.2
-      '@testing-library/dom': 10.4.0
+      '@testing-library/dom': 10.4.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
       '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
-  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
-      '@testing-library/dom': 10.4.0
-
-  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
-    dependencies:
-      '@testing-library/dom': 10.4.0
+      '@testing-library/dom': 10.4.1
 
   '@tootallnate/once@2.0.0': {}
 
@@ -6061,7 +5991,7 @@ snapshots:
       '@babel/types': 7.28.2
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.20.7
+      '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
@@ -6072,7 +6002,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/types': 7.28.2
 
-  '@types/babel__traverse@7.20.7':
+  '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.28.2
 
@@ -6224,13 +6154,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.0.5':
-    dependencies:
-      '@vitest/spy': 2.0.5
-      '@vitest/utils': 2.0.5
-      chai: 5.2.1
-      tinyrainbow: 1.2.0
-
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.2
@@ -6246,10 +6169,6 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)
-
-  '@vitest/pretty-format@2.0.5':
-    dependencies:
-      tinyrainbow: 1.2.0
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6267,20 +6186,9 @@ snapshots:
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@2.0.5':
-    dependencies:
-      tinyspy: 3.0.2
-
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
-
-  '@vitest/utils@2.0.5':
-    dependencies:
-      '@vitest/pretty-format': 2.0.5
-      estree-walker: 3.0.3
-      loupe: 3.2.0
-      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -6408,7 +6316,7 @@ snapshots:
   browserslist@4.25.1:
     dependencies:
       caniuse-lite: 1.0.30001731
-      electron-to-chromium: 1.5.193
+      electron-to-chromium: 1.5.194
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
@@ -6449,16 +6357,6 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.0
       pathval: 2.0.1
-
-  chalk@3.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
 
   check-error@2.1.1: {}
 
@@ -6735,7 +6633,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.193: {}
+  electron-to-chromium@1.5.194: {}
 
   embla-carousel-react@8.6.0(react@19.1.1):
     dependencies:
@@ -7561,10 +7459,10 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next-auth@5.0.0-beta.29(next@15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
+  next-auth@5.0.0-beta.29(next@15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1):
     dependencies:
       '@auth/core': 0.40.0
-      next: 15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      next: 15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       react: 19.1.1
 
   next-themes@0.4.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
@@ -7572,7 +7470,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  next@15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+  next@15.4.5(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.2)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.4.5
       '@swc/helpers': 0.5.15
@@ -7591,7 +7489,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.4.5
       '@next/swc-win32-x64-msvc': 15.4.5
       '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.54.1
+      '@playwright/test': 1.54.2
       babel-plugin-react-compiler: 19.1.0-rc.2
       sharp: 0.34.3
     transitivePeerDependencies:
@@ -7622,7 +7520,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  oauth4webapi@3.6.0: {}
+  oauth4webapi@3.6.1: {}
 
   object-assign@4.1.1: {}
 
@@ -7718,11 +7616,11 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  playwright-core@1.54.1: {}
+  playwright-core@1.54.2: {}
 
-  playwright@1.54.1:
+  playwright@1.54.2:
     dependencies:
-      playwright-core: 1.54.1
+      playwright-core: 1.54.2
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -7820,14 +7718,14 @@ snapshots:
 
   react-day-picker@9.8.1(react@19.1.1):
     dependencies:
-      '@date-fns/tz': 1.2.0
+      '@date-fns/tz': 1.3.1
       date-fns: 4.1.0
       date-fns-jalali: 4.1.0-0
       react: 19.1.1
 
-  react-docgen-typescript@2.4.0(typescript@5.8.3):
+  react-docgen-typescript@2.4.0(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   react-docgen@8.0.0:
     dependencies:
@@ -7835,7 +7733,7 @@ snapshots:
       '@babel/traverse': 7.28.0
       '@babel/types': 7.28.2
       '@types/babel__core': 7.20.5
-      '@types/babel__traverse': 7.20.7
+      '@types/babel__traverse': 7.28.0
       '@types/doctrine': 0.0.9
       '@types/resolve': 1.20.6
       doctrine: 3.0.0
@@ -7849,7 +7747,7 @@ snapshots:
       react: 19.1.1
       scheduler: 0.26.0
 
-  react-hook-form@7.61.1(react@19.1.1):
+  react-hook-form@7.62.0(react@19.1.1):
     dependencies:
       react: 19.1.1
 
@@ -8208,12 +8106,13 @@ snapshots:
 
   std-env@3.9.0: {}
 
-  storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2):
+  storybook@9.1.0(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.4
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.8
@@ -8226,8 +8125,10 @@ snapshots:
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
+      - msw
       - supports-color
       - utf-8-validate
+      - vite
 
   stream-events@1.0.5:
     dependencies:
@@ -8357,11 +8258,7 @@ snapshots:
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@1.2.0: {}
-
   tinyrainbow@2.0.0: {}
-
-  tinyspy@3.0.2: {}
 
   tinyspy@4.0.3: {}
 
@@ -8389,7 +8286,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3):
+  tsup@8.5.0(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.8)
       cac: 6.7.14
@@ -8410,7 +8307,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -8433,7 +8330,7 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript@5.8.3: {}
+  typescript@5.9.2: {}
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
## 概要
汎用的なリストコンポーネント（GenericList）を実装し、同時にStorybookを9.1.0にアップデートしました。

## 主な変更内容

### 1. 🆕 GenericListコンポーネントの実装
- **統合機能**: フィルタリング、ソート、ページネーション、検索機能を一つのコンポーネントに統合
- **URL同期**: リスト状態をURLパラメータで管理し、ブラウザの戻る/進む、共有URLに対応
- **柔軟なカスタマイズ**: 
  - `renderItem`: アイテムの表示方法をカスタマイズ
  - `renderContainer`: コンテナレイアウトをカスタマイズ（グリッド以外のレイアウトにも対応）
  - `renderEmptyState`: 空状態の表示をカスタマイズ
  - `renderLoadingSkeleton`: ローディング表示をカスタマイズ

### 2. 🪝 関連フックの実装
- **useListState**: Reducerパターンによるリスト状態管理
- **useUrlParams**: URLパラメータとの双方向同期

### 3. ⬆️ Storybook 9.1.0へのアップデート
- 全Storybookパッケージを9.0.17から9.1.0へ更新
- 統合インポート（consolidated imports）への対応
- `@storybook/addon-actions` → `storybook/test` への移行

### 4. 🎭 Next.js navigationモックの追加
- Storybook環境でNext.jsのnavigation hooksが使用可能に
- `useRouter`, `useSearchParams`等の完全なモック実装

## 技術的な詳細

### 解決した問題
1. **無限ループの解消**: initialStateの依存配列を最適化し、再レンダリングループを防止
2. **Radix UI Selectの制約対応**: 空文字列の代わりに"all"値を使用
3. **Storybook環境での動作**: Next.js依存を適切にモック化

### 型安全性
- TypeScriptジェネリクスによる完全な型サポート
- フィルター値は`any`型を使用（多様なフィルタータイプに対応するため）

## Storybookドキュメント
包括的なドキュメントとサンプルストーリーを追加：
- Default: 基本的な使用例
- WithMultipleFilters: 複数フィルタータイプの例
- LoadingState/EmptyState/ErrorState: 各種状態の表示例
- CustomGridLayout: レイアウトカスタマイズ例
- Interactive: インタラクティブな使用例

## 今後の拡張予定
- [ ] 追加のフィルタータイプ実装（multiselect, dateRange, range等）
- [ ] 既存リスト（WorkList, VideoList等）の移行
- [ ] コンポーネントのユニットテスト追加

## テスト手順
1. `pnpm --filter @suzumina.click/ui storybook`でStorybookを起動
2. Custom/List/GenericListでコンポーネントの動作を確認
3. 各ストーリーでフィルタリング、ソート、ページネーションが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)