### PR TITLE
perf(web): WorksList の先頭 6 件に priority を立てて Mobile LCP 改善（SPR-9 E2）

### DIFF
--- a/apps/web/src/app/works/components/WorksList.tsx
+++ b/apps/web/src/app/works/components/WorksList.tsx
@@ -81,7 +81,7 @@ export default function WorksList({ initialData }: WorksListProps) {
 			<ConfigurableList<WorkPlainObject>
 				items={initialItems}
 				initialTotal={initialTotal}
-				renderItem={(work) => <WorkListItem work={work} />}
+				renderItem={(work, index) => <WorkListItem work={work} priority={index < 6} />}
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}

--- a/apps/web/src/components/work/WorkListItem.tsx
+++ b/apps/web/src/components/work/WorkListItem.tsx
@@ -3,8 +3,9 @@ import WorkCard from "@/app/works/components/WorkCard";
 
 interface WorkListItemProps {
 	work: WorkPlainObject;
+	priority?: boolean;
 }
 
-export function WorkListItem({ work }: WorkListItemProps) {
-	return <WorkCard work={work} />;
+export function WorkListItem({ work, priority = false }: WorkListItemProps) {
+	return <WorkCard work={work} priority={priority} />;
 }


### PR DESCRIPTION
## Summary

`WorksList` が `ConfigurableList` の `renderItem` に index を渡しておらず、`WorkListItem` も `priority` prop を持っていなかったため、`/works` の先頭画像は `loading="lazy"` / 通常 `fetchPriority` のまま読み込まれていた。`VideoList` が既に採用している `priority={index < 6}` と同じパターンを適用。

[SPR-9](https://linear.app/nothink/issue/SPR-9) の **E2** に相当。

## 変更点

- `WorkListItem`: optional `priority?: boolean` を追加、`WorkCard` に forward
- `WorksList`: `renderItem={(work) => ...}` → `renderItem={(work, index) => <WorkListItem work={work} priority={index < 6} />}`

`WorkCard` 側は既存の `priority` prop (`ThumbnailImage` に `next/image` の `priority` として渡る) を活用するだけ — 既存のインフラを利用。

## 計測根拠 ([SPR-9 PSI v5 / 2026-05-28](https://linear.app/nothink/issue/SPR-9))

| Page | Mobile LCP (今回) | 状態 |
|---|---:|---|
| `/works` | **5.1 s** | 目標 2.0 s + 3.1 s | priority 未適用 → 本 PR の対象 |
| `/videos` | 3.4 s | priority 既適用 ✓ | 参考: 同パターンで効果実証済み |

`/videos` が priority 適用済みで 3.4 s、`/works` が未適用で 5.1 s — 同じパターンを `/works` に適用することで、少なくとも `/videos` 程度の LCP に近づくことを期待。

## 期待効果の補正

Linear の元コメントでは **LCP -0.8-1.2 s** と予測されていたが、PSI 計測時に判明した制約:

- `/works` `/videos` 両ページとも **client-render** (Cache Components 構成のため list 部分は hydration 後にレンダリング)
- 初期 HTML に `<link rel="preload" as="image">` は出ない (静的 SSR ではないため)
- `priority` の効果は **hydration 後の img タグに `fetchpriority="high"` と `loading="eager"` が付く** ことのみ
- そのため LCP 短縮は **-200-500 ms** 程度に留まる見込み (preload 経路の効果が得られないため)

それでも `loading="lazy"` 解除によりブラウザの fetch 判断が前倒しになるため、リスクゼロの改善。

## スコープ外（follow-up 候補）

`WorkListItem` は `/circles/[circleId]` (`CircleWorksList`) と `/creators/[creatorId]` (`CreatorWorksList`) でも使われており、両者とも同パターンを 1 行で適用可能だが、本 PR は E2 スコープ (`/works` `/videos`) に厳格に従う:

- `/circles/[circleId]` は Mobile LCP 2.3 s で既に目標近傍 → 追加 priority は marginal
- `/creators/[creatorId]` は PSI 計測不能 → 効果不明、まず計測経路を回復する別 Issue が先

両者へ展開する小 PR は SPR-9 にコメント残し済 (次タスク候補)。

## Test plan

- [x] `pnpm --filter @suzumina.click/web typecheck` ✓
- [x] `pnpm --filter @suzumina.click/web lint` ✓
- [x] `pnpm --filter @suzumina.click/web test` ✓ (61 files / 685 tests pass / 1 skipped)
- [x] `pnpm --filter @suzumina.click/web build` ✓
- [ ] production deploy 後に PSI v5 mobile `/works` の LCP 再計測 (5.1 s → ?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)