### PR TITLE
chore: TypeScript 6.0 正式対応 — baseUrl 削除・TS6 移行 (SPR-53)

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -41,7 +41,7 @@
 		"dotenv-cli": "^11.0.0",
 		"rimraf": "^6.1.3",
 		"tsx": "^4.22.3",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.7"
 	}
 }

--- a/apps/functions/tsconfig.json
+++ b/apps/functions/tsconfig.json
@@ -4,10 +4,10 @@
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,
 		"outDir": "lib",
+		"rootDir": "./src",
 		"sourceMap": true,
 		"lib": ["ES2022"],
-		"allowSyntheticDefaultImports": true,
-		"baseUrl": "."
+		"allowSyntheticDefaultImports": true
 	},
 	"compileOnSave": true,
 	"include": ["src"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,7 +64,7 @@
 		"playwright": "^1.60.0",
 		"rimraf": "^6.1.3",
 		"tailwindcss": "^4.2.1",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.7"
 	}
 }

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -381,7 +381,7 @@ const nextAuth: NextAuthResult = NextAuth({
  * @see https://authjs.dev/getting-started/installation
  */
 export const handlers = nextAuth.handlers;
-export const auth = nextAuth.auth;
+export const auth: NextAuthResult["auth"] = nextAuth.auth;
 export const signIn: NextAuthResult["signIn"] = nextAuth.signIn;
 export const signOut = nextAuth.signOut;
 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@suzumina.click/typescript-config/nextjs.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"],
 			"@suzumina.click/ui/*": ["../../packages/ui/src/*"]

--- a/apps/web/tsconfig.test.json
+++ b/apps/web/tsconfig.test.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@suzumina.click/typescript-config/vitest.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"],
 			"@suzumina.click/ui/*": ["../../packages/ui/src/*"]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"@vitest/coverage-v8": "^4.1.7",
 		"lefthook": "^2.1.8",
 		"rimraf": "^6.1.3",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.7"
 	},
 	"engines": {

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -31,7 +31,7 @@
 		"@suzumina.click/typescript-config": "workspace:*",
 		"rimraf": "^6.1.3",
 		"tsup": "^8.5.1",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.7"
 	}
 }

--- a/packages/shared-types/tsconfig.dts.json
+++ b/packages/shared-types/tsconfig.dts.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"ignoreDeprecations": "6.0"
+	}
+}

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	entry: ["src/index.ts"],
 	format: ["esm", "cjs"],
 	dts: true,
+	tsconfig: "./tsconfig.dts.json",
 	splitting: true, // Enable code splitting for better tree-shaking
 	sourcemap: true,
 	clean: true,

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -46,7 +46,13 @@
 			}
 		},
 		{
-			"includes": ["**/*.test.tsx", "**/*.test.ts", "**/test-utils/**", "**/chart.tsx"],
+			"includes": [
+				"**/*.test.tsx",
+				"**/*.test.ts",
+				"**/test-utils/**",
+				"**/chart.tsx",
+				"**/vitest.setup.ts"
+			],
 			"linter": {
 				"rules": {
 					"suspicious": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,7 +60,7 @@
 		"rimraf": "^6.1.3",
 		"storybook": "^10.4.1",
 		"tailwindcss": "^4.2.1",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vitest": "^4.1.7"
 	},
 	"exports": {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@suzumina.click/typescript-config/react-library.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@suzumina.click/ui/*": ["./src/*"]
 		},

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -38,6 +38,7 @@ global.IntersectionObserver = class IntersectionObserver {
 	root = null;
 	rootMargin = "";
 	thresholds = [];
+	scrollMargin = "";
 
 	observe() {}
 	unobserve() {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
@@ -71,8 +71,8 @@ importers:
         specifier: ^4.22.3
         version: 4.22.3
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
@@ -183,8 +183,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
@@ -212,10 +212,10 @@ importers:
         version: 6.1.3
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.22.3))
@@ -305,7 +305,7 @@ importers:
         version: 10.4.1(@vitest/runner@4.1.7)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vitest@4.1.7)
       '@storybook/react-vite':
         specifier: ^10.4.1
-        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+        version: 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       '@suzumina.click/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -346,8 +346,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
@@ -4699,8 +4699,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5484,13 +5484,13 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
       glob: 13.0.6
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -6708,12 +6708,12 @@ snapshots:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
-  '@storybook/react-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
+  '@storybook/react-vite@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(esbuild@0.28.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(rollup@4.59.0)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
       '@storybook/builder-vite': 10.4.1(esbuild@0.28.0)(rollup@4.59.0)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
-      '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)
+      '@storybook/react': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 19.2.6
@@ -6732,19 +6732,19 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@5.9.3)':
+  '@storybook/react@10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(storybook@10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       react: 19.2.6
       react-docgen: 8.0.2
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.6(react@19.2.6)
       storybook: 10.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8480,9 +8480,9 @@ snapshots:
       date-fns-jalali: 4.1.0-0
       react: 19.2.6
 
-  react-docgen-typescript@2.4.0(typescript@5.9.3):
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-docgen@8.0.2:
     dependencies:
@@ -9049,7 +9049,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(typescript@6.0.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -9070,7 +9070,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.15
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -9093,7 +9093,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 


### PR DESCRIPTION
## Summary

- 全パッケージの TypeScript を `^5.9.3` → `^6.0.3` に更新
- 4 つの tsconfig から `baseUrl: "."` を削除（NodeNext/Bundler モードでは `paths` のみで解決可能）
- TypeScript 6.0 起因の新規エラーを 3 件修正

## Changes

### Step 1: baseUrl 削除
`apps/web/tsconfig.json`, `apps/web/tsconfig.test.json`, `packages/ui/tsconfig.json`, `apps/functions/tsconfig.json` から `baseUrl: "."` を削除。

### Step 2: tsup DTS ビルド問題の対処
tsup 8.5.1 の DTS ワーカーが内部で `baseUrl: compilerOptions.baseUrl || "."` を強制注入するバグを確認（`rollup.js:6837`）。`packages/shared-types/tsconfig.dts.json`（`ignoreDeprecations: "6.0"` のみ追加）を作成し、`tsup.config.ts` でトップレベルの `tsconfig` に指定することで回避。通常の `tsc --noEmit`（typecheck）はクリーンな `tsconfig.json` を引き続き使用する。

### Step 3: TypeScript 6.0 への更新と追加修正

| エラー | ファイル | 対応 |
|--------|---------|------|
| TS5011: `rootDir` 明示必須 | `apps/functions/tsconfig.json` | `"rootDir": "./src"` を追加 |
| TS2883: `auth` の型推論が非ポータブル | `apps/web/src/auth.ts` | `NextAuthResult["auth"]` を付与（`signIn` と同様） |
| DOM lib: `IntersectionObserver.scrollMargin` 追加 | `packages/ui/vitest.setup.ts` | モックに `scrollMargin = ""` を追加 |

`packages/ui/biome.json` のテストファイルオーバーライドに `vitest.setup.ts` を追加（既存の `noExplicitAny: off` ルールを適用）。

## Verification

```
pnpm typecheck  # ✓ 全パッケージ通過
pnpm build      # ✓ 全パッケージ通過（DTS 含む）
pnpm test       # ✓ 2257 tests passed
pnpm lint       # ✓ 警告のみ（既存）
```

## Notes

tsup の `baseUrl` 強制注入は上流バグ。tsup が修正されたタイミングで `tsconfig.dts.json` と `tsup.config.ts` の `tsconfig` 指定を除去できる。

Closes SPR-53

🤖 Generated with [Claude Code](https://claude.com/claude-code)