### PR TITLE
ci(pr-check): Docker Build Check を高速化・条件絞り込み

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,6 +31,7 @@ jobs:
       typescript-config: ${{ steps.changes.outputs.typescript-config }}
       workflows: ${{ steps.changes.outputs.workflows }}
       dependencies: ${{ steps.changes.outputs.dependencies }}
+      docker: ${{ steps.changes.outputs.docker }}
 
     steps:
       - name: Checkout code
@@ -59,6 +60,17 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
               - 'package.json'
+            docker:
+              - 'apps/web/Dockerfile'
+              - 'apps/web/.dockerignore'
+              - '.dockerignore'
+              - 'apps/web/package.json'
+              - 'packages/shared-types/package.json'
+              - 'packages/ui/package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'package.json'
+              - '.github/workflows/pr-check.yml'
 
   parallel-check:
     name: Parallel Quality Check
@@ -211,14 +223,11 @@ jobs:
     name: Docker Build Check (web)
     runs-on: ubuntu-latest
     needs: changes
-    # Dockerfile / build 依存（shared-types, ui）/ ルート依存 / ワークフロー自身が変わった PR でのみ実行
-    # （Dockerfile は apps/web/** に含まれるため web フィルタでカバー）
-    if: |
-      needs.changes.outputs.web == 'true' ||
-      needs.changes.outputs.shared-types == 'true' ||
-      needs.changes.outputs.ui == 'true' ||
-      needs.changes.outputs.dependencies == 'true' ||
-      needs.changes.outputs.workflows == 'true'
+    # Dockerfile・docker build に効く依存・ワークフロー自身が変わった PR のみ実行
+    # アプリコードのみの変更は Build Verification の pnpm build で検証済み、
+    # 本番 Dockerfile は main マージ後の deploy-web.yml で改めてビルドされるため、
+    # PR で毎回フルビルドする必要はない
+    if: needs.changes.outputs.docker == 'true'
     timeout-minutes: 15
 
     steps:
@@ -228,7 +237,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # push せず build のみ。GHA cache を再利用して2回目以降を高速化
+      # push せず build のみ。cache の export は行わない
+      # （GHA cache へのアップロードがジョブ時間の 60% を占めていたため）
+      # cache は deploy-web.yml が registry に維持するため PR 側で書き戻す必要がない
       - name: Build web image (no push)
         uses: docker/build-push-action@v6
         with:
@@ -237,8 +248,6 @@ jobs:
           push: false
           load: false
           tags: suzumina-web:pr-${{ github.event.pull_request.number }}
-          cache-from: type=gha,scope=web-docker-pr
-          cache-to: type=gha,scope=web-docker-pr,mode=max
           platforms: linux/amd64
 
   security-check:


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 要件

PR Check CI（総時間 約 4 分）のうち Docker Build Check (web) が最も長く、
ほとんどの時間を占めていたため、以下の 2 点で軽量化する。

### 現状の問題

直近 5 件の Docker Build Check ジョブログを分析した結果:

| Run | #18 pnpm install | #24 next build | **#28 GHA cache 書き出し** | 合計 |
|---|---|---|---|---|
| #421 | 12.8s | 48.7s | **152.8s** | 4m9s |
| #420 | 13.0s | 48.4s | **134.8s** | 約 4m |
| #419 | 13.0s | 20.5s | 0.0s (hit) | ~2m |
| #418 | 10.0s | 18.2s | 0.0s (hit) | ~2m |
| #415 | cached | 32.6s | 0.0s (hit) | ~1.5m |

- ボトルネックは `exporting to GitHub Actions Cache` ステップで、ジョブ
  時間の 60% を占める（130〜150 秒）。`mode=max` で巨大な node_modules
  レイヤを含む全中間レイヤを Azure Blob にアップロードしているのが原因。
- トリガが `web`/`shared-types`/`ui`/`dependencies`/`workflows` と
  広く、ほぼ全 PR でフルビルドが走っていた。
- `Build Verification` ジョブも `pnpm --filter @suzumina.click/web build`
  を回しており、ビルド検証は二重実行になっていた。
- `deploy-web.yml` 側は Artifact Registry の `:buildcache` を使う別系統
  のため、PR check の GHA cache は deploy では使われない。

### 変更内容

#### A. トリガ条件を絞り込み

`dorny/paths-filter` に専用 `docker` フィルタを新設し、Docker build に
実質影響する以下のパスのみを監視:

- \`apps/web/Dockerfile\`
- \`apps/web/.dockerignore\` / ルートの \`.dockerignore\`
- 各 \`package.json\`（web / shared-types / ui / root）
- \`pnpm-lock.yaml\` / \`pnpm-workspace.yaml\`
- \`.github/workflows/pr-check.yml\` 自身

\`docker-build-check.if\` を \`needs.changes.outputs.docker == 'true'\` のみ
に変更。アプリコードのみの変更は \`Build Verification\` の \`pnpm build\` で
検証済み、本番 Dockerfile は main マージ後の \`deploy-web.yml\` で改めて
ビルドされるため、PR で毎回フルビルドする必要はない。

#### B. cache export を削除

\`cache-from\`・\`cache-to\` を両方削除。GHA cache への書き出しを停止する
ことで最大ボトルネックを排除。本番 Dockerfile 検証用のキャッシュは
\`deploy-web.yml\` が引き続き Artifact Registry で維持する。

### 想定効果

- **大半の PR（アプリコードのみ）**: Docker Build Check が skip → 全体
  4m → 約 1m
- **Dockerfile/deps を触る PR**: cache export なしのフルビルド → 約
  80〜100 秒程度（従来 4m+ から半分以下）

## テスト項目

- [x] この PR 自体で Docker Build Check が起動すること
      （\`.github/workflows/pr-check.yml\` を変更しているため \`docker\`
      フィルタにヒットする想定）
- [ ] アプリコードのみを触る後続 PR で Docker Build Check が skip
      され、PR Check 全体が約 1 分以内に収まること
- [ ] Dockerfile / pnpm-lock.yaml を触る PR で Docker Build Check が
      起動し、cache export なしで成功すること（約 80〜100 秒目安）
- [ ] main マージ後の \`deploy-web.yml\` が従来どおり成功すること
      （Artifact Registry の :buildcache を使う構成は変更していない）

<!-- I want to review in Japanese. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)