### PR TITLE
chore(deps): googleapis v171 → v172 (SPR-50)

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -32,7 +32,7 @@
 		"@google-cloud/firestore": "^8.6.0",
 		"@google-cloud/functions-framework": "^5.0.2",
 		"@suzumina.click/shared-types": "workspace:*",
-		"googleapis": "^171.4.0"
+		"googleapis": "^172.0.0"
 	},
 	"devDependencies": {
 		"@suzumina.click/typescript-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
       googleapis:
-        specifier: ^171.4.0
-        version: 171.4.0
+        specifier: ^172.0.0
+        version: 172.0.0
     devDependencies:
       '@suzumina.click/typescript-config':
         specifier: workspace:*
@@ -3487,8 +3487,8 @@ packages:
     resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
     engines: {node: '>=18.0.0'}
 
-  googleapis@171.4.0:
-    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
+  googleapis@172.0.0:
+    resolution: {integrity: sha512-cF1m/nwfu9JP+JtR6j2nkQKnhu0z45eUVsWCVeooU8EIvBiPQqbfgAuJsTggCYEpbWJNwq2WS+aigaBC/sriIw==}
     engines: {node: '>=18'}
 
   gopd@1.2.0:
@@ -7772,7 +7772,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@171.4.0:
+  googleapis@172.0.0:
     dependencies:
       google-auth-library: 10.6.1
       googleapis-common: 8.0.1


### PR DESCRIPTION
## Summary

- `googleapis` を `^171.4.0` → `^172.0.0` に更新
- v172 は YouTube を含む多数の API でbreaking changesあり（型定義の変更）
- `apps/functions` 内の YouTube Data API v3 利用箇所（`search.list` / `videos.list` / `playlists.list` / `playlistItems.list`）への影響なしを確認

## Verification

- [x] `pnpm --filter @suzumina.click/functions typecheck` — passed
- [x] `pnpm --filter @suzumina.click/functions test` — 338 passed, 24 skipped
- [x] `pnpm --filter @suzumina.click/functions lint` — no issues

Closes SPR-50

🤖 Generated with [Claude Code](https://claude.com/claude-code)