### PR TITLE
perf(web): Featured*Carousel を next/dynamic 化し Videos/Works も真の lazy 化（SPR-9）

### DIFF
--- a/apps/web/src/components/audio/featured-audio-buttons-carousel.tsx
+++ b/apps/web/src/components/audio/featured-audio-buttons-carousel.tsx
@@ -6,7 +6,7 @@ import { UI_MESSAGES } from "@/constants/ui-messages";
 import { useAudioButtonStatuses } from "@/hooks/use-audio-button-statuses";
 import { AudioButtonWithPlayCount } from "./audio-button-with-play-count";
 
-interface FeaturedAudioButtonsCarouselProps {
+export interface FeaturedAudioButtonsCarouselProps {
 	audioButtons: AudioButtonPlainObject[];
 }
 

--- a/apps/web/src/components/content/featured-videos-carousel.tsx
+++ b/apps/web/src/components/content/featured-videos-carousel.tsx
@@ -9,7 +9,7 @@ import {
 import VideoCard from "@/app/videos/components/VideoCard";
 import { UI_MESSAGES } from "@/constants/ui-messages";
 
-interface FeaturedVideosCarouselProps {
+export interface FeaturedVideosCarouselProps {
 	videos: VideoPlainObject[];
 }
 

--- a/apps/web/src/components/content/featured-works-carousel.tsx
+++ b/apps/web/src/components/content/featured-works-carousel.tsx
@@ -9,7 +9,7 @@ import {
 import WorkCard from "@/app/works/components/WorkCard";
 import { UI_MESSAGES } from "@/constants/ui-messages";
 
-interface FeaturedWorksCarouselProps {
+export interface FeaturedWorksCarouselProps {
 	works: WorkPlainObject[];
 }
 

--- a/apps/web/src/components/optimization/lazy-components.tsx
+++ b/apps/web/src/components/optimization/lazy-components.tsx
@@ -1,29 +1,47 @@
 /**
  * 遅延読み込み対応コンポーネント
  * Core Web Vitals改善のため、フォールドベロー（画面外）のコンポーネントを遅延読み込み
+ *
+ * 重い Featured*Carousel は `next/dynamic({ ssr: true, loading })` で chunk 分離し、
+ * 各セクションの実 skeleton と同じ寸法の placeholder を表示する。
+ * SSR を維持するため Mobile/SEO への副作用なし。
  */
 
+import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
+import dynamic from "next/dynamic";
 import { lazy } from "react";
 
 // 画面外のカルーセルコンポーネントを遅延読み込み
 // LCP改善: サーバーコンポーネントではなくクライアントコンポーネントを直接使用
 // ユーザー状態（いいね・低評価・お気に入り）はクライアントサイドで非同期取得
-export const LazyFeaturedAudioButtonsCarousel = lazy(() =>
-	import("@/components/audio/featured-audio-buttons-carousel").then((module) => ({
-		default: module.FeaturedAudioButtonsCarousel,
-	})),
+export const LazyFeaturedAudioButtonsCarousel = dynamic(
+	() =>
+		import("@/components/audio/featured-audio-buttons-carousel").then(
+			(module) => module.FeaturedAudioButtonsCarousel,
+		),
+	{
+		loading: () => <LoadingSkeleton variant="carousel" height={280} />,
+	},
 );
 
-export const LazyFeaturedVideosCarousel = lazy(() =>
-	import("@/components/content/featured-videos-carousel").then((module) => ({
-		default: module.FeaturedVideosCarousel,
-	})),
+export const LazyFeaturedVideosCarousel = dynamic(
+	() =>
+		import("@/components/content/featured-videos-carousel").then(
+			(module) => module.FeaturedVideosCarousel,
+		),
+	{
+		loading: () => <LoadingSkeleton variant="carousel" height={300} />,
+	},
 );
 
-export const LazyFeaturedWorksCarousel = lazy(() =>
-	import("@/components/content/featured-works-carousel").then((module) => ({
-		default: module.FeaturedWorksCarousel,
-	})),
+export const LazyFeaturedWorksCarousel = dynamic(
+	() =>
+		import("@/components/content/featured-works-carousel").then(
+			(module) => module.FeaturedWorksCarousel,
+		),
+	{
+		loading: () => <LoadingSkeleton variant="carousel" height={350} />,
+	},
 );
 
 // 検索フォームの遅延読み込み（オートコンプリート機能など重い処理）

--- a/apps/web/src/components/sections/videos-section.tsx
+++ b/apps/web/src/components/sections/videos-section.tsx
@@ -4,7 +4,7 @@ import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import Link from "next/link";
-import { FeaturedVideosCarousel } from "@/components/content/featured-videos-carousel";
+import { LazyFeaturedVideosCarousel } from "@/components/optimization/lazy-components";
 
 interface VideosSectionProps {
 	videos?: VideoPlainObject[];
@@ -69,7 +69,7 @@ export function VideosSection({ videos = [], loading = true, error = null }: Vid
 						</Link>
 					</Button>
 				</div>
-				<FeaturedVideosCarousel videos={videos} />
+				<LazyFeaturedVideosCarousel videos={videos} />
 			</div>
 		</section>
 	);

--- a/apps/web/src/components/sections/works-section.tsx
+++ b/apps/web/src/components/sections/works-section.tsx
@@ -4,7 +4,7 @@ import type { WorkPlainObject } from "@suzumina.click/shared-types";
 import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import Link from "next/link";
-import { FeaturedWorksCarousel } from "@/components/content/featured-works-carousel";
+import { LazyFeaturedWorksCarousel } from "@/components/optimization/lazy-components";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 
 interface WorksSectionProps {
@@ -87,7 +87,7 @@ export function WorksSection({
 						</Link>
 					</Button>
 				</div>
-				<FeaturedWorksCarousel works={worksToShow} />
+				<LazyFeaturedWorksCarousel works={worksToShow} />
 			</div>
 		</section>
 	);


### PR DESCRIPTION
## Summary

3 つの Featured*Carousel を `next/dynamic({ ssr: true, loading })` に統一:

- `LazyFeaturedAudioButtonsCarousel`: React.lazy → next/dynamic (skeleton fallback を `loading` prop に統合)
- `LazyFeaturedVideosCarousel`: **これまで dead export** だったので、`videos-section.tsx` の eager import を置換 → 真の lazy 化
- `LazyFeaturedWorksCarousel`: **これまで dead export** だったので、`works-section.tsx` の eager import を置換 → 真の lazy 化

[SPR-9](https://linear.app/nothink/issue/SPR-9) Mobile LCP 改善トラッキングの **E1** に相当。

## 期待と実測の乖離（重要）

[SPR-9 のコメント](https://linear.app/nothink/issue/SPR-9) では「Embla Carousel chunk が全 14 ページに含まれ、本変更で全ページから排除されれば LCP -0.4-0.6s」と予測されていた。

しかし実調査で:
- 全ページ共通の 231 KB chunk (`rootMainFiles` 配下) は **React/Next.js framework code** だった (Embla ではない)
- 実際の Embla + Carousel コードは home 専用 chunk (77 KB) に**すでに分離されている**
- なので「Embla を他ページから排除する」効果は**初めから存在しなかった**

## 実測結果 (local production build vs current main)

| Page | BEFORE | AFTER | Δ |
|------|-------:|------:|---:|
| `/` | 925.5 KB | **919.1 KB** | -6.4 KB |
| `/buttons` | 932.1 KB | 932.1 KB | ±0 |
| `/videos` | 937.1 KB | 937.1 KB | ±0 |
| `/works` | 937.7 KB | 937.7 KB | ±0 |
| `/circles` | 919.5 KB | 919.6 KB | ±0 |
| `/creators` | 920.4 KB | 920.4 KB | ±0 |
| `/search` | 982.5 KB | 982.5 KB | ±0 |
| `/favorites` | 924.2 KB | 924.2 KB | ±0 |
| `/contact` | 1117.7 KB | 1117.7 KB | ±0 |
| `/about` | 770.1 KB | 770.1 KB | ±0 |
| `/settings` | 790.6 KB | 790.6 KB | ±0 |
| `/privacy` | 770.1 KB | 770.1 KB | ±0 |
| `/terms` | 770.1 KB | 770.1 KB | ±0 |

home の -6.4 KB は Videos/Works carousel が初めて chunk 分離されたことによる。

## それでも本 PR の価値

1. **Dead code 排除**: `LazyFeaturedVideosCarousel` / `LazyFeaturedWorksCarousel` がこれまで export されているのに使用されていなかったのを実際に使用化
2. **設計の統一**: 3 つの Featured*Carousel が同じ lazy パターン (`next/dynamic({ ssr: true, loading })`) に揃った。skeleton 寸法 (height=280/300/350) も loading prop に集約
3. **Runtime hydration の deferral**: 静的サイズには現れないが、dynamic chunk が hydration 経路を経由するため、main thread の初期作業が後ろ倒しになる可能性。Mobile CPU での LCP 効果は **PSI v5 で実測が必要**
4. **Props interface を export 化**: next/dynamic の型推論のため `FeaturedAudioButtonsCarouselProps` 等 3 つを export (副作用なし)

## Files changed

- `apps/web/src/components/optimization/lazy-components.tsx`: React.lazy → next/dynamic, LoadingSkeleton import 追加
- `apps/web/src/components/sections/{videos,works}-section.tsx`: 各 Lazy* に切替 (2 行ずつ)
- `apps/web/src/components/{audio/featured-audio-buttons,content/featured-{videos,works}}-carousel.tsx`: props interface を export 化 (1 行ずつ)

## Test plan

- [x] `pnpm --filter @suzumina.click/web typecheck` ✓
- [x] `pnpm --filter @suzumina.click/web lint` ✓
- [x] `pnpm --filter @suzumina.click/web test` ✓ (61 files / 685 tests pass / 1 skipped)
- [x] `pnpm --filter @suzumina.click/web build` ✓ (BEFORE/AFTER 両方成功)
- [ ] production deploy 後に PSI v5 mobile で `/` の LCP / TBT を比較計測

## Linear E1 完了基準への補足

PSI で home の LCP / TBT が改善していない場合、次の選択肢:

- **(a)** Videos/Works に `ssr: false` を追加適用 (mobile で下の方なので initial HTML から外す)。SEO 影響あり
- **(b)** E1 を実質完了とし、より効果が予測可能な E2 (`/works` `/videos` list 先頭画像に `fetchPriority="high"`) に進む
- **(c)** RUM で実ユーザーの LCP/TBT を観測してから判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)