### PR TITLE
perf(web): home の Latest{AudioButtons,Videos,Works} を unstable_cache(60s) 化（SPR-71 Workstream B 検証）

### DIFF
--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -1,5 +1,6 @@
 import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { Button } from "@suzumina.click/ui/components/ui/button";
+import { unstable_cache } from "next/cache";
 import Link from "next/link";
 import { connection } from "next/server";
 import { Suspense } from "react";
@@ -13,7 +14,31 @@ import { WorksSection } from "@/components/sections/works-section";
  * `await connection()` は Firestore SDK 内部の同期的なランダム値参照を
  * Cache Components の build-time prerender が検出してしまうのを回避するため、
  * 「このコンポーネントはリクエスト時に動的レンダリングする」ことを明示する。
+ *
+ * Firestore 取得は unstable_cache で 60s revalidate し、Suspense 解決時間を
+ * 短縮することで Chrome の LCP element render delay を抑制する (SPR-71 Workstream B)。
+ * Cache TTL は next.config.mjs の `/` の Cache-Control: public, s-maxage=60 と整合。
  */
+
+const HOME_REVALIDATE_SECONDS = 60;
+
+const getCachedLatestAudioButtons = unstable_cache(
+	async () => getLatestAudioButtons(10),
+	["home-latest-audio-buttons"],
+	{ revalidate: HOME_REVALIDATE_SECONDS, tags: ["home-audio-buttons"] },
+);
+
+const getCachedLatestVideos = unstable_cache(
+	async () => getLatestVideos(10),
+	["home-latest-videos"],
+	{ revalidate: HOME_REVALIDATE_SECONDS, tags: ["home-videos"] },
+);
+
+const getCachedLatestWorks = unstable_cache(
+	async (excludeR18: boolean) => getLatestWorks(10, excludeR18),
+	["home-latest-works"],
+	{ revalidate: HOME_REVALIDATE_SECONDS, tags: ["home-works"] },
+);
 
 /**
  * セクション共通の header DOM。
@@ -56,7 +81,7 @@ export function AudioButtonsSectionSkeleton() {
 
 export async function AudioButtonsSection() {
 	await connection();
-	const audioButtons = await getLatestAudioButtons(10);
+	const audioButtons = await getCachedLatestAudioButtons();
 
 	return (
 		<section className="py-8 sm:py-12 bg-background">
@@ -72,15 +97,15 @@ export async function AudioButtonsSection() {
 
 export async function VideosSectionAsync() {
 	await connection();
-	const videos = await getLatestVideos(10);
+	const videos = await getCachedLatestVideos();
 	return <VideosSection videos={videos} loading={false} error={null} />;
 }
 
 export async function WorksSectionAsync() {
 	await connection();
 	const [works, allAgesWorks] = await Promise.all([
-		getLatestWorks(10, false),
-		getLatestWorks(10, true),
+		getCachedLatestWorks(false),
+		getCachedLatestWorks(true),
 	]);
 	return <WorksSection works={works} allAgesWorks={allAgesWorks} loading={false} error={null} />;
 }


### PR DESCRIPTION
## Summary

- `/` の Mobile LCP renderDelay 4.8s の root cause = 3 つの動的 Suspense セクション（`AudioButtonsSection` / `VideosSectionAsync` / `WorksSectionAsync`）の Firestore 取得 streaming が、Chrome の LCP API による hero `<p>` LCP 確定タイミングを遅延させていたこと
- それらの取得を `unstable_cache(60s)` で wrap し、cache hit 時に Firestore latency を実質 0ms 化して streaming 完了を早める
- TTL 60s は既存の `next.config.mjs` の `/` Cache-Control: `public, s-maxage=60` と整合

## 背景・調査詳細

[SPR-71](https://linear.app/nothink/issue/SPR-71) Workstream B の検証 PR。PSI v5 で 5 ページ計測した結果、dynamic Suspense セクション数と LCP renderDelay の正の相関を確認:

| Page | dynamic sections | LCP renderDelay |
| -- | -- | -- |
| `/about` | 0 | 919ms |
| `/circles` | 1 | 1392ms |
| `/` | 3 | **4805ms** |

詳細は [SPR-71 のコメント](https://linear.app/nothink/issue/SPR-71#comment-bca50f5e) を参照。

## 変更点

`apps/web/src/components/home/dynamic-home-sections.tsx`:
- `unstable_cache(fn, [key], { revalidate: 60, tags })` で 3 つの Firestore 取得をラップ
- `getLatestAudioButtons`, `getLatestVideos`, `getLatestWorks` の本体 (`apps/web/src/app/actions.ts`) は変更なし
- `await connection()` は維持（Cache Components の安定動作のため）
- tags は `home-audio-buttons` / `home-videos` / `home-works`（将来の `revalidateTag` 用、本実装 PR で ingestion 側に caller を追加）

## 期待効果

- Suspense 内データ取得が cache hit で実質 0ms 化 → streaming 早期完了
- LCP renderDelay が `/about` `/circles` レベル (~1.4s) まで短縮見込み
- **`/` LCP 4.37s → ~2.0s (-2.4s) 推定** (cache hit 時)
- 副作用: データ鮮度 60s ゆれを許容

## Test plan

### 事前 CI 検証 (実施済み)

- [x] `pnpm typecheck` PASS
- [x] `pnpm lint` PASS (新規警告なし)
- [x] `pnpm --filter @suzumina.click/web test` PASS (685/685)
- [x] `pnpm --filter @suzumina.click/web build` PASS、`/` は `◐ Partial Prerender` 維持

### Deploy 後の効果実測 (warm cache 戦略)

⚠️ **重要**: `unstable_cache` の TTL は **60s**、PSI server-side cache は **~5 分**。両者を両立させる測定戦略が必要。

単純に「5 分間隔で 3 サンプル」を取ると **毎回 cold cache** になり、本 PR の効果が一切現れず誤って pivot する可能性があるため、以下の warm cache 戦略を採用:

#### Warm cache measurement protocol

1. **deploy 完了を確認** (Cloud Run revision active)
2. **warm-up**: `curl -s https://suzumina.click/ -H "User-Agent: warmup" > /dev/null` を 1 回実行 (Cloud Run instance の unstable_cache を warm)
3. **直後 (60s 以内)** に PSI を mobile で 1 サンプル取得 (PSI 内部 Lighthouse は cache-bust するが、Cloud Run instance 上の unstable_cache は hit する)
4. PSI server cache を抜けるため **10 分待機**
5. 上記 2-3 を再実行 → **2 サンプル目**
6. 同じく 10 分待機 → **3 サンプル目**

#### 判定基準

- **比較対象**: PR マージ前の cold cache 実測値 (median LCP = 4.37 s, renderDelay 4.8 s)
- **判定**:
  - warm sample 中央値 ≤ **2.5 s** → 仮説確証、本実装 PR (tags の revalidateTag caller を ingestion 側に追加) へ進む
  - warm sample 中央値 **2.5-3.5 s** → 部分的に効果あり、他要因 (initial JS / bootstrap chunk) も検討
  - warm sample 中央値 ≥ **3.5 s** → 仮説棄却、Workstream A (Cloud Run cold start) または C (initial JS) に pivot

#### 補助計測 (任意)

- **cold sample も 1 つ取得** (deploy 直後、warm-up なしの最初の PSI 1 回) → cold/warm の差分から cache の実効効果を確認
- 計測中は `next.config.mjs` の `/` Cache-Control を Cloudflare が尊重しているか `cf-cache-status` ヘッダで確認

## SPR-71 関連

- Linear epic: [SPR-71](https://linear.app/nothink/issue/SPR-71)
- 親トラッキング: [SPR-9](https://linear.app/nothink/issue/SPR-9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)