### PR TITLE
fix(web): production コンソールエラーの対策（CSP / hydration / 画像 fallback）

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -187,11 +187,11 @@ const nextConfig = {
 						key: "Content-Security-Policy",
 						value: [
 							"default-src 'self'",
-							"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com https://ssl.google-analytics.com https://www.youtube.com https://s.ytimg.com https://discord.com",
+							"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com https://ssl.google-analytics.com https://www.youtube.com https://s.ytimg.com https://discord.com https://static.cloudflareinsights.com",
 							"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://tagmanager.google.com",
 							"font-src 'self' https://fonts.gstatic.com",
 							"img-src 'self' data: https: blob:",
-							"connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://region1.google-analytics.com https://www.youtube.com https://i.ytimg.com https://api.github.com https://discord.com https://fonts.googleapis.com https://fonts.gstatic.com",
+							"connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://stats.g.doubleclick.net https://region1.google-analytics.com https://www.youtube.com https://i.ytimg.com https://api.github.com https://discord.com https://fonts.googleapis.com https://fonts.gstatic.com https://cloudflareinsights.com",
 							"frame-src 'self' https://www.youtube.com https://discord.com https://www.google.com",
 							"object-src 'none'",
 							"base-uri 'self'",

--- a/apps/web/src/app/buttons/components/AudioButtonsStats.tsx
+++ b/apps/web/src/app/buttons/components/AudioButtonsStats.tsx
@@ -17,8 +17,8 @@ export function AudioButtonsStats({
 	return (
 		<div className="text-center">
 			<div className="inline-block bg-white/60 backdrop-blur-sm rounded-full px-6 py-2 text-sm text-muted-foreground border border-suzuka-100">
-				{effectiveCount.toLocaleString()}件中 {startIndex.toLocaleString()}〜
-				{endIndex.toLocaleString()}件を表示
+				{effectiveCount.toLocaleString("ja-JP")}件中 {startIndex.toLocaleString("ja-JP")}〜
+				{endIndex.toLocaleString("ja-JP")}件を表示
 			</div>
 		</div>
 	);

--- a/apps/web/src/app/users/[userId]/components/UserProfileContent.tsx
+++ b/apps/web/src/app/users/[userId]/components/UserProfileContent.tsx
@@ -211,7 +211,7 @@ export function UserProfileContent({
 							</div>
 							<div className="text-center">
 								<div className="text-2xl font-bold text-minase-600">
-									{totalPlayCount.toLocaleString()}
+									{totalPlayCount.toLocaleString("ja-JP")}
 								</div>
 								<div className="text-sm text-muted-foreground">総再生数</div>
 							</div>
@@ -314,7 +314,7 @@ export function UserProfileContent({
 							<CardContent className="space-y-4">
 								<div className="flex justify-between">
 									<span>総再生数</span>
-									<span className="font-semibold">{totalPlayCount.toLocaleString()}</span>
+									<span className="font-semibold">{totalPlayCount.toLocaleString("ja-JP")}</span>
 								</div>
 								<div className="flex justify-between">
 									<span>平均再生数</span>
@@ -324,7 +324,9 @@ export function UserProfileContent({
 									<span>最高再生数</span>
 									<span className="font-semibold">
 										{audioButtons.length > 0
-											? Math.max(...audioButtons.map((b) => b.stats.playCount)).toLocaleString()
+											? Math.max(...audioButtons.map((b) => b.stats.playCount)).toLocaleString(
+													"ja-JP",
+												)
 											: 0}
 									</span>
 								</div>

--- a/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
+++ b/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
@@ -192,10 +192,10 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 							{isOnSale && originalPrice ? (
 								<div className="flex items-center gap-3">
 									<span className="text-3xl font-bold text-destructive">
-										¥{currentPrice.toLocaleString()}
+										¥{currentPrice.toLocaleString("ja-JP")}
 									</span>
 									<span className="text-xl text-gray-600 line-through">
-										¥{originalPrice.toLocaleString()}
+										¥{originalPrice.toLocaleString("ja-JP")}
 									</span>
 									<Badge className="bg-destructive/10 text-destructive text-lg px-3 py-1">
 										{work.price.discount}% OFF
@@ -203,7 +203,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 								</div>
 							) : (
 								<span className="text-3xl font-bold text-gray-900">
-									¥{currentPrice.toLocaleString()}
+									¥{currentPrice.toLocaleString("ja-JP")}
 								</span>
 							)}
 						</div>

--- a/apps/web/src/app/works/components/WorkCard.tsx
+++ b/apps/web/src/app/works/components/WorkCard.tsx
@@ -98,16 +98,20 @@ const PriceDisplay = ({
 	if (isOnSale && originalPrice) {
 		return (
 			<div className="flex items-center gap-2">
-				<span className="text-lg font-bold text-destructive">¥{currentPrice.toLocaleString()}</span>
+				<span className="text-lg font-bold text-destructive">
+					¥{currentPrice.toLocaleString("ja-JP")}
+				</span>
 				<span className="text-sm text-muted-foreground line-through">
-					¥{originalPrice.toLocaleString()}
+					¥{originalPrice.toLocaleString("ja-JP")}
 				</span>
 				<Badge className="bg-destructive/10 text-destructive text-xs">{discount}% OFF</Badge>
 			</div>
 		);
 	}
 	return (
-		<span className="text-lg font-bold text-foreground">¥{currentPrice.toLocaleString()}</span>
+		<span className="text-lg font-bold text-foreground">
+			¥{currentPrice.toLocaleString("ja-JP")}
+		</span>
 	);
 };
 

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-stats.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-stats.tsx
@@ -17,21 +17,23 @@ export function AudioButtonDetailStats({
 				<div className="flex items-center justify-center mb-1">
 					<Play className="h-4 w-4 text-suzuka-600" />
 				</div>
-				<div className="text-lg font-bold text-suzuka-700">{playCount.toLocaleString()}</div>
+				<div className="text-lg font-bold text-suzuka-700">{playCount.toLocaleString("ja-JP")}</div>
 				<div className="text-xs text-suzuka-600">再生回数</div>
 			</div>
 			<div className="text-center p-3 bg-rose-50 rounded-lg border border-rose-100">
 				<div className="flex items-center justify-center mb-1">
 					<Heart className="h-4 w-4 text-rose-600" />
 				</div>
-				<div className="text-lg font-bold text-rose-700">{favoriteCount.toLocaleString()}</div>
+				<div className="text-lg font-bold text-rose-700">
+					{favoriteCount.toLocaleString("ja-JP")}
+				</div>
 				<div className="text-xs text-rose-600">お気に入り</div>
 			</div>
 			<div className="text-center p-3 bg-amber-50 rounded-lg border border-amber-100">
 				<div className="flex items-center justify-center mb-1">
 					<ThumbsUp className="h-4 w-4 text-amber-600" />
 				</div>
-				<div className="text-lg font-bold text-amber-700">{likeCount.toLocaleString()}</div>
+				<div className="text-lg font-bold text-amber-700">{likeCount.toLocaleString("ja-JP")}</div>
 				<div className="text-xs text-amber-600">高評価</div>
 			</div>
 		</div>

--- a/apps/web/src/components/audio/audio-button-card.tsx
+++ b/apps/web/src/components/audio/audio-button-card.tsx
@@ -149,7 +149,7 @@ export const AudioButtonCard = memo(function AudioButtonCard({
 				<div className="mb-3 flex items-center gap-4 text-sm text-muted-foreground">
 					<div className="flex items-center gap-1">
 						<Play className="h-3 w-3" />
-						<span>{playCount?.toLocaleString() ?? formattedPlayCount}</span>
+						<span>{playCount?.toLocaleString("ja-JP") ?? formattedPlayCount}</span>
 					</div>
 					<div className="flex items-center gap-1">
 						<ThumbsUp className="h-3 w-3" />

--- a/apps/web/src/components/audio/favorite-button.tsx
+++ b/apps/web/src/components/audio/favorite-button.tsx
@@ -105,7 +105,7 @@ export function FavoriteButton({
 			</Button>
 			{showCount && (
 				<span className="text-sm text-muted-foreground min-w-[2rem]">
-					{favoriteCount > 0 ? favoriteCount.toLocaleString() : ""}
+					{favoriteCount > 0 ? favoriteCount.toLocaleString("ja-JP") : ""}
 				</span>
 			)}
 		</div>

--- a/apps/web/src/components/audio/like-button.tsx
+++ b/apps/web/src/components/audio/like-button.tsx
@@ -104,7 +104,7 @@ export function LikeButton({
 			<ThumbsUp
 				className={`h-4 w-4 ${isLiked ? "fill-current" : ""} ${isPending ? "animate-pulse" : ""}`}
 			/>
-			<span className="text-sm font-medium">{likeCount.toLocaleString()}</span>
+			<span className="text-sm font-medium">{likeCount.toLocaleString("ja-JP")}</span>
 		</Button>
 	);
 }

--- a/apps/web/src/components/audio/like-dislike-buttons.tsx
+++ b/apps/web/src/components/audio/like-dislike-buttons.tsx
@@ -167,7 +167,7 @@ export function LikeDislikeButtons({
 				<ThumbsUp
 					className={`h-4 w-4 ${isLiked ? "fill-current" : ""} ${isPending ? "animate-pulse" : ""}`}
 				/>
-				<span className="text-sm font-medium">{likeCount.toLocaleString()}</span>
+				<span className="text-sm font-medium">{likeCount.toLocaleString("ja-JP")}</span>
 			</Button>
 
 			{/* 低評価ボタン（YouTube方式：集計数は非表示） */}

--- a/apps/web/src/components/price-history/price-history-chart.tsx
+++ b/apps/web/src/components/price-history/price-history-chart.tsx
@@ -209,9 +209,9 @@ export function PriceHistoryChart({
 
 	const formatPrice = (value: number) => {
 		if (currency === "JPY") {
-			return `¥${value.toLocaleString()}`;
+			return `¥${value.toLocaleString("ja-JP")}`;
 		}
-		return `${value.toLocaleString()} ${currency}`;
+		return `${value.toLocaleString("ja-JP")} ${currency}`;
 	};
 
 	const formatTooltipPrice = (value: unknown, name?: string | number) => {
@@ -252,7 +252,7 @@ export function PriceHistoryChart({
 							// 日本円の場合は整数のみ表示
 							if (currency === "JPY") {
 								const intValue = Math.round(value);
-								return `¥${intValue.toLocaleString()}`;
+								return `¥${intValue.toLocaleString("ja-JP")}`;
 							}
 							return formatPrice(value);
 						}}

--- a/apps/web/src/components/price-history/price-statistics.tsx
+++ b/apps/web/src/components/price-history/price-statistics.tsx
@@ -45,9 +45,9 @@ export function PriceStatistics({
 
 	const formatPrice = (value: number) => {
 		if (currency === "JPY") {
-			return `¥${value.toLocaleString()}`;
+			return `¥${value.toLocaleString("ja-JP")}`;
 		}
-		return `${value.toLocaleString()} ${currency}`;
+		return `${value.toLocaleString("ja-JP")} ${currency}`;
 	};
 
 	// 価格統計を計算（通貨指定）

--- a/apps/web/src/components/ui/thumbnail-image.tsx
+++ b/apps/web/src/components/ui/thumbnail-image.tsx
@@ -122,6 +122,16 @@ const ThumbnailImage = memo(function ThumbnailImage({
 					objectPosition: "center",
 				}}
 			/>
+			{isPlaceholderImage && (
+				<div
+					className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center"
+					aria-hidden="true"
+				>
+					<span className="rounded bg-muted/80 px-2 py-0.5 text-[10px] text-muted-foreground">
+						画像なし
+					</span>
+				</div>
+			)}
 		</div>
 	);
 });

--- a/apps/web/src/hooks/use-audio-button.ts
+++ b/apps/web/src/hooks/use-audio-button.ts
@@ -16,17 +16,17 @@ export function useAudioButton(audioButton: AudioButton) {
 
 	// メモ化: 再生回数のフォーマット
 	const formattedPlayCount = useMemo(() => {
-		return audioButton.stats.playCount.toLocaleString();
+		return audioButton.stats.playCount.toLocaleString("ja-JP");
 	}, [audioButton.stats.playCount]);
 
 	// メモ化: いいね数のフォーマット
 	const formattedLikeCount = useMemo(() => {
-		return audioButton.stats.likeCount.toLocaleString();
+		return audioButton.stats.likeCount.toLocaleString("ja-JP");
 	}, [audioButton.stats.likeCount]);
 
 	// メモ化: 低評価数のフォーマット
 	const formattedDislikeCount = useMemo(() => {
-		return audioButton.stats.dislikeCount.toLocaleString();
+		return audioButton.stats.dislikeCount.toLocaleString("ja-JP");
 	}, [audioButton.stats.dislikeCount]);
 
 	// メモ化: YouTube URL

--- a/apps/web/src/hooks/use-video.ts
+++ b/apps/web/src/hooks/use-video.ts
@@ -59,7 +59,7 @@ export function useVideo(video: VideoPlainObject) {
 
 	// メモ化: 視聴回数のフォーマット済み文字列
 	const formattedViewCount = useMemo(() => {
-		return video.statistics?.viewCount?.toLocaleString() || "0";
+		return video.statistics?.viewCount?.toLocaleString("ja-JP") || "0";
 	}, [video]);
 
 	// メモ化: 再生時間のフォーマット済み文字列


### PR DESCRIPTION
# fix(web): production コンソールエラーの対策

production の `suzumina.click` で観測されたブラウザコンソールエラーを 3 commit でまとめて対策。

## 対象エラーと対応

| # | エラー | 対応 |
|---|---|---|
| 1 | CSP 違反 `static.cloudflareinsights.com/beacon.min.js` をブロック | ✅ CSP `script-src` / `connect-src` に CF Insights ドメイン追加 |
| 2 | React error #418 (hydration text mismatch — `args[]=text&args[]=`) | ✅ `.toLocaleString()` を全箇所 `"ja-JP"` 明示に統一 |
| 3 | DLsite 作品画像 404（`RJ01059676_img_main.jpg` 等） | ✅ ThumbnailImage placeholder 状態に「画像なし」テキスト追加（既存の 3 段 fallback はそのまま） |
| 4 | `googletagmanager.com ERR_CONNECTION_REFUSED` | ⏭ ユーザ環境（広告ブロッカー / DNS シンクホール）起因のため対応なし |

## 各 commit の詳細

### 1. `19c33b52` fix(web): CSP に Cloudflare Insights を許可

[apps/web/next.config.mjs](apps/web/next.config.mjs)

production が Cloudflare 配下にあり Web Analytics の beacon が自動 inject される。CSP の `script-src` に `https://static.cloudflareinsights.com`、`connect-src` に `https://cloudflareinsights.com` を追加。

### 2. `b8edb591` fix(web): `.toLocaleString()` に ja-JP locale を明示

13 ファイルの Number.toLocaleString() (引数なし) に `"ja-JP"` を追加。

React error #418 は SSR と client 間で text node が differ した時に出る。本サイトは典型的な原因の 1 つ「ホストデフォルト locale 差異による数値フォーマット差」を踏める構造で、Cloud Run の Node default (en-US) と一部ブラウザ (ja-JP / en-IN / ar-* 等) で出力が differ する可能性があった。両側を `"ja-JP"` に固定して mismatch リスクを根絶。

ja-JP ブラウザでは見た目完全同一。Date.toLocaleString() は元から locale 指定済み（修正不要）。

対象は audio button / video / work / user の統計表示、価格表示、お気に入り・いいね・再生数バッジ、関連 hooks。

**注**: ローカル prod build では Auth secret 未設定により hydration 到達前に SessionProvider が止まるため、本対策の効果検証は production deploy 後となる。残る hydration 要因（Cloudflare Rocket Loader、Email Obfuscation、ブラウザ拡張等）はコード外。

### 3. `e0b224a0` feat(web): ThumbnailImage placeholder に「画像なし」テキスト

[apps/web/src/components/ui/thumbnail-image.tsx](apps/web/src/components/ui/thumbnail-image.tsx)

既存 3 段 fallback (`src` → `fallbackSrc` → 埋め込み SVG placeholder) は機能していたが、placeholder 表示時にアイコンだけで状態が伝わりにくかった。半透明バッジで「画像なし」を併記。`pointer-events-none` + `aria-hidden` で操作とスクリーンリーダーに影響なし、絶対配置で CLS ゼロ。

なお 404 自体は DLsite 側のデータ状態に依存するため Network パネルに残る挙動は変わらない（データ品質側の別問題）。

## テスト

- [x] `pnpm --filter @suzumina.click/web lint` — clean
- [x] `pnpm --filter @suzumina.click/web typecheck` — エラーなし
- [x] `pnpm --filter @suzumina.click/web test` — 685 passed / 1 skipped / 0 failed
- [x] `pnpm --filter @suzumina.click/web build` — 全 33 route ビルド成功
- [x] dev preview で CSP ヘッダー検査 — `static.cloudflareinsights.com` / `cloudflareinsights.com` が含まれることを確認

## 関連

- 直前: [#430](https://github.com/nothink-jp/suzumina.click/pull/430) age-verification cleanup
- 親トラッキング: [SPR-9](https://linear.app/nothink/issue/SPR-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)