### PR TITLE
fix(terraform): Cloudflare ruleset の属性値タイポを修正

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -63,7 +63,7 @@ resource "cloudflare_ruleset" "cache_rules" {
   zone_id = data.cloudflare_zone.main[0].id
   name    = "suzumina.click Cache Rules"
   kind    = "zone"
-  phase   = "http_cache_settings"
+  phase   = "http_request_cache_settings"
 
   # 1. API ルート: キャッシュ完全無効（認証・動的レスポンスを保護）
   rules {
@@ -124,7 +124,7 @@ resource "cloudflare_ruleset" "cache_rules" {
         default = 300
       }
       browser_ttl {
-        mode = "respects_origin"
+        mode = "respect_origin"
       }
     }
     expression  = "(http.request.uri.path eq \"/\")"


### PR DESCRIPTION
## 概要

#391 マージ後に `terraform plan` で発生した `Invalid Attribute Value Match` エラーの修正。

## 変更内容

`terraform/cloudflare.tf` の2箇所のタイポ修正：

| 属性 | 修正前（誤） | 修正後（正） |
|------|------------|------------|
| `cloudflare_ruleset.phase` | `"http_cache_settings"` | `"http_request_cache_settings"` |
| `browser_ttl.mode` | `"respects_origin"` | `"respect_origin"` |

いずれも Cloudflare Terraform プロバイダー v4 の enum 値として許容されない値でした。

## エラー内容

```
Error: Invalid Attribute Value Match
  with cloudflare_ruleset.cache_rules, on cloudflare.tf line 66
  Attribute phase value must be one of: [..., "http_request_cache_settings", ...]

Error: Invalid Attribute Value Match
  with cloudflare_ruleset.cache_rules, on cloudflare.tf line 127
  Attribute rules[3].action_parameters[0].browser_ttl[0].mode value must be one of:
  ["override_origin" "respect_origin" "bypass"], got: "respects_origin"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)