### PR TITLE
fix(functions): DLsiteバッチ処理完了判定バグ修正（新作取得不可の根本原因）

### DIFF
--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -306,11 +306,10 @@ function getContinuationInfo(
 		metadata.currentBatch !== undefined &&
 		metadata.totalBatches !== undefined
 	) {
-		// completedBatchesがtotalBatchesを超えている場合は新規処理として扱う
-		const completedBatchesLength = metadata.completedBatches?.length || 0;
-		if (completedBatchesLength >= metadata.totalBatches) {
+		// currentBatchがtotalBatchesに達している場合は新規処理として扱う
+		if ((metadata.currentBatch ?? 0) >= metadata.totalBatches) {
 			logger.info("前回の処理は完了済み。新規処理として開始します", {
-				completedBatchesLength,
+				currentBatch: metadata.currentBatch,
 				totalBatches: metadata.totalBatches,
 			});
 			return { isContinuation: false as const };
@@ -320,7 +319,6 @@ function getContinuationInfo(
 			currentBatch: metadata.currentBatch,
 			totalBatches: metadata.totalBatches,
 			allWorkIdsLength: metadata.allWorkIds?.length || 0,
-			completedBatchesLength,
 		});
 
 		return {
@@ -407,10 +405,12 @@ async function executeBatchLoop(
 	totalUpdated: number;
 	totalApiCalls: number;
 	completedBatches: number[];
+	allBatchesCompleted: boolean;
 }> {
 	let totalUpdated = 0;
 	let totalApiCalls = 0;
-	const completedBatches = metadata.completedBatches || [];
+	let allBatchesCompleted = true;
+	const completedBatches: number[] = [];
 
 	logger.info(
 		`executeBatchLoop開始: startBatch=${startBatch}, batches.length=${batches.length}, completedBatches=${completedBatches.length}`,
@@ -428,6 +428,7 @@ async function executeBatchLoop(
 		// 実行時間チェック
 		if (Date.now() - startTime > MAX_EXECUTION_TIME) {
 			logger.info(`実行時間制限に達しました。バッチ ${i}/${batches.length} で中断`);
+			allBatchesCompleted = false;
 
 			await updateUnifiedMetadata({
 				currentBatch: i,
@@ -468,7 +469,7 @@ async function executeBatchLoop(
 		}
 	}
 
-	return { totalUpdated, totalApiCalls, completedBatches };
+	return { totalUpdated, totalApiCalls, completedBatches, allBatchesCompleted };
 }
 
 /**
@@ -583,16 +584,13 @@ async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 		}
 
 		// バッチ処理の実行
-		const { totalUpdated, totalApiCalls, completedBatches } = await executeBatchLoop(
+		const { totalUpdated, totalApiCalls, allBatchesCompleted } = await executeBatchLoop(
 			batches,
 			startBatch,
 			startTime,
 			metadata,
 			existingWorksMap,
 		);
-
-		// 処理完了チェック
-		const allBatchesCompleted = completedBatches.length === batches.length;
 
 		if (allBatchesCompleted) {
 			await finalizeCompletedProcessing(allWorkIds, totalUpdated);


### PR DESCRIPTION
## 問題

2025/12/24以降、`fetchDLsiteUnifiedData` が全バッチを完了できず、3月5日以降に発売された作品データが取得できない状態になっていた。

## 根本原因

Firestoreの `dlsiteMetadata/unified_data_collection_metadata` に保存されている `completedBatches` 配列が実行ごとに増殖し続けるバグ（33,345件まで肥大化）。

### バグの連鎖

1. `completedBatches.length (33345) >= totalBatches (38)` → 毎回「新規処理」と誤判定
2. `initializeNewBatchProcessing` がFirestoreの `completedBatches` を `[]` にリセット
3. しかしメモリ上の `metadata` オブジェクトは古い33,345件のまま `executeBatchLoop` に渡される
4. ループ内で古い配列に追記 → Firestoreに33,381件として保存
5. `completedBatches.length (33381) !== batches.length (38)` → `finalizeCompletedProcessing` 未呼び出し
6. 次回実行でも同じループを繰り返す

`order/release`（古い順）のためDLsite新作が最終バッチ(36〜37)に入るため、これらが永続的に未処理になっていた。

## 修正内容

- **`getContinuationInfo`**: 完了判定を `completedBatches.length >= totalBatches` から `currentBatch >= totalBatches` に変更（配列肥大化の影響を受けない）
- **`executeBatchLoop`**: `completedBatches` の初期値を `metadata.completedBatches`（汚染済み）から `[]` に変更
- **完了フラグ**: `completedBatches.length === batches.length` 比較を廃止し、ループが時間切れなく完走したかを `allBatchesCompleted` フラグで直接判定

## 修正後の挙動

次回実行時: `currentBatch (36) < totalBatches (38)` → 継続モードでバッチ36〜37を処理 → `finalizeCompletedProcessing` が呼ばれメタデータリセット → その次の実行で新規作品ID収集が再開

## テスト

- `pnpm typecheck` ✅
- `pnpm test` ✅ (338 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)