### PR TITLE
refactor: 関数の認知的複雑度を削減

### DIFF
--- a/apps/functions/src/services/dlsite/creator-firestore.ts
+++ b/apps/functions/src/services/dlsite/creator-firestore.ts
@@ -67,7 +67,7 @@ function extractCreatorMappings(apiData: DLsiteRawApiResponse): Map<string, Extr
 				// 新規クリエイター
 				mappings.set(creator.id, {
 					id: creator.id,
-					name: creator.name,
+					name: creator.name || "Unknown Creator",
 					roles: [role],
 				});
 			}


### PR DESCRIPTION
## Summary
- Biomeリンターで報告された関数の認知的複雑度（Cognitive Complexity）警告を解消
- すべての関数の複雑度を15以下に削減し、コードの可読性とメンテナンス性を向上

## Changes
### 🔧 リファクタリングした関数

#### 1. `runWeeklyReport`関数（複雑度: 16 → 15以下）
ヘルパー関数に分割:
- `calculateSuccessRate` - 成功率計算
- `getTopFailureReasons` - 失敗理由の集計
- `evaluateSystemStatus` - システム状況評価
- `displayStatistics` - 統計情報表示
- `displayImprovementSuggestions` - 改善提案表示

#### 2. `processBatch`関数（複雑度: 24 → 15以下）
ヘルパー関数に分割:
- `createNoResponseResult` - エラーレスポンス作成
- `aggregateProcessingResults` - 処理結果集計
- `createBatchResult` - バッチ結果変換

#### 3. `executeUnifiedDataCollection`関数（複雑度: 32 → 15以下）
ヘルパー関数に分割:
- `getContinuationInfo` - 継続情報取得
- `collectWorkIdsWithFallback` - 作品ID収集（フォールバック付き）
- `initializeNewBatchProcessing` - 新規バッチ処理初期化
- `executeBatchLoop` - バッチループ実行
- `finalizeCompletedProcessing` - 完了処理

#### 4. `aggregateProcessingResults`関数（複雑度: 18 → 15以下）
- `countSuccessfulUpdates` - 成功カウント処理を分離

### 🐛 その他の修正
- ProcessingResult型のimportを追加
- creator.nameのundefined対応を追加（デフォルト値: "Unknown Creator"）
- 型定義を改善してnon-null assertionを削除

## Test plan
- [x] `pnpm test` - すべてのテストが成功
- [x] `pnpm build` - ビルドが成功
- [x] `pnpm typecheck` - 型チェックが成功
- [x] `pnpm lint` - 複雑度警告が解消

🤖 Generated with [Claude Code](https://claude.ai/code)