### PR TITLE
perf(web): / の FeaturedAudioButtonsCarousel を React.lazy + mounted gate で defer load（SPR-71 Workstream C 検証）

### DIFF
--- a/apps/web/src/components/home/__tests__/audio-buttons-carousel-deferred.test.tsx
+++ b/apps/web/src/components/home/__tests__/audio-buttons-carousel-deferred.test.tsx
@@ -1,0 +1,93 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AudioButtonsCarouselDeferred } from "../audio-buttons-carousel-deferred";
+
+// FeaturedAudioButtonsCarousel をモック化して lazy() の resolve 内容を制御する。
+// 実コンポーネントは next-auth/react や Firestore action を含むため、
+// 本テストでは defer ロジック (skeleton → lazy mount) のみを検証する。
+vi.mock("@/components/audio/featured-audio-buttons-carousel", () => ({
+	FeaturedAudioButtonsCarousel: ({ audioButtons }: { audioButtons: AudioButtonPlainObject[] }) => (
+		<div data-testid="mocked-featured-carousel">
+			<span data-testid="carousel-count">{audioButtons.length}</span>
+			{audioButtons.map((b) => (
+				<span key={b.id} data-testid="carousel-item">
+					{b.title}
+				</span>
+			))}
+		</div>
+	),
+}));
+
+const buildAudioButton = (id: string, title: string): AudioButtonPlainObject =>
+	({
+		id,
+		title,
+		description: "",
+		tags: [],
+		sourceVideoId: "video-1",
+		sourceVideoTitle: "video title",
+		sourceVideoThumbnailUrl: "",
+		startTime: 0,
+		endTime: 1,
+		createdBy: "user-1",
+		createdByName: "user",
+		isPublic: true,
+		playCount: 0,
+		likeCount: 0,
+		dislikeCount: 0,
+		favoriteCount: 0,
+		createdAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+		_computed: {
+			isPopular: false,
+			engagementRate: 0,
+			engagementRatePercentage: 0,
+			popularityScore: 0,
+			searchableText: title,
+			durationText: "1秒",
+			relativeTimeText: "今",
+		},
+	}) as unknown as AudioButtonPlainObject;
+
+describe("AudioButtonsCarouselDeferred", () => {
+	const audioButtons = [buildAudioButton("a-1", "テスト1"), buildAudioButton("a-2", "テスト2")];
+
+	it("初期 render (mounted=false 相当) で skeleton を返す", () => {
+		render(<AudioButtonsCarouselDeferred audioButtons={audioButtons} />);
+
+		// LoadingSkeleton variant="carousel" の testid
+		expect(screen.getByTestId("loading-skeleton-carousel")).toBeInTheDocument();
+		// この時点ではまだ lazy 対象は load されていない
+		expect(screen.queryByTestId("mocked-featured-carousel")).not.toBeInTheDocument();
+	});
+
+	it("useEffect 発火後に lazy chunk が load され、実 carousel が render される", async () => {
+		render(<AudioButtonsCarouselDeferred audioButtons={audioButtons} />);
+
+		// useEffect が発火し mounted=true → Suspense fallback → lazy resolve の順で
+		// 最終的に mocked carousel が現れる
+		await waitFor(() => {
+			expect(screen.getByTestId("mocked-featured-carousel")).toBeInTheDocument();
+		});
+
+		// audioButtons prop が正しく渡されることを確認
+		expect(screen.getByTestId("carousel-count")).toHaveTextContent("2");
+		const items = screen.getAllByTestId("carousel-item");
+		expect(items).toHaveLength(2);
+		expect(items[0]).toHaveTextContent("テスト1");
+		expect(items[1]).toHaveTextContent("テスト2");
+	});
+
+	// Note: 初期 skeleton の存在チェックは test 1 で網羅済み。本 test では
+	// lazy() の module キャッシュが先行 test で温まると skeleton phase を
+	// 観測できないため、final 状態のみを検証する。
+	it("audioButtons が空配列でも lazy resolve 後の carousel が render される", async () => {
+		render(<AudioButtonsCarouselDeferred audioButtons={[]} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("mocked-featured-carousel")).toBeInTheDocument();
+		});
+		expect(screen.getByTestId("carousel-count")).toHaveTextContent("0");
+	});
+});

--- a/apps/web/src/components/home/audio-buttons-carousel-deferred.tsx
+++ b/apps/web/src/components/home/audio-buttons-carousel-deferred.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
+import { lazy, Suspense, useEffect, useState } from "react";
+
+/**
+ * Featured AudioButtons Carousel を初期 bundle から完全に除外する client wrapper。
+ *
+ * 子の AudioButtonWithFavoriteClient が `useSession()` を呼ぶため、
+ * 通常 import すると next-auth/react が `/` の初期 JS bundle に流入する。
+ * `React.lazy` + `useEffect` で hydration 後にのみ chunk import を開始し、
+ * 初期 bundle から完全に除外する (SPR-71 Workstream C 検証)。
+ *
+ * CLS 対策:
+ * - SSR / hydration 初回: 同サイズの skeleton (h=280) を返す
+ * - useEffect 発火後: lazy chunk の Suspense fallback も同じ skeleton
+ * - chunk load 完了: 実 Carousel に差し替え (同サイズなので shift なし)
+ *
+ * 上位の AudioButtonsSection の Suspense fallback (AudioButtonsSectionSkeleton)
+ * は data 取得待ち時に使用され、本 component の skeleton と高さ整合済み。
+ */
+
+const LazyCarousel = lazy(() =>
+	import("@/components/audio/featured-audio-buttons-carousel").then((m) => ({
+		default: m.FeaturedAudioButtonsCarousel,
+	})),
+);
+
+export function AudioButtonsCarouselDeferred({
+	audioButtons,
+}: {
+	audioButtons: AudioButtonPlainObject[];
+}) {
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	const fallback = <LoadingSkeleton variant="carousel" height={280} />;
+
+	if (!mounted) return fallback;
+
+	return (
+		<Suspense fallback={fallback}>
+			<LazyCarousel audioButtons={audioButtons} />
+		</Suspense>
+	);
+}

--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -3,9 +3,8 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 import { unstable_cache } from "next/cache";
 import Link from "next/link";
 import { connection } from "next/server";
-import { Suspense } from "react";
 import { getLatestAudioButtons, getLatestVideos, getLatestWorks } from "@/app/actions";
-import { LazyFeaturedAudioButtonsCarousel } from "@/components/optimization/lazy-components";
+import { AudioButtonsCarouselDeferred } from "@/components/home/audio-buttons-carousel-deferred";
 import { VideosSection } from "@/components/sections/videos-section";
 import { WorksSection } from "@/components/sections/works-section";
 
@@ -87,9 +86,7 @@ export async function AudioButtonsSection() {
 		<section className="py-8 sm:py-12 bg-background">
 			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
 				<AudioButtonsSectionHeader />
-				<Suspense fallback={<LoadingSkeleton variant="carousel" height={280} />}>
-					<LazyFeaturedAudioButtonsCarousel audioButtons={audioButtons} />
-				</Suspense>
+				<AudioButtonsCarouselDeferred audioButtons={audioButtons} />
 			</div>
 		</section>
 	);

--- a/apps/web/src/components/optimization/lazy-components.tsx
+++ b/apps/web/src/components/optimization/lazy-components.tsx
@@ -14,15 +14,10 @@ import { lazy } from "react";
 // 画面外のカルーセルコンポーネントを遅延読み込み
 // LCP改善: サーバーコンポーネントではなくクライアントコンポーネントを直接使用
 // ユーザー状態（いいね・低評価・お気に入り）はクライアントサイドで非同期取得
-export const LazyFeaturedAudioButtonsCarousel = dynamic(
-	() =>
-		import("@/components/audio/featured-audio-buttons-carousel").then(
-			(module) => module.FeaturedAudioButtonsCarousel,
-		),
-	{
-		loading: () => <LoadingSkeleton variant="carousel" height={280} />,
-	},
-);
+//
+// 注: FeaturedAudioButtonsCarousel は SPR-71 Workstream C で初期 bundle から完全に
+// 除外するため `audio-buttons-carousel-deferred.tsx` (React.lazy + mounted gate) に
+// 移行済み。本ファイルには定義しない。
 
 export const LazyFeaturedVideosCarousel = dynamic(
 	() =>


### PR DESCRIPTION
## Summary

- `/` の Mobile LCP の bottleneck が App Router bootstrap chunk の JS execution に移動 (PR #441 検証で判明) したため、ユーザコード側の hydration cost を削減
- `FeaturedAudioButtonsCarousel` 内の `AudioButtonWithFavoriteClient` が `useSession()` を呼ぶため next-auth/react が `/` 初期 bundle に流入していた
- React.lazy + useEffect+mounted state pattern で Carousel chunk (~67 KB uncompressed) を完全に defer load

## 背景

[SPR-71 Workstream C 調査結果](https://linear.app/nothink/issue/SPR-71#comment-228ae9c9) より、`/` 初期 bundle の内訳:
- Next.js framework (bootstrap + runtime + polyfills): ~140 KB compressed (削減不能)
- ユーザコード: ~100 KB compressed (削減可能)
- うち、Carousel + useSession 経由の next-auth/react が約 30-50 KB を占める

## 変更点

### 新規: `apps/web/src/components/home/audio-buttons-carousel-deferred.tsx`

```tsx
"use client";
const LazyCarousel = lazy(() =>
  import("@/components/audio/featured-audio-buttons-carousel").then((m) => ({
    default: m.FeaturedAudioButtonsCarousel,
  })),
);

export function AudioButtonsCarouselDeferred({ audioButtons }) {
  const [mounted, setMounted] = useState(false);
  useEffect(() => { setMounted(true); }, []);
  const fallback = <LoadingSkeleton variant="carousel" height={280} />;
  if (!mounted) return fallback;
  return <Suspense fallback={fallback}><LazyCarousel audioButtons={audioButtons} /></Suspense>;
}
```

### 新規: `apps/web/src/components/home/__tests__/audio-buttons-carousel-deferred.test.tsx`

defer ロジックの smoke test (3 ケース):
- 初期 render で skeleton を返す
- useEffect 発火 → lazy resolve 後に実 carousel が render される
- 空配列でも問題なく defer から resolve まで遷移する

### 修正: `apps/web/src/components/home/dynamic-home-sections.tsx`

`LazyFeaturedAudioButtonsCarousel` (next/dynamic, ssr:true) → `AudioButtonsCarouselDeferred` に置換。

### 修正: `apps/web/src/components/optimization/lazy-components.tsx`

Dead export となった `LazyFeaturedAudioButtonsCarousel` を削除 (`LazyFeaturedVideosCarousel`/`LazyFeaturedWorksCarousel` は引き続き使用中のため残置)。

## ssr:false ではなく lazy+useEffect を採用した理由

`next/dynamic({ ssr: false, loading })` は SSR 時 `null` を返すため、初期 HTML には Carousel 部分が空白となり layout shift (空 → skeleton → 実 carousel) が発生する。

`React.lazy` + `useEffect` で `mounted` を gate にすると:
- **SSR**: `mounted=false` → skeleton をレンダリング
- **client 初回 hydration**: `mounted=false` (useState 初期値) → skeleton (SSR と一致、hydration mismatch なし)
- **useEffect 発火後**: `mounted=true` → lazy chunk の Suspense fallback (同じ skeleton)
- **chunk load 完了**: 実 Carousel に差し替え (同サイズ、CLS=0)

## ローカル build 検証 (実測)

`/` page initial chunks に **Carousel 本体 chunks (3 個、合計 67 KB uncompressed) が含まれないこと**を確認:

```
✅ DEFERRED (not in / initial): 0001.bneu70sz.js (41915 bytes) — FeaturedAudioButtonsCarousel + AudioButtonWithFavoriteClient
✅ DEFERRED (not in / initial): 0b0komr6_fprr.js (12918 bytes)
✅ DEFERRED (not in / initial): 0nsm6kxkzqj_u.js (12891 bytes)
```

## 期待効果

- Initial bundle 削減 (Carousel chunk 67 KB を defer)
- `useSession()` 呼び出しの hydration cost を defer (初期 hydration が早く完了)
- **`/` Mobile LCP -100-300 ms 推定** (主に hydration short-circuit による)

## 注意 / 副作用

- **UX**: 旧実装は SSR で Carousel content を HTML に含めていたため hydration 直後から表示されたが、本 PR では client mount 後の lazy resolve まで skeleton が表示される (体感 100-300 ms の遷移)。CLS は 0 維持
- **SEO 影響 — 限定的だが要観察**:
  - Googlebot は JS 実行可能 (rendered DOM を indexing)
  - **Slack / Twitter / Discord などの link preview generator は基本 JS 非実行** のため、初期 HTML に carousel content が含まれなくなる影響を受ける
  - Bing / Yahoo Japan は JS 実行が Google より不安定
  - 緩和材料: audio button 個別ページは `/buttons/[id]` で sitemap に存在し canonical な discovery path は別途確保されている。home page Carousel は SEO 主要 entry point ではない
- `SessionProvider` 本体 (38 KB chunk) は root layout に残るため、本 PR では除去せず。完全な除去は Workstream C option A (route group 分割) で別途検討

## Test plan

### 事前 CI 検証 (実施済み)

- [x] `pnpm typecheck` PASS
- [x] `pnpm lint` PASS (新規警告なし)
- [x] `pnpm --filter @suzumina.click/web test` PASS (688/688、新規 3 ケース追加)
- [x] `pnpm --filter @suzumina.click/web build` PASS、`/` は `◐ Partial Prerender` 維持
- [x] local build で Carousel chunk が `/` initial bundle から除外されていることを確認

### Deploy 後の効果実測

PR #441 で確立した warm cache protocol で再計測:

1. deploy 完了確認
2. `curl -s https://suzumina.click/?_warm=$(date +%s%N) -o /dev/null` で warm-up
3. 直後 (60s 以内) に PSI mobile sample 取得
4. 10 分待機 → 繰り返し → 計 3 warm samples

### 判定基準

- warm sample median LCP ≤ **3.5 s** (PR #441 deploy 後の 4.61 s から -1.1 s) → 仮説確証、本実装方針 (SessionProvider refactor 含む) へ進む
- 改善幅 < 500 ms → 構造的に user code 削減の余地が小さいと判明、Workstream A (Cloud Run) or 別アプローチに pivot

## SPR-71 関連

- Linear epic: [SPR-71](https://linear.app/nothink/issue/SPR-71)
- 前提となる cache PR: [#441](https://github.com/nothink-jp/suzumina.click/pull/441)
- 調査結果コメント: [SPR-71 Workstream C 調査](https://linear.app/nothink/issue/SPR-71#comment-228ae9c9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)