### PR TITLE
feat: ホームページの音声ボタンでいいね・低評価状態を一括取得

### DIFF
--- a/apps/web/src/components/audio/featured-audio-buttons-carousel-server.tsx
+++ b/apps/web/src/components/audio/featured-audio-buttons-carousel-server.tsx
@@ -1,0 +1,49 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { getLikeDislikeStatusAction } from "@/actions/dislikes";
+import { getFavoritesStatusAction } from "@/actions/favorites";
+import { auth } from "@/auth";
+import { FeaturedAudioButtonsCarousel } from "./featured-audio-buttons-carousel";
+
+interface FeaturedAudioButtonsCarouselServerProps {
+	audioButtons: AudioButtonPlainObject[];
+}
+
+export async function FeaturedAudioButtonsCarouselServer({
+	audioButtons,
+}: FeaturedAudioButtonsCarouselServerProps) {
+	// 認証情報を取得
+	const session = await auth();
+	const userId = session?.user?.discordId;
+
+	// ユーザーがログインしている場合のみ、いいね・低評価・お気に入り状態を一括取得
+	const likeDislikeStatuses: Record<string, { isLiked: boolean; isDisliked: boolean }> = {};
+	const favoriteStatuses: Record<string, boolean> = {};
+
+	if (userId && audioButtons.length > 0) {
+		const audioButtonIds = audioButtons.map((button) => button.id);
+
+		// 並列でステータスを取得
+		const [likeDislikeData, favoriteData] = await Promise.all([
+			getLikeDislikeStatusAction(audioButtonIds),
+			getFavoritesStatusAction(audioButtonIds),
+		]);
+
+		// MapをRecordに変換
+		likeDislikeData.forEach((value, key) => {
+			likeDislikeStatuses[key] = value;
+		});
+
+		favoriteData.forEach((value, key) => {
+			favoriteStatuses[key] = value;
+		});
+	}
+
+	// Client Componentに状態を渡す
+	return (
+		<FeaturedAudioButtonsCarousel
+			audioButtons={audioButtons}
+			initialLikeDislikeStatuses={likeDislikeStatuses}
+			initialFavoriteStatuses={favoriteStatuses}
+		/>
+	);
+}

--- a/apps/web/src/components/audio/featured-audio-buttons-carousel-server.tsx
+++ b/apps/web/src/components/audio/featured-audio-buttons-carousel-server.tsx
@@ -16,8 +16,8 @@ export async function FeaturedAudioButtonsCarouselServer({
 	const userId = session?.user?.discordId;
 
 	// ユーザーがログインしている場合のみ、いいね・低評価・お気に入り状態を一括取得
-	const likeDislikeStatuses: Record<string, { isLiked: boolean; isDisliked: boolean }> = {};
-	const favoriteStatuses: Record<string, boolean> = {};
+	let likeDislikeStatuses: Record<string, { isLiked: boolean; isDisliked: boolean }> = {};
+	let favoriteStatuses: Record<string, boolean> = {};
 
 	if (userId && audioButtons.length > 0) {
 		const audioButtonIds = audioButtons.map((button) => button.id);
@@ -28,9 +28,9 @@ export async function FeaturedAudioButtonsCarouselServer({
 			getFavoritesStatusAction(audioButtonIds),
 		]);
 
-		// MapをRecordに変換（Object.fromEntriesを使用して効率化）
-		Object.assign(likeDislikeStatuses, Object.fromEntries(likeDislikeData));
-		Object.assign(favoriteStatuses, Object.fromEntries(favoriteData));
+		// MapをRecordに変換
+		likeDislikeStatuses = Object.fromEntries(likeDislikeData);
+		favoriteStatuses = Object.fromEntries(favoriteData);
 	}
 
 	// Client Componentに状態を渡す

--- a/apps/web/src/components/audio/featured-audio-buttons-carousel-server.tsx
+++ b/apps/web/src/components/audio/featured-audio-buttons-carousel-server.tsx
@@ -28,14 +28,9 @@ export async function FeaturedAudioButtonsCarouselServer({
 			getFavoritesStatusAction(audioButtonIds),
 		]);
 
-		// MapをRecordに変換
-		likeDislikeData.forEach((value, key) => {
-			likeDislikeStatuses[key] = value;
-		});
-
-		favoriteData.forEach((value, key) => {
-			favoriteStatuses[key] = value;
-		});
+		// MapをRecordに変換（Object.fromEntriesを使用して効率化）
+		Object.assign(likeDislikeStatuses, Object.fromEntries(likeDislikeData));
+		Object.assign(favoriteStatuses, Object.fromEntries(favoriteData));
 	}
 
 	// Client Componentに状態を渡す

--- a/apps/web/src/components/audio/featured-audio-buttons-carousel.tsx
+++ b/apps/web/src/components/audio/featured-audio-buttons-carousel.tsx
@@ -7,9 +7,15 @@ import { AudioButtonWithPlayCount } from "./audio-button-with-play-count";
 
 interface FeaturedAudioButtonsCarouselProps {
 	audioButtons: AudioButtonPlainObject[];
+	initialLikeDislikeStatuses?: Record<string, { isLiked: boolean; isDisliked: boolean }>;
+	initialFavoriteStatuses?: Record<string, boolean>;
 }
 
-export function FeaturedAudioButtonsCarousel({ audioButtons }: FeaturedAudioButtonsCarouselProps) {
+export function FeaturedAudioButtonsCarousel({
+	audioButtons,
+	initialLikeDislikeStatuses = {},
+	initialFavoriteStatuses = {},
+}: FeaturedAudioButtonsCarouselProps) {
 	const [isMobile, setIsMobile] = useState(false);
 
 	useEffect(() => {
@@ -29,14 +35,22 @@ export function FeaturedAudioButtonsCarousel({ audioButtons }: FeaturedAudioButt
 
 	return (
 		<div className="flex flex-wrap gap-2 sm:gap-3 items-start justify-center">
-			{audioButtons.map((audioButton) => (
-				<AudioButtonWithPlayCount
-					key={audioButton.id}
-					audioButton={audioButton}
-					className="shadow-sm hover:shadow-md transition-all duration-200 min-w-0 flex-shrink-0"
-					maxTitleLength={isMobile ? 30 : 50}
-				/>
-			))}
+			{audioButtons.map((audioButton) => {
+				const likeDislikeStatus = initialLikeDislikeStatuses[audioButton.id];
+				const isFavorited = initialFavoriteStatuses[audioButton.id] || false;
+
+				return (
+					<AudioButtonWithPlayCount
+						key={audioButton.id}
+						audioButton={audioButton}
+						className="shadow-sm hover:shadow-md transition-all duration-200 min-w-0 flex-shrink-0"
+						maxTitleLength={isMobile ? 30 : 50}
+						initialIsFavorited={isFavorited}
+						initialIsLiked={likeDislikeStatus?.isLiked || false}
+						initialIsDisliked={likeDislikeStatus?.isDisliked || false}
+					/>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/web/src/components/optimization/lazy-components.tsx
+++ b/apps/web/src/components/optimization/lazy-components.tsx
@@ -7,8 +7,8 @@ import { lazy } from "react";
 
 // 画面外のカルーセルコンポーネントを遅延読み込み
 export const LazyFeaturedAudioButtonsCarousel = lazy(() =>
-	import("@/components/audio/featured-audio-buttons-carousel").then((module) => ({
-		default: module.FeaturedAudioButtonsCarousel,
+	import("@/components/audio/featured-audio-buttons-carousel-server").then((module) => ({
+		default: module.FeaturedAudioButtonsCarouselServer,
 	})),
 );
 


### PR DESCRIPTION
## 概要
ホームページの新着音声ボタンカルーセルで、いいね・低評価・お気に入り状態を一括取得するように改善しました。

## 変更内容
- `FeaturedAudioButtonsCarouselServer` Server Componentを新規作成
- 音声ボタンのいいね・低評価・お気に入り状態を一括取得
- Client Componentに初期状態を渡すことで、個別のAPIリクエストを削減

## パフォーマンス改善
- **Before**: 音声ボタン10個 × 3種類（いいね・低評価・お気に入り） = 最大30回のAPIリクエスト
- **After**: 2回の一括取得APIリクエスト（いいね・低評価状態 + お気に入り状態）
- **削減率**: 93%以上のAPIリクエスト削減

## 関連Issue
- #135 トップページ等でも音声ボタンのいいね・低評価状態を一括取得

## テスト
- [x] ローカル環境で動作確認
- [x] TypeScript型チェック通過
- [x] Lintチェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)