### PR TITLE
refactor(web): SiteHeader の Suspense 境界を auth 依存箇所だけに限定（SPR-65）

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -109,11 +109,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 						<Suspense fallback={null}>
 							<PageViewTracker />
 						</Suspense>
-						{/* SiteHeader は auth() でセッション cookie を読むため動的。
-							Cache Components モデルでは Suspense 境界が必須 */}
-						<Suspense fallback={<div className="h-[73px] border-b" aria-hidden />}>
-							<SiteHeader />
-						</Suspense>
+						{/* SiteHeader 自体は静的シェル。auth() 解決は内部の Suspense 境界で局所化されている */}
+						<SiteHeader />
 						<main id="main-content" className="flex-1">
 							{/* Cache Components 下では、ページが動的データを参照する場合 Suspense 境界が必須。
 								個別ページで PPR したい場合はページ側でさらに細分化できる */}

--- a/apps/web/src/components/layout/site-header.tsx
+++ b/apps/web/src/components/layout/site-header.tsx
@@ -52,11 +52,12 @@ export default function SiteHeader() {
 							</NavigationMenuList>
 						</NavigationMenu>
 
-						{/* 認証関連: auth() 解決を待つ間は同サイズのプレースホルダーを表示し、
-							ヘッダー全体の高さは固定する。Suspense 境界をここに限定することで、
-							ヘッダーのレイアウト・ロゴ・ナビは即座に静的シェルとして配信される。 */}
-						<div className="flex items-center space-x-4">
-							<Suspense fallback={<SessionControlsFallback />}>
+						{/* 認証関連: wrapper の min-h で UserMenu (desktop ~52px) と
+							MobileMenu (mobile 44px) と同じ高さを常に確保する。これにより
+							Suspense リゾルブ前後でヘッダー全体の高さは変動せず CLS=0 を保てる。
+							fallback は枠確保不要なので null で十分。 */}
+						<div className="flex items-center space-x-4 min-h-[44px] md:min-h-[52px]">
+							<Suspense fallback={null}>
 								<SessionAwareControls />
 							</Suspense>
 						</div>
@@ -78,20 +79,6 @@ async function SessionAwareControls() {
 
 			{/* モバイルメニュー */}
 			<MobileMenu user={session?.user} />
-		</>
-	);
-}
-
-/**
- * SessionAwareControls の fallback。
- * AuthButton (desktop, h-10/w-32 相当) と MobileMenu button (mobile, h-11/w-11) と
- * 同じ占有面積のプレースホルダー枠で、Suspense リゾルブ時の CLS を防ぐ。
- */
-function SessionControlsFallback() {
-	return (
-		<>
-			<div className="hidden md:flex h-10 w-32" aria-hidden />
-			<div className="md:hidden h-11 w-11" aria-hidden />
 		</>
 	);
 }

--- a/apps/web/src/components/layout/site-header.tsx
+++ b/apps/web/src/components/layout/site-header.tsx
@@ -5,12 +5,12 @@ import {
 	NavigationMenuList,
 } from "@suzumina.click/ui/components/ui/navigation-menu";
 import Link from "next/link";
+import { Suspense } from "react";
 import { auth } from "@/auth";
 import AuthButton from "../user/auth-button";
 import MobileMenu from "./mobile-menu";
 
-export default async function SiteHeader() {
-	const session = await auth();
+export default function SiteHeader() {
 	return (
 		<>
 			{/* スキップリンク */}
@@ -52,18 +52,46 @@ export default async function SiteHeader() {
 							</NavigationMenuList>
 						</NavigationMenu>
 
+						{/* 認証関連: auth() 解決を待つ間は同サイズのプレースホルダーを表示し、
+							ヘッダー全体の高さは固定する。Suspense 境界をここに限定することで、
+							ヘッダーのレイアウト・ロゴ・ナビは即座に静的シェルとして配信される。 */}
 						<div className="flex items-center space-x-4">
-							{/* 認証ボタン */}
-							<div className="hidden md:flex">
-								<AuthButton user={session?.user} />
-							</div>
-
-							{/* モバイルメニュー */}
-							<MobileMenu user={session?.user} />
+							<Suspense fallback={<SessionControlsFallback />}>
+								<SessionAwareControls />
+							</Suspense>
 						</div>
 					</div>
 				</div>
 			</header>
+		</>
+	);
+}
+
+async function SessionAwareControls() {
+	const session = await auth();
+	return (
+		<>
+			{/* 認証ボタン */}
+			<div className="hidden md:flex">
+				<AuthButton user={session?.user} />
+			</div>
+
+			{/* モバイルメニュー */}
+			<MobileMenu user={session?.user} />
+		</>
+	);
+}
+
+/**
+ * SessionAwareControls の fallback。
+ * AuthButton (desktop, h-10/w-32 相当) と MobileMenu button (mobile, h-11/w-11) と
+ * 同じ占有面積のプレースホルダー枠で、Suspense リゾルブ時の CLS を防ぐ。
+ */
+function SessionControlsFallback() {
+	return (
+		<>
+			<div className="hidden md:flex h-10 w-32" aria-hidden />
+			<div className="md:hidden h-11 w-11" aria-hidden />
 		</>
 	);
 }


### PR DESCRIPTION
## Summary

[SPR-65](https://linear.app/nothink/issue/SPR-65) 対応。SPR-4 ([PR #432](https://github.com/nothink-jp/suzumina.click/pull/432)) で `layout.tsx` に置いた未検証の magic number `h-[73px]` を撤去し、SiteHeader Suspense リゾルブ時の CLS を 0 にする。

「ヘッダー全体を Suspense で包む」アプローチを止め、**SiteHeader 自体を非 async の静的シェルにして、auth 依存箇所だけを内側で Suspense する**構造に組み替えた。さらに auth slot wrapper に `min-h` を持たせることで、ログイン状態に依存しないヘッダー高さの安定化を実現。

## What changed

### `apps/web/src/components/layout/site-header.tsx`
- `SiteHeader` を非 async 化。ロゴ / デスクトップナビ / レイアウトは静的サーバーコンポーネントとして即座に prerender
- `await auth()` と auth 依存子（`AuthButton`, `MobileMenu`）を新規 `SessionAwareControls` 関数に切り出し、内側で `<Suspense>` する
- **auth slot wrapper に `min-h-[44px] md:min-h-[52px]` を付与**: UserMenu (desktop, ~52px) と MobileMenu (mobile, 44px) と同じ高さを常に確保し、Suspense リゾルブ前後でヘッダー全体の高さが変動しない
- 枠の確保が wrapper 側になったため、Suspense fallback は `null` で十分

### `apps/web/src/app/layout.tsx`
- 外側の `<Suspense fallback={<div className="h-[73px] border-b" />}>` を削除
- `<SiteHeader />` を直接配置するだけに

## なぜこの形か

Issue の対応案には Tailwind CSS 変数化が挙げられていたが、構造を見直すと **そもそも layout 側でヘッダー高さを宣言する必要がない**。代わりに「動的部分を内側 Suspense に閉じ込め、その slot のサイズを実コンテンツに揃える」アプローチが本質的:

- **container > `py-4`** (32px) + auth slot `min-h-[44px] md:min-h-[52px]` でヘッダー高さは決定的に決まる
- ログイン (UserMenu ~52px) / 未ログイン (LoginButton 40px, slot の min-h で 52px に padding) どちらでも slot 高さは固定
- magic number / 定数管理が両方とも不要

## 受け入れ条件 (Issue より)

- [x] **ヘッダー高さの定数が単一ソース化されている**: layout 側の magic number は撤廃。`min-h-[44px] md:min-h-[52px]` は SiteHeader 自身が保持し、子コンテンツ (UserMenu/AuthButton/MobileMenu) のスペックから直接導出された値
- [ ] **production で SiteHeader Suspense のリゾルブによる CLS が 0**: production deploy 後に Lighthouse / Web Vitals (GA4) で確認

## 数値の根拠

| 要素 | 計算 | 高さ |
|------|------|------|
| `<header>` 上下 padding | `py-4` × 2 | 32px |
| LoginButton | `py-2` (16) + text-base (24) | 40px |
| UserMenu | `p-2` (16) + max(avatar 32, text-sm+text-xs 36) | 52px |
| MobileMenu trigger | `min-h-[44px]` | 44px |
| auth slot wrapper (本PR) | `min-h-[44px] md:min-h-[52px]` | 44 / 52px |
| header 全体 (signed-in) | py-4 (32) + slot (52) | 84px (固定) |
| header 全体 (signed-out) | py-4 (32) + slot (52, min-h により) | 84px (固定) |

ログイン状態に関わらず header は 84px。CLS = 0。

## Test plan

- [x] `pnpm --filter @suzumina.click/web typecheck` クリーン
- [x] `pnpm --filter @suzumina.click/web lint` クリーン (warning は既存)
- [x] `pnpm --filter @suzumina.click/web test` 685 passed / 1 skipped
- [x] `pnpm --filter @suzumina.click/web build` 成功、`◐ Partial Prerender` 状態維持
- [ ] `pnpm --filter @suzumina.click/web dev` でログイン / 未ログイン / モバイル各状態でヘッダー高さが揺れないことを目視確認

## Notes for reviewer

- 認証コントロール領域の Suspense リゾルブ中は領域が空 (`aria-hidden` なし、単に Suspense fallback が null) になるが、wrapper の min-h で枠は確保されているのでヘッダー全体の高さは変動しない
- `MobileMenu` は `"use client"` だが、server から渡される `user` props がないと適切に描画できないため Suspense 配下に置いている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
