### PR TITLE
fix: GitHub Actions PR Checkワークフローのbash構文エラーを修正

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -89,10 +89,10 @@ jobs:
           declare -a build_pids
           
           # shared-typesのビルド
-          if [[ "${{ needs.changes.outputs.shared-types }}" == "true" || 
-                "${{ needs.changes.outputs.web }}" == "true" || 
-                "${{ needs.changes.outputs.admin }}" == "true" || 
-                "${{ needs.changes.outputs.functions }}" == "true" ]]; then
+          if [[ "${{ needs.changes.outputs.shared-types }}" == "true" ]] || \
+             [[ "${{ needs.changes.outputs.web }}" == "true" ]] || \
+             [[ "${{ needs.changes.outputs.admin }}" == "true" ]] || \
+             [[ "${{ needs.changes.outputs.functions }}" == "true" ]]; then
             pnpm --filter @suzumina.click/shared-types build &
             build_pids+=("$!:shared-types")
           fi


### PR DESCRIPTION
## 概要
PR #160のマージ時に発生したGitHub Actionsのエラーを修正します。

## エラー内容
```
/home/runner/work/_temp/b040039f-0314-4f03-8e71-f742033b9d03.sh: line 26: conditional binary operator expected
```

## 修正内容
bashの条件式で複数行にまたがる[[演算子の構文エラーを修正しました。

## テスト
- GitHub ActionsのPR Checkワークフローが正常に動作することを確認してください

🤖 Generated with [Claude Code](https://claude.ai/code)