### PR TITLE
feat: ユーザープロフィールページの音声ボタンでいいね・低評価状態を一括取得

### DIFF
--- a/apps/web/src/app/users/[userId]/components/UserProfileContent.tsx
+++ b/apps/web/src/app/users/[userId]/components/UserProfileContent.tsx
@@ -30,6 +30,7 @@ interface UserProfileContentProps {
 	totalPlayCount: number;
 	isOwnProfile: boolean;
 	favoritesCount?: number;
+	initialLikeDislikeStatuses?: Record<string, { isLiked: boolean; isDisliked: boolean }>;
 }
 
 // Helper components to reduce complexity
@@ -93,10 +94,12 @@ function AudioButtonsList({
 	audioButtons,
 	user,
 	isOwnProfile,
+	initialLikeDislikeStatuses = {},
 }: {
 	audioButtons: AudioButtonPlainObject[];
 	user: FrontendUserData;
 	isOwnProfile: boolean;
+	initialLikeDislikeStatuses?: Record<string, { isLiked: boolean; isDisliked: boolean }>;
 }) {
 	if (audioButtons.length === 0) {
 		return (
@@ -122,15 +125,20 @@ function AudioButtonsList({
 	return (
 		<>
 			<div className="flex flex-wrap gap-3 items-start">
-				{audioButtons.map((button) => (
-					<AudioButtonWithPlayCount
-						key={button.id}
-						audioButton={button}
-						showFavorite={true}
-						maxTitleLength={50}
-						className="shadow-sm hover:shadow-md transition-all duration-200"
-					/>
-				))}
+				{audioButtons.map((button) => {
+					const likeDislikeStatus = initialLikeDislikeStatuses[button.id];
+					return (
+						<AudioButtonWithPlayCount
+							key={button.id}
+							audioButton={button}
+							showFavorite={true}
+							maxTitleLength={50}
+							className="shadow-sm hover:shadow-md transition-all duration-200"
+							initialIsLiked={likeDislikeStatus?.isLiked || false}
+							initialIsDisliked={likeDislikeStatus?.isDisliked || false}
+						/>
+					);
+				})}
 			</div>
 			{audioButtons.length >= 20 && (
 				<div className="text-center mt-8">
@@ -148,6 +156,7 @@ export function UserProfileContent({
 	totalPlayCount,
 	isOwnProfile,
 	favoritesCount = 0,
+	initialLikeDislikeStatuses = {},
 }: UserProfileContentProps) {
 	const [selectedTab, setSelectedTab] = useState<"buttons" | "stats" | "favorites">("buttons");
 	const averagePlays = audioButtonsCount > 0 ? Math.round(totalPlayCount / audioButtonsCount) : 0;
@@ -239,7 +248,12 @@ export function UserProfileContent({
 				</div>
 
 				{selectedTab === "buttons" && (
-					<AudioButtonsList audioButtons={audioButtons} user={user} isOwnProfile={isOwnProfile} />
+					<AudioButtonsList
+						audioButtons={audioButtons}
+						user={user}
+						isOwnProfile={isOwnProfile}
+						initialLikeDislikeStatuses={initialLikeDislikeStatuses}
+					/>
 				)}
 
 				{selectedTab === "favorites" && (

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -1,6 +1,7 @@
 import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { getLikeDislikeStatusAction } from "@/actions/dislikes";
 import { auth } from "@/auth";
 import { getAudioButtonsByUser } from "@/lib/audio-buttons-firestore";
 import { getUserFavoritesCount } from "@/lib/favorites-firestore";
@@ -75,6 +76,14 @@ export default async function UserProfilePage({ params }: UserProfilePageProps) 
 		favoritesCount = await getUserFavoritesCount(resolvedParams.userId);
 	}
 
+	// いいね・低評価状態を一括取得（ログインユーザーのみ）
+	let likeDislikeStatuses: Record<string, { isLiked: boolean; isDisliked: boolean }> = {};
+	if (session?.user && audioButtons.length > 0) {
+		const audioButtonIds = audioButtons.map((button) => button.id);
+		const likeDislikeData = await getLikeDislikeStatusAction(audioButtonIds);
+		likeDislikeStatuses = Object.fromEntries(likeDislikeData);
+	}
+
 	return (
 		<UserProfileContent
 			user={user}
@@ -83,6 +92,7 @@ export default async function UserProfilePage({ params }: UserProfilePageProps) 
 			totalPlayCount={totalPlayCount}
 			isOwnProfile={isOwnProfile}
 			favoritesCount={favoritesCount}
+			initialLikeDislikeStatuses={likeDislikeStatuses}
 		/>
 	);
 }


### PR DESCRIPTION
## 概要
ユーザープロフィールページでも音声ボタンのいいね・低評価状態を一括取得するように改善しました。

## 変更内容
- `page.tsx`でサーバーサイドで`getLikeDislikeStatusAction`を使用して一括取得
- `UserProfileContent`コンポーネントに`initialLikeDislikeStatuses`プロパティを追加
- `AudioButtonsList`コンポーネントで初期状態を各ボタンに渡すように修正

## 効果
- APIリクエスト数の大幅削減（音声ボタン数×2 → 1回）
- 初期表示時のパフォーマンス向上
- 他のページ（ホーム、動画詳細、検索結果、お気に入り）と同様の実装に統一

## テスト
- ✅ すべてのテストが成功
- ✅ lint/typecheckが通過
- ✅ ログインユーザーのみいいね・低評価状態を取得
- ✅ 非ログインユーザーでも正常に動作

## 関連PR
- #162 ホームページの実装
- #163 動画詳細ページの実装  
- #164 検索結果ページの実装
- #165 お気に入りページの実装

🤖 Generated with [Claude Code](https://claude.ai/code)