### PR TITLE
音声ボタンの編集権限を調整

### DIFF
--- a/apps/web/src/actions/audio-button-actions.ts
+++ b/apps/web/src/actions/audio-button-actions.ts
@@ -50,7 +50,7 @@ export async function getAudioButtonAction(audioButtonId: string): Promise<GetAu
 			return { success: false, error: "音声ボタンが見つかりません" };
 		}
 
-		const data = doc.data() as any;
+		const data = doc.data();
 
 		// AudioButtonエンティティに変換
 		const plainObject = audioButtonTransformers.fromFirestore({
@@ -109,7 +109,7 @@ export async function getAudioButtonsAction(
 			const doc = await firestore.collection("audioButtons").doc(id).get();
 			if (!doc.exists) return null;
 
-			const data = doc.data() as any;
+			const data = doc.data();
 			const plain = audioButtonTransformers.fromFirestore({
 				...data,
 				id: doc.id,
@@ -157,7 +157,7 @@ export async function getPublicAudioButtonsAction(limit = 20): Promise<GetAudioB
 		const audioButtons: AudioButton[] = [];
 
 		snapshot.forEach((doc: QueryDocumentSnapshot) => {
-			const data = doc.data() as any;
+			const data = doc.data();
 			const plainObject = audioButtonTransformers.fromFirestore({
 				...data,
 				id: doc.id,
@@ -204,7 +204,10 @@ export async function recordAudioButtonPlayAction(
 				throw new Error("音声ボタンが見つかりません");
 			}
 
-			const currentData = doc.data() as any;
+			const currentData = doc.data();
+			if (!currentData) {
+				throw new Error("音声ボタンデータが見つかりません");
+			}
 			const currentPlayCount = currentData.stats?.playCount || currentData.playCount || 0;
 
 			transaction.update(docRef, {

--- a/apps/web/src/app/buttons/actions.ts
+++ b/apps/web/src/app/buttons/actions.ts
@@ -827,10 +827,9 @@ export async function updateAudioButtonTags(
 		if (!data) {
 			return { success: false, error: "音声ボタンのデータが無効です" };
 		}
-		const creatorId = data.creatorId || data.createdBy;
-		if (creatorId !== session.user.discordId) {
-			return { success: false, error: "更新権限がありません" };
-		}
+
+		// タグ編集はログインユーザーなら誰でも可能
+		// （作成者チェックを削除）
 
 		await docRef.update({
 			tags,

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
@@ -78,16 +78,14 @@ export function AudioButtonDetailMainContent({
 						{/* 編集・削除ボタン */}
 						<div className="flex items-center gap-2">
 							{/* 編集ボタン */}
-							{session?.user &&
-								(audioButton.creatorId === session.user.discordId ||
-									session.user.role === "admin") && (
-									<Button variant="outline" size="sm" asChild className="flex items-center gap-1">
-										<Link href={`/buttons/${audioButton.id}/edit`}>
-											<Pencil className="h-4 w-4" />
-											編集
-										</Link>
-									</Button>
-								)}
+							{session?.user && audioButton.creatorId === session.user.discordId && (
+								<Button variant="outline" size="sm" asChild className="flex items-center gap-1">
+									<Link href={`/buttons/${audioButton.id}/edit`}>
+										<Pencil className="h-4 w-4" />
+										編集
+									</Link>
+								</Button>
+							)}
 							{/* 削除ボタン */}
 							<AudioButtonDeleteButton
 								audioButtonId={audioButton.id}

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
@@ -121,9 +121,7 @@ export function AudioButtonDetailMainContent({
 						<AudioButtonTagEditorDetail
 							audioButtonId={audioButton.id}
 							tags={audioButton.tags || []}
-							createdBy={audioButton.creatorId}
 							currentUserId={session?.user?.discordId}
-							currentUserRole={session?.user?.role}
 						/>
 					</div>
 

--- a/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
@@ -57,7 +57,7 @@ describe("AudioButtonTagEditorDetail", () => {
 			).not.toBeInTheDocument();
 		});
 
-		it("作成者でない一般ユーザーには編集権限がない", () => {
+		it("ログインユーザーなら誰でも編集権限がある", () => {
 			render(
 				<AudioButtonTagEditorDetail
 					{...defaultProps}
@@ -66,10 +66,10 @@ describe("AudioButtonTagEditorDetail", () => {
 				/>,
 			);
 
-			expect(screen.queryByText("編集")).not.toBeInTheDocument();
+			expect(screen.getByText("編集")).toBeInTheDocument();
 			expect(
-				screen.getByText("※ タグを編集するには、ボタンの作成者としてログインする必要があります"),
-			).toBeInTheDocument();
+				screen.queryByText("※ タグを編集するには、ボタンの作成者としてログインする必要があります"),
+			).not.toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
@@ -14,9 +14,7 @@ describe("AudioButtonTagEditorDetail", () => {
 	const defaultProps = {
 		audioButtonId: "test-button-id",
 		tags: [],
-		createdBy: "creator-id",
 		currentUserId: undefined,
-		currentUserRole: undefined,
 	};
 
 	beforeEach(() => {
@@ -43,13 +41,7 @@ describe("AudioButtonTagEditorDetail", () => {
 		});
 
 		it("管理者には編集権限がある", () => {
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					currentUserId="admin-id"
-					currentUserRole="admin"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} currentUserId="admin-id" />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
 			expect(
@@ -58,13 +50,7 @@ describe("AudioButtonTagEditorDetail", () => {
 		});
 
 		it("ログインユーザーなら誰でも編集権限がある", () => {
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					currentUserId="other-user-id"
-					currentUserRole="member"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} currentUserId="other-user-id" />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
 			expect(

--- a/apps/web/src/components/audio/audio-button-delete-button.tsx
+++ b/apps/web/src/components/audio/audio-button-delete-button.tsx
@@ -34,9 +34,7 @@ export function AudioButtonDeleteButton({
 	const [isPending, startTransition] = useTransition();
 
 	// 削除権限チェック
-	const canDelete =
-		session?.user?.discordId &&
-		(session.user.discordId === createdBy || session.user.role === "admin");
+	const canDelete = session?.user?.discordId && session.user.discordId === createdBy;
 
 	if (!canDelete) {
 		return null;

--- a/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
+++ b/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
@@ -44,8 +44,8 @@ export function AudioButtonTagEditorDetail({
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
-	// 編集権限チェック
-	const canEdit = currentUserId && (currentUserId === createdBy || currentUserRole === "admin");
+	// 編集権限チェック（ログインユーザーなら誰でも編集可能）
+	const canEdit = !!currentUserId;
 
 	/**
 	 * AutocompleteSuggestion を TagSuggestion に変換

--- a/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
+++ b/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
@@ -20,12 +20,8 @@ export interface AudioButtonTagEditorDetailProps {
 	audioButtonId: string;
 	/** 現在のタグ配列 */
 	tags: string[];
-	/** 作成者のDiscord ID */
-	createdBy: string;
 	/** 現在のユーザーのDiscord ID */
 	currentUserId?: string;
-	/** 現在のユーザーの権限 */
-	currentUserRole?: string;
 	/** 追加のクラス名 */
 	className?: string;
 }
@@ -33,9 +29,7 @@ export interface AudioButtonTagEditorDetailProps {
 export function AudioButtonTagEditorDetail({
 	audioButtonId,
 	tags,
-	createdBy,
 	currentUserId,
-	currentUserRole,
 	className,
 }: AudioButtonTagEditorDetailProps) {
 	const router = useRouter();

--- a/packages/shared-types/src/transformers/audio-button.ts
+++ b/packages/shared-types/src/transformers/audio-button.ts
@@ -42,14 +42,16 @@ interface LegacyAudioButtonData {
 		favoriteCount?: number;
 		engagementRate?: number;
 	};
-	createdAt?: any;
-	updatedAt?: any;
+	createdAt?: string | { toDate?: () => Date; _seconds?: number };
+	updatedAt?: string | { toDate?: () => Date; _seconds?: number };
 }
 
 /**
  * Convert timestamp to ISO string
  */
-function toISOString(timestamp: any): string {
+function toISOString(
+	timestamp: string | { toDate?: () => Date; _seconds?: number } | undefined,
+): string {
 	if (typeof timestamp === "string") return timestamp;
 	if (timestamp?.toDate) return timestamp.toDate().toISOString();
 	if (timestamp?._seconds) {
@@ -156,8 +158,17 @@ export function fromFirestore(data: LegacyAudioButtonData & { id?: string }): Au
  * Transforms AudioButton to Firestore document format
  */
 export function toFirestore(audioButton: Partial<AudioButton>): AudioButtonDocument {
-	const { id, ...data } = audioButton as AudioButton;
-	return data;
+	// idと_computedフィールドを除外してFirestore用のドキュメントを作成
+	const { id, _computed, ...documentData } = audioButton as AudioButton & {
+		id?: string;
+		_computed?: unknown;
+	};
+
+	// 未使用変数の警告を抑制（構造化代入で除外するため）
+	void id;
+	void _computed;
+
+	return documentData as AudioButtonDocument;
 }
 
 /**


### PR DESCRIPTION
## 概要
音声ボタンの編集権限を見直し、より民主的で協調的なコンテンツ管理を実現します。

## 変更内容

### 🔒 編集・削除権限の変更
- **音声ボタンの編集**: 作成者のみに制限（管理者権限を削除）
- **音声ボタンの削除**: 作成者のみに制限（管理者権限を削除）

### 🏷️ タグ編集権限の開放
- **タグ編集**: ログインユーザー全員が編集可能に変更
- コミュニティ全体でタグを改善できるように開放

## 変更理由
1. **所有権の明確化**: 音声ボタンの基本的な内容（テキスト、時間範囲）は作成者が責任を持って管理
2. **コミュニティ貢献**: タグはコミュニティ全体で協力して改善できる仕組みに
3. **民主的な運営**: より多くのユーザーがコンテンツの改善に参加可能

## 技術的変更
### フロントエンド
- `audio-button-detail-main-content.tsx`: 編集ボタンの権限チェックから管理者権限を削除
- `audio-button-delete-button.tsx`: 削除ボタンの権限チェックから管理者権限を削除  
- `audio-button-tag-editor-detail.tsx`: タグ編集を全ログインユーザーに開放

### バックエンド
- `buttons/actions.ts`: `updateAudioButtonTags`関数から作成者チェックを削除

### テスト
- `audio-button-tag-editor-detail.test.tsx`: 新しい権限設定に合わせてテストケースを更新

## テスト結果
- ✅ 型チェック: 成功
- ✅ ユニットテスト: 1件のテストを修正済み
- ⚠️ リント: 既存の警告のみ（今回の変更とは無関係）

## 動作確認項目
- [ ] 作成者のみが音声ボタンを編集できることを確認
- [ ] 作成者のみが音声ボタンを削除できることを確認
- [ ] ログインユーザーなら誰でもタグを編集できることを確認
- [ ] 非ログインユーザーはタグを編集できないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)