### PR TITLE
feat: サークル一覧とクリエイター一覧ページを追加

### DIFF
--- a/apps/web/src/app/circles/actions.ts
+++ b/apps/web/src/app/circles/actions.ts
@@ -1,0 +1,79 @@
+"use server";
+
+import type { CircleDocument, CirclePlainObject } from "@suzumina.click/shared-types";
+import { convertToCirclePlainObject } from "@suzumina.click/shared-types";
+import { getFirestore } from "@/lib/firestore";
+
+/**
+ * サークル一覧を取得（ConfigurableList用）
+ * @param params パラメータ
+ * @returns サークル一覧と総件数
+ */
+export async function getCircles(params: {
+	page?: number;
+	limit?: number;
+	sort?: string;
+	search?: string;
+}): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {
+	const { page = 1, limit = 12, sort = "name", search } = params;
+
+	try {
+		const firestore = getFirestore();
+
+		// 全サークルを取得
+		const circlesSnapshot = await firestore.collection("circles").get();
+
+		// CirclePlainObjectに変換
+		const allCircles: CirclePlainObject[] = [];
+		for (const doc of circlesSnapshot.docs) {
+			const data = doc.data() as CircleDocument;
+			const plainObject = convertToCirclePlainObject(data);
+			if (plainObject) {
+				allCircles.push(plainObject);
+			}
+		}
+
+		// 検索フィルタリング
+		let filteredCircles = allCircles;
+		if (search) {
+			const searchLower = search.toLowerCase();
+			filteredCircles = allCircles.filter((circle) => {
+				const searchableText = [circle.name, circle.nameEn].filter(Boolean).join(" ").toLowerCase();
+				return searchableText.includes(searchLower);
+			});
+		}
+
+		// ソート処理
+		filteredCircles.sort((a, b) => {
+			switch (sort) {
+				case "name":
+					// 名前順（昇順）
+					return a.name.localeCompare(b.name, "ja");
+				case "nameDesc":
+					// 名前順（降順）
+					return b.name.localeCompare(a.name, "ja");
+				case "workCount":
+					// 作品数順（多い順）
+					return b.workCount - a.workCount;
+				case "workCountAsc":
+					// 作品数順（少ない順）
+					return a.workCount - b.workCount;
+				default:
+					return a.name.localeCompare(b.name, "ja");
+			}
+		});
+
+		// ページネーション適用
+		const startIndex = (page - 1) * limit;
+		const endIndex = startIndex + limit;
+		const paginatedCircles = filteredCircles.slice(startIndex, endIndex);
+
+		return {
+			circles: paginatedCircles,
+			totalCount: filteredCircles.length,
+		};
+	} catch (_error) {
+		// エラー発生時は空配列を返す
+		return { circles: [], totalCount: 0 };
+	}
+}

--- a/apps/web/src/app/circles/components/CirclesList.tsx
+++ b/apps/web/src/app/circles/components/CirclesList.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import type { CirclePlainObject } from "@suzumina.click/shared-types";
+import {
+	ConfigurableList,
+	type StandardListParams,
+} from "@suzumina.click/ui/components/custom/list";
+import Link from "next/link";
+import { useCallback, useMemo } from "react";
+import { ListWrapper } from "@/components/list/ListWrapper";
+import { DEFAULT_LIST_PROPS } from "@/constants/list-options";
+import { getCircles } from "../actions";
+
+interface CirclesListProps {
+	initialData?: {
+		circles: CirclePlainObject[];
+		totalCount: number;
+	};
+}
+
+// サークルのソートオプション
+const CIRCLE_SORT_OPTIONS = [
+	{ value: "name", label: "名前順（昇順）" },
+	{ value: "nameDesc", label: "名前順（降順）" },
+	{ value: "workCount", label: "作品数（多い順）" },
+	{ value: "workCountAsc", label: "作品数（少ない順）" },
+];
+
+// サークルアイテムコンポーネント
+function CircleListItem({ circle }: { circle: CirclePlainObject }) {
+	return (
+		<Link
+			href={`/circles/${circle.circleId}`}
+			className="block p-4 rounded-lg border bg-card hover:bg-accent transition-colors"
+		>
+			<div className="flex items-center justify-between">
+				<div className="flex-1 min-w-0">
+					<h3 className="font-semibold text-lg truncate">{circle.name}</h3>
+					{circle.nameEn && (
+						<p className="text-sm text-muted-foreground truncate">{circle.nameEn}</p>
+					)}
+				</div>
+				<div className="flex-shrink-0 ml-4">
+					<div className="text-right">
+						<div className="text-2xl font-bold text-primary">{circle.workCount}</div>
+						<div className="text-xs text-muted-foreground">作品</div>
+					</div>
+				</div>
+			</div>
+		</Link>
+	);
+}
+
+export default function CirclesList({ initialData }: CirclesListProps) {
+	// 初期データを準備
+	const initialItems = initialData?.circles || [];
+	const initialTotal = initialData?.totalCount || 0;
+
+	// データアダプター
+	const dataAdapter = useMemo(
+		() => ({
+			toParams: (params: StandardListParams) => {
+				return {
+					page: params.page,
+					limit: params.itemsPerPage,
+					sort: params.sort || "name",
+					search: params.search,
+				};
+			},
+			fromResult: (result: unknown) => result as { items: CirclePlainObject[]; total: number },
+		}),
+		[],
+	);
+
+	// フェッチ関数
+	const fetchFn = useCallback(async (params: unknown) => {
+		const typedParams = params as Parameters<typeof getCircles>[0];
+		const result = await getCircles(typedParams);
+		return {
+			items: result.circles,
+			total: result.totalCount || 0,
+		};
+	}, []);
+
+	return (
+		<ListWrapper>
+			<ConfigurableList<CirclePlainObject>
+				items={initialItems}
+				initialTotal={initialTotal}
+				renderItem={(circle) => <CircleListItem circle={circle} />}
+				fetchFn={fetchFn}
+				dataAdapter={dataAdapter}
+				{...DEFAULT_LIST_PROPS}
+				sorts={CIRCLE_SORT_OPTIONS}
+				defaultSort="name"
+				itemsPerPageOptions={[12, 24, 48]}
+				emptyMessage="サークルが見つかりませんでした"
+				searchPlaceholder="サークル名で検索"
+			/>
+		</ListWrapper>
+	);
+}

--- a/apps/web/src/app/circles/page.tsx
+++ b/apps/web/src/app/circles/page.tsx
@@ -1,0 +1,41 @@
+import { CirclesPageClient } from "@/components/content/circles-page-client";
+import { getCircles } from "./actions";
+
+interface CirclesPageProps {
+	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function CirclesPage({ searchParams }: CirclesPageProps) {
+	const params = await searchParams;
+	const pageNumber = Number.parseInt(params.page as string, 10) || 1;
+	const validPage = Math.max(1, pageNumber);
+	const sort = typeof params.sort === "string" ? params.sort : "name";
+	const search = typeof params.q === "string" ? params.q : undefined;
+	const limitValue = Number.parseInt(params.limit as string, 10) || 12;
+	const validLimit = [12, 24, 48].includes(limitValue) ? limitValue : 12;
+
+	// 初期データを取得
+	const result = await getCircles({
+		page: validPage,
+		limit: validLimit,
+		sort,
+		search,
+	});
+
+	return <CirclesPageClient initialData={result} />;
+}
+
+// メタデータ設定
+export const metadata = {
+	title: "サークル一覧",
+	description: "DLsiteで活動するサークルの一覧。作品数やサークル名で検索・並び替えができます。",
+	keywords: ["DLsite", "サークル", "制作者", "クリエイター", "音声作品"],
+	openGraph: {
+		title: "サークル一覧 | すずみなくりっく！",
+		description: "DLsiteで活動するサークルの一覧。作品数やサークル名で検索・並び替えができます。",
+		url: "https://suzumina.click/circles",
+	},
+	alternates: {
+		canonical: "/circles",
+	},
+};

--- a/apps/web/src/app/creators/actions.ts
+++ b/apps/web/src/app/creators/actions.ts
@@ -1,0 +1,115 @@
+"use server";
+
+import type {
+	CreatorDocument,
+	CreatorPageInfo,
+	CreatorWorkRelation,
+} from "@suzumina.click/shared-types";
+import { getFirestore } from "@/lib/firestore";
+
+/**
+ * クリエイター一覧を取得（ConfigurableList用）
+ * @param params パラメータ
+ * @returns クリエイター一覧と総件数
+ */
+export async function getCreators(params: {
+	page?: number;
+	limit?: number;
+	sort?: string;
+	search?: string;
+	role?: string;
+}): Promise<{ creators: CreatorPageInfo[]; totalCount: number }> {
+	const { page = 1, limit = 12, sort = "name", search, role } = params;
+
+	try {
+		const firestore = getFirestore();
+
+		// 全クリエイターを取得
+		const creatorsSnapshot = await firestore.collection("creators").get();
+
+		// CreatorPageInfoに変換
+		const allCreators: CreatorPageInfo[] = [];
+
+		for (const doc of creatorsSnapshot.docs) {
+			const creatorData = doc.data() as CreatorDocument;
+
+			// worksサブコレクションから作品数と役割を取得
+			const worksSnapshot = await doc.ref.collection("works").get();
+
+			const allTypes = new Set<string>();
+			worksSnapshot.docs.forEach((workDoc) => {
+				const workRelation = workDoc.data() as CreatorWorkRelation;
+				workRelation.roles?.forEach((r) => allTypes.add(r));
+			});
+
+			// primaryRoleが設定されていて、typesに含まれていない場合は追加
+			if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
+				allTypes.add(creatorData.primaryRole);
+			}
+
+			const creatorInfo: CreatorPageInfo = {
+				id: creatorData.creatorId,
+				name: creatorData.name,
+				types: Array.from(allTypes),
+				workCount: worksSnapshot.size,
+			};
+
+			allCreators.push(creatorInfo);
+		}
+
+		// 役割でフィルタリング
+		let filteredCreators = allCreators;
+		if (role && role !== "all") {
+			filteredCreators = allCreators.filter((creator) => creator.types.includes(role));
+		}
+
+		// 検索フィルタリング
+		if (search) {
+			const searchLower = search.toLowerCase();
+			filteredCreators = filteredCreators.filter((creator) => {
+				return creator.name.toLowerCase().includes(searchLower);
+			});
+		}
+
+		// ソート処理
+		filteredCreators.sort((a, b) => {
+			switch (sort) {
+				case "name":
+					// 名前順（昇順）
+					return a.name.localeCompare(b.name, "ja");
+				case "nameDesc":
+					// 名前順（降順）
+					return b.name.localeCompare(a.name, "ja");
+				case "workCount":
+					// 作品数順（多い順）
+					if (b.workCount !== a.workCount) {
+						return b.workCount - a.workCount;
+					}
+					// 作品数が同じ場合は名前順
+					return a.name.localeCompare(b.name, "ja");
+				case "workCountAsc":
+					// 作品数順（少ない順）
+					if (a.workCount !== b.workCount) {
+						return a.workCount - b.workCount;
+					}
+					// 作品数が同じ場合は名前順
+					return a.name.localeCompare(b.name, "ja");
+				default:
+					return a.name.localeCompare(b.name, "ja");
+			}
+		});
+
+		// ページネーション適用
+		const startIndex = (page - 1) * limit;
+		const endIndex = startIndex + limit;
+		const paginatedCreators = filteredCreators.slice(startIndex, endIndex);
+
+		return {
+			creators: paginatedCreators,
+			totalCount: filteredCreators.length,
+		};
+	} catch (_error) {
+		// エラー発生時は空配列を返す
+		return { creators: [], totalCount: 0 };
+	}
+}

--- a/apps/web/src/app/creators/components/CreatorsList.tsx
+++ b/apps/web/src/app/creators/components/CreatorsList.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+	CREATOR_TYPE_LABELS,
+	type CreatorPageInfo,
+	type CreatorType,
+} from "@suzumina.click/shared-types";
+import {
+	ConfigurableList,
+	type StandardListParams,
+} from "@suzumina.click/ui/components/custom/list";
+import { Badge } from "@suzumina.click/ui/components/ui/badge";
+import Link from "next/link";
+import { useCallback, useMemo } from "react";
+import { ListWrapper } from "@/components/list/ListWrapper";
+import { DEFAULT_LIST_PROPS } from "@/constants/list-options";
+import { getCreators } from "../actions";
+
+interface CreatorsListProps {
+	initialData?: {
+		creators: CreatorPageInfo[];
+		totalCount: number;
+	};
+}
+
+// クリエイターのソートオプション
+const CREATOR_SORT_OPTIONS = [
+	{ value: "name", label: "名前順（昇順）" },
+	{ value: "nameDesc", label: "名前順（降順）" },
+	{ value: "workCount", label: "作品数（多い順）" },
+	{ value: "workCountAsc", label: "作品数（少ない順）" },
+];
+
+// 役割フィルターのオプション
+const ROLE_OPTIONS = [
+	{ value: "all", label: "すべての役割" },
+	...Object.entries(CREATOR_TYPE_LABELS).map(([value, label]) => ({
+		value,
+		label,
+	})),
+];
+
+// クリエイターアイテムコンポーネント
+function CreatorListItem({ creator }: { creator: CreatorPageInfo }) {
+	return (
+		<Link
+			href={`/creators/${creator.id}`}
+			className="block p-4 rounded-lg border bg-card hover:bg-accent transition-colors"
+		>
+			<div className="flex items-center justify-between">
+				<div className="flex-1 min-w-0">
+					<h3 className="font-semibold text-lg truncate">{creator.name}</h3>
+					<div className="flex flex-wrap gap-1 mt-2">
+						{creator.types.map((type) => {
+							const label = CREATOR_TYPE_LABELS[type as CreatorType] || type;
+							return (
+								<Badge key={type} variant="secondary" className="text-xs">
+									{label}
+								</Badge>
+							);
+						})}
+					</div>
+				</div>
+				<div className="flex-shrink-0 ml-4">
+					<div className="text-right">
+						<div className="text-2xl font-bold text-primary">{creator.workCount}</div>
+						<div className="text-xs text-muted-foreground">作品</div>
+					</div>
+				</div>
+			</div>
+		</Link>
+	);
+}
+
+export default function CreatorsList({ initialData }: CreatorsListProps) {
+	// 初期データを準備
+	const initialItems = initialData?.creators || [];
+	const initialTotal = initialData?.totalCount || 0;
+
+	// データアダプター
+	const dataAdapter = useMemo(
+		() => ({
+			toParams: (params: StandardListParams) => {
+				return {
+					page: params.page,
+					limit: params.itemsPerPage,
+					sort: params.sort || "name",
+					search: params.search,
+					role: params.filters.role as string | undefined,
+				};
+			},
+			fromResult: (result: unknown) => result as { items: CreatorPageInfo[]; total: number },
+		}),
+		[],
+	);
+
+	// フェッチ関数
+	const fetchFn = useCallback(async (params: unknown) => {
+		const typedParams = params as Parameters<typeof getCreators>[0];
+		const result = await getCreators(typedParams);
+		return {
+			items: result.creators,
+			total: result.totalCount || 0,
+		};
+	}, []);
+
+	return (
+		<ListWrapper>
+			<ConfigurableList<CreatorPageInfo>
+				items={initialItems}
+				initialTotal={initialTotal}
+				renderItem={(creator) => <CreatorListItem creator={creator} />}
+				fetchFn={fetchFn}
+				dataAdapter={dataAdapter}
+				{...DEFAULT_LIST_PROPS}
+				sorts={CREATOR_SORT_OPTIONS}
+				defaultSort="name"
+				filters={{
+					role: {
+						type: "select",
+						label: "役割",
+						placeholder: "すべての役割",
+						options: ROLE_OPTIONS,
+						showAll: false, // "all" オプションを明示的に含めているのでshowAllは不要
+						emptyValue: "all",
+					},
+				}}
+				itemsPerPageOptions={[12, 24, 48]}
+				emptyMessage="クリエイターが見つかりませんでした"
+				searchPlaceholder="クリエイター名で検索"
+			/>
+		</ListWrapper>
+	);
+}

--- a/apps/web/src/app/creators/page.tsx
+++ b/apps/web/src/app/creators/page.tsx
@@ -1,0 +1,45 @@
+import { CreatorsPageClient } from "@/components/content/creators-page-client";
+import { getCreators } from "./actions";
+
+interface CreatorsPageProps {
+	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function CreatorsPage({ searchParams }: CreatorsPageProps) {
+	const params = await searchParams;
+	const pageNumber = Number.parseInt(params.page as string, 10) || 1;
+	const validPage = Math.max(1, pageNumber);
+	const sort = typeof params.sort === "string" ? params.sort : "name";
+	const search = typeof params.q === "string" ? params.q : undefined;
+	const role = typeof params.role === "string" ? params.role : undefined;
+	const limitValue = Number.parseInt(params.limit as string, 10) || 12;
+	const validLimit = [12, 24, 48].includes(limitValue) ? limitValue : 12;
+
+	// 初期データを取得
+	const result = await getCreators({
+		page: validPage,
+		limit: validLimit,
+		sort,
+		search,
+		role,
+	});
+
+	return <CreatorsPageClient initialData={result} />;
+}
+
+// メタデータ設定
+export const metadata = {
+	title: "クリエイター一覧",
+	description:
+		"音声作品を手がけるクリエイターの一覧。声優、イラストレーター、シナリオライターなど、役割別に検索・並び替えができます。",
+	keywords: ["クリエイター", "声優", "イラストレーター", "シナリオライター", "音楽", "音声作品"],
+	openGraph: {
+		title: "クリエイター一覧 | すずみなくりっく！",
+		description:
+			"音声作品を手がけるクリエイターの一覧。声優、イラストレーター、シナリオライターなど、役割別に検索・並び替えができます。",
+		url: "https://suzumina.click/creators",
+	},
+	alternates: {
+		canonical: "/creators",
+	},
+};

--- a/apps/web/src/components/content/circles-page-client.tsx
+++ b/apps/web/src/components/content/circles-page-client.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { CirclePlainObject } from "@suzumina.click/shared-types";
+import {
+	ListPageContent,
+	ListPageHeader,
+	ListPageLayout,
+} from "@suzumina.click/ui/components/custom/list-page-layout";
+import { Suspense } from "react";
+import CirclesList from "@/app/circles/components/CirclesList";
+
+interface CirclesPageClientProps {
+	initialData: {
+		circles: CirclePlainObject[];
+		totalCount: number;
+	};
+}
+
+export function CirclesPageClient({ initialData }: CirclesPageClientProps) {
+	return (
+		<ListPageLayout>
+			<ListPageHeader
+				title="サークル一覧"
+				description="DLsiteで活動するサークルの一覧。作品数やサークル名で検索・並び替えができます"
+			/>
+
+			<ListPageContent>
+				<Suspense
+					fallback={
+						<div className="text-center py-12">
+							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+							<p className="mt-2 text-muted-foreground">読み込み中...</p>
+						</div>
+					}
+				>
+					<CirclesList initialData={initialData} />
+				</Suspense>
+			</ListPageContent>
+		</ListPageLayout>
+	);
+}

--- a/apps/web/src/components/content/creators-page-client.tsx
+++ b/apps/web/src/components/content/creators-page-client.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { CreatorPageInfo } from "@suzumina.click/shared-types";
+import {
+	ListPageContent,
+	ListPageHeader,
+	ListPageLayout,
+} from "@suzumina.click/ui/components/custom/list-page-layout";
+import { Suspense } from "react";
+import CreatorsList from "@/app/creators/components/CreatorsList";
+
+interface CreatorsPageClientProps {
+	initialData: {
+		creators: CreatorPageInfo[];
+		totalCount: number;
+	};
+}
+
+export function CreatorsPageClient({ initialData }: CreatorsPageClientProps) {
+	return (
+		<ListPageLayout>
+			<ListPageHeader
+				title="クリエイター一覧"
+				description="音声作品を手がけるクリエイターの一覧。声優、イラストレーター、シナリオライターなど、役割別に検索・並び替えができます"
+			/>
+
+			<ListPageContent>
+				<Suspense
+					fallback={
+						<div className="text-center py-12">
+							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+							<p className="mt-2 text-muted-foreground">読み込み中...</p>
+						</div>
+					}
+				>
+					<CreatorsList initialData={initialData} />
+				</Suspense>
+			</ListPageContent>
+		</ListPageLayout>
+	);
+}


### PR DESCRIPTION
## 概要
サークル一覧ページ（`/circles`）とクリエイター一覧ページ（`/creators`）を新規実装しました。
既存の作品一覧ページと同じConfigurableListコンポーネントを使用した統一的な実装です。

## 実装内容

### 🎯 サークル一覧 (/circles)
- サークル名（日本語/英語）と作品数を表示
- 名前順・作品数順でソート可能
- サークル名での検索機能
- ページネーション対応 (12/24/48件表示)
- URLパラメータ同期

### 👥 クリエイター一覧 (/creators)
- クリエイター名と参加作品数を表示
- 役割（声優/イラスト/シナリオ/音楽/その他）をバッジ表示
- 役割別フィルター機能
- 名前順・作品数順でソート可能
- クリエイター名での検索機能
- ページネーション対応 (12/24/48件表示)
- URLパラメータ同期

## 技術詳細
- `ConfigurableList`コンポーネントを使用した統一的な実装
- 既存の`/works`ページと同じパターンに準拠
- Server Actions経由でFirestoreからデータ取得
- URL同期により検索条件・ページ番号を保持
- TypeScript型安全性を確保
- レスポンシブデザイン対応

## 変更ファイル
- `apps/web/src/app/circles/` - サークル一覧ページ実装
- `apps/web/src/app/creators/` - クリエイター一覧ページ実装
- `apps/web/src/components/content/` - クライアントコンポーネント

## テスト
- ✅ TypeScript型チェック通過
- ✅ Biomeリンティング通過
- ✅ 既存テストすべて通過（640 passed）

## スクリーンショット
（実装後、手動でアクセスして確認をお願いします）

## 今後の改善案
- 画像サムネイル表示の追加
- より詳細なフィルター機能
- お気に入り機能の追加

🤖 Generated with [Claude Code](https://claude.ai/code)