### PR TITLE
feat: サークル詳細ページをGenericList化して検索機能を追加

### DIFF
--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -109,7 +109,7 @@ vi.mock("@/lib/firestore", () => ({
 
 // テスト対象のインポート（モック設定後）
 
-import { getCircleInfo, getCircleWorks, getCircleWorksWithPagination } from "../actions";
+import { fetchCircleWorksForConfigurableList, getCircleInfo } from "../actions";
 
 describe("Circle page server actions", () => {
 	beforeEach(() => {
@@ -250,239 +250,9 @@ describe("Circle page server actions", () => {
 		});
 	});
 
-	describe("getCircleWorks", () => {
-		it("サークルの作品一覧を正しく取得する", async () => {
-			// サークル情報のモック
+	describe("fetchCircleWorksForConfigurableList", () => {
+		it("検索機能が正しく動作する", async () => {
 			const mockCircleData = {
-				circleId: "RG12345",
-				name: "テストサークル",
-				workCount: 2,
-			};
-
-			const mockWorks = [
-				{
-					id: "RJ111111",
-					productId: "RJ111111",
-					title: "作品1",
-					circle: "テストサークル",
-					circleId: "RG12345",
-					price: { current: 1100, currency: "JPY" },
-					registDate: "2025-01-15",
-					releaseDateISO: "2025-01-15",
-					releaseDateDisplay: "2025年01月15日",
-					thumbnailUrl: "image1.jpg",
-					workUrl: "https://example.com/work1.html",
-					category: "SOU",
-					workType: "SOU",
-					genres: ["ボイス・ASMR"],
-					customGenres: [],
-					tags: ["tag1", "tag2"],
-					rating: { stars: 4.5, count: 5 },
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
-					salesStatus: {},
-					sampleImages: [],
-					description: "",
-					ageRating: "general",
-					updateDate: "2025-01-15",
-					createdAt: "2025-01-15T00:00:00.000Z",
-					updatedAt: "2025-01-15T00:00:00.000Z",
-					lastFetchedAt: "2025-01-15T00:00:00.000Z",
-				},
-				{
-					id: "RJ222222",
-					productId: "RJ222222",
-					title: "作品2",
-					circle: "テストサークル",
-					circleId: "RG12345",
-					price: { current: 2200, currency: "JPY" },
-					registDate: "2025-01-10",
-					releaseDateISO: "2025-01-10",
-					releaseDateDisplay: "2025年01月10日",
-					thumbnailUrl: "image2.jpg",
-					workUrl: "https://example.com/work2.html",
-					category: "SOU",
-					workType: "SOU",
-					genres: ["音声作品"],
-					customGenres: [],
-					tags: ["tag3"],
-					rating: { stars: 4.0, count: 3 },
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
-					salesStatus: {},
-					sampleImages: [],
-					description: "",
-					ageRating: "general",
-					updateDate: "2025-01-10",
-					createdAt: "2025-01-10T00:00:00.000Z",
-					updatedAt: "2025-01-10T00:00:00.000Z",
-					lastFetchedAt: "2025-01-10T00:00:00.000Z",
-				},
-				{
-					id: "RJ333333",
-					productId: "RJ333333",
-					title: "他のサークル作品",
-					circle: "他のサークル",
-					circleId: "RG99999",
-					price: { current: 3300, currency: "JPY" },
-					registDate: "2025-01-12",
-					releaseDateISO: "2025-01-12",
-					releaseDateDisplay: "2025年01月12日",
-					thumbnailUrl: "image3.jpg",
-					workUrl: "https://example.com/work3.html",
-					category: "SOU",
-					workType: "SOU",
-					genres: [],
-					customGenres: [],
-					tags: [],
-					rating: undefined,
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
-					salesStatus: {},
-					sampleImages: [],
-					description: "",
-					ageRating: "general",
-					updateDate: "2025-01-12",
-					createdAt: "2025-01-12T00:00:00.000Z",
-					updatedAt: "2025-01-12T00:00:00.000Z",
-					lastFetchedAt: "2025-01-12T00:00:00.000Z",
-				},
-			];
-
-			// Mock collection method to return appropriate mock based on collection name
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: false,
-							docs: mockWorks.map((work) => ({
-								id: work.id,
-								data: () => work,
-							})),
-						}),
-					};
-				}
-				return {};
-			});
-
-			const result = await getCircleWorks("RG12345");
-
-			expect(result).toHaveLength(2); // フィルタリングにより該当する作品のみ
-			expect(result[0]).toMatchObject({
-				id: "RJ111111",
-				title: "作品1",
-			});
-			expect(result[1]).toMatchObject({
-				id: "RJ222222",
-				title: "作品2",
-			});
-		});
-
-		it("作品が存在しない場合は空配列を返す", async () => {
-			// Mock for circle that exists but has no works
-			const mockCircleData = {
-				circleId: "RG99999",
-				name: "作品なしサークル",
-				workCount: 0,
-			};
-
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: true,
-							docs: [],
-						}),
-					};
-				}
-				return {};
-			});
-
-			const result = await getCircleWorks("RG99999");
-
-			expect(result).toEqual([]);
-		});
-
-		it("無効なサークルIDの場合は空配列を返す", async () => {
-			const result = await getCircleWorks("INVALID_ID");
-
-			expect(result).toEqual([]);
-			expect(mockWhere).not.toHaveBeenCalled();
-		});
-
-		it("エラー発生時は空配列を返す", async () => {
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockRejectedValue(new Error("Firestore error")),
-						}),
-					};
-				}
-				return {};
-			});
-
-			const result = await getCircleWorks("RG12345");
-
-			expect(result).toEqual([]);
-		});
-
-		it("データ変換時のエラーをハンドリングする", async () => {
-			// Mock circle data but error on works collection
-			const mockCircleData = {
-				circleId: "RG12345",
-				name: "テストサークル",
-				workCount: 2,
-			};
-
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockRejectedValue(new Error("Firestore error")),
-					};
-				}
-				return {};
-			});
-
-			const result = await getCircleWorks("RG12345");
-
-			// エラーが発生してもクラッシュせず、空配列を返す
-			expect(result).toEqual([]);
-		});
-	});
-
-	describe("getCircleWorksWithPagination", () => {
-		it("ページネーション付きでサークルの作品一覧を正しく取得する", async () => {
-			// サークル情報のモック
-			const mockCircleData = {
-				id: "RG12345",
 				circleId: "RG12345",
 				name: "テストサークル",
 				workCount: 3,
@@ -492,7 +262,7 @@ describe("Circle page server actions", () => {
 				{
 					id: "RJ111111",
 					productId: "RJ111111",
-					title: "作品1",
+					title: "魔法少女の冒険",
 					circle: "テストサークル",
 					circleId: "RG12345",
 					price: { current: 1100, currency: "JPY" },
@@ -503,12 +273,18 @@ describe("Circle page server actions", () => {
 					registDate: "2025-01-15",
 					releaseDateISO: "2025-01-15",
 					releaseDateDisplay: "2025年01月15日",
-					genres: [],
-					customGenres: [],
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
+					description: "魔法の世界",
+					genres: ["ファンタジー"],
+					customGenres: ["魔法"],
+					creators: {
+						voiceActors: [{ name: "声優A", id: "VA001" }],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
 					salesStatus: {},
 					sampleImages: [],
-					description: "",
 					ageRating: "general",
 					updateDate: "2025-01-15",
 					createdAt: "2025-01-15T00:00:00.000Z",
@@ -518,7 +294,7 @@ describe("Circle page server actions", () => {
 				{
 					id: "RJ222222",
 					productId: "RJ222222",
-					title: "作品2",
+					title: "勇者の物語",
 					circle: "テストサークル",
 					circleId: "RG12345",
 					price: { current: 2200, currency: "JPY" },
@@ -529,12 +305,18 @@ describe("Circle page server actions", () => {
 					registDate: "2025-01-10",
 					releaseDateISO: "2025-01-10",
 					releaseDateDisplay: "2025年01月10日",
-					genres: [],
-					customGenres: [],
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
+					description: "勇者の冒険",
+					genres: ["RPG"],
+					customGenres: ["冒険"],
+					creators: {
+						voiceActors: [],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
 					salesStatus: {},
 					sampleImages: [],
-					description: "",
 					ageRating: "general",
 					updateDate: "2025-01-10",
 					createdAt: "2025-01-10T00:00:00.000Z",
@@ -544,7 +326,7 @@ describe("Circle page server actions", () => {
 				{
 					id: "RJ333333",
 					productId: "RJ333333",
-					title: "作品3",
+					title: "日常系作品",
 					circle: "テストサークル",
 					circleId: "RG12345",
 					price: { current: 3300, currency: "JPY" },
@@ -555,12 +337,18 @@ describe("Circle page server actions", () => {
 					registDate: "2025-01-05",
 					releaseDateISO: "2025-01-05",
 					releaseDateDisplay: "2025年01月05日",
-					genres: [],
+					description: "日常の風景",
+					genres: ["日常系"],
 					customGenres: [],
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
+					creators: {
+						voiceActors: [],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
 					salesStatus: {},
 					sampleImages: [],
-					description: "",
 					ageRating: "general",
 					updateDate: "2025-01-05",
 					createdAt: "2025-01-05T00:00:00.000Z",
@@ -594,23 +382,20 @@ describe("Circle page server actions", () => {
 				return {};
 			});
 
-			const result = await getCircleWorksWithPagination("RG12345", 1, 2, "newest");
+			// "魔法"で検索
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG12345",
+				search: "魔法",
+			});
 
-			// Debug log
-			if (result.totalCount === 0) {
-				console.log("Circle doc get calls:", mockDoc.mock.calls);
-				console.log("Collection get calls:", mockGet.mock.calls);
-			}
-
-			expect(result.totalCount).toBe(3);
-			expect(result.works).toHaveLength(2); // ページサイズ2でページ1なので2件
-			expect(result.works[0].title).toBe("作品1"); // 新しい順で1番目
-			expect(result.works[1].title).toBe("作品2"); // 新しい順で2番目
+			expect(result.totalCount).toBe(3); // 全作品数
+			expect(result.filteredCount).toBe(1); // フィルター後の作品数
+			expect(result.works).toHaveLength(1);
+			expect(result.works[0].title).toBe("魔法少女の冒険");
 		});
 
-		it("ソート機能が正しく動作する", async () => {
+		it("声優名で検索できる", async () => {
 			const mockCircleData = {
-				id: "RG12345",
 				circleId: "RG12345",
 				name: "テストサークル",
 				workCount: 2,
@@ -620,10 +405,10 @@ describe("Circle page server actions", () => {
 				{
 					id: "RJ111111",
 					productId: "RJ111111",
-					title: "高価格作品",
+					title: "作品1",
 					circle: "テストサークル",
 					circleId: "RG12345",
-					price: { current: 2000, currency: "JPY" },
+					price: { current: 1100, currency: "JPY" },
 					category: "SOU",
 					workType: "SOU",
 					thumbnailUrl: "https://example.com/thumb.jpg",
@@ -631,12 +416,18 @@ describe("Circle page server actions", () => {
 					registDate: "2025-01-15",
 					releaseDateISO: "2025-01-15",
 					releaseDateDisplay: "2025年01月15日",
+					description: "",
 					genres: [],
 					customGenres: [],
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
+					creators: {
+						voiceActors: [{ name: "田中太郎", id: "VA001" }],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
 					salesStatus: {},
 					sampleImages: [],
-					description: "",
 					ageRating: "general",
 					updateDate: "2025-01-15",
 					createdAt: "2025-01-15T00:00:00.000Z",
@@ -646,10 +437,10 @@ describe("Circle page server actions", () => {
 				{
 					id: "RJ222222",
 					productId: "RJ222222",
-					title: "低価格作品",
+					title: "作品2",
 					circle: "テストサークル",
 					circleId: "RG12345",
-					price: { current: 1000, currency: "JPY" },
+					price: { current: 2200, currency: "JPY" },
 					category: "SOU",
 					workType: "SOU",
 					thumbnailUrl: "https://example.com/thumb.jpg",
@@ -657,12 +448,18 @@ describe("Circle page server actions", () => {
 					registDate: "2025-01-10",
 					releaseDateISO: "2025-01-10",
 					releaseDateDisplay: "2025年01月10日",
+					description: "",
 					genres: [],
 					customGenres: [],
-					creators: { voiceActors: [], scenario: [], illustration: [], music: [], others: [] },
+					creators: {
+						voiceActors: [{ name: "鈴木花子", id: "VA002" }],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
 					salesStatus: {},
 					sampleImages: [],
-					description: "",
 					ageRating: "general",
 					updateDate: "2025-01-10",
 					createdAt: "2025-01-10T00:00:00.000Z",
@@ -696,11 +493,289 @@ describe("Circle page server actions", () => {
 				return {};
 			});
 
-			// 価格の低い順でソート
-			const result = await getCircleWorksWithPagination("RG12345", 1, 10, "price_low");
+			// 声優名で検索
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG12345",
+				search: "田中",
+			});
 
-			expect(result.works[0].title).toBe("低価格作品");
-			expect(result.works[1].title).toBe("高価格作品");
+			expect(result.filteredCount).toBe(1);
+			expect(result.works).toHaveLength(1);
+			expect(result.works[0].creators.voiceActors[0].name).toBe("田中太郎");
+		});
+
+		it("ページネーションと検索を組み合わせて正しく動作する", async () => {
+			const mockCircleData = {
+				circleId: "RG12345",
+				name: "テストサークル",
+				workCount: 5,
+			};
+
+			// 5つの作品（3つが"冒険"を含む）
+			const mockWorks = Array.from({ length: 5 }, (_, i) => ({
+				id: `RJ${i + 1}11111`,
+				productId: `RJ${i + 1}11111`,
+				title: i < 3 ? `冒険作品${i + 1}` : `日常作品${i - 2}`,
+				circle: "テストサークル",
+				circleId: "RG12345",
+				price: { current: (i + 1) * 1000, currency: "JPY" },
+				category: "SOU",
+				workType: "SOU",
+				thumbnailUrl: "https://example.com/thumb.jpg",
+				workUrl: "https://example.com/work.html",
+				registDate: `2025-01-${15 - i}`,
+				releaseDateISO: `2025-01-${15 - i}`,
+				releaseDateDisplay: `2025年01月${15 - i}日`,
+				description: i < 3 ? "冒険の物語" : "日常の物語",
+				genres: [],
+				customGenres: [],
+				creators: {
+					voiceActors: [],
+					scenario: [],
+					illustration: [],
+					music: [],
+					others: [],
+				},
+				salesStatus: {},
+				sampleImages: [],
+				ageRating: "general",
+				updateDate: `2025-01-${15 - i}`,
+				createdAt: `2025-01-${15 - i}T00:00:00.000Z`,
+				updatedAt: `2025-01-${15 - i}T00:00:00.000Z`,
+				lastFetchedAt: `2025-01-${15 - i}T00:00:00.000Z`,
+			}));
+
+			mockCollection.mockImplementation((collectionName) => {
+				if (collectionName === "circles") {
+					return {
+						doc: vi.fn().mockReturnValue({
+							get: vi.fn().mockResolvedValue({
+								exists: true,
+								data: () => mockCircleData,
+							}),
+						}),
+					};
+				}
+				if (collectionName === "works") {
+					return {
+						get: vi.fn().mockResolvedValue({
+							empty: false,
+							docs: mockWorks.map((work) => ({
+								id: work.id,
+								data: () => work,
+							})),
+						}),
+					};
+				}
+				return {};
+			});
+
+			// "冒険"で検索、ページ2を取得（limit=2）
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG12345",
+				search: "冒険",
+				page: 2,
+				limit: 2,
+			});
+
+			expect(result.totalCount).toBe(5); // 全作品数
+			expect(result.filteredCount).toBe(3); // "冒険"を含む作品数
+			expect(result.works).toHaveLength(1); // ページ2には1件のみ（3件中の3件目）
+			expect(result.works[0].title).toBe("冒険作品3");
+		});
+
+		it("検索語が見つからない場合は空の結果を返す", async () => {
+			const mockCircleData = {
+				circleId: "RG12345",
+				name: "テストサークル",
+				workCount: 2,
+			};
+
+			const mockWorks = [
+				{
+					id: "RJ111111",
+					productId: "RJ111111",
+					title: "作品1",
+					circle: "テストサークル",
+					circleId: "RG12345",
+					price: { current: 1100, currency: "JPY" },
+					category: "SOU",
+					workType: "SOU",
+					thumbnailUrl: "https://example.com/thumb.jpg",
+					workUrl: "https://example.com/work.html",
+					registDate: "2025-01-15",
+					releaseDateISO: "2025-01-15",
+					releaseDateDisplay: "2025年01月15日",
+					description: "",
+					genres: [],
+					customGenres: [],
+					creators: {
+						voiceActors: [],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
+					salesStatus: {},
+					sampleImages: [],
+					ageRating: "general",
+					updateDate: "2025-01-15",
+					createdAt: "2025-01-15T00:00:00.000Z",
+					updatedAt: "2025-01-15T00:00:00.000Z",
+					lastFetchedAt: "2025-01-15T00:00:00.000Z",
+				},
+			];
+
+			mockCollection.mockImplementation((collectionName) => {
+				if (collectionName === "circles") {
+					return {
+						doc: vi.fn().mockReturnValue({
+							get: vi.fn().mockResolvedValue({
+								exists: true,
+								data: () => mockCircleData,
+							}),
+						}),
+					};
+				}
+				if (collectionName === "works") {
+					return {
+						get: vi.fn().mockResolvedValue({
+							empty: false,
+							docs: mockWorks.map((work) => ({
+								id: work.id,
+								data: () => work,
+							})),
+						}),
+					};
+				}
+				return {};
+			});
+
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG12345",
+				search: "存在しない検索語",
+			});
+
+			expect(result.totalCount).toBe(1);
+			expect(result.filteredCount).toBe(0);
+			expect(result.works).toHaveLength(0);
+		});
+
+		it("検索パラメータがない場合はfilteredCountを返さない", async () => {
+			const mockCircleData = {
+				circleId: "RG12345",
+				name: "テストサークル",
+				workCount: 1,
+			};
+
+			const mockWorks = [
+				{
+					id: "RJ111111",
+					productId: "RJ111111",
+					title: "作品1",
+					circle: "テストサークル",
+					circleId: "RG12345",
+					price: { current: 1100, currency: "JPY" },
+					category: "SOU",
+					workType: "SOU",
+					thumbnailUrl: "https://example.com/thumb.jpg",
+					workUrl: "https://example.com/work.html",
+					registDate: "2025-01-15",
+					releaseDateISO: "2025-01-15",
+					releaseDateDisplay: "2025年01月15日",
+					description: "",
+					genres: [],
+					customGenres: [],
+					creators: {
+						voiceActors: [],
+						scenario: [],
+						illustration: [],
+						music: [],
+						others: [],
+					},
+					salesStatus: {},
+					sampleImages: [],
+					ageRating: "general",
+					updateDate: "2025-01-15",
+					createdAt: "2025-01-15T00:00:00.000Z",
+					updatedAt: "2025-01-15T00:00:00.000Z",
+					lastFetchedAt: "2025-01-15T00:00:00.000Z",
+				},
+			];
+
+			mockCollection.mockImplementation((collectionName) => {
+				if (collectionName === "circles") {
+					return {
+						doc: vi.fn().mockReturnValue({
+							get: vi.fn().mockResolvedValue({
+								exists: true,
+								data: () => mockCircleData,
+							}),
+						}),
+					};
+				}
+				if (collectionName === "works") {
+					return {
+						get: vi.fn().mockResolvedValue({
+							empty: false,
+							docs: mockWorks.map((work) => ({
+								id: work.id,
+								data: () => work,
+							})),
+						}),
+					};
+				}
+				return {};
+			});
+
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG12345",
+			});
+
+			expect(result.totalCount).toBe(1);
+			expect(result.filteredCount).toBeUndefined();
+			expect(result.works).toHaveLength(1);
+		});
+
+		it("無効なサークルIDの場合は空の結果を返す", async () => {
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "INVALID_ID",
+			});
+
+			expect(result).toEqual({ works: [], totalCount: 0 });
+		});
+
+		it("サークルが存在しない場合は空の結果を返す", async () => {
+			mockCollection.mockImplementation((collectionName) => {
+				if (collectionName === "circles") {
+					return {
+						doc: vi.fn().mockReturnValue({
+							get: vi.fn().mockResolvedValue({
+								exists: false,
+							}),
+						}),
+					};
+				}
+				return {};
+			});
+
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG99999",
+			});
+
+			expect(result).toEqual({ works: [], totalCount: 0 });
+		});
+
+		it("エラー発生時は空の結果を返す", async () => {
+			mockCollection.mockImplementation(() => {
+				throw new Error("Firestore error");
+			});
+
+			const result = await fetchCircleWorksForConfigurableList({
+				circleId: "RG12345",
+			});
+
+			expect(result).toEqual({ works: [], totalCount: 0 });
 		});
 	});
 

--- a/apps/web/src/app/circles/[circleId]/components/CirclePageClient.tsx
+++ b/apps/web/src/app/circles/[circleId]/components/CirclePageClient.tsx
@@ -1,84 +1,20 @@
 "use client";
 
-import type { CirclePlainObject, WorkPlainObject } from "@suzumina.click/shared-types";
+import type { CirclePlainObject, WorkListResultPlain } from "@suzumina.click/shared-types";
 import {
 	ListPageContent,
 	ListPageHeader,
 	ListPageLayout,
 } from "@suzumina.click/ui/components/custom/list-page-layout";
-import { useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useState } from "react";
-import WorkList from "@/app/works/components/WorkList";
-import { getCircleWorksWithPagination } from "../actions";
+import { Suspense } from "react";
+import CircleWorksList from "./CircleWorksList";
 
 interface CirclePageClientProps {
 	circle: CirclePlainObject;
-	initialData: WorkPlainObject[];
-	initialTotalCount: number;
-	initialPage: number;
+	initialData: WorkListResultPlain;
 }
 
-export function CirclePageClient({
-	circle,
-	initialData,
-	initialTotalCount,
-	initialPage,
-}: CirclePageClientProps) {
-	const searchParamsHook = useSearchParams();
-	const [data, setData] = useState<WorkPlainObject[]>(initialData);
-	const [totalCount, setTotalCount] = useState(initialTotalCount);
-	const [isLoading, setIsLoading] = useState(false);
-
-	// ヘルパー関数：状態を更新
-	const updateState = useCallback((works: WorkPlainObject[], count: number) => {
-		setData(works);
-		setTotalCount(count);
-	}, []);
-
-	// 現在のページ状態を管理
-	const [currentPage, setCurrentPage] = useState(initialPage);
-
-	// ページネーション変更時のデータ取得
-	useEffect(() => {
-		const pageFromUrl = Number.parseInt(searchParamsHook.get("page") || "1", 10);
-		const limitFromUrl = Number.parseInt(searchParamsHook.get("limit") || "12", 10);
-		const sortFromUrl = searchParamsHook.get("sort") || "newest";
-
-		// 初期ロード時は既にデータがあるのでスキップ
-		if (
-			pageFromUrl === initialPage &&
-			limitFromUrl === 12 &&
-			sortFromUrl === "newest" &&
-			data.length > 0
-		) {
-			return;
-		}
-
-		// ページが変更された場合は更新
-		if (pageFromUrl !== currentPage) {
-			setCurrentPage(pageFromUrl);
-		}
-
-		const fetchData = async () => {
-			setIsLoading(true);
-			try {
-				const result = await getCircleWorksWithPagination(
-					circle.circleId,
-					pageFromUrl,
-					limitFromUrl,
-					sortFromUrl,
-				);
-				updateState(result.works, result.totalCount);
-			} catch (_error) {
-				// Error handling - silent fail to prevent console noise
-			} finally {
-				setIsLoading(false);
-			}
-		};
-
-		fetchData();
-	}, [searchParamsHook, circle.circleId, currentPage, updateState, initialPage, data.length]);
-
+export function CirclePageClient({ circle, initialData }: CirclePageClientProps) {
 	return (
 		<ListPageLayout>
 			<ListPageHeader
@@ -95,20 +31,7 @@ export function CirclePageClient({
 						</div>
 					}
 				>
-					{isLoading ? (
-						<div className="text-center py-12">
-							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-							<p className="mt-2 text-muted-foreground">ページ読み込み中...</p>
-						</div>
-					) : (
-						<WorkList
-							data={data}
-							totalCount={totalCount}
-							currentPage={currentPage}
-							showFilters={false}
-							baseUrl={`/circles/${circle.circleId}`}
-						/>
-					)}
+					<CircleWorksList circleId={circle.circleId} initialData={initialData} />
 				</Suspense>
 			</ListPageContent>
 		</ListPageLayout>

--- a/apps/web/src/app/circles/[circleId]/components/CircleWorksList.tsx
+++ b/apps/web/src/app/circles/[circleId]/components/CircleWorksList.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
+import {
+	ConfigurableList,
+	type StandardListParams,
+} from "@suzumina.click/ui/components/custom/list";
+import { useCallback, useMemo } from "react";
+import WorkCard from "@/app/works/components/WorkCard";
+import { fetchCircleWorksForConfigurableList } from "../actions";
+
+interface CircleWorksListProps {
+	circleId: string;
+	initialData?: WorkListResultPlain;
+}
+
+// 作品表示用のコンポーネント
+function WorkItem({ work }: { work: WorkPlainObject }) {
+	return <WorkCard work={work} />;
+}
+
+export default function CircleWorksList({ circleId, initialData }: CircleWorksListProps) {
+	// 初期データを変換
+	const transformedInitialData = useMemo(() => {
+		if (!initialData) return null;
+		return {
+			items: initialData.works,
+			total: initialData.totalCount || 0,
+			page: 1,
+			itemsPerPage: initialData.works.length,
+		};
+	}, [initialData]);
+
+	// データアダプター
+	const dataAdapter = useMemo(
+		() => ({
+			toParams: (params: StandardListParams) => {
+				return {
+					circleId,
+					page: params.page,
+					limit: params.itemsPerPage,
+					sort: params.sort || "newest",
+					search: params.search,
+				};
+			},
+			fromResult: (result: unknown) => result as { items: WorkPlainObject[]; total: number },
+		}),
+		[circleId],
+	);
+
+	// フェッチ関数
+	const fetchFn = useCallback(async (params: unknown) => {
+		const typedParams = params as Parameters<typeof fetchCircleWorksForConfigurableList>[0];
+		const result = await fetchCircleWorksForConfigurableList(typedParams);
+		return {
+			items: result.works,
+			total: result.totalCount || 0,
+		};
+	}, []);
+
+	return (
+		<div className="bg-white/80 backdrop-blur-sm rounded-xl shadow-lg border border-suzuka-100 p-6">
+			<ConfigurableList<WorkPlainObject>
+				items={transformedInitialData?.items || []}
+				initialTotal={transformedInitialData?.total || 0}
+				renderItem={(work) => <WorkItem work={work} />}
+				fetchFn={fetchFn}
+				dataAdapter={dataAdapter}
+				searchable
+				searchPlaceholder="作品タイトルで検索..."
+				urlSync
+				layout="grid"
+				gridColumns={{
+					default: 1,
+					sm: 2,
+					lg: 3,
+					xl: 4,
+				}}
+				sorts={[
+					{ value: "newest", label: "新しい順" },
+					{ value: "oldest", label: "古い順" },
+					{ value: "popular", label: "人気順" },
+					{ value: "price_low", label: "価格が安い順" },
+					{ value: "price_high", label: "価格が高い順" },
+				]}
+				defaultSort="newest"
+				itemsPerPageOptions={[12, 24, 48]}
+				emptyMessage="作品が見つかりませんでした"
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## 概要
サークル詳細ページ（`/circles/[circleId]`）を他のリストページと同様のGenericListアーキテクチャに移行し、検索機能を追加しました。

## 変更内容

### ✨ 新機能
- **検索機能の追加**: 作品タイトル、説明、声優名、ジャンルで検索可能
- **統一されたUI**: 他のリストページ（videos、audio buttons、works）と同じConfigurableListコンポーネントを使用

### 🔧 技術的改善
- `CircleWorksList`コンポーネントをConfigurableListベースに再実装
- 新しい`fetchCircleWorksForConfigurableList`関数でURLパラメータ連動を実装
- URLパラメータ`q`による検索機能の実装

### 🧹 クリーンアップ
- 重複していた以下の関数を削除：
  - `getCircleWorks`
  - `getCircleWorksWithPagination`
  - `getCircleWithWorksWithPagination`
  - `getCircleWithWorks`
- 旧実装のコンポーネントを削除
- **コード量を約50%削減**（566行 → 274行）

## メリット
- 🔍 **使いやすさ向上**: 検索機能により目的の作品を素早く見つけられる
- 🏗️ **保守性向上**: 統一されたパターンにより、他のリストページと同じ方法で保守可能
- 📦 **コード削減**: 重複コードの除去により複雑性が低減
- 🚀 **拡張性向上**: ConfigurableListの機能（フィルターなど）を将来的に追加可能

## テスト
- ✅ 全てのテストが合格
- ✅ 不要なテストケースを削除
- ✅ 新機能のテストを追加

## スクリーンショット
（検索機能やUIの変更がある場合は、スクリーンショットを追加してください）

🤖 Generated with [Claude Code](https://claude.ai/code)