### PR TITLE
refactor: Phase 1 Week 3 - Work Entity使用箇所を関数型APIに移行

### DIFF
--- a/apps/web/src/app/circles/[circleId]/actions.ts
+++ b/apps/web/src/app/circles/[circleId]/actions.ts
@@ -8,8 +8,8 @@ import type {
 } from "@suzumina.click/shared-types";
 import {
 	convertToCirclePlainObject,
-	convertToWorkPlainObject,
 	isValidCircleId,
+	workTransformers,
 } from "@suzumina.click/shared-types";
 import { getFirestore } from "@/lib/firestore";
 import { warn } from "@/lib/logger";
@@ -143,16 +143,13 @@ export async function getCircleWorksList(params: {
 		// WorkPlainObjectに変換
 		const convertedWorks: WorkPlainObject[] = [];
 		for (const work of allMatchingWorks) {
-			const result = convertToWorkPlainObject(work);
-			if (result.isOk()) {
-				convertedWorks.push(result.value);
-			} else {
+			try {
+				const converted = workTransformers.fromFirestore(work);
+				convertedWorks.push(converted);
+			} catch (error) {
 				// Log warning but continue processing other items
 				warn(`Failed to convert work ${work.id}`, {
-					error:
-						result.error.type === "DatabaseError"
-							? result.error.detail
-							: `${result.error.resource} not found: ${result.error.id}`,
+					error: error instanceof Error ? error.message : String(error),
 				});
 			}
 		}

--- a/apps/web/src/components/content/featured-works-carousel.tsx
+++ b/apps/web/src/components/content/featured-works-carousel.tsx
@@ -34,7 +34,7 @@ export function FeaturedWorksCarousel({ works }: FeaturedWorksCarouselProps) {
 			<CarouselContent className="-ml-2 md:-ml-4">
 				{works.map((work, index) => (
 					<CarouselItem
-						key={work.id}
+						key={work.id || work.productId || `work-${index}`}
 						className="pl-2 md:pl-4 min-w-0"
 						style={{
 							flexBasis: "clamp(240px, 45vw, 320px)",

--- a/packages/shared-types/src/transformers/firestore.ts
+++ b/packages/shared-types/src/transformers/firestore.ts
@@ -16,7 +16,11 @@ export function fromFirestore(doc: WorkDocument): WorkPlainObject {
 	// Temporary: Use existing conversion utilities
 	// This will be replaced with proper implementation in Week 3
 	const { convertToWorkPlainObject } = require("../utilities/work-conversions");
-	return convertToWorkPlainObject(doc as unknown);
+	const result = convertToWorkPlainObject(doc as unknown);
+	if (result.isOk()) {
+		return result.value;
+	}
+	throw new Error(`Failed to convert work document: ${doc.id || doc.productId}`);
 }
 
 /**


### PR DESCRIPTION
## Summary
Phase 1 Week 3の実装として、`convertToWorkPlainObject`の使用箇所を新しい`workTransformers.fromFirestore()`に移行しました。

## 変更内容
### 移行したファイル
- `apps/web/src/app/works/actions.ts`
- `apps/web/src/app/circles/[circleId]/actions.ts`  
- `apps/web/src/app/creators/[creatorId]/actions.ts`
- `apps/web/src/app/actions/work-actions.ts`

### 変更パターン
```typescript
// Before: Result型を使用
const result = convertToWorkPlainObject(data);
if (result.isOk()) {
  works.push(result.value);
}

// After: try-catchパターン
try {
  const converted = workTransformers.fromFirestore(data);
  works.push(converted);
} catch (error) {
  logger.warn("変換エラー", { error });
}
```

## 確認済み項目
- [x] すべてのテストが合格
- [x] ビルドが成功  
- [x] 型チェックが通過
- [x] lintエラーなし

## 関連PR
- #227: Phase 0-1 - 関数型モジュールの基盤作成
- #228: Phase 1 Week 1 - 基本的なWork操作の移行
- #229: Phase 1 Week 2 - 互換性レイヤーの実装

## 次のステップ
Phase 2 (Week 4-5)でVideo Entityの簡素化に進みます。

🤖 Generated with [Claude Code](https://claude.ai/code)