### PR TITLE
feat: システムフォントへの移行で帯域使用を削減

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { M_PLUS_Rounded_1c } from "next/font/google";
 import "@suzumina.click/ui/globals.css";
 import { Toaster } from "@suzumina.click/ui/components/ui/sonner";
 import { GoogleAnalyticsScript } from "@/components/analytics/google-analytics-script";
@@ -16,18 +15,6 @@ import SiteHeader from "@/components/layout/site-header";
 import PerformanceMonitor from "@/components/system/performance-monitor";
 import { SessionProvider } from "@/components/user/session-provider";
 import { AgeVerificationProvider } from "@/contexts/age-verification-context";
-
-// フォント最適化: 必要な重みのみを読み込み、LCP改善
-const mPlusRounded = M_PLUS_Rounded_1c({
-	subsets: ["latin", "latin-ext"], // 拡張ラテン文字対応
-	weight: ["400", "500", "700"], // 必要な重みのみ読み込み
-	display: "swap", // FOUT回避
-	preload: true, // LCP改善
-	fallback: ["Hiragino Kaku Gothic ProN", "Hiragino Sans", "Meiryo", "sans-serif"], // 日本語フォールバック
-	adjustFontFallback: true, // CLS改善
-	// 日本語サブセット追加検討（ファイルサイズとのトレードオフ）
-	// subsets: ["latin", "latin-ext"], // 現在はlatin-extで十分
-});
 
 export const metadata: Metadata = {
 	title: {
@@ -96,14 +83,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<html lang="ja" className="scroll-smooth">
 			<head>
 				{/* DNS prefetch for external domains */}
-				<link rel="dns-prefetch" href="//fonts.googleapis.com" />
 				<link rel="dns-prefetch" href="//www.google-analytics.com" />
 				<link rel="dns-prefetch" href="//img.dlsite.jp" />
 				<link rel="dns-prefetch" href="//i.ytimg.com" />
-
-				{/* Preconnect for critical domains */}
-				<link rel="preconnect" href="https://fonts.googleapis.com" />
-				<link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
 
 				{/* Resource hints for performance */}
 				<link rel="prefetch" href="/api/health" />
@@ -112,9 +94,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				<GoogleAnalyticsScript />
 				<GoogleTagManager />
 			</head>
-			<body
-				className={`${mPlusRounded.className} min-h-screen flex flex-col antialiased gradient-bg`}
-			>
+			<body className="min-h-screen flex flex-col antialiased gradient-bg">
 				<GoogleTagManagerNoscript />
 				<AgeVerificationProvider>
 					<AgeVerificationWrapper>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -416,6 +416,35 @@
 		color: hsl(var(--foreground));
 	}
 
+	/* 日本語システムフォントスタック */
+	/* Web Fontを使用せず帯域を節約し、各OSネイティブフォントを活用 */
+	body {
+		font-family:
+			/* 丸みのあるフォント優先 (macOS/iOS) */
+			"ヒラギノ丸ゴ ProN",
+			"Hiragino Maru Gothic ProN",
+			/* 懐が広く読みやすいフォント (Windows) */
+			"メイリオ",
+			Meiryo,
+			/* UD（ユニバーサルデザイン）フォント (Windows 10+) */
+			"BIZ UDゴシック",
+			"BIZ UDGothic",
+			/* 標準ゴシック体 */
+			"ヒラギノ角ゴ ProN",
+			"Hiragino Kaku Gothic ProN",
+			"游ゴシック体",
+			YuGothic,
+			"Yu Gothic",
+			/* システムデフォルト */
+			system-ui,
+			-apple-system,
+			BlinkMacSystemFont,
+			"Segoe UI",
+			Roboto,
+			"Noto Sans CJK JP",
+			sans-serif;
+	}
+
 	/* フォーカス状態の改善 */
 	*:focus-visible {
 		outline: none;


### PR DESCRIPTION
## 概要
Google Fonts (M PLUS Rounded 1c)から日本語システムフォントスタックへ移行し、Web Fontのダウンロードを不要にすることで帯域使用量を削減します。

## 背景
最適化されたフォントのダウンロードで帯域を消費しているユーザーが見受けられるため、各OSの標準フォントを活用することで帯域使用を削減し、パフォーマンスを向上させます。

## 変更内容
- 🗑️ Google Fontsの読み込みを削除（M_PLUS_Rounded_1c）
- ✨ 日本語システムフォントスタックを実装
- 🔧 不要なpreconnect/dns-prefetchタグを削除

## フォント優先順位
1. **ヒラギノ丸ゴ ProN** (macOS/iOS) - 丸みのあるフォント
2. **メイリオ** (Windows) - 懐が広く読みやすい
3. **BIZ UDゴシック** (Windows 10+) - ユニバーサルデザイン
4. **ヒラギノ角ゴ/游ゴシック** - 標準ゴシック体
5. システムデフォルトフォントへフォールバック

## 効果
- 🚀 Web Fontダウンロードが不要になり、初期表示速度が向上
- 📉 帯域使用量の削減（特にモバイル環境で有効）
- 🎨 各OSネイティブのフォントレンダリングを活用

## テスト
- ✅ ビルド成功
- ✅ TypeScript型チェック通過
- ✅ Linting通過

## 今後の展開
一旦このデフォルトフォント構成でリリースし、実際のユーザーニーズに基づいて判断する予定です。必要に応じて、Web Fontの再導入も検討可能です。

🤖 Generated with [Claude Code](https://claude.ai/code)