### PR TITLE
fix(cd): Cloud Run デプロイフラグを 1vCPU + cpu_idle=false に合わせて修正

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -172,9 +172,10 @@ jobs:
             --service-account="cloud-run-nextjs@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
             --set-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }},NEXTAUTH_URL=https://suzumina.click,AUTH_TRUST_HOST=true,NEXT_PUBLIC_GA_MEASUREMENT_ID=G-9SYZ48LBPH,NEXT_PUBLIC_GTM_ID=GTM-W7QT5PCR" \
             --set-secrets="DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,NEXTAUTH_SECRET=NEXTAUTH_SECRET:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest,RESEND_API_KEY=RESEND_API_KEY:latest,CONTACT_EMAIL_RECIPIENTS=CONTACT_EMAIL_RECIPIENTS:latest" \
-            --memory 512Mi \
-            --cpu 0.5 \
-            --min-instances 0 \
+            --memory 1024Mi \
+            --cpu 1 \
+            --no-cpu-throttling \
+            --min-instances 1 \
             --max-instances 2 \
             --timeout 300 \
             --port 8080


### PR DESCRIPTION
## Summary

#395 (Terraform 側の Cloud Run CPU/memory 変更) の CD 側の対応。

`gcloud run deploy` にハードコードされた設定が Terraform の変更を毎デプロイで上書きしていたため修正。

| フラグ | 変更前 | 変更後 |
|---|---|---|
| `--cpu` | `0.5` | `1` |
| `--memory` | `512Mi` | `1024Mi` |
| `--min-instances` | `0` | `1` |
| CPU スロットリング | (未指定=有効) | `--no-cpu-throttling` |

## Background

#395 で Terraform の Cloud Run 設定を 1vCPU + cpu_idle=false に変更したが、
CD パイプラインの `gcloud run deploy` にも旧設定がハードコードされており、
デプロイのたびに設定が 0.5vCPU + cpu_idle=true に戻ってしまう状態だった。

Relates to #369, Linear SPR-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)