### PR TITLE
feat: 作品詳細ページに説明文表示機能を追加

### DIFF
--- a/apps/web/src/app/works/[workId]/components/WorkDescription.tsx
+++ b/apps/web/src/app/works/[workId]/components/WorkDescription.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@suzumina.click/ui/components/ui/card";
+import { ChevronDown, ChevronUp, FileText } from "lucide-react";
+import { useState } from "react";
+import { formatWorkDescription, generateDescriptionSummary } from "@/utils/format-description";
+
+interface WorkDescriptionProps {
+	description: string;
+	title: string;
+}
+
+export default function WorkDescription({ description, title }: WorkDescriptionProps) {
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	if (!description) {
+		return null;
+	}
+
+	// 説明文が長い場合は折りたたみ表示
+	const shouldTruncate = description.length > 300;
+	const summary = generateDescriptionSummary(description, 300);
+	const formattedDescription = formatWorkDescription(description);
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2">
+					<FileText className="h-5 w-5" />
+					作品説明
+				</CardTitle>
+				<CardDescription>「{title}」の詳細説明</CardDescription>
+			</CardHeader>
+			<CardContent>
+				{shouldTruncate && !isExpanded ? (
+					<div>
+						<p className="text-gray-700 leading-relaxed mb-4">{summary}</p>
+						<button
+							type="button"
+							onClick={() => setIsExpanded(true)}
+							className="text-primary hover:underline flex items-center gap-1 text-sm font-medium"
+						>
+							続きを読む
+							<ChevronDown className="h-4 w-4" />
+						</button>
+					</div>
+				) : (
+					<div>
+						<div
+							dangerouslySetInnerHTML={{ __html: formattedDescription }}
+							className="prose prose-sm max-w-none"
+						/>
+						{shouldTruncate && (
+							<button
+								type="button"
+								onClick={() => setIsExpanded(false)}
+								className="text-primary hover:underline flex items-center gap-1 text-sm font-medium mt-4"
+							>
+								折りたたむ
+								<ChevronUp className="h-4 w-4" />
+							</button>
+						)}
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
+++ b/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
@@ -39,6 +39,7 @@ import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { formatJSTDateTime } from "@/utils/date-format";
 import { generateMockCharacteristicData } from "@/utils/mock-evaluation-data";
 import SampleImageGallery from "./SampleImageGallery";
+import WorkDescription from "./WorkDescription";
 import { WorkEvaluation } from "./work-evaluation";
 
 interface WorkDetailProps {
@@ -344,6 +345,9 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 
 						{/* 詳細情報タブ（基本情報・制作陣） */}
 						<TabsContent value="overview" className="space-y-6">
+							{/* 作品説明 */}
+							<WorkDescription description={work.description} title={work.title} />
+
 							{/* 作品基本情報 */}
 							<Card>
 								<CardHeader>

--- a/apps/web/src/utils/__tests__/format-description.test.ts
+++ b/apps/web/src/utils/__tests__/format-description.test.ts
@@ -1,0 +1,87 @@
+import { formatWorkDescription, generateDescriptionSummary } from "../format-description";
+
+describe("formatWorkDescription", () => {
+	it("空の文字列を処理できる", () => {
+		expect(formatWorkDescription("")).toBe("");
+	});
+
+	it("HTMLをエスケープする", () => {
+		const input = "<script>alert('XSS')</script>";
+		const result = formatWorkDescription(input);
+		expect(result).toContain("&lt;script&gt;");
+		expect(result).not.toContain("<script>");
+	});
+
+	it("改行を段落に変換する", () => {
+		const input = "段落1\n\n段落2\n\n段落3";
+		const result = formatWorkDescription(input);
+		expect(result).toContain('<p class="mb-4 last:mb-0 text-gray-700 leading-relaxed">段落1</p>');
+		expect(result).toContain('<p class="mb-4 last:mb-0 text-gray-700 leading-relaxed">段落2</p>');
+		expect(result).toContain('<p class="mb-4 last:mb-0 text-gray-700 leading-relaxed">段落3</p>');
+	});
+
+	it("単一改行を<br>に変換する", () => {
+		const input = "行1\n行2\n行3";
+		const result = formatWorkDescription(input);
+		expect(result).toContain("行1<br>行2<br>行3");
+	});
+
+	it("URLをリンクに変換する", () => {
+		const input = "詳細はこちら: https://example.com をご覧ください。";
+		const result = formatWorkDescription(input);
+		expect(result).toContain('<a href="https://example.com"');
+		expect(result).toContain('target="_blank"');
+		expect(result).toContain('rel="noopener noreferrer"');
+		expect(result).toContain('class="text-primary hover:underline"');
+	});
+
+	it("URLの末尾の句読点を除去する", () => {
+		const input = "サイト: https://example.com.";
+		const result = formatWorkDescription(input);
+		expect(result).toContain('<a href="https://example.com"');
+		expect(result).not.toContain('<a href="https://example.com."');
+	});
+
+	it("複数の段落とURLを正しく処理する", () => {
+		const input = `作品の説明です。
+
+詳細情報は以下のURLをご覧ください:
+https://example.com/info
+
+お問い合わせは support@example.com まで。`;
+		const result = formatWorkDescription(input);
+		expect(result).toContain('<p class="mb-4 last:mb-0 text-gray-700 leading-relaxed">');
+		expect(result).toContain('<a href="https://example.com/info"');
+		expect(result).toMatch(/<p[^>]*>.*<\/p>.*<p[^>]*>.*<\/p>/s);
+	});
+});
+
+describe("generateDescriptionSummary", () => {
+	it("空の文字列を処理できる", () => {
+		expect(generateDescriptionSummary("")).toBe("");
+	});
+
+	it("短いテキストはそのまま返す", () => {
+		const input = "短い説明文です。";
+		expect(generateDescriptionSummary(input, 20)).toBe(input);
+	});
+
+	it("長いテキストを指定文字数で切り詰める", () => {
+		const input = "これは非常に長い説明文で、指定された文字数を超えています。";
+		const result = generateDescriptionSummary(input, 10);
+		expect(result).toBe("これは非常に長い説明...");
+		expect(result.length).toBe(13); // 10文字 + "..."
+	});
+
+	it("改行をスペースに変換する", () => {
+		const input = "行1\n行2\n\n行3";
+		const result = generateDescriptionSummary(input);
+		expect(result).toBe("行1 行2 行3");
+	});
+
+	it("デフォルトの文字数制限が150文字である", () => {
+		const input = "あ".repeat(200);
+		const result = generateDescriptionSummary(input);
+		expect(result).toBe(`${"あ".repeat(150)}...`);
+	});
+});

--- a/apps/web/src/utils/format-description.ts
+++ b/apps/web/src/utils/format-description.ts
@@ -1,0 +1,70 @@
+/**
+ * 作品の説明文をHTMLに整形する
+ * - 改行を段落に変換
+ * - URLをリンクに変換
+ * - 基本的なHTMLエスケープ
+ */
+export function formatWorkDescription(description: string): string {
+	if (!description) return "";
+
+	// HTMLエスケープ（基本的なもののみ）
+	const escapeHtml = (text: string): string => {
+		return text
+			.replace(/&/g, "&amp;")
+			.replace(/</g, "&lt;")
+			.replace(/>/g, "&gt;")
+			.replace(/"/g, "&quot;")
+			.replace(/'/g, "&#039;");
+	};
+
+	// URLパターンを検出してリンクに変換
+	const linkifyUrls = (text: string): string => {
+		const urlPattern = /(https?:\/\/[^\s]+)/g;
+		return text.replace(urlPattern, (url) => {
+			const cleanUrl = url.replace(/[.,;:!?]$/, ""); // 末尾の句読点を除去
+			return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">${cleanUrl}</a>`;
+		});
+	};
+
+	// 連続する改行で段落を分割
+	const paragraphs = description
+		.split(/\n{2,}/)
+		.map((para) => para.trim())
+		.filter((para) => para.length > 0);
+
+	// 各段落を処理
+	const formattedParagraphs = paragraphs.map((paragraph) => {
+		// HTMLエスケープ
+		let formatted = escapeHtml(paragraph);
+
+		// 単一改行は<br>に変換
+		formatted = formatted.replace(/\n/g, "<br>");
+
+		// URLをリンクに変換
+		formatted = linkifyUrls(formatted);
+
+		return `<p class="mb-4 last:mb-0 text-gray-700 leading-relaxed">${formatted}</p>`;
+	});
+
+	return formattedParagraphs.join("");
+}
+
+/**
+ * 説明文の概要を生成（プレーンテキスト）
+ * @param description 元の説明文
+ * @param maxLength 最大文字数
+ * @returns 概要テキスト
+ */
+export function generateDescriptionSummary(description: string, maxLength = 150): string {
+	if (!description) return "";
+
+	// 改行をスペースに変換して整形
+	const plainText = description.replace(/\n+/g, " ").trim();
+
+	if (plainText.length <= maxLength) {
+		return plainText;
+	}
+
+	// 指定文字数で切り詰めて省略記号を追加
+	return `${plainText.substring(0, maxLength)}...`;
+}


### PR DESCRIPTION
## 概要
作品詳細ページに説明文を整形して表示する機能を追加しました。

## 変更内容
- 🎨 作品説明文をHTML形式で整形・表示する`WorkDescription`コンポーネントを実装
- 🔗 URLの自動リンク化機能
- 📝 改行を段落に変換する機能
- 🔒 XSS対策のためのHTMLエスケープ処理
- 📏 長い説明文（300文字以上）の折りたたみ/展開機能
- 🧪 `formatWorkDescription`ユーティリティ関数とテストを追加

## 技術的詳細
- `formatWorkDescription`: 説明文をHTMLに整形
  - HTMLエスケープ処理
  - 連続改行で段落分割
  - 単一改行を`<br>`タグに変換
  - URLを自動的にリンクに変換
- `generateDescriptionSummary`: プレーンテキストの概要生成
- `WorkDescription`コンポーネント: 折りたたみ可能な説明文表示

## 注意事項
現在、`work.description`フィールドの値が正確に取得できていない問題があるため、実際の表示は期待通りではない可能性があります。
将来的にデータが正確になった際に活用される実装として残しています。

## テスト
- ✅ 全テスト合格
- ✅ TypeScript型チェック通過
- ✅ Biomeリンティング通過

🤖 Generated with [Claude Code](https://claude.ai/code)