### PR TITLE
test: AudioButton EntityテストをPlainObject使用に移行

### DIFF
--- a/apps/web/src/app/favorites/__tests__/actions.test.ts
+++ b/apps/web/src/app/favorites/__tests__/actions.test.ts
@@ -11,11 +11,15 @@ vi.mock("@/actions/dislikes", () => ({
 	getLikeDislikeStatusAction: vi.fn(),
 }));
 
-vi.mock("@suzumina.click/shared-types", () => ({
-	AudioButton: {
-		fromFirestoreData: vi.fn(),
-	},
-}));
+vi.mock("@suzumina.click/shared-types", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@suzumina.click/shared-types")>();
+	return {
+		...actual,
+		audioButtonTransformers: {
+			fromFirestore: vi.fn(),
+		},
+	};
+});
 
 describe("getFavoritesList", () => {
 	beforeEach(() => {
@@ -38,7 +42,7 @@ describe("getFavoritesList", () => {
 			"@/lib/favorites-firestore"
 		);
 		const { getLikeDislikeStatusAction } = await import("@/actions/dislikes");
-		const { AudioButton } = await import("@suzumina.click/shared-types");
+		const { audioButtonTransformers } = await import("@suzumina.click/shared-types");
 
 		vi.mocked(getUserFavoritesCount).mockResolvedValue(1);
 		vi.mocked(getUserFavorites).mockResolvedValue({
@@ -48,7 +52,7 @@ describe("getFavoritesList", () => {
 		vi.mocked(getAudioButtonsFromFavorites).mockResolvedValue(
 			new Map([[mockAudioButtonId, { id: mockAudioButtonId }]]),
 		);
-		vi.mocked(AudioButton.fromFirestoreData).mockReturnValue(mockAudioButton);
+		vi.mocked(audioButtonTransformers.fromFirestore).mockReturnValue(mockAudioButton);
 		vi.mocked(getLikeDislikeStatusAction).mockResolvedValue([
 			[mockAudioButtonId, { isLiked: true, isDisliked: false }],
 		]);
@@ -95,7 +99,7 @@ describe("getFavoritesList", () => {
 		const { getUserFavoritesCount, getUserFavorites, getAudioButtonsFromFavorites } = await import(
 			"@/lib/favorites-firestore"
 		);
-		const { AudioButton } = await import("@suzumina.click/shared-types");
+		const { audioButtonTransformers } = await import("@suzumina.click/shared-types");
 
 		vi.mocked(getUserFavoritesCount).mockResolvedValue(1);
 		vi.mocked(getUserFavorites).mockResolvedValue({
@@ -103,7 +107,7 @@ describe("getFavoritesList", () => {
 			hasMore: false,
 		});
 		vi.mocked(getAudioButtonsFromFavorites).mockResolvedValue(new Map());
-		vi.mocked(AudioButton.fromFirestoreData).mockReturnValue(null);
+		vi.mocked(audioButtonTransformers.fromFirestore).mockReturnValue(null);
 
 		const result = await getFavoritesList({
 			userId: "test-user-id",

--- a/apps/web/src/components/audio/__tests__/audio-button-card.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-card.test.tsx
@@ -1,4 +1,8 @@
-import { AudioButton, type FirestoreServerAudioButtonData } from "@suzumina.click/shared-types";
+import {
+	type AudioButtonPlainObject,
+	audioButtonTransformers,
+	type FirestoreServerAudioButtonData,
+} from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/navigation";
@@ -81,8 +85,8 @@ interface MockAudioButtonLegacyData {
 	updatedAt?: string;
 }
 
-// テスト用のAudioButtonエンティティを作成するヘルパー
-function createMockAudioButton(overrides?: MockAudioButtonLegacyData): AudioButton {
+// テスト用のAudioButtonPlainObjectを作成するヘルパー
+function createMockAudioButton(overrides?: MockAudioButtonLegacyData): AudioButtonPlainObject {
 	const defaultData = {
 		id: "test-button-123",
 		title: "テスト音声ボタン",
@@ -110,11 +114,11 @@ function createMockAudioButton(overrides?: MockAudioButtonLegacyData): AudioButt
 		createdAt: new Date(defaultData.createdAt),
 		updatedAt: new Date(defaultData.updatedAt),
 	};
-	const audioButton = AudioButton.fromFirestoreData(firestoreData);
-	if (!audioButton) {
+	const plainObject = audioButtonTransformers.fromFirestore(firestoreData);
+	if (!plainObject) {
 		throw new Error("Failed to create mock AudioButton");
 	}
-	return audioButton;
+	return plainObject;
 }
 
 describe("AudioButtonCard", () => {

--- a/apps/web/src/components/audio/__tests__/audio-button-list.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-list.test.tsx
@@ -1,4 +1,8 @@
-import { AudioButton, type FirestoreServerAudioButtonData } from "@suzumina.click/shared-types";
+import {
+	type AudioButtonPlainObject,
+	audioButtonTransformers,
+	type FirestoreServerAudioButtonData,
+} from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -45,8 +49,11 @@ interface MockAudioButtonLegacyData {
 	updatedAt?: string;
 }
 
-// テスト用のAudioButtonエンティティを作成するヘルパー
-function createMockAudioButton(id: string, overrides?: MockAudioButtonLegacyData): AudioButton {
+// テスト用のAudioButtonPlainObjectを作成するヘルパー
+function createMockAudioButton(
+	id: string,
+	overrides?: MockAudioButtonLegacyData,
+): AudioButtonPlainObject {
 	const defaultData = {
 		id,
 		title: `音声ボタン ${id}`,
@@ -74,11 +81,11 @@ function createMockAudioButton(id: string, overrides?: MockAudioButtonLegacyData
 		createdAt: new Date(defaultData.createdAt),
 		updatedAt: new Date(defaultData.updatedAt),
 	};
-	const audioButton = AudioButton.fromFirestoreData(firestoreData);
-	if (!audioButton) {
+	const plainObject = audioButtonTransformers.fromFirestore(firestoreData);
+	if (!plainObject) {
 		throw new Error("Failed to create mock AudioButton");
 	}
-	return audioButton;
+	return plainObject;
 }
 
 describe("AudioButtonList", () => {

--- a/apps/web/src/hooks/__tests__/use-audio-button.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-audio-button.test.tsx
@@ -1,10 +1,16 @@
-import { AudioButton, type FirestoreServerAudioButtonData } from "@suzumina.click/shared-types";
+import {
+	type AudioButtonPlainObject,
+	audioButtonTransformers,
+	type FirestoreServerAudioButtonData,
+} from "@suzumina.click/shared-types";
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { useAudioButton } from "../use-audio-button";
 
-// テスト用のAudioButtonエンティティを作成するヘルパー
-function createMockAudioButton(overrides?: Partial<FirestoreServerAudioButtonData>): AudioButton {
+// テスト用のAudioButtonPlainObjectを作成するヘルパー
+function createMockAudioButton(
+	overrides?: Partial<FirestoreServerAudioButtonData>,
+): AudioButtonPlainObject {
 	const defaultData: FirestoreServerAudioButtonData = {
 		id: "test-button-123",
 		title: "テスト音声ボタン",
@@ -27,11 +33,11 @@ function createMockAudioButton(overrides?: Partial<FirestoreServerAudioButtonDat
 		...overrides,
 	};
 
-	const audioButton = AudioButton.fromFirestoreData(defaultData);
-	if (!audioButton) {
+	const plainObject = audioButtonTransformers.fromFirestore(defaultData);
+	if (!plainObject) {
 		throw new Error("Failed to create mock AudioButton");
 	}
-	return audioButton;
+	return plainObject;
 }
 
 describe("useAudioButton", () => {

--- a/docs/decisions/architecture/ADR-004-audiobutton-entity-removal-plan.md
+++ b/docs/decisions/architecture/ADR-004-audiobutton-entity-removal-plan.md
@@ -1,0 +1,47 @@
+# ADR-004: AudioButton Entity完全削除計画
+
+## ステータス
+提案中 (2025-08-19)
+
+## コンテキスト
+
+AudioButton Entityの段階的移行が進行中：
+- 互換レイヤー（AudioButtonCompat）実装済み
+- Server Actions移行済み
+- Componentsは互換レイヤー使用中
+- テストが22件失敗（Entity直接使用）
+
+## 決定
+
+AudioButton Entityを完全に削除し、PlainObject + 純粋関数パターンに統一する。
+
+## 実施計画
+
+### Phase 1: テスト修正（即時）
+- [ ] テストをPlainObject使用に変更
+- [ ] AudioButtonCompatのテスト追加
+- [ ] すべてのテストをパス
+
+### Phase 2: Entity削除（Phase 1完了後）
+- [ ] AudioButton Entityクラス削除
+- [ ] 関連Value Object削除
+  - AudioContent
+  - AudioReference
+  - ButtonStatistics
+- [ ] fromFirestoreData静的メソッド削除
+
+### Phase 3: クリーンアップ（Phase 2完了後）
+- [ ] 未使用インポート削除
+- [ ] ドキュメント更新
+- [ ] パフォーマンス測定
+
+## 結果
+
+- コードベース簡素化（約2,000行削減見込み）
+- ビルド時間短縮
+- 保守性向上
+
+## リスク
+
+- テスト修正に時間がかかる可能性
+- 一時的な機能停止リスク（ロールバック計画必要）


### PR DESCRIPTION
## 概要
AudioButton Entityから関数型アーキテクチャへの移行の一環として、テストファイルをPlainObject使用に更新しました。

## 変更内容

### テストファイルの更新
- **use-audio-button.test.tsx**: AudioButtonPlainObject使用に変更
- **audio-button-card.test.tsx**: audioButtonTransformers使用
- **audio-button-list.test.tsx**: PlainObject変換処理追加
- **favorites/actions.test.ts**: モック定義を更新

### 改善結果
- ✅ テスト失敗: **22件 → 1件**に大幅削減
- ✅ Entity依存を削減
- ✅ PlainObject + 純粋関数パターンへの移行進展

### ドキュメント追加
- **ADR-004**: AudioButton Entity完全削除計画を文書化

## テスト結果
```
Test Files  1 failed | 58 passed (59)
Tests  1 failed | 672 passed | 1 skipped (675)
```

## 残作業
- [ ] 最後の1件のテスト失敗修正（favorites/actions.test.ts）
- [ ] AudioButton Entity自体の削除
- [ ] 関連Value Objectの削除（AudioContent, AudioReference, ButtonStatistics）

## 関連PR
- #233: AudioButton Entity互換レイヤーの実装
- #234: Server Actions移行（第2フェーズ）

🤖 Generated with [Claude Code](https://claude.ai/code)