### PR TITLE
refactor(web): SPR-7 後続 — age-verification 周りと透過 gradient の cleanup

### DIFF
--- a/apps/web/src/app/buttons/[id]/page.tsx
+++ b/apps/web/src/app/buttons/[id]/page.tsx
@@ -137,7 +137,7 @@ export default async function AudioButtonDetailPage({ params }: AudioButtonDetai
 	}
 
 	return (
-		<div className="min-h-screen bg-gradient-to-br from-suzuka-50 via-background to-minase-50">
+		<div className="min-h-screen">
 			{/* パンくずナビゲーション */}
 			<AudioButtonDetailHeader title={audioButton.buttonText} />
 

--- a/apps/web/src/components/consent/age-verification-overlay.tsx
+++ b/apps/web/src/components/consent/age-verification-overlay.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
 import { AlertTriangle, Calendar, Heart, Shield } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 
 // Match the server-side list that previously lived in lib/seo/bot-detection.ts
@@ -61,6 +61,7 @@ export function AgeVerificationOverlay() {
 	const { isAgeVerified, isLoading, updateAgeVerification } = useAgeVerification();
 	const [showMinorMessage, setShowMinorMessage] = useState(false);
 	const [botChecked, setBotChecked] = useState(false);
+	const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	useEffect(() => {
 		if (BOT_UA_PATTERN.test(navigator.userAgent)) {
@@ -68,6 +69,14 @@ export function AgeVerificationOverlay() {
 		}
 		setBotChecked(true);
 	}, [updateAgeVerification]);
+
+	useEffect(() => {
+		return () => {
+			if (redirectTimerRef.current !== null) {
+				clearTimeout(redirectTimerRef.current);
+			}
+		};
+	}, []);
 
 	const visible = !isLoading && botChecked && (!isAgeVerified || showMinorMessage);
 
@@ -89,7 +98,7 @@ export function AgeVerificationOverlay() {
 		}
 		updateAgeVerification(false);
 		setShowMinorMessage(true);
-		setTimeout(() => {
+		redirectTimerRef.current = setTimeout(() => {
 			window.location.href = "/";
 		}, 3000);
 	};
@@ -102,7 +111,7 @@ export function AgeVerificationOverlay() {
 				aria-labelledby="age-verification-minor-title"
 				className="fixed inset-0 z-50 flex items-center justify-center suzuka-gradient p-4"
 			>
-				<Card className="w-full max-w-md mx-auto bg-card/95 backdrop-blur-sm shadow-xl">
+				<Card className="w-full max-w-md mx-auto shadow-xl">
 					<CardHeader className="text-center pb-4">
 						<div className="mx-auto w-16 h-16 bg-suzuka-100 rounded-full flex items-center justify-center mb-4">
 							<Shield className="h-8 w-8 text-suzuka-600" />
@@ -143,7 +152,7 @@ export function AgeVerificationOverlay() {
 			aria-labelledby="age-verification-title"
 			className="fixed inset-0 z-50 flex items-center justify-center suzuka-gradient p-4"
 		>
-			<Card className="w-full max-w-md mx-auto bg-card/95 backdrop-blur-sm shadow-xl">
+			<Card className="w-full max-w-md mx-auto shadow-xl">
 				<CardHeader className="text-center pb-4">
 					<div className="mx-auto w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center mb-4">
 						<AlertTriangle className="h-8 w-8 text-amber-600" />

--- a/apps/web/src/contexts/age-verification-context.tsx
+++ b/apps/web/src/contexts/age-verification-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 interface AgeVerificationContextType {
 	/** 年齢確認済みかどうか */
@@ -52,7 +52,7 @@ export function AgeVerificationProvider({ children }: AgeVerificationProviderPro
 		setIsLoading(false);
 	}, []);
 
-	const updateAgeVerification = (adult: boolean) => {
+	const updateAgeVerification = useCallback((adult: boolean) => {
 		setIsAgeVerified(true);
 		setIsAdult(adult);
 
@@ -60,22 +60,23 @@ export function AgeVerificationProvider({ children }: AgeVerificationProviderPro
 		localStorage.setItem("age-verified", "true");
 		localStorage.setItem("age-verification-date", new Date().toISOString());
 		localStorage.setItem("age-verification-adult", adult.toString());
-	};
+	}, []);
 
 	const showR18Content = isAgeVerified && isAdult;
 
+	const value = useMemo<AgeVerificationContextType>(
+		() => ({
+			isAgeVerified,
+			isAdult,
+			showR18Content,
+			updateAgeVerification,
+			isLoading,
+		}),
+		[isAgeVerified, isAdult, showR18Content, updateAgeVerification, isLoading],
+	);
+
 	return (
-		<AgeVerificationContext.Provider
-			value={{
-				isAgeVerified,
-				isAdult,
-				showR18Content,
-				updateAgeVerification,
-				isLoading,
-			}}
-		>
-			{children}
-		</AgeVerificationContext.Provider>
+		<AgeVerificationContext.Provider value={value}>{children}</AgeVerificationContext.Provider>
 	);
 }
 


### PR DESCRIPTION
# refactor(web): SPR-7 後続 — age-verification 周りと透過 gradient の cleanup

[PR #429](https://github.com/nothink-jp/suzumina.click/pull/429)（SPR-7 オーバーレイ化）の **レビューで SKIP した cosmetic / 堅牢性まわり**、および同 PR の検証中に発見した **buttons/[id] ページの dead gradient** をまとめて整理。

## 変更内容

### 1. `AgeVerificationProvider` の identity 安定化

[contexts/age-verification-context.tsx](apps/web/src/contexts/age-verification-context.tsx)

- `updateAgeVerification` を `useCallback([])` で stable ref 化
- Context value を `useMemo` で memoize

これにより `AgeVerificationOverlay` 側の `useEffect(.., [updateAgeVerification])` が Provider の再 render（state 変化）ごとに走らなくなる。bot 判定の regex test や `setBotChecked(true)` の冪等再実行が止まる効果。

### 2. リダイレクト `setTimeout` の漏れ防止

[components/consent/age-verification-overlay.tsx](apps/web/src/components/consent/age-verification-overlay.tsx)

- `handleAgeConfirmation(false)` で発火する 3 秒後 `/` リダイレクトの timer id を `useRef` に保持
- mount 時の cleanup effect で unmount 時に `clearTimeout`

`<AgeVerificationOverlay>` は root layout 配置で通常 unmount されないが、防御的に。

### 3. 内側 Card の dead style class を削除

同ファイル: `bg-card/95 backdrop-blur-sm` を 2 箇所削除。

外側コンテナが opaque な `suzuka-gradient` なので、内側 Card の 5% 透過と backdrop blur は視覚的に no-op だった。Card のデフォルト `bg-card`（fully opaque）が残り、見た目は完全に同一。className 簡素化。

### 4. `buttons/[id]/page.tsx` の透過 gradient を除去

[app/buttons/[id]/page.tsx:140](apps/web/src/app/buttons/[id]/page.tsx)

`bg-gradient-to-br from-suzuka-50 via-background to-minase-50` は Tailwind v4 + 手動定義カラートークンの組み合わせで computed gradient stops が **全て `rgba(0,0,0,0)`** に解決される実質透明 class（SPR-7 検証時に発見済み）。実描画は body の `gradient-bg`（単色白）が透けているだけだったため class 全体を除去。

**視覚は変化なし**。本来意図したと思われる桜色背景に restore したい場合は別タスクで `.suzuka-gradient` 等への置き換えを検討。

## テスト

- [x] `pnpm --filter @suzumina.click/web lint` — clean（既存 7 warnings のみ）
- [x] `pnpm --filter @suzumina.click/web typecheck` — エラーなし
- [x] `pnpm --filter @suzumina.click/web test` — 685 passed / 1 skipped / 0 failed
- [x] `pnpm --filter @suzumina.click/web build` — 全 33 route ビルド成功（前回 PR で CI 落ちた `_not-found` も pass）
- [x] dev preview 手動検証:
  - 初回訪問 → 桜色 backdrop + opaque Card 表示
  - 「18歳以上」確定 → overlay 消失、`body.overflow` 復元、localStorage 永続化
  - 「18歳未満」確定 → minor 用 dialog 表示 → 3 秒後 `/` リダイレクト

## 関連

- 親 PR: [#429](https://github.com/nothink-jp/suzumina.click/pull/429) (SPR-7)
- 親トラッキング: [SPR-9](https://linear.app/nothink/issue/SPR-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)