### PR TITLE
perf(infra): Cloud Run warm-up scheduler を /api/health から / に変更（SPR-71 Workstream A 検証）

### DIFF
--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -33,15 +33,26 @@ resource "google_cloud_scheduler_job" "fetch_youtube_videos_hourly" {
 # ==============================================================================
 # Cloud Runウォームアップスケジューラー
 # ==============================================================================
-# 目的: コールドスタートを防ぐために定期的にヘルスチェックエンドポイントを呼び出す
+# 目的:
+#   1. コールドスタートを防ぐために定期的にエンドポイントを呼び出す
+#   2. Next.js App Router の SSR path (Server Components + Firestore unstable_cache)
+#      を実際に exercise し、V8 JIT を `/` route handler 側で warm に保つ
+#
+# `/api/health` ではなく `/` を ping する理由 (SPR-71 Workstream A):
+#   - /api/health は static JSON で Next.js app handler を warm にしない
+#   - PSI の warm sample で TTFB が間欠的に 1s 超に跳ねる現象 (sample #4) は、
+#     instance は生きているが `/` route の handler が deoptimize されている
+#     "JIT warmth degradation" が疑われたため、実 route を直接 ping する
+#   - 直 Cloud Run URL 経由なので Cloudflare CDN cache は bypass される
+#
 # 実行時間: 日中（8-20時）の5分ごと
-# コスト: 約50円/月
+# コスト: ~50円/月 (Firestore 取得は unstable_cache 60s でほぼ cache hit)
 # ==============================================================================
 resource "google_cloud_scheduler_job" "cloud_run_warmup" {
   project     = var.gcp_project_id
   region      = var.region
   name        = "cloud-run-warmup"
-  description = "Cloud Runのコールドスタートを防ぐためのウォームアップジョブ"
+  description = "Cloud Run のコールドスタート防止 + `/` route handler の JIT warmth 維持"
 
   # 日本時間8-20時の間、5分ごとに実行
   # この時間帯が主要なアクセス時間と想定
@@ -50,7 +61,8 @@ resource "google_cloud_scheduler_job" "cloud_run_warmup" {
 
   # HTTPターゲット設定
   http_target {
-    uri         = "${google_cloud_run_v2_service.nextjs_app.uri}/api/health"
+    # 実 SSR path (`/`) を ping することで Next.js handler の JIT を維持する
+    uri         = google_cloud_run_v2_service.nextjs_app.uri
     http_method = "GET"
 
     # タイムアウト設定


### PR DESCRIPTION
## Summary

- PR #441/#442 deploy 後の PSI warm sample で TTFB が間欠的に 1 s 超に跳ねる現象を観測 (sample #4: FCP 2.4 s / TTFB 1.08 s)
- Cloud Run は `min_instances=1` + `cpu_idle=false` + `startup_cpu_boost=true` で起動済みのため、典型的 cold start ではなく **"V8 JIT warmth degradation"** を疑う
- 既存 warm-up scheduler は `/api/health` (static JSON) を ping していたため、Node.js process は生きていても Next.js app handler の JIT は冷えていた
- Warm-up endpoint を `/` (実 SSR path) に変更し、Server Components / Firestore unstable_cache / V8 JIT を全て active に保つ

## 背景

[SPR-71 Workstream C 検証コメント](https://linear.app/nothink/issue/SPR-71#comment-935022f5) より、warm sample の variance を支配しているのは bootstrap chunk × Cloud Run instance warmth の相互作用と判明:

| sample | LCP | FCP | TBT | TTFB | 評価 |
| -- | -- | -- | -- | -- | -- |
| post-#442 cold | 3306 ms | 1206 ms | 461 ms | 1.6 ms | OK |
| post-#442 warm #2 | 4361 ms | 1201 ms | 449 ms | 9 ms | OK |
| post-#442 warm #3 | 3077 ms | 1068 ms | 1234 ms | 0.9 ms | OK (TBT 高) |
| post-#442 warm #4 | **5121 ms** | **2372 ms** | 615 ms | **1.08 s** | **異常** |

`#4` の TTFB 1.08 s + FCP 2.4 s は instance は生きているが `/` route handler が deoptimize されている状態と整合する。Cloud Run の `cpu_boost=true` は instance startup のみ適用され、JIT 再 optimize には効かない。

## 変更内容

`terraform/scheduler.tf` 1 ファイル:

```diff
- uri         = "${google_cloud_run_v2_service.nextjs_app.uri}/api/health"
+ uri         = google_cloud_run_v2_service.nextjs_app.uri
```

加えて変更理由をコメントで詳細記述。

### なぜ `/api/health` から `/` に?

`apps/web/src/app/api/health/route.ts` は単に `NextResponse.json({status:"healthy",...})` を返す static handler で、Next.js app handler / Server Components / Firestore SDK を一切 exercise しない。Node.js process は alive のまま `/` route の handler コードが deoptimize される。

`/` を ping することで:
- Server Components の SSR pipeline 全体を exercise (静的シェル prerender + Suspense streaming)
- Firestore `unstable_cache` を維持 (60 s TTL)
- V8 JIT を `/` route handler 側で active に保つ

### CDN bypass

scheduler は `google_cloud_run_v2_service.nextjs_app.uri` (直 Cloud Run URL) を使用しているため Cloudflare CDN cache を bypass し、毎回 origin (Cloud Run) を確実に warm にする。

## コスト影響 (見積)

| 項目 | 旧 (/api/health) | 新 (/) | 差分 |
| -- | -- | -- | -- |
| Cloud Run CPU/req | ~100 ms | ~500 ms (SSR + cache hit) | +400 ms |
| 1日あたり ping 回数 | 156 (5min × 13h) | 156 | ±0 |
| Cloud Run CPU/day | ~16 sec | ~78 sec | +62 sec |
| Firestore reads/day | 0 | ~12 (cache miss as warm-up spans 60s TTL) | +12 |
| **月額追加コスト推定** | - | **~10-50 円** | - |

## 期待効果

- warm sample の TTFB variance (1+ s 跳ね) が改善
- warm sample LCP の median が安定し、PR #441/#442 の cold 改善 (4370 → 3306 ms) が warm でも観測可能になる見込み
- FCP の安定化 (現状 sample 間で 1.0-2.4 s と振れている)

## Test plan

terraform は GitHub Actions 経由でデプロイされるため事前検証は限定的:

- [x] `terraform fmt -check -diff` PASS (整形済)
- [x] terraform syntax 確認 (validate は provider plugin が無いと完全実行できないが、当該ファイルの記述は v2 service の attribute reference として既存パターンを踏襲)

### Deploy 後の効果実測

PR #441/#442 で使用した warm cache PSI protocol を再利用:

1. terraform apply 完了確認 (scheduler が新 URI に更新されたことを Cloud Console で確認)
2. ~10 分待機して新 scheduler が 1 回以上発火するのを待つ
3. warm cache protocol で 3 samples (5+ 分間隔、PSI server cache 回避)

### 判定基準

| 観察項目 | 合格 |
| -- | -- |
| warm sample 全 3 個で TTFB ≤ 0.5 s | sample #4 級の TTFB 1+ s が出ない |
| warm sample median LCP ≤ 3.5 s | PR #441/#442 後の 4.61/4.36 s から -0.86 s 以上 |
| FCP variance < 200 ms (3 sample 内) | bootstrap warmth が均一化 |

判定:
- TTFB variance 解消 + LCP median 改善 → 仮説確証、cold 改善 (3.3 s) と warm 一致を目指す
- variance のみ解消、LCP は不変 → bootstrap chunk 実行時間が真の lower bound、SPR-71 LCP 2.0 s 目標は Next.js framework 自体の高速化を待つ
- 全く改善せず → JIT warmth 仮説棄却、warm sample variance は PSI 環境ノイズ

## SPR-71 関連

- Linear epic: [SPR-71](https://linear.app/nothink/issue/SPR-71)
- 前提 PR: [#441 (cache)](https://github.com/nothink-jp/suzumina.click/pull/441), [#442 (carousel defer)](https://github.com/nothink-jp/suzumina.click/pull/442)
- 計測サマリーコメント: [SPR-71 Workstream A pivot](https://linear.app/nothink/issue/SPR-71#comment-935022f5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)