### PR TITLE
chore: react-day-picker v10 対応（CSS 修正・アクセシビリティ改善） (SPR-52)

### DIFF
--- a/apps/web/src/components/search/search-filters.tsx
+++ b/apps/web/src/components/search/search-filters.tsx
@@ -119,7 +119,7 @@ function DateRangeFilter({
 									mode="single"
 									selected={customDateFrom}
 									onSelect={setCustomDateFrom}
-									initialFocus
+									autoFocus
 								/>
 							</PopoverContent>
 						</Popover>
@@ -146,7 +146,7 @@ function DateRangeFilter({
 									mode="single"
 									selected={customDateTo}
 									onSelect={setCustomDateTo}
-									initialFocus
+									autoFocus
 								/>
 							</PopoverContent>
 						</Popover>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,7 @@
 		"next-themes": "^0.4.6",
 		"radix-ui": "latest",
 		"react": "^19.2.6",
-		"react-day-picker": "^9.14.0",
+		"react-day-picker": "^10.0.1",
 		"react-dom": "^19.2.6",
 		"react-hook-form": "^7.76.1",
 		"react-resizable-panels": "^4.11.2",

--- a/packages/ui/src/components/ui/calendar.tsx
+++ b/packages/ui/src/components/ui/calendar.tsx
@@ -114,7 +114,7 @@ function Calendar({
 						: "rounded-md pl-2 pr-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5",
 					defaultClassNames.caption_label,
 				),
-				table: "w-full border-collapse",
+				month_grid: "w-full",
 				weekdays: cn("flex", defaultClassNames.weekdays),
 				weekday: cn(
 					"text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,8 +261,8 @@ importers:
         specifier: ^19.2.6
         version: 19.2.6
       react-day-picker:
-        specifier: ^9.14.0
-        version: 9.14.0(react@19.2.6)
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.15)(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
@@ -2529,10 +2529,6 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
-  '@tabby_ai/hijri-converter@1.0.5':
-    resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
-    engines: {node: '>=16.0.0'}
-
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -3138,9 +3134,6 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  date-fns-jalali@4.1.0-0:
-    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.3.0:
     resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
@@ -4185,11 +4178,15 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-day-picker@9.14.0:
-    resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
     engines: {node: '>=18'}
     peerDependencies:
+      '@types/react': '>=16.8.0'
       react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -6752,8 +6749,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tabby_ai/hijri-converter@1.0.5': {}
-
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -7360,8 +7355,6 @@ snapshots:
   d3-timer@3.0.1: {}
 
   data-uri-to-buffer@4.0.1: {}
-
-  date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.3.0: {}
 
@@ -8472,13 +8465,13 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-day-picker@9.14.0(react@19.2.6):
+  react-day-picker@10.0.1(@types/react@19.2.15)(react@19.2.6):
     dependencies:
       '@date-fns/tz': 1.4.1
-      '@tabby_ai/hijri-converter': 1.0.5
       date-fns: 4.3.0
-      date-fns-jalali: 4.1.0-0
       react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.15
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- react-day-picker を v9.14.0 → v10.0.1 にアップデート
- `calendar.tsx`: classNames の `table` キーを `month_grid` に変更（v10 で HTML が `<table>` → CSS Grid の `<div>` に変わったため `border-collapse` も削除）
- `search-filters.tsx`: v10 で削除された `initialFocus` prop を `autoFocus` prop に置き換え（開始日・終了日の両ポップオーバー）

Closes SPR-52

## Test plan

- [x] `pnpm --filter @suzumina.click/ui typecheck` — pass
- [x] `pnpm --filter @suzumina.click/web typecheck` — pass
- [x] `pnpm --filter @suzumina.click/ui test` — 332 tests passed
- [x] `pnpm --filter @suzumina.click/ui lint` — warnings のみ（既存・本 PR と無関係）
- [ ] カレンダーコンポーネントの目視確認（レイアウト崩れがないか）
- [ ] キーボード操作確認（Tab / Enter でカレンダー操作できるか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)