### PR TITLE
fix(terraform): Cloudflare ruleset を Free プラン対応の演算子に変更

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -71,7 +71,7 @@ resource "cloudflare_ruleset" "cache_rules" {
     action_parameters {
       cache = false
     }
-    expression  = "(http.request.uri.path matches \"^/api/\")"
+    expression  = "(http.request.uri.path starts_with \"/api/\")"
     description = "API: キャッシュ無効"
     enabled     = true
   }
@@ -90,7 +90,7 @@ resource "cloudflare_ruleset" "cache_rules" {
         default = 31536000
       }
     }
-    expression  = "(http.request.uri.path matches \"^/_next/static/\")"
+    expression  = "(http.request.uri.path starts_with \"/_next/static/\")"
     description = "Next.js 静的アセット: 1年キャッシュ"
     enabled     = true
   }
@@ -109,7 +109,7 @@ resource "cloudflare_ruleset" "cache_rules" {
         default = 86400
       }
     }
-    expression  = "(http.request.uri.path matches \"^/_next/image/\")"
+    expression  = "(http.request.uri.path starts_with \"/_next/image/\")"
     description = "Next.js 画像最適化: 1日キャッシュ"
     enabled     = true
   }


### PR DESCRIPTION
## 概要

`terraform apply` で発生した以下のエラーの修正。

```
not entitled: the use of operator Matches is not allowed,
a Business plan or a WAF Advanced plan is required
```

## 原因

`matches` 演算子（正規表現マッチ）は Cloudflare の **Business プラン以上**が必要。Free プランでは使用不可。

## 変更内容

`terraform/cloudflare.tf` の全 `matches` 式を Free プランで使用可能な `starts_with` に置き換え。

| ルール | 修正前 | 修正後 |
|--------|--------|--------|
| API bypass | `matches "^/api/"` | `starts_with "/api/"` |
| 静的アセット | `matches "^/_next/static/"` | `starts_with "/_next/static/"` |
| 画像最適化 | `matches "^/_next/image/"` | `starts_with "/_next/image/"` |

`eq "/"` はそのまま（変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)