### PR TITLE
fix(terraform): Cloudflare filter 式を関数呼び出し構文に修正

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -71,7 +71,7 @@ resource "cloudflare_ruleset" "cache_rules" {
     action_parameters {
       cache = false
     }
-    expression  = "(http.request.uri.path starts_with \"/api/\")"
+    expression  = "(starts_with(http.request.uri.path, \"/api/\"))"
     description = "API: キャッシュ無効"
     enabled     = true
   }
@@ -90,7 +90,7 @@ resource "cloudflare_ruleset" "cache_rules" {
         default = 31536000
       }
     }
-    expression  = "(http.request.uri.path starts_with \"/_next/static/\")"
+    expression  = "(starts_with(http.request.uri.path, \"/_next/static/\"))"
     description = "Next.js 静的アセット: 1年キャッシュ"
     enabled     = true
   }
@@ -109,7 +109,7 @@ resource "cloudflare_ruleset" "cache_rules" {
         default = 86400
       }
     }
-    expression  = "(http.request.uri.path starts_with \"/_next/image/\")"
+    expression  = "(starts_with(http.request.uri.path, \"/_next/image/\"))"
     description = "Next.js 画像最適化: 1日キャッシュ"
     enabled     = true
   }


### PR DESCRIPTION
## 概要

`terraform apply` で発生したフィルター式パースエラーの修正。

## 原因

Cloudflare の Wirefilter 式言語において `starts_with` は**演算子ではなく関数**。

```
# ❌ 誤（演算子構文 → パースエラー）
http.request.uri.path starts_with "/api/"

# ✅ 正（関数呼び出し構文）
starts_with(http.request.uri.path, "/api/")
```

## 変更内容

`terraform/cloudflare.tf` の3箇所を関数呼び出し構文に修正。

| ルール | 修正前 | 修正後 |
|--------|--------|--------|
| API bypass | `http.request.uri.path starts_with "/api/"` | `starts_with(http.request.uri.path, "/api/")` |
| 静的アセット | `http.request.uri.path starts_with "/_next/static/"` | `starts_with(http.request.uri.path, "/_next/static/")` |
| 画像最適化 | `http.request.uri.path starts_with "/_next/image/"` | `starts_with(http.request.uri.path, "/_next/image/")` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)