### PR TITLE
fix(web): トップページを force-dynamic 化し build 時 Firestore アクセスを除去（SPR-60 follow-up 2）

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,9 +1,10 @@
 import { HomePage } from "@/components/home/home-page";
 import { getLatestAudioButtons, getLatestVideos, getLatestWorks } from "./actions";
 
-// Static generation with ISR for better performance
-// 5 minute cache to reduce Firestore queries and improve LCP
-export const revalidate = 300;
+// build 時の Firestore アクセスを避けるため force-dynamic を採用 (SPR-60 follow-up)
+// CDN 側で s-maxage=300, stale-while-revalidate=600（next.config.mjs）が効くため
+// 実質的なキャッシュ挙動は ISR と同等
+export const dynamic = "force-dynamic";
 
 // Server Component として実装し、全データを並列取得
 export default async function Home() {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
# SPR-60 follow-up 2: トップページの ISR を force-dynamic に変更

## 要件

### 真因
`apps/web/src/app/page.tsx` の `export const revalidate = 300;`（ISR）が build 時にトップページを静的生成しようとし、その過程で 4 並列の Firestore クエリ（`getLatestAudioButtons` / `getLatestVideos` / `getLatestWorks` × 2）が実行されていた。

credential が無い Docker build コンテナで以下が 20 件以上発生:
- `Could not load the default credentials`
- `MetadataLookupWarning`

PR #410 / #411 / #412 で `sitemap.xml` を片付けた後の残件（35件 → 20件 → 0件 を目指す）。

### 変更
- `revalidate = 300` → `dynamic = "force-dynamic"` に変更
- CDN 側で `s-maxage=300, stale-while-revalidate=600` ([apps/web/next.config.mjs:259-264](apps/web/next.config.mjs#L259-L264)) が設定済みのため、実質的なキャッシュ挙動は ISR と同等

### 影響
- build 時に `/` の静的生成が走らなくなる → credential エラーが消える
- リクエスト時は dynamic SSR + CDN キャッシュ（s-maxage=300）で配信されるため、エンドユーザー体感は変化なし

## テスト項目

ローカル `pnpm build`（credential なし）で確認済:

- [x] credential 関連エラー 0 件
  - `grep -c "credentials\|MetadataLookup\|Could not load" = 0`
- [x] ルート表示が `ƒ /`（Dynamic）に変わり、build 時に静的生成されない
  - `Generating static pages (24/24)`（変更前は 25/25）
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過（warning 数変化なし）
- [x] `pnpm test` 通過（674 tests passed / 1 skipped）

## 受け入れ条件

- [x] Deploy Web ワークフローのビルドフェーズで `Could not load the default credentials` / `MetadataLookupWarning` が 0 件
- [x] 既存機能に regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)