### PR TITLE
fix(web): sitemap の isPublic フィルタ誤りで videos/works が全件除外されていたのを修正

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -30,15 +30,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		const dynamicPages: MetadataRoute.Sitemap = [];
 
 		// 動画ページを追加
+		// videos コレクションには isPublic フィールドが無く、可視性は status.privacyStatus で判定する。
+		// 一覧ページ (apps/web/src/app/videos/actions.ts) と同じく、status 未設定も公開扱いする。
 		try {
-			const videosSnapshot = await firestore
-				.collection("videos")
-				.where("isPublic", "==", true)
-				.limit(1000)
-				.get();
+			const videosSnapshot = await firestore.collection("videos").limit(50000).get();
 
 			for (const doc of videosSnapshot.docs) {
 				const video = doc.data();
+				const privacyStatus = video.status?.privacyStatus;
+				if (video.status && privacyStatus !== "public") continue;
 				dynamicPages.push({
 					url: `${baseUrl}/videos/${doc.id}`,
 					lastModified: new Date(video.updatedAt || video.createdAt || Date.now()),
@@ -51,12 +51,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		}
 
 		// 作品ページを追加
+		// works コレクションには公開/非公開の概念が無く、全件が公開対象。
 		try {
-			const worksSnapshot = await firestore
-				.collection("works")
-				.where("isPublic", "==", true)
-				.limit(1000)
-				.get();
+			const worksSnapshot = await firestore.collection("works").limit(50000).get();
 
 			for (const doc of worksSnapshot.docs) {
 				const work = doc.data();
@@ -76,7 +73,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			const audioButtonsSnapshot = await firestore
 				.collection("audioButtons")
 				.where("isPublic", "==", true)
-				.limit(1000)
+				.limit(50000)
 				.get();
 
 			for (const doc of audioButtonsSnapshot.docs) {


### PR DESCRIPTION
## Summary

- 本番 sitemap.xml で動的 URL が 66 件しかなく、内訳がすべて audioButtons だけだった原因を修正
- `videos` / `works` コレクションには `isPublic` フィールドが存在しないため、`.where(\"isPublic\", \"==\", true)` が常に 0 件マッチしていた
- 結果として **videos 533 件・works 2,016 件** がまるごと sitemap から欠落していた

## Root cause

| collection | total | `isPublic == true` | sitemap 反映 |
|---|---:|---:|---:|
| videos | 533 | **0** | 0 件 ❌ |
| works | 2,016 | **0** | 0 件 ❌ |
| audioButtons | 66 | 66 | 66 件 ✅ |

- `videos`: `isPublic` は存在せず、可視性は `status.privacyStatus` で表現される（[shared-types](https://github.com/nothink-jp/suzumina.click/blob/main/packages/shared-types/src/types/firestore/video.ts#L95-L103) 参照）
- `works`: そもそも公開/非公開の概念が無く全件公開対象（[work-document-schema.ts](https://github.com/nothink-jp/suzumina.click/blob/main/packages/shared-types/src/entities/work/work-document-schema.ts) に `isPublic` 無し）
- `audioButtons`: `isPublic: boolean` が定義済みでフィルタは正しい

## 変更内容

- `videos`: `isPublic` フィルタを削除し、in-memory で `status.privacyStatus === \"public\" || !video.status` 判定に変更（[list 実装](https://github.com/nothink-jp/suzumina.click/blob/main/apps/web/src/app/videos/actions.ts#L247) と同じロジック）
- `works`: `isPublic` フィルタを削除（公開/非公開の概念なし）
- `audioButtons`: 変更なし
- `.limit(1000)` → `.limit(50000)`: works が既に 2,000 件超のため。Google sitemap の単一ファイル上限と一致

## Expected impact

修正後の sitemap 件数: **約 2,626 件** (static 11 + videos 533 + works 2,016 + buttons 66)

## Test plan

- [x] `pnpm --filter @suzumina.click/web lint` 通過
- [x] `pnpm --filter @suzumina.click/web typecheck` 通過
- [x] `pnpm --filter @suzumina.click/web test` 通過 (674 passed / 1 skipped)
- [ ] デプロイ後に `curl https://suzumina.click/sitemap.xml | grep -oE '<loc>https://suzumina.click/[^<]+</loc>' | awk -F/ '{print \$1}' | sort | uniq -c` で件数が videos/works/buttons それぞれ想定通り増えていることを確認

## Follow-up（別 issue 推奨）

- dynamic sitemap で毎リクエスト 2,600 件の Firestore read が走るため、クローラ流入次第ではコスト最適化（ISR / revalidate）の再検討余地あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)