### PR TITLE
perf(infra): Infrastructure-level LCP improvements

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -224,6 +224,26 @@ const nextConfig = {
 					},
 				],
 			},
+			// 動的ページのstale-while-revalidate（LCP改善）
+			// force-dynamicページでもブラウザキャッシュを活用
+			{
+				source: "/creators/:path*",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "public, s-maxage=60, stale-while-revalidate=300",
+					},
+				],
+			},
+			{
+				source: "/circles/:path*",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "public, s-maxage=60, stale-while-revalidate=300",
+					},
+				],
+			},
 		];
 	},
 };

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,8 +2,8 @@ import { HomePage } from "@/components/home/home-page";
 import { getLatestAudioButtons, getLatestVideos, getLatestWorks } from "./actions";
 
 // Static generation with ISR for better performance
-// Start with 1 minute cache, gradually increase after testing
-export const revalidate = 60;
+// 5 minute cache to reduce Firestore queries and improve LCP
+export const revalidate = 300;
 
 // Server Component として実装し、全データを並列取得
 export default async function Home() {

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -22,7 +22,7 @@ locals {
     }
     production = {
       # 本番環境（個人利用レベル・パフォーマンス改善）
-      cloud_run_min_instances = 0        # コールドスタート許容（ウォームアップで対応）
+      cloud_run_min_instances = 1        # LCP改善: コールドスタート排除
       cloud_run_max_instances = 2        # 最大インスタンス数を制限
       cloud_run_cpu           = "500m"   # CPU維持（0.5vCPU）
       cloud_run_memory        = "1024Mi" # メモリ増強（1GB）でGC改善


### PR DESCRIPTION
## Summary
- Cloud Run 本番環境の最小インスタンス数を 1 に設定（コールドスタート排除で約1-3秒改善）
- ISR revalidate を 60秒から 300秒に延長（Firestore クエリ頻度を5分の1に削減）
- 動的ページ（/creators/*, /circles/*）に stale-while-revalidate ヘッダーを追加

## Changes
| 項目 | 変更前 | 変更後 | 効果 |
|------|--------|--------|------|
| Cloud Run min instances | 0 | 1 | コールドスタート排除（LCP 1-3秒改善） |
| ISR revalidate | 60秒 | 300秒 | Firestore クエリ削減、キャッシュヒット率向上 |
| 動的ページキャッシュ | なし | s-maxage=60, swr=300 | CDN/ブラウザキャッシュ活用 |

## Cost Impact
- Cloud Run 常時1インスタンス維持により月額コスト増加（約500-1000円程度）
- ただし、Firestore読み取り回数削減によりコスト最適化

## Test plan
- [x] pnpm test - 全テスト通過
- [x] pnpm lint - リント通過
- [x] pnpm typecheck - 型チェック通過
- [x] Terraform plan/apply でインフラ反映
- [x] PageSpeed Insights で LCP 測定

🤖 Generated with [Claude Code](https://claude.com/claude-code)