### PR TITLE
feat: お気に入りページの音声ボタンでいいね・低評価状態を一括取得

### DIFF
--- a/apps/web/src/app/favorites/components/FavoritesList.tsx
+++ b/apps/web/src/app/favorites/components/FavoritesList.tsx
@@ -13,12 +13,14 @@ interface FavoritesListProps {
 	audioButtons: AudioButtonPlainObject[];
 	totalCount: number;
 	currentSort: string;
+	initialLikeDislikeStatuses?: Record<string, { isLiked: boolean; isDisliked: boolean }>;
 }
 
 export default function FavoritesList({
 	audioButtons,
 	totalCount,
 	currentSort,
+	initialLikeDislikeStatuses = {},
 }: FavoritesListProps) {
 	const router = useRouter();
 
@@ -60,16 +62,22 @@ export default function FavoritesList({
 			/>
 
 			<div className="flex flex-wrap gap-3 items-start">
-				{audioButtons.map((audioButton) => (
-					<AudioButtonWithPlayCount
-						key={audioButton.id}
-						audioButton={audioButton}
-						showFavorite={true}
-						maxTitleLength={50}
-						className="shadow-sm hover:shadow-md transition-all duration-200"
-						initialIsFavorited={true}
-					/>
-				))}
+				{audioButtons.map((audioButton) => {
+					const likeDislikeStatus = initialLikeDislikeStatuses[audioButton.id];
+
+					return (
+						<AudioButtonWithPlayCount
+							key={audioButton.id}
+							audioButton={audioButton}
+							showFavorite={true}
+							maxTitleLength={50}
+							className="shadow-sm hover:shadow-md transition-all duration-200"
+							initialIsFavorited={true}
+							initialIsLiked={likeDislikeStatus?.isLiked || false}
+							initialIsDisliked={likeDislikeStatus?.isDisliked || false}
+						/>
+					);
+				})}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## 概要
お気に入りページで表示される音声ボタンのいいね・低評価状態を一括取得するように改善しました。

## 変更内容
- お気に入りページのServer Componentでいいね・低評価状態を一括取得
- `FavoritesList`コンポーネントに初期状態をPropsとして渡す
- Client Component内で個別のAPIリクエストを削減

## パフォーマンス改善
- **Before**: お気に入り数 × 2種類（いいね・低評価） = 大量のAPIリクエスト
- **After**: 1回の一括取得APIリクエスト
- **削減率**: 90%以上のAPIリクエスト削減（お気に入りが多いほど効果大）

## 関連タスク
- #147 お気に入りページの音声ボタンいいね・低評価状態を一括取得に変更

## テスト
- [x] ローカル環境で動作確認
- [x] TypeScript型チェック通過
- [x] Lintチェック通過
- [x] お気に入りは既にtrueなので、お気に入り状態の一括取得は不要

## 備考
- お気に入りページでは全ての音声ボタンが既にお気に入り済みなので、お気に入り状態の一括取得は行っていません

🤖 Generated with [Claude Code](https://claude.ai/code)