### PR TITLE
fix(web): sitemap.xml を ISR 化して build 時 Firestore アクセスを回避（SPR-60）

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -2,6 +2,9 @@ import type { MetadataRoute } from "next";
 import { getFirestore } from "@/lib/firestore";
 import { warn as logWarn } from "@/lib/logger";
 
+// ISR: build 時の Firestore アクセスを避け、リクエスト時に Cloud Run の SA credentials で生成する (SPR-60)
+export const revalidate = 3600;
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://suzumina.click";
 


### PR DESCRIPTION
## Summary

- `apps/web/src/app/sitemap.ts` に `export const revalidate = 3600` を 1 行追加し ISR 化
- build 時に Firestore へクエリして発生していた credential エラー（1 ビルドあたり 40+ 件）を解消
- リクエスト時に Cloud Run の SA credentials で生成されるため、本番 sitemap.xml に videos / works / audioButtons の動的 URL が含まれるようになる

Linear: [SPR-60](https://linear.app/nothink/issue/SPR-60/appswebsitemapts-が-build-時に-firestore-へアクセスし本番-sitemapxml-が動的-url)

## 検証結果

- `pnpm --filter @suzumina.click/web typecheck` — pass
- `pnpm --filter @suzumina.click/web lint` — pass（既存警告のみ、本変更に起因する指摘なし）
- `pnpm --filter @suzumina.click/web test` — 674 passed
- `pnpm --filter @suzumina.click/web build`
  - `Could not load the default credentials` / `MetadataLookupWarning` のログが **0 件**（修正前は 40+ 件）
  - Route 表示で `/sitemap.xml` に `Revalidate 1h` カラムが付与され ISR 化を確認

## Test plan

- [x] PR Check（typecheck / lint / test）が pass
- [ ] マージ → Deploy Web ワークフローのビルドフェーズに credential エラーが含まれないこと
- [ ] デプロイ後 `curl -s https://suzumina.click/sitemap.xml | grep -c '<loc>'` が 6 → 数百以上に増えること
- [ ] Cloud Run のレスポンスタイム劣化が無いこと（ISR キャッシュ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)