### PR TITLE
chore: Node.js 24.16.0 (LTS) / pnpm 11.3.0 へのアップデート (SPR-55)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '26.2.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '26.2.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -169,7 +169,7 @@ jobs:
             if (!pkg.engines) {
               pkg.engines = {};
             }
-            pkg.engines.node = '24';
+            pkg.engines.node = '26';
             
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
@@ -219,7 +219,7 @@ jobs:
           gcloud functions deploy fetchYouTubeVideos \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
-            --runtime nodejs24 \
+            --runtime nodejs26 \
             --entry-point fetchYouTubeVideos \
             --trigger-topic youtube-video-fetch-trigger \
             --region asia-northeast1 \
@@ -236,7 +236,7 @@ jobs:
           gcloud functions deploy fetchDLsiteUnifiedData \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
-            --runtime nodejs24 \
+            --runtime nodejs26 \
             --entry-point fetchDLsiteUnifiedData \
             --trigger-topic dlsite-individual-api-trigger \
             --region asia-northeast1 \
@@ -253,7 +253,7 @@ jobs:
           gcloud functions deploy checkDataIntegrity \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
-            --runtime nodejs24 \
+            --runtime nodejs26 \
             --entry-point checkDataIntegrity \
             --trigger-topic data-integrity-check-trigger \
             --region asia-northeast1 \

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26.2.0'
+          node-version: '24.16.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26.2.0'
+          node-version: '24.16.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -169,7 +169,7 @@ jobs:
             if (!pkg.engines) {
               pkg.engines = {};
             }
-            pkg.engines.node = '26';
+            pkg.engines.node = '24';
             
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
@@ -219,7 +219,7 @@ jobs:
           gcloud functions deploy fetchYouTubeVideos \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
-            --runtime nodejs26 \
+            --runtime nodejs24 \
             --entry-point fetchYouTubeVideos \
             --trigger-topic youtube-video-fetch-trigger \
             --region asia-northeast1 \
@@ -236,7 +236,7 @@ jobs:
           gcloud functions deploy fetchDLsiteUnifiedData \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
-            --runtime nodejs26 \
+            --runtime nodejs24 \
             --entry-point fetchDLsiteUnifiedData \
             --trigger-topic dlsite-individual-api-trigger \
             --region asia-northeast1 \
@@ -253,7 +253,7 @@ jobs:
           gcloud functions deploy checkDataIntegrity \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
-            --runtime nodejs26 \
+            --runtime nodejs24 \
             --entry-point checkDataIntegrity \
             --trigger-topic data-integrity-check-trigger \
             --region asia-northeast1 \

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26.2.0'
+          node-version: '24.16.0'
           cache: 'pnpm'
       
       - name: Install dependencies

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '26.2.0'
           cache: 'pnpm'
       
       - name: Install dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26.2.0'
+          node-version: '24.16.0'
           cache: 'pnpm'
       
       - name: Install dependencies
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26.2.0'
+          node-version: '24.16.0'
           cache: 'pnpm'
       
       - name: Install dependencies
@@ -257,7 +257,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '26.2.0'
+          node-version: '24.16.0'
           cache: 'pnpm'
       
       - name: Install dependencies

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '26.2.0'
           cache: 'pnpm'
       
       - name: Install dependencies
@@ -213,7 +213,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '26.2.0'
           cache: 'pnpm'
       
       - name: Install dependencies
@@ -257,7 +257,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24.13.0'
+          node-version: '26.2.0'
           cache: 'pnpm'
       
       - name: Install dependencies

--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -26,7 +26,7 @@
 	},
 	"main": "lib/endpoints/index.js",
 	"engines": {
-		"node": "24.14.0"
+		"node": "26.2.0"
 	},
 	"dependencies": {
 		"@google-cloud/firestore": "^8.6.0",

--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -26,7 +26,7 @@
 	},
 	"main": "lib/endpoints/index.js",
 	"engines": {
-		"node": "26.2.0"
+		"node": "24.16.0"
 	},
 	"dependencies": {
 		"@google-cloud/firestore": "^8.6.0",

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 # Install pnpm (use latest version 10 to match engines)
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable pnpm && corepack use pnpm@10
+RUN corepack enable pnpm && corepack use pnpm@11
 # Ensure yarn is disabled to prevent conflicts
 RUN npm config delete prefix 2>/dev/null || true
 
@@ -34,7 +34,7 @@ WORKDIR /app
 # Install pnpm
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable pnpm && corepack use pnpm@10
+RUN corepack enable pnpm && corepack use pnpm@11
 # Ensure yarn is disabled to prevent conflicts
 RUN npm config delete prefix 2>/dev/null || true
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,7 +1,7 @@
 # suzumina.click Web Application Dockerfile for Cloud Run
 # Optimized for Next.js 15 with advanced caching and monorepo structure
 
-FROM node:24.14.0-alpine AS base
+FROM node:26.2.0-alpine AS base
 RUN apk add --no-cache libc6-compat tini
 
 # Install dependencies only when needed

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache libc6-compat tini
 FROM base AS deps
 WORKDIR /app
 
-# Install pnpm (use latest version 10 to match engines)
+# Install pnpm (use latest version 11 to match engines)
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable pnpm && corepack use pnpm@11

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,7 +1,7 @@
 # suzumina.click Web Application Dockerfile for Cloud Run
 # Optimized for Next.js 15 with advanced caching and monorepo structure
 
-FROM node:26.2.0-alpine AS base
+FROM node:24.16.0-alpine AS base
 RUN apk add --no-cache libc6-compat tini
 
 # Install dependencies only when needed

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "24.16.0"
-pnpm = "latest"
+pnpm = "11.3.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "lts"
+node = "24.16.0"
 pnpm = "latest"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"vitest": "^4.1.7"
 	},
 	"engines": {
-		"node": "26.2.0",
+		"node": "24.16.0",
 		"pnpm": "10.32.0"
 	},
 	"packageManager": "pnpm@10.32.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"vitest": "^4.1.7"
 	},
 	"engines": {
-		"node": "24.14.0",
+		"node": "26.2.0",
 		"pnpm": "10.32.0"
 	},
 	"packageManager": "pnpm@10.32.0",

--- a/package.json
+++ b/package.json
@@ -25,19 +25,7 @@
 	},
 	"engines": {
 		"node": "24.16.0",
-		"pnpm": "10.32.0"
+		"pnpm": "11.3.0"
 	},
-	"packageManager": "pnpm@10.32.0",
-	"pnpm": {
-		"overrides": {
-			"protobufjs": ">=7.5.8",
-			"vite": ">=7.3.2",
-			"path-to-regexp": ">=8.4.0",
-			"uuid": ">=11.1.1",
-			"ws": ">=8.20.1",
-			"@tootallnate/once": ">=2.0.1",
-			"postcss": ">=8.5.10",
-			"qs": ">=6.15.2"
-		}
-	}
+	"packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,8 @@ overrides:
   postcss: ">=8.5.10"
   qs: ">=6.15.2"
 
-onlyBuiltDependencies:
-  - esbuild
-  - lefthook
-  - protobufjs
-  - sharp
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  protobufjs: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
 packages:
   - apps/*
   - packages/*
+
+overrides:
+  protobufjs: ">=7.5.8"
+  vite: ">=7.3.2"
+  path-to-regexp: ">=8.4.0"
+  uuid: ">=11.1.1"
+  ws: ">=8.20.1"
+  "@tootallnate/once": ">=2.0.1"
+  postcss: ">=8.5.10"
+  qs: ">=6.15.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,9 @@ overrides:
   "@tootallnate/once": ">=2.0.1"
   postcss: ">=8.5.10"
   qs: ">=6.15.2"
+
+onlyBuiltDependencies:
+  - esbuild
+  - lefthook
+  - protobufjs
+  - sharp


### PR DESCRIPTION
## Summary

Node.js 26 は GCP Cloud Functions で未対応のため、Node.js 24 最新 LTS (24.16.0) にプロジェクト全体を統一。
あわせて pnpm を 10.32.0 → 11.3.0 へメジャーアップデート。

### Node.js

- `package.json` / `apps/functions/package.json` の `engines.node`: `24.16.0`
- `apps/web/Dockerfile`: `node:24.16.0-alpine`
- CI ワークフロー (`pr-check`, `deploy-web`, `deploy-functions`) の `node-version`: `24.16.0`
- Cloud Functions ランタイム: `nodejs24`（変更なし・GCP対応版を維持）
- `mise.toml`: `node = "lts"` → `node = "24.16.0"` に固定

### pnpm

- `package.json` `packageManager` / `engines.pnpm`: `pnpm@10.32.0` → `pnpm@11.3.0`
- `apps/web/Dockerfile`: `corepack use pnpm@10` → `pnpm@11`
- `mise.toml`: `pnpm = "latest"` → `pnpm = "11.3.0"` に固定
- **`overrides` を `package.json` → `pnpm-workspace.yaml` へ移行**
  pnpm 11 では `package.json` の `"pnpm"` フィールドが無視されるため、セキュリティ用 overrides（`protobufjs`, `vite`, `ws`, `path-to-regexp` 等）が無効になっていた問題を修正

## Background

Node.js 26 へのアップグレードを検討したが、GCP Cloud Functions は最大 `nodejs24` までしか対応していない（26は未サポート）。Web (Cloud Run) は Docker ベースのため 26 も使えるが、Functions と分離するとバージョン二重管理になるため、24.16.0 に統一する方針を採用。

## Verification

`pnpm why` で overrides の適用を確認済み：

- `protobufjs@8.4.1` （`>=7.5.8` 満たす、1バージョンに統一）✅
- `ws@8.20.1` （`>=8.20.1` 満たす）✅

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm test` 通過（全 2257 テスト）
- [x] `pnpm lint` 通過

Closes SPR-55

🤖 Generated with [Claude Code](https://claude.com/claude-code)