### PR TITLE
perf(web): Cache Components を有効化してホームを PPR 化（SPR-4）

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -23,12 +23,14 @@ const nextConfig = {
 	// React Compiler（Next.js 16対応）
 	reactCompiler: true,
 
+	// Cache Components（Next.js 16 で PPR を置き換えた新モデル）
+	// 静的シェルは prerender し、動的部分は `<Suspense>` 境界でストリーミング
+	cacheComponents: true,
+
 	// 実験的機能・パフォーマンス最適化
 	experimental: {
 		// App Router最適化
 		optimizePackageImports: ["lucide-react", "date-fns", "zod", "react-hook-form", "sonner"],
-		// 並列レンダリング最適化
-		ppr: false, // Partial Prerendering（実験的）
 		// ダイナミックインポート最適化
 		optimizeServerReact: true,
 		// Critical CSS自動抽出（LCP改善）- 実験的機能

--- a/apps/web/src/app/__tests__/sitemap.test.ts
+++ b/apps/web/src/app/__tests__/sitemap.test.ts
@@ -24,6 +24,16 @@ vi.mock("next/cache", () => ({
 	},
 }));
 
+// next/server.connection() は Next.js のリクエストスコープが必要。
+// テストではダイナミック化のシグナルだけ必要なので no-op に差し替える。
+vi.mock("next/server", async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		connection: vi.fn().mockResolvedValue(undefined),
+	};
+});
+
 vi.mock("@/lib/firestore", () => ({
 	getFirestore: vi.fn(),
 }));

--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -39,7 +39,8 @@ function getErrorMessage(error: string | undefined): {
 	}
 }
 
-function ErrorContent({ error }: { error?: string }) {
+async function ErrorContent({ searchParams }: AuthErrorPageProps) {
+	const { error } = await searchParams;
 	const errorInfo = getErrorMessage(error);
 
 	return (
@@ -120,9 +121,7 @@ function ErrorContent({ error }: { error?: string }) {
 	);
 }
 
-export default async function AuthErrorPage({ searchParams }: AuthErrorPageProps) {
-	const params = await searchParams;
-
+export default function AuthErrorPage({ searchParams }: AuthErrorPageProps) {
 	return (
 		<Suspense
 			fallback={
@@ -134,7 +133,7 @@ export default async function AuthErrorPage({ searchParams }: AuthErrorPageProps
 				</div>
 			}
 		>
-			<ErrorContent error={params.error} />
+			<ErrorContent searchParams={searchParams} />
 		</Suspense>
 	);
 }

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -5,7 +5,8 @@ interface SignInPageProps {
 	searchParams: Promise<{ callbackUrl?: string; error?: string }>;
 }
 
-function SignInForm({ callbackUrl, error }: { callbackUrl?: string; error?: string }) {
+async function SignInForm({ searchParams }: SignInPageProps) {
+	const { callbackUrl, error } = await searchParams;
 	return (
 		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 to-pink-50">
 			<div className="max-w-md w-full space-y-8 p-8 bg-white rounded-xl shadow-lg">
@@ -84,9 +85,7 @@ function SignInForm({ callbackUrl, error }: { callbackUrl?: string; error?: stri
 	);
 }
 
-export default async function SignInPage({ searchParams }: SignInPageProps) {
-	const params = await searchParams;
-
+export default function SignInPage({ searchParams }: SignInPageProps) {
 	return (
 		<Suspense
 			fallback={
@@ -98,7 +97,7 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
 				</div>
 			}
 		>
-			<SignInForm callbackUrl={params.callbackUrl} error={params.error} />
+			<SignInForm searchParams={searchParams} />
 		</Suspense>
 	);
 }

--- a/apps/web/src/app/circles/[circleId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/circles/[circleId]/__tests__/page.test.tsx
@@ -46,7 +46,7 @@ vi.mock("@suzumina.click/shared-types", () => ({
 
 // テスト対象のインポート（モック設定後）
 import * as actions from "../actions";
-import CirclePage from "../page";
+import { CircleContent } from "../page";
 
 describe("CirclePage", () => {
 	const mockCircleData = {
@@ -112,13 +112,13 @@ describe("CirclePage", () => {
 		});
 
 		// 非同期コンポーネントの実行を待つ
-		const CirclePageComponent = await CirclePage({
+		const CircleContentComponent = await CircleContent({
 			params: Promise.resolve({ circleId: "RG12345" }),
 			searchParams: Promise.resolve({ page: "1" }),
 		});
 
 		// レンダリング
-		render(CirclePageComponent);
+		render(CircleContentComponent);
 
 		// サークル名の表示確認
 		expect(screen.getByText("テストサークル")).toBeInTheDocument();
@@ -142,7 +142,7 @@ describe("CirclePage", () => {
 
 		// 非同期コンポーネントの実行を試みる
 		try {
-			await CirclePage({
+			await CircleContent({
 				params: Promise.resolve({ circleId: "RG99999" }),
 				searchParams: Promise.resolve({}),
 			});
@@ -164,13 +164,13 @@ describe("CirclePage", () => {
 		});
 
 		// 非同期コンポーネントの実行を待つ
-		const CirclePageComponent = await CirclePage({
+		const CircleContentComponent = await CircleContent({
 			params: Promise.resolve({ circleId: "RG12345" }),
 			searchParams: Promise.resolve({}),
 		});
 
 		// レンダリング
-		render(CirclePageComponent);
+		render(CircleContentComponent);
 
 		// サークル名の表示確認
 		expect(screen.getByText("テストサークル")).toBeInTheDocument();
@@ -193,13 +193,13 @@ describe("CirclePage", () => {
 		});
 
 		// 非同期コンポーネントの実行を待つ
-		const CirclePageComponent = await CirclePage({
+		const CircleContentComponent = await CircleContent({
 			params: Promise.resolve({ circleId: "RG12345" }),
 			searchParams: Promise.resolve({}),
 		});
 
 		// レンダリング
-		render(CirclePageComponent);
+		render(CircleContentComponent);
 
 		// サークル名の表示確認
 		expect(screen.getByText("テストサークル")).toBeInTheDocument();
@@ -253,7 +253,7 @@ describe("CirclePage", () => {
 			limit: "24",
 		});
 
-		await CirclePage({ params, searchParams });
+		await CircleContent({ params, searchParams });
 
 		expect(actions.getCircleWorksList).toHaveBeenCalledWith({
 			circleId: "RG12345",
@@ -275,7 +275,7 @@ describe("CirclePage", () => {
 		const params = Promise.resolve({ circleId: "RG12345" });
 		const searchParams = Promise.resolve({ q: "検索キーワード" });
 
-		await CirclePage({ params, searchParams });
+		await CircleContent({ params, searchParams });
 
 		// searchパラメータとして渡される
 		expect(actions.getCircleWorksList).toHaveBeenCalledWith(

--- a/apps/web/src/app/circles/[circleId]/page.tsx
+++ b/apps/web/src/app/circles/[circleId]/page.tsx
@@ -1,8 +1,8 @@
+import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { getCircleInfo, getCircleWorksList } from "./actions";
 import { CirclePageClient } from "./components/CirclePageClient";
-
-export const dynamic = "force-dynamic";
 
 interface CirclePageProps {
 	params: Promise<{ circleId: string }>;
@@ -30,7 +30,15 @@ export async function generateMetadata({ params }: { params: Promise<{ circleId:
 	};
 }
 
-export default async function CirclePage({ params, searchParams }: CirclePageProps) {
+export default function CirclePage(props: CirclePageProps) {
+	return (
+		<Suspense fallback={<LoadingSkeleton variant="card" />}>
+			<CircleContent {...props} />
+		</Suspense>
+	);
+}
+
+export async function CircleContent({ params, searchParams }: CirclePageProps) {
 	const { circleId } = await params;
 	const searchParamsData = await searchParams;
 

--- a/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
@@ -63,7 +63,7 @@ vi.mock("@suzumina.click/shared-types", () => ({
 
 // テスト対象のインポート（モック設定後）
 import * as actions from "../actions";
-import CreatorPage from "../page";
+import { CreatorContent } from "../page";
 
 describe("CreatorPage", () => {
 	const mockCreatorInfo = {
@@ -126,13 +126,13 @@ describe("CreatorPage", () => {
 		});
 
 		// 非同期コンポーネントの実行を待つ
-		const CreatorPageComponent = await CreatorPage({
+		const CreatorContentComponent = await CreatorContent({
 			params: Promise.resolve({ creatorId: "creator123" }),
 			searchParams: Promise.resolve({ page: "1" }),
 		});
 
 		// レンダリング
-		render(CreatorPageComponent);
+		render(CreatorContentComponent);
 
 		// 役割の表示
 		expect(screen.getByText(/声優 \/ イラスト/)).toBeInTheDocument();
@@ -150,7 +150,7 @@ describe("CreatorPage", () => {
 
 		// 非同期コンポーネントの実行を試みる
 		try {
-			await CreatorPage({
+			await CreatorContent({
 				params: Promise.resolve({ creatorId: "nonexistent" }),
 				searchParams: Promise.resolve({}),
 			});
@@ -171,13 +171,13 @@ describe("CreatorPage", () => {
 		});
 
 		// 非同期コンポーネントの実行を待つ
-		const CreatorPageComponent = await CreatorPage({
+		const CreatorContentComponent = await CreatorContent({
 			params: Promise.resolve({ creatorId: "creator123" }),
 			searchParams: Promise.resolve({ page: "1" }),
 		});
 
 		// レンダリング
-		render(CreatorPageComponent);
+		render(CreatorContentComponent);
 
 		// クリエイター名の表示確認
 		expect(screen.getByText("テストクリエイター")).toBeInTheDocument();
@@ -198,13 +198,13 @@ describe("CreatorPage", () => {
 		});
 
 		// 非同期コンポーネントの実行を待つ
-		const CreatorPageComponent = await CreatorPage({
+		const CreatorContentComponent = await CreatorContent({
 			params: Promise.resolve({ creatorId: "creator123" }),
 			searchParams: Promise.resolve({ page: "1" }),
 		});
 
 		// レンダリング
-		render(CreatorPageComponent);
+		render(CreatorContentComponent);
 
 		// クリエイター名の表示確認
 		expect(screen.getByText("テストクリエイター")).toBeInTheDocument();

--- a/apps/web/src/app/creators/[creatorId]/page.tsx
+++ b/apps/web/src/app/creators/[creatorId]/page.tsx
@@ -1,9 +1,9 @@
 import { getCreatorTypeLabel } from "@suzumina.click/shared-types";
+import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { getCreatorInfo, getCreatorWorksList } from "./actions";
 import { CreatorPageClient } from "./components/CreatorPageClient";
-
-export const dynamic = "force-dynamic";
 
 interface CreatorPageProps {
 	params: Promise<{ creatorId: string }>;
@@ -33,7 +33,15 @@ export async function generateMetadata({ params }: { params: Promise<{ creatorId
 	};
 }
 
-export default async function CreatorPage({ params, searchParams }: CreatorPageProps) {
+export default function CreatorPage(props: CreatorPageProps) {
+	return (
+		<Suspense fallback={<LoadingSkeleton variant="card" />}>
+			<CreatorContent {...props} />
+		</Suspense>
+	);
+}
+
+export async function CreatorContent({ params, searchParams }: CreatorPageProps) {
 	const { creatorId } = await params;
 	const searchParamsData = await searchParams;
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -109,9 +109,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 						<Suspense fallback={null}>
 							<PageViewTracker />
 						</Suspense>
-						<SiteHeader />
+						{/* SiteHeader は auth() でセッション cookie を読むため動的。
+							Cache Components モデルでは Suspense 境界が必須 */}
+						<Suspense fallback={<div className="h-[73px] border-b" aria-hidden />}>
+							<SiteHeader />
+						</Suspense>
 						<main id="main-content" className="flex-1">
-							{children}
+							{/* Cache Components 下では、ページが動的データを参照する場合 Suspense 境界が必須。
+								個別ページで PPR したい場合はページ側でさらに細分化できる */}
+							<Suspense fallback={null}>{children}</Suspense>
 						</main>
 						<SiteFooter />
 						<Toaster />

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,27 +1,17 @@
-import { HomePage } from "@/components/home/home-page";
-import { getLatestAudioButtons, getLatestVideos, getLatestWorks } from "./actions";
+import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
+import { Suspense } from "react";
+import { DynamicHomeSections } from "@/components/home/dynamic-home-sections";
+import { HeroSection } from "@/components/home/hero-section";
 
-// build 時の Firestore アクセスを避けるため force-dynamic を採用 (SPR-60 follow-up)
-// CDN 側で s-maxage=300, stale-while-revalidate=600（next.config.mjs）が効くため
-// 実質的なキャッシュ挙動は ISR と同等
-export const dynamic = "force-dynamic";
-
-// Server Component として実装し、全データを並列取得
-export default async function Home() {
-	// 🚀 全てのデータを並列で取得（真の並列実行）
-	const [audioButtons, videos, works, allAgesWorks] = await Promise.all([
-		getLatestAudioButtons(10),
-		getLatestVideos(10),
-		getLatestWorks(10, false), // 通常版（R18含む）
-		getLatestWorks(10, true), // 全年齢版（R18除外）
-	]);
-
+// Cache Components モデル: HeroSection は静的シェルとして prerender され、
+// データ取得を伴う DynamicHomeSections は Suspense 境界内でストリーミング配信。
+export default function Home() {
 	return (
-		<HomePage
-			initialAudioButtons={audioButtons}
-			initialVideos={videos}
-			initialWorks={works}
-			initialAllAgesWorks={allAgesWorks}
-		/>
+		<div>
+			<HeroSection />
+			<Suspense fallback={<LoadingSkeleton variant="carousel" height={400} />}>
+				<DynamicHomeSections />
+			</Suspense>
+		</div>
 	);
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,17 +1,30 @@
 import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { Suspense } from "react";
-import { DynamicHomeSections } from "@/components/home/dynamic-home-sections";
+import {
+	AudioButtonsSection,
+	CommunitySection,
+	VideosSectionAsync,
+	WorksSectionAsync,
+} from "@/components/home/dynamic-home-sections";
 import { HeroSection } from "@/components/home/hero-section";
 
-// Cache Components モデル: HeroSection は静的シェルとして prerender され、
-// データ取得を伴う DynamicHomeSections は Suspense 境界内でストリーミング配信。
+// Cache Components モデル: HeroSection と CommunitySection は静的シェル、
+// 各データセクションはそれぞれ個別の <Suspense> 境界で並列ストリーミングされる。
+// セクション単位のスケルトンが実コンテンツに近い高さを持つため、CLS を最小化できる。
 export default function Home() {
 	return (
 		<div>
 			<HeroSection />
-			<Suspense fallback={<LoadingSkeleton variant="carousel" height={400} />}>
-				<DynamicHomeSections />
+			<Suspense fallback={<LoadingSkeleton variant="carousel" height={320} />}>
+				<AudioButtonsSection />
 			</Suspense>
+			<Suspense fallback={<LoadingSkeleton variant="carousel" height={480} />}>
+				<VideosSectionAsync />
+			</Suspense>
+			<Suspense fallback={<LoadingSkeleton variant="carousel" height={560} />}>
+				<WorksSectionAsync />
+			</Suspense>
+			<CommunitySection />
 		</div>
 	);
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,11 +1,13 @@
 import type { MetadataRoute } from "next";
 import { unstable_cache } from "next/cache";
+import { connection } from "next/server";
 import { getFirestore } from "@/lib/firestore";
 import { warn as logWarn } from "@/lib/logger";
 
 // build 時の Firestore アクセスを避け、リクエスト時に Cloud Run の SA credentials で生成する (SPR-60)
 // Firestore 取得部分は unstable_cache で 1 時間キャッシュし、毎リクエストでクエリが走らないようにする
-export const dynamic = "force-dynamic";
+// cacheComponents 有効下では route segment config `dynamic` が使えないため、
+// `await connection()` でリクエストスコープに入り build-time prerender を回避する
 
 const SITEMAP_REVALIDATE_SECONDS = 3600;
 
@@ -81,6 +83,7 @@ const getDynamicSitemapPages = unstable_cache(
 );
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	await connection();
 	const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://suzumina.click";
 
 	// 静的ページ（公開ページのみ。要認証ページや action ページは robots.txt 側で disallow する）

--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -1,64 +1,31 @@
-import type {
-	AudioButtonPlainObject,
-	VideoPlainObject,
-	WorkPlainObject,
-} from "@suzumina.click/shared-types";
 import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import Link from "next/link";
+import { connection } from "next/server";
 import { Suspense } from "react";
-import { HomeSearchForm } from "@/components/home/home-search-form";
+import { getLatestAudioButtons, getLatestVideos, getLatestWorks } from "@/app/actions";
 import { LazyFeaturedAudioButtonsCarousel } from "@/components/optimization/lazy-components";
 import { VideosSection } from "@/components/sections/videos-section";
 import { WorksSection } from "@/components/sections/works-section";
 
-interface HomePageProps {
-	initialAudioButtons: AudioButtonPlainObject[];
-	initialVideos: VideoPlainObject[];
-	initialWorks: WorkPlainObject[];
-	initialAllAgesWorks: WorkPlainObject[];
-}
+/**
+ * Firestore データ取得を伴うホームページの動的セクション群。
+ * PPR の `<Suspense>` 境界内でストリーミング配信される。
+ */
+export async function DynamicHomeSections() {
+	// Cache Components 下で「Firestore からの uncached fetch」を実行する前に
+	// リクエストスコープに入る必要がある。これでこのコンポーネントが完全に動的扱いになる。
+	await connection();
 
-export function HomePage({
-	initialAudioButtons,
-	initialVideos,
-	initialWorks,
-	initialAllAgesWorks,
-}: HomePageProps) {
+	const [audioButtons, videos, works, allAgesWorks] = await Promise.all([
+		getLatestAudioButtons(10),
+		getLatestVideos(10),
+		getLatestWorks(10, false),
+		getLatestWorks(10, true),
+	]);
+
 	return (
-		<div>
-			{/* メインビジュアル - LCP最適化済み + suzukaブランドカラー背景 */}
-			<section className="py-12 sm:py-16 md:py-20 text-center bg-suzuka-50 critical-above-fold critical-hero">
-				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
-					<div className="max-w-4xl mx-auto">
-						{/* LCP要素として最適化 - 明示的サイズとフォント最適化 */}
-						<h1
-							className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-4 sm:mb-6"
-							style={{
-								// LCP改善: 明示的なサイズとレイアウト
-								minHeight: "2.5rem",
-								contentVisibility: "visible",
-							}}
-						>
-							すずみなくりっく！
-						</h1>
-						<p
-							className="text-base sm:text-lg md:text-xl text-muted-foreground mb-6 sm:mb-8 px-4 sm:px-0"
-							style={{
-								// CLS防止: 明示的な高さ
-								minHeight: "3rem",
-							}}
-						>
-							涼花みなせさんのYouTube動画から、好きな場面を再生できるボタンを作ろう！
-							<br />
-							あーたたちが集まる、あーたたちのためのファンサイトです
-						</p>
-						{/* 検索フォーム - LCP改善のため eager load */}
-						<HomeSearchForm />
-					</div>
-				</div>
-			</section>
-
+		<>
 			{/* 新着音声ボタンセクション - 遅延読み込み最適化 */}
 			<section
 				className="py-8 sm:py-12 bg-background"
@@ -81,21 +48,16 @@ export function HomePage({
 						</Button>
 					</div>
 					<Suspense fallback={<LoadingSkeleton variant="carousel" height={280} />}>
-						<LazyFeaturedAudioButtonsCarousel audioButtons={initialAudioButtons} />
+						<LazyFeaturedAudioButtonsCarousel audioButtons={audioButtons} />
 					</Suspense>
 				</div>
 			</section>
 
 			{/* 新着動画セクション */}
-			<VideosSection videos={initialVideos} loading={false} error={null} />
+			<VideosSection videos={videos} loading={false} error={null} />
 
 			{/* 新着作品セクション */}
-			<WorksSection
-				works={initialWorks}
-				allAgesWorks={initialAllAgesWorks}
-				loading={false}
-				error={null}
-			/>
+			<WorksSection works={works} allAgesWorks={allAgesWorks} loading={false} error={null} />
 
 			{/* コミュニティセクション - 遅延読み込み最適化 */}
 			<section
@@ -125,6 +87,6 @@ export function HomePage({
 					</div>
 				</div>
 			</section>
-		</div>
+		</>
 	);
 }

--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -9,84 +9,89 @@ import { VideosSection } from "@/components/sections/videos-section";
 import { WorksSection } from "@/components/sections/works-section";
 
 /**
- * Firestore データ取得を伴うホームページの動的セクション群。
- * PPR の `<Suspense>` 境界内でストリーミング配信される。
+ * 各セクションは個別の `<Suspense>` 境界配下で並列にストリーミングされる。
+ * `await connection()` は Firestore SDK 内部の同期的なランダム値参照を
+ * Cache Components の build-time prerender が検出してしまうのを回避するため、
+ * 「このコンポーネントはリクエスト時に動的レンダリングする」ことを明示する。
  */
-export async function DynamicHomeSections() {
-	// Cache Components 下で「Firestore からの uncached fetch」を実行する前に
-	// リクエストスコープに入る必要がある。これでこのコンポーネントが完全に動的扱いになる。
-	await connection();
 
-	const [audioButtons, videos, works, allAgesWorks] = await Promise.all([
-		getLatestAudioButtons(10),
-		getLatestVideos(10),
+export async function AudioButtonsSection() {
+	await connection();
+	const audioButtons = await getLatestAudioButtons(10);
+
+	return (
+		<section
+			className="py-8 sm:py-12 bg-background"
+			style={{ contentVisibility: "auto", containIntrinsicSize: "320px" }}
+		>
+			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+				<div className="flex items-center justify-between mb-6 sm:mb-8">
+					<div>
+						<h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground mb-2 flex items-center gap-2">
+							🎵 新着音声ボタン
+						</h2>
+						<p className="text-sm sm:text-base text-muted-foreground">
+							最新の音声ボタンをチェック！
+						</p>
+					</div>
+					<Button asChild variant="outline">
+						<Link href="/buttons" className="font-medium">
+							すべて見る
+						</Link>
+					</Button>
+				</div>
+				<Suspense fallback={<LoadingSkeleton variant="carousel" height={280} />}>
+					<LazyFeaturedAudioButtonsCarousel audioButtons={audioButtons} />
+				</Suspense>
+			</div>
+		</section>
+	);
+}
+
+export async function VideosSectionAsync() {
+	await connection();
+	const videos = await getLatestVideos(10);
+	return <VideosSection videos={videos} loading={false} error={null} />;
+}
+
+export async function WorksSectionAsync() {
+	await connection();
+	const [works, allAgesWorks] = await Promise.all([
 		getLatestWorks(10, false),
 		getLatestWorks(10, true),
 	]);
+	return <WorksSection works={works} allAgesWorks={allAgesWorks} loading={false} error={null} />;
+}
 
+/** コミュニティ CTA は完全静的。データ取得なし。 */
+export function CommunitySection() {
 	return (
-		<>
-			{/* 新着音声ボタンセクション - 遅延読み込み最適化 */}
-			<section
-				className="py-8 sm:py-12 bg-background"
-				style={{ contentVisibility: "auto", containIntrinsicSize: "320px" }}
-			>
-				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
-					<div className="flex items-center justify-between mb-6 sm:mb-8">
-						<div>
-							<h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground mb-2 flex items-center gap-2">
-								🎵 新着音声ボタン
-							</h2>
-							<p className="text-sm sm:text-base text-muted-foreground">
-								最新の音声ボタンをチェック！
-							</p>
-						</div>
-						<Button asChild variant="outline">
-							<Link href="/buttons" className="font-medium">
-								すべて見る
+		<section
+			className="py-8 sm:py-12 bg-suzuka-100"
+			style={{ contentVisibility: "auto", containIntrinsicSize: "260px" }}
+		>
+			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+				<div className="text-center mb-6 sm:mb-8">
+					<h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground mb-2 sm:mb-4">
+						コミュニティに参加しよう
+					</h2>
+					<p className="text-sm sm:text-base text-muted-foreground mb-6 sm:mb-8">
+						音声ボタンを作成・共有して、ファンコミュニティを盛り上げよう！
+					</p>
+					<div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+						<Button asChild size="lg">
+							<Link href="/buttons/create" className="font-medium">
+								音声ボタンを作る
+							</Link>
+						</Button>
+						<Button asChild size="lg" variant="outline">
+							<Link href="/about" className="font-medium">
+								サイトについて
 							</Link>
 						</Button>
 					</div>
-					<Suspense fallback={<LoadingSkeleton variant="carousel" height={280} />}>
-						<LazyFeaturedAudioButtonsCarousel audioButtons={audioButtons} />
-					</Suspense>
 				</div>
-			</section>
-
-			{/* 新着動画セクション */}
-			<VideosSection videos={videos} loading={false} error={null} />
-
-			{/* 新着作品セクション */}
-			<WorksSection works={works} allAgesWorks={allAgesWorks} loading={false} error={null} />
-
-			{/* コミュニティセクション - 遅延読み込み最適化 */}
-			<section
-				className="py-8 sm:py-12 bg-suzuka-100"
-				style={{ contentVisibility: "auto", containIntrinsicSize: "260px" }}
-			>
-				<div className="container mx-auto px-4 sm:px-6 lg:px-8">
-					<div className="text-center mb-6 sm:mb-8">
-						<h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground mb-2 sm:mb-4">
-							コミュニティに参加しよう
-						</h2>
-						<p className="text-sm sm:text-base text-muted-foreground mb-6 sm:mb-8">
-							音声ボタンを作成・共有して、ファンコミュニティを盛り上げよう！
-						</p>
-						<div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-							<Button asChild size="lg">
-								<Link href="/buttons/create" className="font-medium">
-									音声ボタンを作る
-								</Link>
-							</Button>
-							<Button asChild size="lg" variant="outline">
-								<Link href="/about" className="font-medium">
-									サイトについて
-								</Link>
-							</Button>
-						</div>
-					</div>
-				</div>
-			</section>
-		</>
+			</div>
+		</section>
 	);
 }

--- a/apps/web/src/components/home/hero-section.tsx
+++ b/apps/web/src/components/home/hero-section.tsx
@@ -1,0 +1,36 @@
+import { HomeSearchForm } from "@/components/home/home-search-form";
+
+/**
+ * ホームページのヒーローセクション。
+ * PPR の静的シェルに含めるため、データ取得を持たない純粋なサーバーコンポーネント。
+ */
+export function HeroSection() {
+	return (
+		<section className="py-12 sm:py-16 md:py-20 text-center bg-suzuka-50 critical-above-fold critical-hero">
+			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
+				<div className="max-w-4xl mx-auto">
+					<h1
+						className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-4 sm:mb-6"
+						style={{
+							minHeight: "2.5rem",
+							contentVisibility: "visible",
+						}}
+					>
+						すずみなくりっく！
+					</h1>
+					<p
+						className="text-base sm:text-lg md:text-xl text-muted-foreground mb-6 sm:mb-8 px-4 sm:px-0"
+						style={{
+							minHeight: "3rem",
+						}}
+					>
+						涼花みなせさんのYouTube動画から、好きな場面を再生できるボタンを作ろう！
+						<br />
+						あーたたちが集まる、あーたたちのためのファンサイトです
+					</p>
+					<HomeSearchForm />
+				</div>
+			</div>
+		</section>
+	);
+}


### PR DESCRIPTION
## Summary

[SPR-4](https://linear.app/nothink/issue/SPR-4) / [#370](https://github.com/nothink-jp/suzumina.click/issues/370) の目的（ホームの PPR 化）を、Next.js 16 で PPR を置き換えた **Cache Components** モデルで実現。`force-dynamic` を全廃し、動的データ参照箇所には `<Suspense>` 境界と `await connection()` を導入。さらにホームの動的セクションを per-section Suspense に分割して CLS を最小化。

- ホーム含む 28 ルートが `◐ (Partial Prerender)` になり、静的シェルが先行ストリーミングされる
- ヒーロー H1（LCP 候補）は Firestore クエリを待たず即座にレンダリングされる
- 音声/動画/作品セクションがそれぞれ独立してストリーミングされ、データが揃った順に段階的に描画される

## Why Cache Components (not `experimental.ppr`)

Next.js 16 では `experimental.ppr` が削除され、トップレベル `cacheComponents` に統合されている。SPR-4 の元 Issue は Next.js 15 前提だったが、Next.js 16.2 の現環境では cacheComponents に移行するのが正攻法。cacheComponents 有効下では route segment config `dynamic` / `experimental_ppr` が禁止されるため、既存の `force-dynamic` も同時に撤去する必要があった。

## Changes

### Config
- `next.config.mjs`: `experimental.ppr: false` を削除、トップレベルに `cacheComponents: true`

### Home page split (本来の SPR-4 対応 + CLS 対策)
- `app/page.tsx`: 静的 `HeroSection` / `CommunitySection` と、データセクションごとに独立した `<Suspense>` 境界（音声/動画/作品）に分割
- `components/home/hero-section.tsx`: **新規** 静的シェル（h1, p, 検索フォーム）
- `components/home/dynamic-home-sections.tsx`: **新規** 4 つの export
  - `AudioButtonsSection` / `VideosSectionAsync` / `WorksSectionAsync`: 各セクション独立の async server component（Firestore データ取得 + `await connection()`）
  - `CommunitySection`: データ取得を持たない完全静的セクション
- `components/home/home-page.tsx`: 役割分離により削除
- React Server Components の sibling 並列レンダリングにより、`Promise.all` を解いてもデータ取得の wall-clock 時間は不変

### Layout
- `app/layout.tsx`: `SiteHeader`（`auth()` でセッション cookie を読む）と `<main>{children}</main>` を `<Suspense>` で包む

### Force-dynamic 撤去 + Suspense 化
- `app/circles/[circleId]/page.tsx`: `CircleContent` に分離して Suspense 化
- `app/creators/[creatorId]/page.tsx`: `CreatorContent` に分離して Suspense 化
- `app/auth/signin/page.tsx` / `auth/error/page.tsx`: `searchParams` の `await` を Suspense 子コンポーネント内に移動
- `app/sitemap.ts`: `export const dynamic = "force-dynamic"` → `await connection()` に置換

### Tests
- `circles/[circleId]/__tests__/page.test.tsx` / `creators/[creatorId]/__tests__/page.test.tsx`: 新しい export 名（`CircleContent` / `CreatorContent`）に追従
- `app/__tests__/sitemap.test.ts`: `next/server.connection` を no-op で mock

## Test plan

- [x] `pnpm --filter @suzumina.click/web build` 成功（33 ページ生成、28 が Partial Prerender）
- [x] `pnpm --filter @suzumina.click/web typecheck` クリーン
- [x] `pnpm --filter @suzumina.click/web lint` クリーン（warning は既存）
- [x] `pnpm --filter @suzumina.click/web test` 685 passed / 1 skipped
- [x] `pnpm --filter @suzumina.click/web dev` でヒーロー → 各セクションが順次ストリーミングされ、CLS が悪化しないことを目視確認
- [ ] production deploy 後、トップページの TTFB / FCP / LCP / CLS 改善を計測（[SPR-66](https://linear.app/nothink/issue/SPR-66) で追跡）

## Follow-ups

レビューで挙がった軽微な改善は別 Issue に分離:

- [SPR-65](https://linear.app/nothink/issue/SPR-65): `SiteHeader` の Suspense fallback 高さ（暫定 73px）を実測値に揃え、定数を単一ソース化
- [SPR-66](https://linear.app/nothink/issue/SPR-66): PPR 化後の CDN キャッシュ挙動を production で計測し、`next.config.mjs` の `Cache-Control` ヘッダー設定を最適化

## Notes for reviewer

- Cache Components はプロジェクト全体に効くグローバル設定。今後新規ページを追加する際は、`searchParams` / `params` の `await` や `auth()`、`cookies()` 等を Suspense 子コンポーネントに切り出すパターンを意識する必要あり
- `layout.tsx` の `<main>` を包む `Suspense fallback={null}` は安全網。ページ側で個別に Suspense を設計すれば、より積極的な PPR が可能
- `sitemap.ts` の `await connection()` は build-time prerender 回避のため必須（Firestore に build 時アクセスできないため）
- Videos/Works セクションの fallback height（480 / 560）は推定値。production 計測（[SPR-66](https://linear.app/nothink/issue/SPR-66)）で実値に合わせる予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
