### PR TITLE
perf(web): /works の priority 適用範囲を 6 → 2 に縮小（TBT regression fix, SPR-9 E2 follow-up）

### DIFF
--- a/apps/web/src/app/works/components/WorksList.tsx
+++ b/apps/web/src/app/works/components/WorksList.tsx
@@ -81,7 +81,10 @@ export default function WorksList({ initialData }: WorksListProps) {
 			<ConfigurableList<WorkPlainObject>
 				items={initialItems}
 				initialTotal={initialTotal}
-				renderItem={(work, index) => <WorkListItem work={work} priority={index < 6} />}
+				// 先頭 2 件のみ priority。PR #439 で <6 を試したが /works の DLsite
+				// 画像 (~250x250) は decode コストが高く、6 並列で TBT +210ms regression
+				// (SPR-9 / 2026-05-28 PSI 3 サンプル中央値で確認) したため縮小。
+				renderItem={(work, index) => <WorkListItem work={work} priority={index < 2} />}
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}


### PR DESCRIPTION
## Summary

PR [#439](https://github.com/nothink-jp/suzumina.click/pull/439) で `WorksList` に `priority={index < 6}` を適用したところ、deploy 後の PSI 計測で **TBT が +210 ms regression** していたため、`< 6` → `< 2` に縮小して原状回復を狙う 1 行修正。

LCP 改善 (-0.3 s) は維持される見込み。

[SPR-9](https://linear.app/nothink/issue/SPR-9) E2 の follow-up。

## 計測根拠 (deploy 後 3 サンプル中央値, SPR-9 コメント参照)

| Metric | Pre-#439 | After-#439 | After-本PR (予測) |
|---|---:|---:|---:|
| Score | 68 | 63 | ~67 (戻る) |
| LCP | 5.1 s | **4.8 s** ✓ | 4.7-4.9 s (維持) |
| TBT | 330 ms | **540 ms** ⚠️ | 330-400 ms (戻る) |
| SI | 6.3 s | 5.7 s | ~6.0 s |

## 原因分析

`/works` の thumbnail は **DLsite 画像 (~250×250 px)**、`/videos` の thumbnail は **YouTube 画像 (~120×90 px)**。Mobile 4G + CPU throttling 下で:

- `/works` priority < 6: **6 並列の高解像度 image decode → main thread の long task が増 → TBT 悪化**
- `/videos` priority < 6: 小さいサムネなので decode が軽く、TBT 320 ms と安定

`/works` には絞り込んだ priority 適用が必要。

## なぜ「2」か

- Mobile (1-2 col grid): 先頭 1-2 件が above-the-fold = LCP element
- Desktop (4 col grid): 先頭 4 件が above-the-fold だが、最初の 2 件が左寄り = visual priority 高
- 2 件は Google の image priority hints best practice ("1-2 above-the-fold images") に沿う
- 3 サンプル中央値で TBT 戻りを次の deploy で確認

VideoList の `< 6` はそのまま維持 (regression していないため)。

## Files changed

- `apps/web/src/app/works/components/WorksList.tsx`: 1 行修正 + 経緯コメント 3 行追加

## Test plan

- [x] `pnpm --filter @suzumina.click/web typecheck` ✓
- [x] `pnpm --filter @suzumina.click/web lint` ✓
- [ ] deploy 後に PSI v5 mobile `/works` 3 サンプルで TBT 中央値 < 400 ms を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)