### PR TITLE
perf(web): sitemap.xml の Firestore クエリを unstable_cache で 1 時間キャッシュ

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,31 +1,16 @@
 import type { MetadataRoute } from "next";
+import { unstable_cache } from "next/cache";
 import { getFirestore } from "@/lib/firestore";
 import { warn as logWarn } from "@/lib/logger";
 
 // build 時の Firestore アクセスを避け、リクエスト時に Cloud Run の SA credentials で生成する (SPR-60)
-// クローラートラフィックのみなので毎リクエスト生成でも Cloud Run コストは無視できる
+// Firestore 取得部分は unstable_cache で 1 時間キャッシュし、毎リクエストでクエリが走らないようにする
 export const dynamic = "force-dynamic";
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-	const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://suzumina.click";
+const SITEMAP_REVALIDATE_SECONDS = 3600;
 
-	// 静的ページ（公開ページのみ。要認証ページや action ページは robots.txt 側で disallow する）
-	const now = new Date();
-	const staticPages: MetadataRoute.Sitemap = [
-		{ url: baseUrl, lastModified: now, changeFrequency: "daily", priority: 1 },
-		{ url: `${baseUrl}/buttons`, lastModified: now, changeFrequency: "daily", priority: 0.9 },
-		{ url: `${baseUrl}/videos`, lastModified: now, changeFrequency: "daily", priority: 0.9 },
-		{ url: `${baseUrl}/works`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
-		{ url: `${baseUrl}/circles`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
-		{ url: `${baseUrl}/creators`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
-		{ url: `${baseUrl}/search`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
-		{ url: `${baseUrl}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
-		{ url: `${baseUrl}/contact`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
-		{ url: `${baseUrl}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
-		{ url: `${baseUrl}/privacy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
-	];
-
-	try {
+const getDynamicSitemapPages = unstable_cache(
+	async (baseUrl: string): Promise<MetadataRoute.Sitemap> => {
 		const firestore = getFirestore();
 		const dynamicPages: MetadataRoute.Sitemap = [];
 
@@ -92,6 +77,33 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			logWarn("Failed to fetch audio buttons for sitemap:", { error });
 		}
 
+		return dynamicPages;
+	},
+	["sitemap-dynamic-pages"],
+	{ revalidate: SITEMAP_REVALIDATE_SECONDS, tags: ["sitemap"] },
+);
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://suzumina.click";
+
+	// 静的ページ（公開ページのみ。要認証ページや action ページは robots.txt 側で disallow する）
+	const now = new Date();
+	const staticPages: MetadataRoute.Sitemap = [
+		{ url: baseUrl, lastModified: now, changeFrequency: "daily", priority: 1 },
+		{ url: `${baseUrl}/buttons`, lastModified: now, changeFrequency: "daily", priority: 0.9 },
+		{ url: `${baseUrl}/videos`, lastModified: now, changeFrequency: "daily", priority: 0.9 },
+		{ url: `${baseUrl}/works`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+		{ url: `${baseUrl}/circles`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+		{ url: `${baseUrl}/creators`, lastModified: now, changeFrequency: "weekly", priority: 0.7 },
+		{ url: `${baseUrl}/search`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+		{ url: `${baseUrl}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+		{ url: `${baseUrl}/contact`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+		{ url: `${baseUrl}/terms`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+		{ url: `${baseUrl}/privacy`, lastModified: now, changeFrequency: "yearly", priority: 0.3 },
+	];
+
+	try {
+		const dynamicPages = await getDynamicSitemapPages(baseUrl);
 		return [...staticPages, ...dynamicPages];
 	} catch (error) {
 		// Firestoreが利用できない場合は静的ページのみ返す


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 要件

\`apps/web/src/app/sitemap.ts\` は [#411](https://github.com/nothink-jp/suzumina.click/pull/411) / [#412](https://github.com/nothink-jp/suzumina.click/pull/412) 以降 \`export const dynamic = \"force-dynamic\"\` で動作しており、毎リクエストで Firestore へ 3 クエリ（\`videos\` / \`works\` / \`audioButtons\` 各最大 1000 docs）を発行している。クローラートラフィックは少ないので実害は出ていないものの、想定外の bot や DDoS で Firestore コストが青天井になる懸念とレスポンスタイム劣化があるため、コスト最適化のためキャッシュ層を導入する。

### アプローチ

Next.js の \`unstable_cache\` で Firestore 取得部分（\`getDynamicSitemapPages\`）をラップ:

- \`revalidate: 3600\` で Firestore クエリを 1 時間に最大 1 回まで抑制
- cache tag \`\"sitemap\"\` を付与し将来的な on-demand revalidate（\`revalidateTag\`）に備える
- \`dynamic = \"force-dynamic\"\` は維持（build 時 pre-render を回避し SPR-60 の再発を防ぐ）
- 静的ページ部分は \`lastModified: now\` の意味を保つためキャッシュ対象外
- \`baseUrl\` をキャッシュ関数の引数として渡し、環境ごとにキャッシュを分離

### スコープ

- \`apps/web/src/app/sitemap.ts\` 1 ファイルのみ

## テスト項目

- [x] \`pnpm --filter @suzumina.click/web typecheck\` pass
- [x] \`pnpm --filter @suzumina.click/web test\` pass（674 passing / 1 skipped）
- [x] \`pnpm --filter @suzumina.click/web lint\` pass（既存の 7 warnings は本変更と無関係）
- [x] \`pnpm --filter @suzumina.click/web build\` 成功、ルート表示が \`ƒ /sitemap.xml\` のまま、\`Collecting page data\` で Firestore 未アクセス
- [ ] ローカル \`pnpm dev\` で \`/sitemap.xml\` を 2 回連続取得し、2 回目に Firestore クエリが実行されないことをログで確認
- [ ] デプロイ後、\`curl https://suzumina.click/sitemap.xml\` を高頻度叩いても GCP Console で Firestore 使用量が増えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)