### PR TITLE
perf(shared-types): sideEffects: false で client bundle を全ページ約 31KB 削減（SPR-9）

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,6 +3,7 @@
 	"version": "0.3.12",
 	"description": "涼花みなせウェブサイト用の共有型定義",
 	"private": true,
+	"sideEffects": false,
 	"exports": {
 		".": {
 			"types": "./src/index.ts",


### PR DESCRIPTION
## Summary

- `@suzumina.click/shared-types` の `package.json` に `"sideEffects": false` を 1 行追加
- Turbopack の tree-shake が有効化され、全 10 ページの First Load JS が一律 **28-32KB 減少**
- [SPR-9](https://linear.app/nothink/issue/SPR-9) Mobile LCP 改善トラッキング配下の子タスク **E3-a**

## 計測結果（local production build / `pnpm build`）

`.next/server/app/*.meta` の `postponed.resumableState.scriptResources` から各ページが読み込む chunk を抽出して合計サイズを比較。

| Page | BEFORE | AFTER | Δ |
|------|-------:|------:|---:|
| `/` | 1245.9 KB | 1214.3 KB | **-31.6 KB** |
| `/buttons` | 1252.5 KB | 1220.9 KB | -31.6 KB |
| `/videos` | 1257.4 KB | 1225.9 KB | -31.5 KB |
| `/works` | 1258.0 KB | 1226.5 KB | -31.5 KB |
| `/circles` | 1239.9 KB | 1208.3 KB | -31.6 KB |
| `/creators` | 1240.4 KB | 1209.7 KB | -30.7 KB |
| `/search` | 1301.2 KB | 1272.6 KB | -28.6 KB |
| `/favorites` | 1244.5 KB | 1213.0 KB | -31.5 KB |
| `/contact` | 1152.6 KB | 1121.1 KB | -31.5 KB |
| `/about` | 1090.4 KB | 1058.9 KB | -31.5 KB |

**Chunk 内訳**:
- 5 chunks (合計 221 KB) が消えて 4 chunks (合計 189 KB) に置換 → ネット -32 KB / 全ページ
- 削除側に Zod 識別子を含む chunk (`0bi8yrra97aft.js`, 36 KB) が含まれていたため、Zod 関連スキーマの一部は tree-shake された

## 期待との差分

Linear コメント ([SPR-9 #61be4d05](https://linear.app/nothink/issue/SPR-9)) で期待された「Zod chunk (292 KB) の大幅減」は **実現していない**。Turbopack の chunking 上、shared-types の barrel re-export 経由で各 entity の Zod schema を import している以上、`sideEffects: false` だけでは Zod 本体を 1 chunk にまとめる挙動を打破できない。

抜本的な削減には次の手段が必要:
- **E3-b**: client component (25+ ファイル) の `@suzumina.click/shared-types` import を `import type {}` に置換
- **E3-c**: `shared-types/types` (types-only) と `shared-types` (schemas) を subpath 分離

これらは本 PR の scope 外で別 PR にて対応。

## Mobile LCP への影響見積もり

- 31 KB transfer の削減 (gzip 後 ~8-10 KB)
- 4G mobile (~10Mbps, 200ms RTT) で **約 25-50ms** の DL 短縮
- main-thread parsing も若干減少
- 単独で LCP 2.0s 目標達成には至らないが、ノーリスクな改善

## Test plan

- [x] `pnpm --filter @suzumina.click/shared-types typecheck` ✓
- [x] `pnpm --filter @suzumina.click/shared-types lint` ✓ (Checked 97 files, no fixes)
- [x] `pnpm --filter @suzumina.click/shared-types test` ✓ (33 files / 913 tests)
- [x] `pnpm --filter @suzumina.click/web typecheck` ✓
- [x] `pnpm --filter @suzumina.click/web build` ✓ (BEFORE / AFTER 両方成功)
- [ ] production deploy 後に PSI v5 mobile で `/` の LCP 再計測（5.0s → ?）

🤖 Generated with [Claude Code](https://claude.com/claude-code)