### PR TITLE
fix(functions): Align MAX_EXECUTION_TIME with Cloud Functions timeout

### DIFF
--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -31,7 +31,7 @@ const METADATA_COLLECTION = "dlsiteMetadata";
 const MAX_CONCURRENT_API_REQUESTS = 5; // 6 → 3 → 5（バッチ処理を効率化: 50件を10回の並列処理で実行）
 const API_REQUEST_DELAY = 400;
 const BATCH_SIZE = 50; // 100 → 50に削減（エラー率低下とタイムアウト回避）
-const MAX_EXECUTION_TIME = 420000; // 7分
+const MAX_EXECUTION_TIME = 270000; // 4.5分（Cloud Functions 5分タイムアウトより短く設定）
 
 // Note: CollectionMetadata type is now imported from @suzumina.click/shared-types
 


### PR DESCRIPTION
## Summary

- `MAX_EXECUTION_TIME` を 420000ms (7分) から 270000ms (4.5分) に変更
- Cloud Functions のタイムアウト (5分) より短く設定することで、正常終了を保証

## Background

Cloud Run ログで「実行時間制限に達しました。バッチ 34/35 で中断」が発生し、データが更新されない問題が報告されました。

### 問題の原因

| 設定箇所 | タイムアウト値 |
|---------|--------------|
| Terraform (Cloud Functions) | 300秒 (5分) |
| コード (MAX_EXECUTION_TIME) | 420000ms (7分) ← **長すぎた** |

コードのタイムアウトがCloud Functionsのタイムアウトより長かったため：

1. コードが7分待とうとする間に、Cloud Functionsが5分で**強制終了**
2. 強制終了のため、メタデータ（`currentBatch`, `completedBatches`など）が正しく更新されない
3. 継続処理が機能せず、次回実行時に正しく再開できない

### 修正後

- `MAX_EXECUTION_TIME = 270000` (4.5分) に変更
- Cloud Functions タイムアウトまで30秒のマージンを確保
- 正常終了するため、継続処理のメタデータが正しく保存される

## Test plan

- [x] 既存のユニットテストがパス
- [x] Lint チェックがパス
- [x] 型チェックがパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)