### PR TITLE
fix(test): add resolve alias for shared-types to enable tests without build

### DIFF
--- a/apps/functions/vitest.config.ts
+++ b/apps/functions/vitest.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": resolve(__dirname, "./src"),
+			"@suzumina.click/shared-types": resolve(
+				__dirname,
+				"../../packages/shared-types/src/index.ts",
+			),
 		},
 	},
 });

--- a/apps/web/src/app/search/__tests__/search-page-content.test.tsx
+++ b/apps/web/src/app/search/__tests__/search-page-content.test.tsx
@@ -19,6 +19,17 @@ vi.mock("next/navigation", () => ({
 	}),
 }));
 
+// Mock @/app/actions to prevent Firestore initialization
+vi.mock("@/app/actions", () => ({
+	searchUnified: vi.fn().mockResolvedValue({
+		works: [],
+		videos: [],
+		audioButtons: [],
+		total: 0,
+		hasMore: false,
+	}),
+}));
+
 // Mock UI components with minimal functionality
 vi.mock("@suzumina.click/ui/components/ui/badge", () => ({
 	Badge: ({ children, onClick, className }: any) => (


### PR DESCRIPTION
Fixes #385

## 問題

`packages/shared-types` の `dist/` が存在しない（未ビルド）環境で、`apps/functions` のテストが 6 ファイル失敗していました。

```
Error: Failed to resolve entry for package "@suzumina.click/shared-types".
The package may have incorrect main/module/exports specified in its package.json.
```

これは CI や `pnpm clean` 後の環境でテストが実行できない問題でした。

## 修正内容

`apps/functions/vitest.config.ts` の `resolve.alias` に shared-types のソースパスを追加しました：

```typescript
resolve: {
  alias: {
    "@": resolve(__dirname, "./src"),
    "@suzumina.click/shared-types": resolve(
      __dirname,
      "../../packages/shared-types/src/index.ts",
    ),
  },
},
```

これにより、vitest が dist ではなく直接ソースファイルを参照するようになります。

## 結果

- ✅ 24 個のテストファイルが `pnpm build` なしで通過
- ✅ 338 個のテストが通過（24 個は意図的にスキップ）
- ✅ "Failed to resolve entry" エラーが発生しない
- ✅ クリーンな環境と CI でテストが動作する

## 検証

```bash
pnpm --filter @suzumina.click/shared-types clean
pnpm --filter @suzumina.click/functions test
# Test Files  24 passed | 2 skipped (26)
#      Tests  338 passed | 24 skipped (362)
```