### PR TITLE
feat: 動画詳細ページの音声ボタンでいいね・低評価状態を一括取得

### DIFF
--- a/apps/web/src/app/videos/[videoId]/components/RelatedAudioButtons.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/RelatedAudioButtons.tsx
@@ -33,7 +33,7 @@ export function RelatedAudioButtons({
 			<div className="text-center py-8 text-muted-foreground">
 				<p className="mb-4">この動画の音声ボタンはまだありません</p>
 				<Button asChild size="sm" variant="outline">
-					<Link href={`/buttons/create?videoId=${videoId}`}>
+					<Link href={`/buttons/create?video_id=${videoId}`}>
 						<Plus className="h-4 w-4 mr-2" />
 						最初の音声ボタンを作る
 					</Link>

--- a/apps/web/src/app/videos/[videoId]/components/RelatedAudioButtons.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/RelatedAudioButtons.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { ArrowRight, Plus } from "lucide-react";
+import Link from "next/link";
+import { AudioButtonWithPlayCount } from "@/components/audio";
+
+interface RelatedAudioButtonsProps {
+	audioButtons: AudioButtonPlainObject[];
+	totalCount: number;
+	videoId: string;
+	loading?: boolean;
+	initialLikeDislikeStatuses?: Record<string, { isLiked: boolean; isDisliked: boolean }>;
+	initialFavoriteStatuses?: Record<string, boolean>;
+}
+
+export function RelatedAudioButtons({
+	audioButtons,
+	totalCount,
+	videoId,
+	loading = false,
+	initialLikeDislikeStatuses = {},
+	initialFavoriteStatuses = {},
+}: RelatedAudioButtonsProps) {
+	if (loading) {
+		return <LoadingSkeleton count={3} height={60} />;
+	}
+
+	if (audioButtons.length === 0) {
+		return (
+			<div className="text-center py-8 text-muted-foreground">
+				<p className="mb-4">この動画の音声ボタンはまだありません</p>
+				<Button asChild size="sm" variant="outline">
+					<Link href={`/buttons/create?videoId=${videoId}`}>
+						<Plus className="h-4 w-4 mr-2" />
+						最初の音声ボタンを作る
+					</Link>
+				</Button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-4">
+			{/* 音声ボタン一覧 */}
+			<div className="flex flex-wrap gap-2">
+				{audioButtons.map((audioButton) => {
+					const likeDislikeStatus = initialLikeDislikeStatuses[audioButton.id];
+					const isFavorited = initialFavoriteStatuses[audioButton.id] || false;
+
+					return (
+						<AudioButtonWithPlayCount
+							key={audioButton.id}
+							audioButton={audioButton}
+							maxTitleLength={15}
+							className="shadow-sm hover:shadow-md transition-all duration-200"
+							initialIsFavorited={isFavorited}
+							initialIsLiked={likeDislikeStatus?.isLiked || false}
+							initialIsDisliked={likeDislikeStatus?.isDisliked || false}
+						/>
+					);
+				})}
+			</div>
+
+			{/* もっと見るボタン */}
+			{totalCount > audioButtons.length && (
+				<div className="text-center pt-2">
+					<Button asChild variant="outline" size="sm">
+						<Link href={`/buttons?sourceVideoId=${videoId}`}>
+							<ArrowRight className="h-4 w-4 mr-2" />
+							すべての音声ボタンを見る ({totalCount}件)
+						</Link>
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/app/videos/[videoId]/components/RelatedAudioButtonsServer.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/RelatedAudioButtonsServer.tsx
@@ -1,0 +1,53 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { getLikeDislikeStatusAction } from "@/actions/dislikes";
+import { getFavoritesStatusAction } from "@/actions/favorites";
+import { auth } from "@/auth";
+import { RelatedAudioButtons } from "./RelatedAudioButtons";
+
+interface RelatedAudioButtonsServerProps {
+	audioButtons: AudioButtonPlainObject[];
+	totalCount: number;
+	videoId: string;
+	loading?: boolean;
+}
+
+export async function RelatedAudioButtonsServer({
+	audioButtons,
+	totalCount,
+	videoId,
+	loading = false,
+}: RelatedAudioButtonsServerProps) {
+	// 認証情報を取得
+	const session = await auth();
+	const userId = session?.user?.discordId;
+
+	// ユーザーがログインしている場合のみ、いいね・低評価・お気に入り状態を一括取得
+	let likeDislikeStatuses: Record<string, { isLiked: boolean; isDisliked: boolean }> = {};
+	let favoriteStatuses: Record<string, boolean> = {};
+
+	if (userId && audioButtons.length > 0) {
+		const audioButtonIds = audioButtons.map((button) => button.id);
+
+		// 並列でステータスを取得
+		const [likeDislikeData, favoriteData] = await Promise.all([
+			getLikeDislikeStatusAction(audioButtonIds),
+			getFavoritesStatusAction(audioButtonIds),
+		]);
+
+		// MapをRecordに変換
+		likeDislikeStatuses = Object.fromEntries(likeDislikeData);
+		favoriteStatuses = Object.fromEntries(favoriteData);
+	}
+
+	// Client Componentに状態を渡す
+	return (
+		<RelatedAudioButtons
+			audioButtons={audioButtons}
+			totalCount={totalCount}
+			videoId={videoId}
+			loading={loading}
+			initialLikeDislikeStatuses={likeDislikeStatuses}
+			initialFavoriteStatuses={favoriteStatuses}
+		/>
+	);
+}

--- a/apps/web/src/app/videos/[videoId]/page.tsx
+++ b/apps/web/src/app/videos/[videoId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getAudioButtonCount, getAudioButtons } from "@/app/buttons/actions";
 import { getVideoById } from "../actions";
+import { RelatedAudioButtonsServer } from "./components/RelatedAudioButtonsServer";
 import VideoDetail from "./components/VideoDetail";
 
 interface VideoDetailPageProps {
@@ -30,16 +31,20 @@ export default async function VideoDetailPage({ params }: VideoDetailPageProps) 
 
 	// 音声ボタンデータの準備
 	const audioButtons = audioButtonsResult.success ? audioButtonsResult.data.audioButtons : [];
-	const audioCount = audioButtons.length;
 
 	return (
 		<div className="min-h-screen suzuka-gradient-subtle">
 			<main className="container mx-auto px-4 py-8">
 				<VideoDetail
 					video={video}
-					initialAudioButtons={audioButtons}
-					initialAudioCount={audioCount}
 					initialTotalAudioCount={audioButtonCount}
+					relatedAudioButtonsSlot={
+						<RelatedAudioButtonsServer
+							audioButtons={audioButtons}
+							totalCount={audioButtonCount}
+							videoId={videoId}
+						/>
+					}
 				/>
 			</main>
 		</div>


### PR DESCRIPTION
## 概要
動画詳細ページのサイドバーに表示される関連音声ボタンで、いいね・低評価・お気に入り状態を一括取得するように改善しました。

## 変更内容
- `RelatedAudioButtonsServer` Server Componentを新規作成
- `RelatedAudioButtons` Client Componentに分離
- 音声ボタンのいいね・低評価・お気に入り状態を一括取得
- VideoDetailコンポーネントからSlotパターンで関連音声ボタンを注入

## パフォーマンス改善
- **Before**: 音声ボタン最大6個 × 3種類（いいね・低評価・お気に入り） = 最大18回のAPIリクエスト
- **After**: 2回の一括取得APIリクエスト（いいね・低評価状態 + お気に入り状態）
- **削減率**: 88%以上のAPIリクエスト削減

## 関連タスク
- #145 動画詳細ページの音声ボタンいいね・低評価状態を一括取得に変更

## テスト
- [x] ローカル環境で動作確認
- [x] TypeScript型チェック通過
- [x] Lintチェック通過
- [x] テスト全件通過

🤖 Generated with [Claude Code](https://claude.ai/code)