### PR TITLE
test(web): sitemap/robots テストを現状の実装に追随させる

### DIFF
--- a/apps/web/src/app/__tests__/robots.test.ts
+++ b/apps/web/src/app/__tests__/robots.test.ts
@@ -33,10 +33,10 @@ describe("robots", () => {
 		const result = robots();
 		const disallow = (result.rules as { disallow: string[] }).disallow;
 
-		expect(disallow).toContain("/admin");
-		expect(disallow).toContain("/admin/*");
-		expect(disallow).toContain("/auth");
-		expect(disallow).toContain("/auth/*");
+		// prefix match のワイルドカード表記。/admin* は /admin・/admin/* を、
+		// /auth* は /auth・/auth/* をそれぞれカバーする (#413)。
+		expect(disallow).toContain("/admin*");
+		expect(disallow).toContain("/auth*");
 		expect(disallow).toContain("/_next/");
 		expect(disallow).toContain("/api/");
 	});

--- a/apps/web/src/app/__tests__/sitemap.test.ts
+++ b/apps/web/src/app/__tests__/sitemap.test.ts
@@ -1,5 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// next/cache の unstable_cache は Next.js ランタイム外では
+// "Invariant: incrementalCache missing" を投げてしまうため、
+// テストではキャッシュをパススルーして毎回 inner 関数を呼ばせる。
+// 同時に登録時の cache key / revalidate / tags を捕捉して
+// 回帰検知用に検証する。clearAllMocks の影響を受けないよう
+// vi.fn ではなく素の配列に push する。
+const { unstableCacheCalls } = vi.hoisted(() => ({
+	unstableCacheCalls: [] as Array<{
+		keys?: string[];
+		options?: { revalidate?: number; tags?: string[] };
+	}>,
+}));
+
+vi.mock("next/cache", () => ({
+	unstable_cache: (
+		fn: (...args: unknown[]) => unknown,
+		keys?: string[],
+		options?: { revalidate?: number; tags?: string[] },
+	) => {
+		unstableCacheCalls.push({ keys, options });
+		return fn;
+	},
+}));
+
 vi.mock("@/lib/firestore", () => ({
 	getFirestore: vi.fn(),
 }));
@@ -30,11 +54,14 @@ function buildCollectionResolvers(
 			if (!resolver) {
 				throw new Error(`Unexpected collection: ${name}`);
 			}
+			// sitemap.ts は videos/works を `.collection().limit().get()`、
+			// audioButtons を `.collection().where().limit().get()` で呼び分ける。
+			// 両方のチェーンを同じ resolver に解決する。
+			const limitChain = { get: () => resolver() };
 			return {
+				limit: () => limitChain,
 				where: () => ({
-					limit: () => ({
-						get: () => resolver(),
-					}),
+					limit: () => limitChain,
 				}),
 			};
 		},
@@ -222,5 +249,14 @@ describe("sitemap", () => {
 		const urls = result.map((entry) => entry.url);
 
 		expect(urls).toContain("https://suzumina.click/buttons/create");
+	});
+
+	// 動的部分は unstable_cache で 1h キャッシュされる前提 (#416)。
+	// キャッシュキー / revalidate / tags が意図せず変わったら検知する。
+	it("回帰検知: unstable_cache が固定キー・revalidate=3600・tag=sitemap で登録される", () => {
+		expect(unstableCacheCalls).toContainEqual({
+			keys: ["sitemap-dynamic-pages"],
+			options: expect.objectContaining({ revalidate: 3600, tags: ["sitemap"] }),
+		});
 	});
 });


### PR DESCRIPTION
## Summary

apps/web のテストで sitemap/robots 関連 4 件が失敗していたのを修正。

PR #415 (テスト追加) が #413 (robots disallow 整理) と #416 (sitemap unstable_cache 導入) と並走し、リベース無しでマージされた結果、テストが現状の実装と乖離していた。

- **[robots.test.ts](apps/web/src/app/__tests__/robots.test.ts)** — disallow 期待値を `/admin*` `/auth*` のワイルドカード表記に追随 (#413 の整理を反映)
- **[sitemap.test.ts](apps/web/src/app/__tests__/sitemap.test.ts)** —
  - `next/cache` を pass-through mock。`unstable_cache` は Next.js ランタイム外で `Invariant: incrementalCache missing` を投げるため、テストではキャッシュを無効化して inner 関数を毎回呼ばせる
  - Firestore mock のチェーンを `.collection().limit().get()` / `.collection().where().limit().get()` の両方に対応 (videos/works は前者、audioButtons は後者を使う。これは #414 で `.where("isPublic", ...)` を外した際に発生した pre-existing バグで、unstable_cache の障害に隠れていた)
  - cache key / revalidate / tags の回帰検知テストを 1 件追加

production コード (`sitemap.ts` / `robots.ts`) は変更していない。

## Test plan

- [x] `pnpm --filter @suzumina.click/web test` — 全 685 件 pass (+1 件 回帰検知テスト追加)
- [x] `pnpm --filter @suzumina.click/web typecheck` — エラーなし
- [x] lint — 既存 warning 7 件のみ (本 PR の変更とは無関係)

🤖 Generated with [Claude Code](https://claude.com/claude-code)