### PR TITLE
fix(test): shared-types 未ビルドでのテスト失敗と Firestore Unhandled Rejection を修正

### DIFF
--- a/apps/functions/vitest.config.ts
+++ b/apps/functions/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
 				external: ["googleapis"],
 				inline: [
 					"cheerio",
-					"@suzumina.click/shared-types",
 					"css-select",
 					"css-what",
 					"cheerio-select",
@@ -50,6 +49,10 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": resolve(__dirname, "./src"),
+			"@suzumina.click/shared-types": resolve(
+				__dirname,
+				"../../packages/shared-types/src/index.ts",
+			),
 		},
 	},
 });

--- a/apps/web/src/app/search/__tests__/search-page-content.test.tsx
+++ b/apps/web/src/app/search/__tests__/search-page-content.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgeVerificationProvider } from "../../../contexts/age-verification-context";
+import { searchUnified } from "@/app/actions";
 import SearchPageContent from "../search-page-content";
 
 // Mock dependencies
@@ -151,6 +152,17 @@ vi.mock("@/hooks/useFavoriteStatusBulk", () => ({
 	}),
 }));
 
+// Mock searchUnified to prevent Firestore initialization in test environment
+vi.mock("@/app/actions", () => ({
+	searchUnified: vi.fn().mockResolvedValue({
+		audioButtons: [],
+		videos: [],
+		works: [],
+		totalCount: { buttons: 0, videos: 0, works: 0 },
+		hasMore: { buttons: false, videos: false, works: false },
+	}),
+}));
+
 // Test wrapper component
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
 	<AgeVerificationProvider>{children}</AgeVerificationProvider>
@@ -228,7 +240,7 @@ describe("SearchPageContent", () => {
 
 			await waitFor(
 				() => {
-					expect(global.fetch).toHaveBeenCalled();
+					expect(vi.mocked(searchUnified)).toHaveBeenCalled();
 				},
 				{ timeout: 3000 },
 			);

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),
+			"@suzumina.click/shared-types": path.resolve(
+				__dirname,
+				"../../packages/shared-types/src/index.ts",
+			),
 		},
 	},
 	define: {

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,7 +1,16 @@
+import { resolve } from "node:path";
 /// <reference types="vitest" />
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	resolve: {
+		alias: {
+			"@suzumina.click/shared-types": resolve(
+				__dirname,
+				"../shared-types/src/index.ts",
+			),
+		},
+	},
 	test: {
 		globals: true,
 		environment: "happy-dom",


### PR DESCRIPTION
Closes #385
Closes #386

## 変更概要

### Issue #385: `@suzumina.click/shared-types` 未ビルド環境で functions テストが失敗する

`dist/` が存在しない環境（CI・`pnpm clean` 後）でもテストが通るよう、各 vitest.config.ts に `resolve.alias` を追加した。

| ファイル | 変更内容 |
|---------|---------|
| `apps/functions/vitest.config.ts` | `resolve.alias` に shared-types ソースパスを追加、`server.deps.inline` から除外 |
| `apps/web/vitest.config.ts` | `resolve.alias` に shared-types ソースパスを追加 |
| `packages/ui/vitest.config.ts` | `resolve` セクションを追加し shared-types ソースパスを設定 |

```typescript
// 追加した alias（各ファイルで相対パスは異なる）
"@suzumina.click/shared-types": resolve(__dirname, "../../packages/shared-types/src/index.ts")
```

### Issue #386: `search-page-content` テストで Firestore Unhandled Rejection が発生する

`SearchPageContent` が `searchUnified` 経由で Firestore を初期化しようとしテスト後に非同期認証エラーが発生していた。`@/app/actions` をモックすることで Firestore 初期化を防止した。

| ファイル | 変更内容 |
|---------|---------|
| `apps/web/src/app/search/__tests__/search-page-content.test.tsx` | `@/app/actions` モック追加、`searchUnified` import 追加、テストアサーションを `vi.mocked(searchUnified)` の呼び出し確認に更新 |

テストアサーションの変更:
```typescript
// Before: Firestore 内部の fetch 呼び出しを間接的に確認（実装詳細への依存）
expect(global.fetch).toHaveBeenCalled();

// After: searchUnified が呼ばれたことを直接確認（意図が明確）
expect(vi.mocked(searchUnified)).toHaveBeenCalled();
```

## テスト結果

`packages/shared-types/dist/` を削除した状態（未ビルド）で全テストがパス:

| パッケージ | テストファイル | テスト数 |
|-----------|-------------|---------|
| shared-types | 33 passed | 913 passed |
| functions | 24 passed, 2 skipped | 338 passed, 24 skipped |
| ui | 19 passed | 332 passed |
| web | 59 passed | 674 passed, 1 skipped |

※ functions の 2 skipped は `describe.skip` による既存の意図的スキップ（PlainObject 移行待ち）

https://claude.ai/code/session_01BAzC67Sv8XaPYMz61PNK7k

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAzC67Sv8XaPYMz61PNK7k)_