### PR TITLE
chore: web を shared-types source 直接消費に切り替え (SPR-57)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,7 +6,7 @@ const withBundleAnalyzer = bundleAnalyzer({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	transpilePackages: ["@suzumina.click/ui"],
+	transpilePackages: ["@suzumina.click/ui", "@suzumina.click/shared-types"],
 
 	// Cloud Run向けのstandaloneビルド設定
 	output: "standalone",

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -6,8 +6,14 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
+			"import": {
+				"types": "./src/index.ts",
+				"default": "./src/index.ts"
+			},
+			"require": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			}
 		}
 	},
 	"files": [


### PR DESCRIPTION
## Summary

- shared-types の exports を `import`/`require` の条件分岐に変更し、web (Next.js bundler / ESM) は `src/index.ts` を、functions (Node CJS) は `dist/index.js` をそれぞれ解決する構成にした
- `apps/web/next.config.mjs` の `transpilePackages` に `@suzumina.click/shared-types` を追加し、Next が src を直接トランスパイル/バンドルできるようにした
- これで web build が shared-types の dist ビルドに依存しなくなる（Phase A 完了）

Linear: [SPR-57](https://linear.app/nothink/issue/SPR-57/chore-web-を-shared-types-source-直接消費に切り替えphase-a)

## 設計判断

issue 本文では `\"./src/*\": \"./src/*\"` のサブパス export を案として提示していたが、これはルートパス `@suzumina.click/shared-types` の解決経路を変えないため、dist 無し状態だと MODULE_NOT_FOUND になることを実機で確認。代わりに `import`/`require` の条件分岐を採用した:

\`\`\`json
\"exports\": {
  \".\": {
    \"import\": {
      \"types\": \"./src/index.ts\",
      \"default\": \"./src/index.ts\"
    },
    \"require\": {
      \"types\": \"./dist/index.d.ts\",
      \"default\": \"./dist/index.js\"
    }
  }
}
\`\`\`

これで:
- web (Next bundler / vitest ESM) → `import` 条件 → src
- functions (CJS require) → `require` 条件 → dist
- 旧来の top-level `main` / `types` フィールドはレガシー互換のため残置

## 検証結果

| 項目 | 結果 |
|---|---|
| web build (dist 無し) | ✅ 成功 → source-direct 実証 |
| web typecheck / lint / test | ✅ 通過 (674 passed) |
| functions build / typecheck / test | ✅ dist 経由で従来通り (338 passed) |
| shared-types typecheck / test / lint | ✅ 通過 (913 passed) |
| ui typecheck | ✅ 通過 |
| バンドルサイズ | **JS chunks 3.10MB → 2.64MB (-14.7%)** ※ ESM source の方が SWC のツリーシェイクが効きやすいため |

## Test plan

- [x] \`pnpm --filter @suzumina.click/web build\` が shared-types の dist 無しで成功
- [x] \`pnpm --filter @suzumina.click/web typecheck\` / \`test\` / \`lint\` 通過
- [x] \`pnpm --filter @suzumina.click/functions build\` / \`typecheck\` / \`test\` 通過 (dist 経由)
- [x] バンドルサイズ回帰なし（ANALYZE=true でビフォーアフター比較、むしろ改善）
- [ ] dev server (\`pnpm dev\`) で hot reload が src 変更で発火（手動確認）
- [ ] Storybook (\`pnpm --filter @suzumina.click/ui storybook\`) で shared-types が解決される（手動確認）

## 関連

- 前提: SPR-56 (tsup → tsc 移行)
- 次工程: SPR-58 (functions の esbuild bundle 化)
- 最終: SPR-59 (shared-types no-build 化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)