### PR TITLE
fix: TypeScriptエラーを修正

### DIFF
--- a/apps/functions/src/tools/check-price-history.ts
+++ b/apps/functions/src/tools/check-price-history.ts
@@ -78,7 +78,9 @@ async function checkPriceHistory(workId: string): Promise<void> {
 		if (todayDoc.exists) {
 			logger.info(`\n今日（${today}）のデータが存在します`);
 			const todayData = todayDoc.data();
-			logger.info(`保存時刻: ${todayData.capturedAt}`);
+			if (todayData) {
+				logger.info(`保存時刻: ${todayData.capturedAt}`);
+			}
 		} else {
 			logger.warn(`\n今日（${today}）のデータが存在しません`);
 		}

--- a/apps/functions/src/tools/debug-price-history.ts
+++ b/apps/functions/src/tools/debug-price-history.ts
@@ -86,13 +86,15 @@ async function debugPriceHistory(workId: string): Promise<void> {
 
 		if (todayDoc.exists) {
 			const todayData = todayDoc.data();
-			logger.info(`\n今日（${today}）のデータ: 存在する`);
-			logger.info(`- capturedAt: ${todayData.capturedAt}`);
-			if (todayData.capturedAt) {
-				const capturedDate = new Date(todayData.capturedAt);
-				logger.info(
-					`- 保存時刻 (JST): ${capturedDate.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}`,
-				);
+			if (todayData) {
+				logger.info(`\n今日（${today}）のデータ: 存在する`);
+				logger.info(`- capturedAt: ${todayData.capturedAt}`);
+				if (todayData.capturedAt) {
+					const capturedDate = new Date(todayData.capturedAt);
+					logger.info(
+						`- 保存時刻 (JST): ${capturedDate.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}`,
+					);
+				}
 			}
 		} else {
 			logger.warn(`\n今日（${today}）のデータ: 存在しない`);
@@ -108,8 +110,10 @@ async function debugPriceHistory(workId: string): Promise<void> {
 
 		if (yesterdayDoc.exists) {
 			const yesterdayData = yesterdayDoc.data();
-			logger.info(`\n昨日（${yesterdayStr}）のデータ: 存在する`);
-			logger.info(`- capturedAt: ${yesterdayData.capturedAt}`);
+			if (yesterdayData) {
+				logger.info(`\n昨日（${yesterdayStr}）のデータ: 存在する`);
+				logger.info(`- capturedAt: ${yesterdayData.capturedAt}`);
+			}
 		} else {
 			logger.info(`\n昨日（${yesterdayStr}）のデータ: 存在しない`);
 		}

--- a/apps/functions/src/tools/test-price-history-date.ts
+++ b/apps/functions/src/tools/test-price-history-date.ts
@@ -2,7 +2,6 @@
  * 価格履歴の日付ロジックをテストするスクリプト
  */
 
-import { savePriceHistory } from "../services/price-history";
 import * as logger from "../shared/logger";
 
 /**
@@ -31,14 +30,16 @@ async function testDateCalculation(): Promise<void> {
 
 	// 現在の各種時刻を表示
 	const now = new Date();
-	logger.info("現在のUTC時刻:", now.toISOString());
-	logger.info("現在のローカル時刻:", now.toString());
-	logger.info("現在のJST時刻:", now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" }));
-	logger.info("getJSTDate()の結果:", getJSTDate());
+	logger.info("現在のUTC時刻:", { time: now.toISOString() });
+	logger.info("現在のローカル時刻:", { time: now.toString() });
+	logger.info("現在のJST時刻:", { time: now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" }) });
+	logger.info("getJSTDate()の結果:", { date: getJSTDate() });
 
 	// タイムゾーン情報
-	logger.info("実行環境のタイムゾーン:", Intl.DateTimeFormat().resolvedOptions().timeZone);
-	logger.info("UTC時刻のミリ秒:", Date.now());
+	logger.info("実行環境のタイムゾーン:", {
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+	});
+	logger.info("UTC時刻のミリ秒:", { milliseconds: Date.now() });
 
 	// 特定の時刻でのテスト（0:03 JST相当）
 	const testTimes = [
@@ -73,8 +74,8 @@ async function testDateCalculation(): Promise<void> {
 	};
 
 	logger.info("\n=== 価格履歴保存テスト ===");
-	logger.info("テスト作品ID:", testApiResponse.workno);
-	logger.info("現在のJST日付:", getJSTDate());
+	logger.info("テスト作品ID:", { workno: testApiResponse.workno });
+	logger.info("現在のJST日付:", { date: getJSTDate() });
 
 	// 実際の保存は実行しない（ドライラン）
 	logger.info("保存処理のドライランを実行（実際には保存しません）");


### PR DESCRIPTION
## Summary
PR #196マージ後のCIで発生したTypeScriptエラーを修正します。

## 変更内容

### 1. check-price-history.ts
- `todayData`の未定義チェックを追加

### 2. debug-price-history.ts  
- `todayData`と`yesterdayData`の未定義チェックを追加

### 3. test-price-history-date.ts
- 未使用の`savePriceHistory`インポートを削除
- `logger.info`の引数をオブジェクト形式に修正（TypeScript型エラーの解消）

## Test plan
- [x] TypeScriptの型チェックがパスすること
- [x] CI/CDパイプラインが正常に通ること

🤖 Generated with [Claude Code](https://claude.ai/code)