### PR TITLE
fix(ui): Storybook 起動時の `__dirname is not defined` を修正

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,5 +1,8 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { StorybookConfig } from "@storybook/react-vite";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const config: StorybookConfig = {
 	stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
# fix(ui): Storybook 起動時の \`__dirname is not defined\` を修正

## 要件

\`packages/ui\` で \`pnpm storybook\` を実行すると preview ビルドが失敗し、
Storybook が起動できなくなっていた問題を修正する。

\`\`\`
■  ReferenceError: __dirname is not defined
│  at Object.viteFinal (file://./.storybook/main.ts:23:34)
\`\`\`

### 原因

- \`packages/ui/package.json\` は \`"type": "module"\` を指定しており、
  \`.storybook/main.ts\` は ESM として読み込まれる。
- ESM では CommonJS グローバルである \`__dirname\` が未定義のため、
  \`viteFinal\` 内の \`resolve(__dirname, "./mocks/next-navigation.ts")\` が
  実行時に \`ReferenceError\` を起こしていた。

### 修正内容

- \`import.meta.url\` を \`fileURLToPath\` + \`dirname\` で解決し、
  ファイル先頭で \`__dirname\` を定数として定義することで、
  \`resolve(__dirname, ...)\` の呼び出しを変更せず ESM 上でも動作するようにした。

## テスト項目

- [x] \`cd packages/ui && pnpm storybook\` で Storybook dev server が
  \`http://localhost:6006/\` で起動することを確認した。

### 補足

同じ起動ログに残る以下の警告は本クラッシュとは別件で、Storybook の起動自体には影響しない。

- \`No story files found for the specified pattern: src/**/*.mdx\`
  （\`.mdx\` 形式の story が存在しないことに対する警告）
- \`unable to find package.json for radix-ui\`
  （Storybook 側の \`radix-ui\` パッケージメタデータ参照に関する既知の警告）

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)