### PR TITLE
chore(functions): ビルド/デプロイを esbuild bundle に刷新（SPR-58 Phase B）

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -66,22 +66,11 @@ jobs:
       - name: Quick validation
         run: |
           echo "🧪 Running quick validation for direct push..."
-          
-          # Build shared-types
-          pnpm --filter=@suzumina.click/shared-types build
-          
-          # Run build and test in parallel
-          pnpm --filter=@suzumina.click/functions build &
-          BUILD_PID=$!
-          
-          # Wait for build to complete
-          if wait $BUILD_PID; then
-            echo "✅ Build completed"
-          else
-            echo "❌ Build failed"
-            exit 1
-          fi
-          
+
+          # esbuild bundle (shared-types は src から直接 inline されるので別途 build 不要)
+          pnpm --filter=@suzumina.click/functions build
+          echo "✅ Build completed"
+
           # Run critical tests
           NODE_ENV=test pnpm --filter=@suzumina.click/functions test --bail 1
           echo "✅ Critical tests passed"
@@ -109,10 +98,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build packages
+      - name: Build functions (esbuild bundle)
         run: |
-          echo "🔨 Building packages..."
-          pnpm --filter=@suzumina.click/shared-types build
+          echo "🔨 Building Cloud Functions bundle..."
           pnpm --filter=@suzumina.click/functions build
 
       - name: Authenticate to GCP
@@ -127,68 +115,45 @@ jobs:
 
       - name: Create deployment bundle
         run: |
-          # 一時的なデプロイメントディレクトリを作成
+          # esbuild 後のバンドル lib/index.js と縮小 package.json のみをデプロイ
           mkdir -p ./deployment-temp
-          
-          # shared-typesをパッケージ化
-          cd packages/shared-types
-          pnpm pack --pack-destination ../../deployment-temp
-          
-          # パッケージファイル名を確実に取得
-          cd ../../deployment-temp
-          SHARED_TYPES_FILE=$(ls suzumina.click-shared-types-*.tgz | head -n1)
-          echo "Found shared-types package: $SHARED_TYPES_FILE"
-          
-          # functionsのビルド成果物とpackage.jsonをコピー
-          cp -r ../apps/functions/lib ./
-          cp ../apps/functions/package.json ./
-          
-          # Node.jsスクリプトでpackage.jsonを安全に変更
-          SHARED_TYPES_FILE="$SHARED_TYPES_FILE" node -e "
+          cp -r apps/functions/lib ./deployment-temp/
+          cp apps/functions/package.json ./deployment-temp/
+
+          # workspace 依存（shared-types）を削除し、dev フィールドも除去
+          cd ./deployment-temp
+          node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            
-            // workspace依存関係を実際のファイルパスに変更
-            if (pkg.dependencies && pkg.dependencies['@suzumina.click/shared-types']) {
-              pkg.dependencies['@suzumina.click/shared-types'] = 'file:./' + process.env.SHARED_TYPES_FILE;
+
+            // shared-types は esbuild で inline 済み → ランタイム依存から削除
+            if (pkg.dependencies) {
+              delete pkg.dependencies['@suzumina.click/shared-types'];
             }
-            
-            // 開発用スクリプトを削除
-            if (pkg.scripts) {
-              delete pkg.scripts.build;
-              delete pkg.scripts['build:watch'];
-              delete pkg.scripts.lint;
-              delete pkg.scripts.format;
-              delete pkg.scripts.check;
-              delete pkg.scripts.test;
-              delete pkg.scripts['test:watch'];
-              delete pkg.scripts['test:coverage'];
-            }
-            
-            // devDependenciesを削除
+
+            // 開発用スクリプト・devDependencies を削除
+            delete pkg.scripts;
             delete pkg.devDependencies;
-            
-            // Cloud Functions v2ではFunctions Frameworkが自動的に起動するため、
-            // startスクリプトは不要。mainエントリーポイントのみ設定
-            pkg.main = 'lib/endpoints/index.js';
-            
-            // enginesフィールドも確実に設定
-            if (!pkg.engines) {
-              pkg.engines = {};
-            }
+
+            // main は esbuild バンドルの単一ファイルを指す
+            pkg.main = 'lib/index.js';
+
+            // enginesフィールドを確実に設定
+            pkg.engines = pkg.engines || {};
             pkg.engines.node = '24';
-            
+
             fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
-          
-          # 依存関係をインストール（production用）
-          pnpm install --prod --frozen-lockfile
-          
-          # デプロイ用のzipファイルを作成（Cloud Functionsはzipを要求）
+
+          # 本番依存をインストール（workspace 依存がなくなったので標準フロー）
+          pnpm install --prod --no-frozen-lockfile
+
+          # デプロイ用のzipファイルを作成
           zip -r ../functions-deployment.zip *
           cd ..
-          
+
           echo "Deployment bundle created: functions-deployment.zip"
+          ls -lh ../functions-deployment.zip 2>/dev/null || ls -lh functions-deployment.zip
 
       - name: Upload to Cloud Storage
         run: |

--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -3,8 +3,8 @@
 	"version": "0.3.12",
 	"private": true,
 	"scripts": {
-		"build": "tsc && cp -r src/assets lib/assets",
-		"build:watch": "tsc --watch",
+		"build": "node scripts/build.mjs",
+		"build:watch": "node scripts/build.mjs --watch",
 		"lint": "biome check ./src",
 		"format": "biome format --write ./src",
 		"check": "biome check --write ./src",
@@ -24,7 +24,7 @@
 		"check:price-history": "dotenv -e .env -- tsx src/tools/check-price-history.ts",
 		"debug:price-history": "dotenv -e .env -- tsx src/tools/debug-price-history.ts"
 	},
-	"main": "lib/endpoints/index.js",
+	"main": "lib/index.js",
 	"engines": {
 		"node": "24.16.0"
 	},
@@ -39,6 +39,7 @@
 		"@types/node": "^25.9.1",
 		"@vitest/coverage-v8": "^4.1.7",
 		"dotenv-cli": "^11.0.0",
+		"esbuild": "^0.28.0",
 		"rimraf": "^6.1.3",
 		"tsx": "^4.22.3",
 		"typescript": "^6.0.3",

--- a/apps/functions/scripts/build.mjs
+++ b/apps/functions/scripts/build.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+import { rm, stat } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build, context } from "esbuild";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(__dirname, "..");
+const outdir = resolve(projectRoot, "lib");
+const watch = process.argv.includes("--watch");
+
+await rm(outdir, { recursive: true, force: true });
+
+const buildOptions = {
+	entryPoints: [resolve(projectRoot, "src/endpoints/index.ts")],
+	outfile: resolve(outdir, "index.js"),
+	bundle: true,
+	platform: "node",
+	target: "node24",
+	format: "cjs",
+	sourcemap: true,
+	minify: !watch,
+	conditions: ["import", "node"],
+	mainFields: ["module", "main"],
+	external: ["googleapis", "@google-cloud/firestore", "@google-cloud/functions-framework"],
+	logLevel: "info",
+	legalComments: "none",
+};
+
+if (watch) {
+	const ctx = await context(buildOptions);
+	await ctx.watch();
+	console.log("watching for changes...");
+} else {
+	const result = await build({ ...buildOptions, metafile: true });
+	const bundleStat = await stat(resolve(outdir, "index.js"));
+	console.log(`\nBundle size: ${(bundleStat.size / 1024).toFixed(1)} KB`);
+	const inputs = Object.entries(result.metafile.inputs);
+	const sharedTypes = inputs.filter(([p]) => p.includes("shared-types/src"));
+	console.log(
+		`shared-types files inlined: ${sharedTypes.length} (total ${inputs.length} input files)`,
+	);
+}

--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -348,10 +348,7 @@ async function collectWorkIdsWithFallback(): Promise<string[]> {
 
 		// エラー時はアセットファイルから読み込み
 		try {
-			const { readFileSync } = await import("node:fs");
-			const { join } = await import("node:path");
-			const assetPath = join(__dirname, "../assets/dlsite-work-ids.json");
-			const data = JSON.parse(readFileSync(assetPath, "utf-8"));
+			const { default: data } = await import("../assets/dlsite-work-ids.json");
 			const workIds = data.workIds || [];
 			logger.warn(`アセットファイルから${workIds.length}件の作品IDを読み込みました`);
 			return workIds;

--- a/apps/functions/src/services/dlsite/__tests__/work-id-validator.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/work-id-validator.test.ts
@@ -18,6 +18,13 @@ vi.mock("../../shared/logger", () => ({
 	error: vi.fn(),
 }));
 
+// アセット JSON のモック（esbuild bundle で inline されるため import モックで差し替え）
+vi.mock("../../../assets/dlsite-work-ids.json", () => ({
+	default: {
+		workIds: ["RJ123456", "RJ789012", "RJ111111", "RJ222222"],
+	},
+}));
+
 describe("Work ID Validator", () => {
 	describe("validateWorkIds", () => {
 		it("基本的な検証機能が動作する", () => {
@@ -111,15 +118,6 @@ describe("Work ID Validator", () => {
 	});
 
 	describe("createUnionWorkIds", () => {
-		// ファイルシステムのモック
-		vi.mock("node:fs", () => ({
-			readFileSync: vi.fn().mockReturnValue(
-				JSON.stringify({
-					workIds: ["RJ123456", "RJ789012", "RJ111111", "RJ222222"],
-				}),
-			),
-		}));
-
 		it("和集合が正しく作成される", () => {
 			const currentRegionIds = ["RJ123456", "RJ333333"];
 			const result = createUnionWorkIds(currentRegionIds);

--- a/apps/functions/src/services/dlsite/work-id-validator.ts
+++ b/apps/functions/src/services/dlsite/work-id-validator.ts
@@ -3,8 +3,7 @@
  * リージョン差異を考慮した柔軟な検証機能を提供
  */
 
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import workIdsAsset from "../../assets/dlsite-work-ids.json";
 import * as logger from "../../shared/logger";
 
 interface WorkIdValidationResult {
@@ -36,23 +35,7 @@ interface UnionWorkIdResult {
  */
 function loadExpectedWorkIds(): Set<string> {
 	try {
-		// Cloud Functionsの実行環境でのパスを想定
-		const possiblePaths = [
-			join(process.cwd(), "src/assets/dlsite-work-ids.json"),
-			join(process.cwd(), "lib/assets/dlsite-work-ids.json"),
-			join(__dirname, "../../assets/dlsite-work-ids.json"),
-		];
-
-		for (const filePath of possiblePaths) {
-			try {
-				const data = JSON.parse(readFileSync(filePath, "utf-8"));
-				return new Set(data.workIds);
-			} catch {
-				// 次のパスを試行
-			}
-		}
-
-		throw new Error("作品IDリストファイルが見つかりません");
+		return new Set(workIdsAsset.workIds);
 	} catch (error) {
 		logger.warn("作品IDリストファイルが読み込めませんでした。検証をスキップします。", { error });
 		return new Set();

--- a/apps/functions/tsconfig.json
+++ b/apps/functions/tsconfig.json
@@ -1,15 +1,14 @@
 {
 	"extends": "@suzumina.click/typescript-config/base.json",
 	"compilerOptions": {
+		"noEmit": true,
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,
-		"outDir": "lib",
 		"rootDir": "./src",
 		"sourceMap": true,
 		"lib": ["ES2022"],
 		"allowSyntheticDefaultImports": true
 	},
-	"compileOnSave": true,
 	"include": ["src"],
 	"exclude": ["src/**/*.test.ts", "src/development/**/*"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,9 @@ importers:
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3


### PR DESCRIPTION
## Summary

[SPR-58](https://linear.app/nothink/issue/SPR-58/chore-cloud-functions-のビルドデプロイ方式を-esbuild-bundle-に刷新phase-b) Phase B 対応。

- `apps/functions` のビルドを **tsc → esbuild** に置換し、`lib/index.js` 単一バンドル化（**459 KB / 30ms ビルド**）
- shared-types を **src から 57 ファイル inline**（`import` condition を経由）
- `.github/workflows/deploy-functions.yml` の **60 行 tgz 注入ハックを撤廃**、縮小 `package.json` 生成のみのクリーンなフローに
- アセット JSON は `__dirname` 参照を廃止し **import 構文で bundle に inline**（assets ディレクトリ自体が deploy 不要に）

shared-types の dist 撤去は SPR-59（Phase C）で対応します。

## 主な変更

| ファイル | 内容 |
|---|---|
| `apps/functions/scripts/build.mjs` | 新規。esbuild build / watch ランナー |
| `apps/functions/package.json` | build スクリプトを esbuild に切替、main を `lib/index.js` に、esbuild を devDeps 追加 |
| `apps/functions/tsconfig.json` | `noEmit: true` 追加（typecheck 専用に） |
| `.github/workflows/deploy-functions.yml` | tgz 注入ブロック削除、shared-types build step も撤去 |
| `apps/functions/src/services/dlsite/work-id-validator.ts` | 3 パスフォールバックを廃し JSON 直接 import |
| `apps/functions/src/endpoints/dlsite-individual-info-api.ts` | dynamic import で JSON 取得 |
| `apps/functions/src/services/dlsite/__tests__/work-id-validator.test.ts` | mock 対象を `node:fs` → JSON モジュールに変更 |

## external 戦略

| パッケージ | 扱い | 理由 |
|---|---|---|
| `googleapis` | external | 201 MB。inline するとコールドスタート悪化 |
| `@google-cloud/firestore` | external | `build/protos/*.proto` を fs 動的ロード（protobufjs）|
| `@google-cloud/functions-framework` | external | Cloud Functions ランタイムが共有レジストリ経由でハンドラを呼ぶため別インスタンス化を避ける必要 |
| `@suzumina.click/shared-types` + transitive (`neverthrow`, `zod` 等) | inline | 本 Issue の主目的 |

## 事前検証で確認済み

- ✅ `madge --circular` で shared-types / functions 共に循環参照ゼロ
- ✅ functions-framework v5 は CJS のみ → 出力フォーマット CJS 確定
- ✅ Bundle ローカル smoke test で 3 ハンドラ全て `getFunction()` から取得可能
- ✅ Bundle 内に shared-types の dist 経路混入ゼロ
- ✅ minimum package.json simulation：runtime deps 3 件のみ、workspace 依存ゼロ

## ローカル品質チェック

- ✅ `pnpm --filter=@suzumina.click/functions build` 成功
- ✅ `pnpm --filter=@suzumina.click/functions typecheck` 成功
- ✅ `pnpm --filter=@suzumina.click/functions lint` 成功（build script の console.log 3 件のみ warning）
- ✅ `pnpm --filter=@suzumina.click/functions test` **338 passed / 24 skipped / 0 failed**

## ⚠️ リスク・注意点

- 本 PR は **HIGH リスク**（本番デプロイ経路の置換）。staging で疎通確認後にマージ推奨
- `pnpm install --prod` を `--no-frozen-lockfile` に変更（デプロイバンドルには lockfile を含めないため）。runtime deps は 3 件かつ `^` 指定なので影響は限定的
- `lib/index.js` 単一ファイル化に伴い `main: lib/endpoints/index.js` → `main: lib/index.js` に変更

## Test plan

- [x] PR チェック通過
- [ ] staging へ手動デプロイ（`workflow_dispatch`）
- [ ] Cloud Functions ログに module resolution エラーがないこと
- [ ] `fetchYouTubeVideos` Scheduler 起動で正常実行
- [ ] `fetchDLsiteUnifiedData` Scheduler 起動で正常実行
- [ ] `checkDataIntegrity` Scheduler 起動で正常実行
- [ ] Cloud Run コールドスタート時間に劣化がないこと
- [ ] 1〜2 週間 staging 観測後に SPR-59 へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)