### PR TITLE
perf(web): SPR-9 Desktop home CLS + Mobile LCP（main min-h + GTM/GA lazyOnload）

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -111,9 +111,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 						</Suspense>
 						{/* SiteHeader 自体は静的シェル。auth() 解決は内部の Suspense 境界で局所化されている */}
 						<SiteHeader />
-						<main id="main-content" className="flex-1">
+						<main id="main-content" className="flex-1 min-h-screen">
 							{/* Cache Components 下では、ページが動的データを参照する場合 Suspense 境界が必須。
-								個別ページで PPR したい場合はページ側でさらに細分化できる */}
+								個別ページで PPR したい場合はページ側でさらに細分化できる。
+								main に min-h-screen を持たせ、Suspense 解決前後で main 高さが viewport を
+								下回らないようにする。これにより footer が常に viewport 外に位置し、
+								下位セクションのストリーミングによる累積シフトが footer の CLS に
+								波及しないようにしている (SPR-9 Desktop CLS 0.486 対策) */}
 							<Suspense fallback={null}>{children}</Suspense>
 						</main>
 						<SiteFooter />

--- a/apps/web/src/components/analytics/google-analytics-script.tsx
+++ b/apps/web/src/components/analytics/google-analytics-script.tsx
@@ -22,14 +22,19 @@ export function GoogleAnalyticsScript() {
 
 	return (
 		<>
-			{/* Google Analytics 4 Script */}
+			{/* Google Analytics 4 Script
+			 * lazyOnload で `load` 後にロードし、Mobile LCP への影響を抑える (SPR-9)。
+			 * Consent Mode の default は ConsentModeScript の useEffect で hydration 直後に
+			 * dataLayer に push 済み。GA 本体は send_page_view: false で、page view は
+			 * PageViewTracker から手動送信するため、ロード順序の遅延は
+			 * 計測結果の整合性に影響しない。 */}
 			<Script
-				strategy="afterInteractive"
+				strategy="lazyOnload"
 				src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
 			/>
 			<Script
 				id="google-analytics"
-				strategy="afterInteractive"
+				strategy="lazyOnload"
 				dangerouslySetInnerHTML={{
 					__html: `
 						window.dataLayer = window.dataLayer || [];

--- a/apps/web/src/components/analytics/google-tag-manager.tsx
+++ b/apps/web/src/components/analytics/google-tag-manager.tsx
@@ -13,10 +13,14 @@ export function GoogleTagManager() {
 
 	return (
 		<>
-			{/* Google Tag Manager Script */}
+			{/* Google Tag Manager Script
+			 * lazyOnload で `load` 後にロードし、Mobile LCP への影響を抑える (SPR-9)。
+			 * `ConsentModeScript` は useEffect で hydration 直後に
+			 * gtag('consent','default',...) を実行済みなので、GTM ロード前に
+			 * 同意状態が dataLayer に積まれる順序は維持される。 */}
 			<Script
 				id="google-tag-manager"
-				strategy="afterInteractive"
+				strategy="lazyOnload"
 				dangerouslySetInnerHTML={{
 					__html: `
 						(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/apps/web/src/components/consent/consent-mode-script.tsx
+++ b/apps/web/src/components/consent/consent-mode-script.tsx
@@ -80,9 +80,20 @@ function initializeGoogleConsent() {
 
 /**
  * Setup Google Analytics dataLayer
+ *
+ * `gtag.js` を lazyOnload で `load` 後にロードしているため、hydration 直後から
+ * `load` までの間に呼ばれる `window.gtag(...)` を取りこぼさないよう、
+ * dataLayer に積むだけの polyfill 関数を先に定義しておく。
+ * gtag.js ロード時に `window.gtag` は GA 本体の実装で上書きされ、積み残しの
+ * dataLayer は通常通り処理される。
  */
 function setupDataLayer() {
 	window.dataLayer = window.dataLayer || [];
+	if (typeof window.gtag !== "function") {
+		window.gtag = function gtag(...args: unknown[]) {
+			window.dataLayer.push(args as unknown as Parameters<typeof window.dataLayer.push>[0]);
+		};
+	}
 }
 
 /**

--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -45,10 +45,7 @@ function AudioButtonsSectionHeader() {
  */
 export function AudioButtonsSectionSkeleton() {
 	return (
-		<section
-			className="py-8 sm:py-12 bg-background"
-			style={{ contentVisibility: "auto", containIntrinsicSize: "320px" }}
-		>
+		<section className="py-8 sm:py-12 bg-background">
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 				<AudioButtonsSectionHeader />
 				<LoadingSkeleton variant="carousel" height={280} />
@@ -62,10 +59,7 @@ export async function AudioButtonsSection() {
 	const audioButtons = await getLatestAudioButtons(10);
 
 	return (
-		<section
-			className="py-8 sm:py-12 bg-background"
-			style={{ contentVisibility: "auto", containIntrinsicSize: "320px" }}
-		>
+		<section className="py-8 sm:py-12 bg-background">
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 				<AudioButtonsSectionHeader />
 				<Suspense fallback={<LoadingSkeleton variant="carousel" height={280} />}>
@@ -94,10 +88,7 @@ export async function WorksSectionAsync() {
 /** コミュニティ CTA は完全静的。データ取得なし。 */
 export function CommunitySection() {
 	return (
-		<section
-			className="py-8 sm:py-12 bg-suzuka-100"
-			style={{ contentVisibility: "auto", containIntrinsicSize: "260px" }}
-		>
+		<section className="py-8 sm:py-12 bg-suzuka-100">
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 				<div className="text-center mb-6 sm:mb-8">
 					<h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground mb-2 sm:mb-4">


### PR DESCRIPTION
## Summary
SPR-9 (FCP/LCP 改善トラッキング) の一次対応。本番 PSI v5（2026-05-27, main `867348ab`）の結果に基づく 2 コミット。

- **A: Desktop home CLS 0.486 抑制** (`91e10057`)
  - `<main>` に `min-h-screen` を追加し、初期 main 高さ ≥ 100vh を保証。footer を常に viewport 外に位置させて、下位セクションの Suspense ストリーミングによる累積シフトが viewport 内 CLS としてカウントされないようにする。
  - `AudioButtonsSection` / `CommunitySection` から `contentVisibility:auto` + `containIntrinsicSize` を撤去。Desktop で初期 viewport 内に入るセクションには効果が薄く、描画タイミングのズレが CLS の一因になっていた疑い。

- **B: Mobile LCP 6.2s 対策（GTM/GA を lazyOnload 化）** (`37703628`)
  - `GoogleTagManager` / `GoogleAnalyticsScript` の Script strategy を `afterInteractive` → `lazyOnload` に変更。`load` イベント後ロードに下げて LCP への被りを排除（PSI で wasted JS の最大は gtag.js 73KB / gtm.js 72KB）。
  - `ConsentModeScript` の `setupDataLayer` で `window.gtag` を polyfill（dataLayer push 関数）。lazyOnload で gtag.js ロード前に呼ばれる `window.gtag(...)` を dataLayer に積み、ロード後にまとめて処理される。GA は `send_page_view: false` で page view は `PageViewTracker` から手動送信しているため、ロード順序の遅延は計測整合性に影響しない。

関連 Linear: [SPR-9](https://linear.app/nothink/issue/SPR-9/perf-fcplcp-改善トラッキングfcp-30s08s-lcp-60s20s) / 派生 [SPR-68](https://linear.app/nothink/issue/SPR-68/bugweb-videos-mobile-が-psi-で-page-hungdesktop-tbt-54s)

## 計測ベースライン（PSI v5 / 2026-05-27, main `867348ab`）
| Page | Strategy | Score | FCP | LCP | CLS |
|---|---|---|---|---|---|
| / | mobile | 60 | 1.2s | **6.2s** | 0 |
| / | desktop | 47 | 0.4s | 1.0s | **0.486** |
| /buttons | mobile | 38 | 2.7s | 6.8s | **0.507** |
| /buttons | desktop | 66 | 0.3s | 1.5s | **0.158** |

目標: FCP 0.8s / LCP 2.0s / CLS <0.1

Desktop CLS 0.486 のうち **footer 単体で score 0.466**。`/buttons` の CLS も footer 単体が主因（Mobile 0.506 / Desktop 0.154）。

## Test plan
- [x] `pnpm --filter @suzumina.click/web lint` — 0 errors
- [x] `pnpm --filter @suzumina.click/web typecheck` — pass
- [x] `pnpm --filter @suzumina.click/web test` — 685 passed / 1 skipped
- [x] `pnpm --filter @suzumina.click/web build` — pass（ホーム は `◐` PPR）
- [ ] **デプロイ後に PSI 再計測**（mobile/desktop / `/`, `/buttons`）
  - Desktop / の CLS が 0.1 未満に下がること
  - Mobile / の LCP が下がること（未使用 JS 600ms 削減の効果）
  - Mobile /buttons の CLS も連動で下がること（同じ footer 主因）
- [ ] 同意モード/Page View が production で動作していること（GA Realtime で確認）

## Follow-up（同 PR には含めない）
- skeleton (carousel height=280/300/350) と実 VideoCard / WorkCard / AudioButtonCard の高さ整合（実測が必要）
- /buttons 残 CLS（A 適用後に再計測して必要なら個別対応）
- [SPR-68](https://linear.app/nothink/issue/SPR-68): /videos PAGE_HUNG / TBT 5.4s 調査。主犯チャンク `10b37z4.ooa6j.js` (scripting 2.4s) を特定済み、`ConfigurableList` / `VideoCard` の hydration コストが疑われる

🤖 Generated with [Claude Code](https://claude.com/claude-code)