### PR TITLE
feat: YouTube動画の埋め込み制限チェック機能を実装

### DIFF
--- a/apps/functions/src/services/mappers/video-mapper.ts
+++ b/apps/functions/src/services/mappers/video-mapper.ts
@@ -167,6 +167,7 @@ function createVideoContentFromYouTube(video: youtube_v3.Schema$Video): VideoCon
 		const publishedAt = new PublishedAt(publishedDate);
 		const privacyStatus = (video.status?.privacyStatus || "public") as PrivacyStatus;
 		const uploadStatus = (video.status?.uploadStatus || "processed") as UploadStatus;
+		const embeddable = video.status?.embeddable ?? undefined;
 
 		// Create ContentDetails if available
 		const contentDetails = video.contentDetails
@@ -187,6 +188,7 @@ function createVideoContentFromYouTube(video: youtube_v3.Schema$Video): VideoCon
 			contentDetails,
 			video.player?.embedHtml || undefined,
 			video.snippet.tags || undefined,
+			embeddable,
 		);
 	} catch (error) {
 		logger.error("Failed to create VideoContent", {

--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -62,6 +62,47 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 		notFound();
 	}
 
+	// 埋め込み制限チェック
+	if (videoResult.status?.embeddable === false) {
+		return (
+			<div className="container mx-auto px-4 py-8 max-w-4xl">
+				<div className="mb-6">
+					<Button variant="ghost" size="sm" asChild>
+						<Link href="/videos" className="flex items-center gap-2">
+							<ArrowLeft className="h-4 w-4" />
+							動画一覧に戻る
+						</Link>
+					</Button>
+				</div>
+
+				<div className="flex flex-col items-center justify-center py-12 text-center space-y-4">
+					<AlertCircle className="h-12 w-12 text-destructive" />
+					<h1 className="text-2xl font-bold text-foreground">
+						この動画は埋め込みが制限されています
+					</h1>
+					<p className="text-muted-foreground max-w-md">
+						動画の所有者によって埋め込みが無効にされているため、音声ボタンを作成できません。
+					</p>
+					<p className="text-sm text-muted-foreground">動画タイトル: {videoResult.title}</p>
+					<div className="flex gap-3">
+						<Button asChild>
+							<Link href="/videos">他の動画を選ぶ</Link>
+						</Button>
+						<Button variant="outline" asChild>
+							<a
+								href={`https://youtube.com/watch?v=${videoId}`}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								YouTubeで見る
+							</a>
+						</Button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	// 動画の長さを取得（秒数に変換）
 	const videoDurationSeconds = parseDurationToSeconds(videoResult.duration);
 	// フォールバック: 取得失敗時は10分

--- a/apps/web/src/app/videos/components/VideoCard.tsx
+++ b/apps/web/src/app/videos/components/VideoCard.tsx
@@ -9,7 +9,7 @@ import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
-import { Calendar, Clock, ExternalLink, Eye, Plus, Radio, Video } from "lucide-react";
+import { Calendar, Clock, ExternalLink, Eye, Lock, Plus, Radio, Video } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -186,6 +186,14 @@ const VideoCard = memo(function VideoCard({
 			};
 		}
 
+		// 埋め込み制限チェック
+		if (video.status?.embeddable === false) {
+			return {
+				canCreate: false,
+				reason: "この動画は埋め込みが制限されているため、音声ボタンを作成できません",
+			};
+		}
+
 		// 動画の条件をチェック
 		const videoCanCreate = canCreateAudioButton(video);
 		if (!videoCanCreate) {
@@ -252,6 +260,19 @@ const VideoCard = memo(function VideoCard({
 								aria-label={`${actualButtonCount}個の音声ボタンが作成されています`}
 							>
 								{actualButtonCount} ボタン
+							</Badge>
+						</div>
+					)}
+					{video.status?.embeddable === false && (
+						<div className="absolute top-2 right-2">
+							<Badge
+								variant="destructive"
+								className="bg-red-600/90 text-white"
+								aria-label="埋め込み制限あり"
+								title="この動画は埋め込みが制限されているため、音声ボタンを作成できません"
+							>
+								<Lock className="h-3 w-3 mr-1" aria-hidden="true" />
+								埋め込み不可
 							</Badge>
 						</div>
 					)}

--- a/packages/shared-types/src/entities/video.ts
+++ b/packages/shared-types/src/entities/video.ts
@@ -305,11 +305,12 @@ export class Video {
 	}
 
 	get status():
-		| { privacyStatus: string; uploadStatus: string; commentStatus?: string }
+		| { privacyStatus: string; uploadStatus: string; embeddable?: boolean; commentStatus?: string }
 		| undefined {
 		return {
 			privacyStatus: this._content.privacyStatus,
 			uploadStatus: this._content.uploadStatus,
+			embeddable: this._content.embeddable,
 		};
 	}
 
@@ -325,6 +326,13 @@ export class Video {
 	 */
 	isAvailable(): boolean {
 		return this._content.isAvailable();
+	}
+
+	/**
+	 * Checks if the video is embeddable
+	 */
+	isEmbeddable(): boolean {
+		return this._content.isEmbeddable();
 	}
 
 	/**
@@ -593,6 +601,7 @@ export class Video {
 			Video.createContentDetailsFromFirestore(data),
 			data.player?.embedHtml,
 			data.tags,
+			data.status?.embeddable,
 		);
 
 		// Create metadata
@@ -760,10 +769,15 @@ export class Video {
 	 * Add status to Firestore data if available
 	 */
 	private addStatusToFirestore(data: FirestoreServerVideoData): void {
-		if (this._content.privacyStatus || this._content.uploadStatus) {
+		if (
+			this._content.privacyStatus ||
+			this._content.uploadStatus ||
+			this._content.embeddable !== undefined
+		) {
 			data.status = {
 				privacyStatus: this._content.privacyStatus,
 				uploadStatus: this._content.uploadStatus,
+				embeddable: this._content.embeddable,
 			};
 		}
 	}

--- a/packages/shared-types/src/value-objects/video/video-content.ts
+++ b/packages/shared-types/src/value-objects/video/video-content.ts
@@ -250,6 +250,7 @@ export class VideoContent
 		public readonly contentDetails?: ContentDetails,
 		public readonly embedHtml?: string,
 		public readonly tags?: string[],
+		public readonly embeddable?: boolean,
 	) {
 		super();
 	}
@@ -271,6 +272,7 @@ export class VideoContent
 		};
 		embedHtml?: string;
 		tags?: string[];
+		embeddable?: boolean;
 	}): VideoContent {
 		return new VideoContent(
 			new VideoId(data.videoId),
@@ -288,6 +290,7 @@ export class VideoContent
 				: undefined,
 			data.embedHtml,
 			data.tags,
+			data.embeddable,
 		);
 	}
 
@@ -303,6 +306,13 @@ export class VideoContent
 	 */
 	isAvailable(): boolean {
 		return this.uploadStatus === "processed" && this.privacyStatus !== "private";
+	}
+
+	/**
+	 * Checks if video is embeddable
+	 */
+	isEmbeddable(): boolean {
+		return this.embeddable !== false;
 	}
 
 	/**
@@ -379,6 +389,7 @@ export class VideoContent
 		};
 		embedHtml?: string;
 		tags?: string[];
+		embeddable?: boolean;
 	} {
 		return {
 			videoId: this.videoId.toString(),
@@ -396,6 +407,7 @@ export class VideoContent
 				: undefined,
 			embedHtml: this.embedHtml,
 			tags: this.tags,
+			embeddable: this.embeddable,
 		};
 	}
 
@@ -408,6 +420,7 @@ export class VideoContent
 			this.contentDetails?.clone(),
 			this.embedHtml,
 			this.tags ? [...this.tags] : undefined,
+			this.embeddable,
 		);
 	}
 
@@ -448,7 +461,8 @@ export class VideoContent
 			this.uploadStatus === other.uploadStatus &&
 			contentDetailsEqual &&
 			this.embedHtml === other.embedHtml &&
-			tagsEqual
+			tagsEqual &&
+			this.embeddable === other.embeddable
 		);
 	}
 }


### PR DESCRIPTION
## 概要
動画の所有者が埋め込みを無効にしている動画を判定し、音声ボタン作成を制限する機能を追加しました。

## 背景
ユーザーから「初配信のアーカイブから音声ボタンを作成しようとしたが再生できなかった」というバグ報告をいただきました。調査の結果、一部の動画で埋め込みが制限されていることが判明したため、適切にハンドリングする必要がありました。

## 実装内容

### バックエンド
- YouTube Data APIから`status.embeddable`フィールドを取得するようにVideoMapperを修正
- `VideoContent`クラスに`embeddable`プロパティと`isEmbeddable()`メソッドを追加
- `Video`エンティティがembeddable情報をFirestoreに保存するように修正

### フロントエンド  
- 音声ボタン作成ページで埋め込み制限をチェック
- 埋め込み不可の動画では専用のエラー画面を表示
  - 動画タイトルを表示
  - YouTubeで視聴するリンクを提供
  - 他の動画を選ぶオプションを提供
- 動画一覧で埋め込み不可動画に視覚的インジケーターを追加
  - 赤色の「埋め込み不可」バッジ（鍵アイコン付き）
  - ツールチップで詳細説明

## スクリーンショット
- 埋め込み制限のある動画で音声ボタン作成を試みた際のエラー画面
- 動画一覧での埋め込み不可バッジ表示

## 互換性
- 既存データとの互換性を維持（`embeddable`が`undefined`の場合は埋め込み可能と判定）
- 今後のYouTube動画データ更新時に自動的にembeddable情報が取得される

## テスト
- [x] 型チェック: `pnpm typecheck` ✅
- [x] ユニットテスト: `pnpm test` ✅  
- [x] Lintチェック: `pnpm lint` ✅

## チェックリスト
- [x] コードがプロジェクトのスタイルガイドラインに従っている
- [x] セルフレビューを実施した
- [x] 既存の機能に影響を与えない
- [x] 依存関係の変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)