### PR TITLE
fix(web): sitemap.xml を force-dynamic に変更（SPR-60 follow-up）

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -2,8 +2,9 @@ import type { MetadataRoute } from "next";
 import { getFirestore } from "@/lib/firestore";
 import { warn as logWarn } from "@/lib/logger";
 
-// ISR: build 時の Firestore アクセスを避け、リクエスト時に Cloud Run の SA credentials で生成する (SPR-60)
-export const revalidate = 3600;
+// build 時の Firestore アクセスを避け、リクエスト時に Cloud Run の SA credentials で生成する (SPR-60)
+// クローラートラフィックのみなので毎リクエスト生成でも Cloud Run コストは無視できる
+export const dynamic = "force-dynamic";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://suzumina.click";


### PR DESCRIPTION
## Background

[#410](https://github.com/nothink-jp/suzumina.click/pull/410) で `export const revalidate = 3600` を追加して ISR 化を試みたが、Next.js 16 では `revalidate` 単独では build 時の pre-render を skip しない（ルート表示は `○ Static` + Revalidate 1h）。

実際の Deploy Web ワークフロー（[run 26381569277](https://github.com/nothink-jp/suzumina.click/actions/runs/26381569277/job/77651734627)）では修正後も credential エラーが **35 件発生** していた。ローカル検証で 0 件だったのは検証マシンに ADC があり Firestore 呼び出しが成功していたため。

Linear: [SPR-60](https://linear.app/nothink/issue/SPR-60/appswebsitemapts-が-build-時に-firestore-へアクセスし本番-sitemapxml-が動的-url)

## Change

`export const revalidate = 3600` を **`export const dynamic = "force-dynamic"`** に置換。

これにより:
- ルート表示が `ƒ /sitemap.xml`（Dynamic）になり、build 時の pre-render が完全に skip される
- 毎リクエストで Firestore に問い合わせるが、sitemap はクローラートラフィック数十 req/日のみなので Cloud Run コスト実害は無視できる
- 本番では Cloud Run の SA credentials で正常に動的 URL が含まれた sitemap が返る

## 検証

- `pnpm --filter @suzumina.click/web build` のルート表示で `/sitemap.xml` が `ƒ` (Dynamic) に変化（修正前: `○` Static + Revalidate 1h）
- `pnpm --filter @suzumina.click/web typecheck` pass
- Compiled successfully

## Test plan

- [x] PR Check が pass
- [ ] マージ → Deploy Web ワークフローのビルドフェーズで `Could not load the default credentials` / `MetadataLookupWarning` が **0 件**
- [ ] デプロイ後 `curl -s https://suzumina.click/sitemap.xml | grep -c '<loc>'` が数百以上
- [ ] Cloud Run の sitemap.xml レスポンスタイムが許容範囲

🤖 Generated with [Claude Code](https://claude.com/claude-code)