### PR TITLE
perf(terraform): Cloud Run を 1vCPU + cpu_idle=false に変更してレスポンス遅延を改善する

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -26,8 +26,7 @@ resource "google_cloud_run_v2_service" "nextjs_app" {
       max_instance_count = local.current_env.cloud_run_max_instances
     }
 
-    # コンテナ同時実行数（0.5vCPU環境では1に制限）
-    max_instance_request_concurrency = var.environment == "production" && local.current_env.cloud_run_cpu == "500m" ? 1 : 50
+    max_instance_request_concurrency = 50
 
     # コンテナ設定
     containers {
@@ -40,7 +39,7 @@ resource "google_cloud_run_v2_service" "nextjs_app" {
           cpu    = local.current_env.cloud_run_cpu
           memory = local.current_env.cloud_run_memory
         }
-        cpu_idle          = true                            # コスト削減のため、全環境でCPUアイドルを有効化
+        cpu_idle          = local.current_env.cloud_run_cpu_idle
         startup_cpu_boost = var.environment == "production" # 本番のみCPUブースト
       }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -12,6 +12,7 @@ locals {
       cloud_run_min_instances = 0
       cloud_run_max_instances = 1 # 最小限（テスト用）
       cloud_run_cpu           = "1000m"
+      cloud_run_cpu_idle      = true    # コスト削減のためCPUアイドル有効
       cloud_run_memory        = "512Mi" # 最小メモリ
       functions_memory        = "256Mi" # 最小メモリ
       functions_timeout       = 120     # 短いタイムアウト
@@ -24,7 +25,8 @@ locals {
       # 本番環境（個人利用レベル・パフォーマンス改善）
       cloud_run_min_instances = 1        # LCP改善: コールドスタート排除
       cloud_run_max_instances = 2        # 最大インスタンス数を制限
-      cloud_run_cpu           = "500m"   # CPU維持（0.5vCPU）
+      cloud_run_cpu           = "1000m"  # 1vCPU: アイドル後レスポンス遅延を改善
+      cloud_run_cpu_idle      = false    # CPUを常時割り当て: アイドル後のスロットリング防止
       cloud_run_memory        = "1024Mi" # メモリ増強（1GB）でGC改善
       functions_memory        = "256Mi"  # YouTube API軽量処理用に最適化
       functions_timeout       = 120      # API呼び出し最適化


### PR DESCRIPTION
## Summary

- 本番環境の Cloud Run CPU を `500m` (0.5vCPU) → `1000m` (1vCPU) に変更
- `cpu_idle = false` に変更し、CPU を常時割り当てることでアイドル後のスロットリングを防止
- `cpu_idle` の設定を `locals.tf` の環境別設定に移動し、staging は `true`（コスト削減）、production は `false`（パフォーマンス優先）で管理
- 0.5vCPU 前提だった `max_instance_request_concurrency` の条件分岐を削除（常に 50）
- **CD パイプライン (`deploy-web.yml`) のハードコード設定も修正**: `gcloud run deploy` のフラグが Terraform の設定を毎デプロイで上書きしていた

## Background

本番環境が `cpu = "500m"` かつ `cpu_idle = true` で動作しており、アイドル後の最初のリクエストで CPU が絞られた状態から処理を開始するため、実質的なコールドスタートに近い遅延が発生していた。

また CD パイプラインにも `--cpu 0.5 --memory 512Mi --min-instances 0` がハードコードされており、Terraform を apply しても次のデプロイで設定が元に戻る問題があった。

## Changes

| ファイル | 変更内容 |
|---|---|
| `terraform/locals.tf` | production: cpu `500m`→`1000m`、`cpu_idle=false` 追加。staging: `cpu_idle=true` 明示 |
| `terraform/cloud_run.tf` | `cpu_idle` を環境変数参照に変更。concurrency 条件分岐を削除 |
| `.github/workflows/deploy-web.yml` | `--cpu 1 --memory 1024Mi --min-instances 1 --no-cpu-throttling` に更新 |

## Test plan

- [ ] `terraform plan` で差分が意図通りであることを確認
- [ ] 本番環境へ `terraform apply` を適用
- [ ] CD パイプラインを実行して Cloud Run が正しい設定でデプロイされることを確認
- [ ] Cloud Run のレスポンスタイムが改善されていることを確認（FCP/LCP 計測）

Closes #369
Relates to Linear SPR-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)