### PR TITLE
chore: configure noUnusedPrivateClassMembers as warning

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.3.6/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -39,7 +39,8 @@
 			"recommended": true,
 			"correctness": {
 				"noNodejsModules": "off",
-				"useExhaustiveDependencies": "warn"
+				"useExhaustiveDependencies": "warn",
+				"noUnusedPrivateClassMembers": "warn"
 			},
 			"suspicious": {
 				"noConsole": "warn",


### PR DESCRIPTION
## Summary

Biome 2.3.6の`noUnusedPrivateClassMembers`ルールが、実際に使用されているprivate staticメソッドを誤って未使用と判定する問題への一時的な対策として、このルールを`warn`レベルに設定。

## Changes

- **biome.json**: `noUnusedPrivateClassMembers`を`warn`レベルに設定
- **biome.json**: スキーマバージョンを2.1.4から2.3.6に更新

## Details

### 問題

Biome 2.3.6では、以下のような13個のprivate static `validate`メソッドが誤って「未使用」と判定される：

```typescript
// packages/shared-types/src/value-objects/work/circle.ts
private static validate(data: { id: string; name: string; nameEn?: string }): {
  isValid: boolean;
  error?: string;
} {
  // ...
}

// 実際には同じクラス内で使用されている
isValid(): boolean {
  return Circle.validate({
    id: this._id as string,
    name: this._name,
    nameEn: this._nameEn,
  }).isValid;
}
```

### 対策

このルールを`error`（デフォルト）から`warn`に変更することで：
- ✅ lintがエラーで失敗しなくなる
- ✅ 警告は表示されるため、将来的な修正の必要性を認識できる
- ✅ 次回のBiomeアップデートで問題が解決される可能性がある

### 影響を受けるファイル

以下のvalue objectファイルで13個の誤検知が発生：
- `circle.ts`
- `creator-type.ts`
- `date-range.ts`
- `price.ts`
- `rating.ts` (2個のメソッド)
- `work-creators.ts`
- `work-id.ts` (2個のメソッド)
- `work-price.ts` (2個のメソッド)
- `work-rating.ts`
- `work-title.ts`

## Verification

- ✅ `pnpm lint` - 警告のみで成功
- ✅ `pnpm typecheck` - 成功
- ✅ 全テストパス（YouTube Player関連の既存の失敗を除く）

## Future Work

次回のBiomeアップデート時に、この問題が修正されているか確認し、修正されていれば`warn`設定を削除してデフォルトの`error`に戻す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)