### PR TITLE
feat: 検索結果ページの音声ボタンでいいね・低評価状態を一括取得

### DIFF
--- a/apps/web/src/app/search/search-page-content.tsx
+++ b/apps/web/src/app/search/search-page-content.tsx
@@ -586,7 +586,7 @@ export default function SearchPageContent() {
 
 	// 音声ボタンのいいね・低評価・お気に入り状態を一括取得
 	const audioButtonIds = useMemo(
-		() => searchResult?.audioButtons.map((button) => button.id) || [],
+		() => (searchResult?.audioButtons ? searchResult.audioButtons.map((button) => button.id) : []),
 		[searchResult?.audioButtons],
 	);
 


### PR DESCRIPTION
## 概要
検索結果ページで表示される音声ボタンのいいね・低評価・お気に入り状態を一括取得するように改善しました。

## 変更内容
- `SearchResults`コンポーネントにいいね・低評価状態のPropsを追加
- `useLikeDislikeStatusBulk`と`useFavoriteStatusBulk`フックを使用して状態を一括取得
- 全体タブと音声ボタンタブの両方で一括状態取得を実装
- Client Component内でフックを使用することで実装を簡潔化

## パフォーマンス改善
- **Before**: 音声ボタン数 × 3種類（いいね・低評価・お気に入り） = 大量のAPIリクエスト
- **After**: 2回の一括取得APIリクエスト（いいね・低評価状態 + お気に入り状態）
- **削減率**: 最大90%以上のAPIリクエスト削減

## 関連タスク
- #146 検索結果ページの音声ボタンいいね・低評価状態を一括取得に変更

## テスト
- [x] ローカル環境で動作確認
- [x] TypeScript型チェック通過
- [x] Lintチェック通過
- [ ] 検索ページのテストはSessionProvider依存のため要修正（別タスク）

🤖 Generated with [Claude Code](https://claude.ai/code)