### PR TITLE
docs(ui): SPR-26 後始末 — Storybook 関連の陳腐化箇所を更新

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -1283,12 +1283,14 @@ export function VideoCard({ video }: { video: VideoData }) {
 **トークン構成**:
 ```text
 packages/ui/src/components/design-tokens/
-├── color-palette.stories.tsx    # ブランドカラー + セマンティックカラー
-├── typography.stories.tsx       # フォントサイズ・行間・ウェイト
-├── spacing.stories.tsx          # 4px基準のスペーシング
-├── borders-shadows.stories.tsx  # 角丸・ボーダー・シャドウ
-└── icons.stories.tsx           # Lucide Reactアイコンセット
+├── colors.mdx              # ブランドカラー（ColorPalette）
+├── typography.mdx          # フォントスケール（Typeset）
+├── spacing.mdx             # 4px基準のスペーシング
+├── borders-shadows.mdx     # 角丸・ボーダー・シャドウ
+└── icons.mdx               # Lucide Reactアイコン（IconGallery）
 ```
+
+各ファイルは Storybook addon-docs の DocBlocks（`<ColorPalette>` / `<Typeset>` / `<IconGallery>`）を利用し、`*.mdx` として記述します。トップページ（`packages/ui/src/Introduction.mdx`）もデザインシステムの概要を案内します。
 
 **使用例**:
 ```typescript
@@ -1309,14 +1311,14 @@ packages/ui/src/components/design-tokens/
 
 ### Storybook デザイントークン管理
 
-**Lint設定**: デザイントークンStorybook は `biome.json` でlint除外
-- 理由: ドキュメンテーション目的のため未使用変数が多数存在
-- 対象: `**/src/components/design-tokens/*.stories.tsx`
+**ドキュメント形式**: MDX + `@storybook/addon-docs/blocks`（`ColorPalette` / `Typeset` / `IconGallery`）を利用
+- 対象: `packages/ui/src/components/design-tokens/*.mdx`
+- MDX は biome のチェック対象外なので、lint 除外設定は不要
 
 **メンテナンス方針**:
-- デザイントークンの変更時は対応するStorybookを更新
-- 新しいカラー・スペース・アイコン追加時はStorybook反映
-- Chromaticによる視覚的回帰テスト対象
+- デザイントークンの変更時は対応する MDX を更新
+- 新しいカラー・スペース・アイコン追加時は MDX に追記
+- Chromatic による視覚的回帰テスト対象
 
 ## 📦 依存関係管理
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"build": "echo 'UI package does not require build step' && exit 0",
-		"lint": "find src -name '*.tsx' -not -name '*.stories.tsx' -not -path '*/design-tokens/*' -o -name '*.ts' -not -path '*/design-tokens/*' | xargs biome check --max-diagnostics=120",
+		"lint": "find src -name '*.tsx' -not -name '*.stories.tsx' -o -name '*.ts' | xargs biome check --max-diagnostics=120",
 		"format": "biome format --write .",
 		"check": "biome check --write .",
 		"typecheck": "tsc --noEmit",


### PR DESCRIPTION
## 概要

[PR #423](https://github.com/nothink-jp/suzumina.click/pull/423)（[SPR-26](https://linear.app/nothink/issue/SPR-26/chore-storybookの最新化)）の追従。design-tokens の `.stories.tsx` が `.mdx` に置き換わったが、関連する設定・ドキュメントが古い記述のまま残っていたので追随させます。

## 変更内容

### `packages/ui/package.json`
lint スクリプトから `-not -path '*/design-tokens/*'` 除外を撤去。

| Before | After |
| ------ | ----- |
| `find src -name '*.tsx' -not -name '*.stories.tsx' -not -path '*/design-tokens/*' -o -name '*.ts' -not -path '*/design-tokens/*' \| xargs biome check ...` | `find src -name '*.tsx' -not -name '*.stories.tsx' -o -name '*.ts' \| xargs biome check ...` |

design-tokens 配下には `.mdx` しか残らず biome は MDX を扱わないため除外不要。

### `docs/guides/development.md`
- "トークン構成" のディレクトリツリーが `.stories.tsx` を列挙していたので、現在の `.mdx` 構成へ更新
- "Storybook デザイントークン管理" 節の「lint 除外設定」記述を撤去し、MDX + DocBlocks ベースの実態へ追随

## 検証
- ✅ `pnpm --filter @suzumina.click/ui lint` — 既存の警告 6 件のみ（本 PR とは無関係、`audio-player.tsx` の `useExhaustiveDependencies`）

## Test plan
- [ ] `pnpm --filter @suzumina.click/ui lint` がローカルで通る
- [ ] [docs/guides/development.md](docs/guides/development.md) の該当節が誤情報を含まない

🤖 Generated with [Claude Code](https://claude.com/claude-code)