### PR TITLE
fix: PR #189マージ後のtypecheckエラーを修正

### DIFF
--- a/apps/functions/src/services/dlsite/work-id-collector.ts
+++ b/apps/functions/src/services/dlsite/work-id-collector.ts
@@ -79,14 +79,14 @@ function isValidWorkId(workId: string | undefined): boolean {
 /**
  * パターンマッチングで作品IDを抽出
  */
-function extractWorkIdsWithPatterns(html: string, patterns: RegExp[]): Set<string> {
+function extractWorkIdsWithPatterns(html: string, patterns: readonly RegExp[]): Set<string> {
 	const workIds = new Set<string>();
 
 	for (const pattern of patterns) {
 		const matches = [...html.matchAll(pattern)];
 		for (const match of matches) {
 			const workId = match[1];
-			if (isValidWorkId(workId)) {
+			if (workId && isValidWorkId(workId)) {
 				workIds.add(workId);
 			}
 		}


### PR DESCRIPTION
## Summary
PR #189のマージ後に発生したTypeScriptのtypecheckエラーを修正

## Changes
- `extractWorkIdsWithPatterns`関数でreadonly配列を受け入れるように修正
- `workId`がundefinedの場合のチェックを追加 
- TypeScriptの型エラーを解決

## Test plan
- [x] `pnpm typecheck` - エラーなし
- [x] `pnpm test -- --testPathPattern=work-id-collector` - 全テスト通過
- [x] `pnpm lint` - エラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)