### PR TITLE
chore: bump version to 0.3.12

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@suzumina.click/functions",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"private": true,
 	"scripts": {
 		"build": "tsc && cp -r src/assets lib/assets",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@suzumina.click/web",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "suzumina.click",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"private": true,
 	"scripts": {
 		"build": "pnpm --filter @suzumina.click/shared-types build && pnpm -r build",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@suzumina.click/shared-types",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"description": "涼花みなせウェブサイト用の共有型定義",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@suzumina.click/typescript-config",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"private": true,
 	"license": "PROPRIETARY",
 	"publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@suzumina.click/ui",
-	"version": "0.3.11",
+	"version": "0.3.12",
 	"type": "module",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
## Summary

- Bump version to 0.3.12 across all packages

## Changes in this release

- **feat(web)**: Integrate web-vitals library with GA4 for Core Web Vitals monitoring (#345)
  - Replace custom performance monitoring with official `web-vitals` library
  - Send Core Web Vitals (LCP, INP, CLS, FCP, TTFB) to Google Analytics 4
  - Respect user consent via Google Consent Mode v2
  - Remove unused `/api/metrics` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)