### PR TITLE
chore: lucide-react v1 対応（YouTube アイコン代替実装含む） (SPR-51)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,7 +33,7 @@
 		"@hookform/resolvers": "^5.4.0",
 		"@suzumina.click/shared-types": "workspace:*",
 		"@suzumina.click/ui": "workspace:*",
-		"lucide-react": "^0.577.0",
+		"lucide-react": "^1.16.0",
 		"next": "^16.2.6",
 		"next-auth": "5.0.0-beta.30",
 		"react": "^19.2.6",

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
@@ -174,7 +174,7 @@ export function AudioButtonDetailMainContent({
 									target="_blank"
 									rel="noopener noreferrer"
 								>
-									<Youtube className="h-4 w-4 mr-2" />
+									<YoutubeIcon className="h-4 w-4 mr-2" />
 									YouTubeで開く
 								</a>
 							</Button>

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
@@ -1,8 +1,9 @@
 import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
 import { TimeDisplay } from "@suzumina.click/ui/components/custom/time-display";
+import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent } from "@suzumina.click/ui/components/ui/card";
-import { Calendar, Clock, Pencil, Youtube } from "lucide-react";
+import { Calendar, Clock, Pencil } from "lucide-react";
 import Link from "next/link";
 import type { Session } from "next-auth";
 import { AudioButtonDeleteButton } from "@/components/audio/audio-button-delete-button";
@@ -149,7 +150,7 @@ export function AudioButtonDetailMainContent({
 					{/* YouTube動画情報 */}
 					<div className="bg-gradient-to-r from-suzuka-50 to-minase-50 p-6 rounded-lg border border-suzuka-100">
 						<h3 className="font-medium text-sm text-muted-foreground mb-3 flex items-center gap-2">
-							<Youtube className="h-4 w-4" />
+							<YoutubeIcon className="h-4 w-4" />
 							切り抜き範囲
 						</h3>
 						<div className="space-y-3">

--- a/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
+++ b/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
@@ -1,7 +1,7 @@
 import type { AudioButton } from "@suzumina.click/shared-types";
+import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
-import { Youtube } from "lucide-react";
 import Link from "next/link";
 import { getAudioButtonsList } from "@/app/buttons/actions";
 import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
@@ -40,7 +40,7 @@ export async function RelatedAudioButtons({
 					<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">
 						<CardHeader>
 							<CardTitle className="flex items-center gap-2 text-lg">
-								<Youtube className="h-5 w-5 text-suzuka-600" />
+								<YoutubeIcon className="h-5 w-5 text-suzuka-600" />
 								同じ動画の音声ボタン
 							</CardTitle>
 						</CardHeader>

--- a/apps/web/src/components/audio-button-detail/video-card-wrapper.tsx
+++ b/apps/web/src/components/audio-button-detail/video-card-wrapper.tsx
@@ -1,6 +1,6 @@
+import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent } from "@suzumina.click/ui/components/ui/card";
-import { Youtube } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { getVideoById } from "@/app/videos/actions";
@@ -50,7 +50,7 @@ export async function VideoCardWrapper({ videoId, fallbackTitle }: VideoCardWrap
 										target="_blank"
 										rel="noopener noreferrer"
 									>
-										<Youtube className="h-4 w-4 mr-1" />
+										<YoutubeIcon className="h-4 w-4 mr-1" />
 										YouTube
 									</a>
 								</Button>
@@ -102,7 +102,7 @@ export async function VideoCardWrapper({ videoId, fallbackTitle }: VideoCardWrap
 									target="_blank"
 									rel="noopener noreferrer"
 								>
-									<Youtube className="h-4 w-4 mr-1" />
+									<YoutubeIcon className="h-4 w-4 mr-1" />
 									YouTube
 								</a>
 							</Button>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,7 +25,7 @@
 		"date-fns": "4.3.0",
 		"embla-carousel-react": "8.6.0",
 		"input-otp": "1.4.2",
-		"lucide-react": "^0.577.0",
+		"lucide-react": "^1.16.0",
 		"next": "^16.2.6",
 		"next-themes": "^0.4.6",
 		"radix-ui": "latest",

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -24,12 +24,12 @@ import {
 	ThumbsUp,
 	User,
 	Video,
-	Youtube,
 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { type AudioControls, AudioPlayer } from "./audio-player";
 import { HighlightText } from "./highlight-text";
 import { TagList } from "./tag-list";
+import { YoutubeIcon } from "./youtube-icon";
 
 interface AudioButtonProps {
 	audioButton: AudioButtonType;
@@ -338,7 +338,7 @@ function PopoverActions({
 				className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
 				onClick={(e) => e.stopPropagation()}
 			>
-				<Youtube className="h-4 w-4" />
+				<YoutubeIcon className="h-4 w-4" />
 				YouTube
 			</a>
 

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -55,6 +55,7 @@ export { TimeDisplay } from "./time-display";
 export type { ValidationMessageProps } from "./validation-message";
 export { ValidationMessage, ValidationMessages } from "./validation-message";
 
+export { YoutubeIcon } from "./youtube-icon";
 // YouTube components
 export { YouTubePlayer } from "./youtube-player";
 export type { YTPlayer, YTPlayerOptions, YTPlayerQuality, YTPlayerState } from "./youtube-types";

--- a/packages/ui/src/components/custom/youtube-icon.tsx
+++ b/packages/ui/src/components/custom/youtube-icon.tsx
@@ -1,0 +1,34 @@
+import type { SVGProps } from "react";
+
+interface YoutubeIconProps extends SVGProps<SVGSVGElement> {
+	size?: string | number;
+	color?: string;
+}
+
+export function YoutubeIcon({
+	size = 24,
+	color = "currentColor",
+	strokeWidth = 2,
+	className,
+	...props
+}: YoutubeIconProps) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			width={size}
+			height={size}
+			stroke={color}
+			strokeWidth={strokeWidth}
+			className={className}
+			aria-hidden="true"
+			{...props}
+		>
+			<path d="M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17" />
+			<path d="m10 15 5-3-5-3z" />
+		</svg>
+	);
+}

--- a/packages/ui/src/components/design-tokens/icons.stories.tsx
+++ b/packages/ui/src/components/design-tokens/icons.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import {
 	AlertCircle,
 	ArrowLeft,
@@ -42,7 +43,6 @@ import {
 	Users,
 	Video,
 	X,
-	Youtube,
 } from "lucide-react";
 
 const meta: Meta = {
@@ -110,7 +110,7 @@ const statusIcons = [
 const mediaIcons = [
 	{ icon: PlayCircle, name: "PlayCircle", usage: "動画プレビュー" },
 	{ icon: Video, name: "Video", usage: "動画コンテンツ" },
-	{ icon: Youtube, name: "Youtube", usage: "YouTube連携" },
+	{ icon: YoutubeIcon, name: "YoutubeIcon", usage: "YouTube連携" },
 	{ icon: FileText, name: "FileText", usage: "テキストコンテンツ" },
 	{ icon: Sparkles, name: "Sparkles", usage: "特別コンテンツ" },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.6)
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -246,8 +246,8 @@ importers:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.6)
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3850,8 +3850,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -8090,7 +8090,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.577.0(react@19.2.6):
+  lucide-react@1.16.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 


### PR DESCRIPTION
## Summary

- `YoutubeIcon` カスタムコンポーネントを新規作成（`packages/ui/src/components/custom/youtube-icon.tsx`）
  - lucide-react 0.x の `Youtube` SVG パスを使用した代替実装
  - `size` / `className` / `color` / `strokeWidth` props で lucide-react 互換 API
  - `aria-hidden="true"` デフォルト設定
- 5ファイルの `Youtube` import を `YoutubeIcon` に差し替え
- `lucide-react` を `^0.577.0` → `^1.16.0` に更新（brands アイコン全廃対応）
- `YoutubeIcon` を `@suzumina.click/ui/components/custom` から re-export

## Changes

- `packages/ui/src/components/custom/youtube-icon.tsx` （新規）
- `packages/ui/src/components/custom/audio-button.tsx`
- `packages/ui/src/components/custom/index.ts`
- `packages/ui/src/components/design-tokens/icons.stories.tsx`
- `apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx`
- `apps/web/src/components/audio-button-detail/related-audio-buttons.tsx`
- `apps/web/src/components/audio-button-detail/video-card-wrapper.tsx`
- `packages/ui/package.json` / `apps/web/package.json` / `pnpm-lock.yaml`

## Test plan

- [x] `pnpm lint` — エラー 0
- [x] `pnpm test` — 全テスト通過（332 + 674 + 338 件）
- [x] lucide-react v1 で削除・リネームされた他アイコンがないことを typecheck で確認

Closes SPR-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)