### PR TITLE
perf(web): /creators の getCreators を Promise.all で並列化（SPR-70）

### DIFF
--- a/apps/web/src/app/creators/actions.ts
+++ b/apps/web/src/app/creators/actions.ts
@@ -27,37 +27,33 @@ export async function getCreators(params: {
 		// 全クリエイターを取得
 		const creatorsSnapshot = await firestore.collection("creators").get();
 
-		// CreatorPageInfoに変換
-		const allCreators: CreatorPageInfo[] = [];
+		// 各クリエイターの works サブコレクションを並列取得して N+1 直列待ちを回避
+		const allCreators: CreatorPageInfo[] = await Promise.all(
+			creatorsSnapshot.docs.map(async (doc) => {
+				const creatorData = doc.data() as CreatorDocument;
+				const worksSnapshot = await doc.ref.collection("works").get();
 
-		for (const doc of creatorsSnapshot.docs) {
-			const creatorData = doc.data() as CreatorDocument;
-
-			// worksサブコレクションから作品数と役割を取得
-			const worksSnapshot = await doc.ref.collection("works").get();
-
-			const allTypes = new Set<string>();
-			worksSnapshot.docs.forEach((workDoc) => {
-				const workRelation = workDoc.data() as CreatorWorkRelation;
-				workRelation.roles?.forEach((r) => {
-					allTypes.add(r);
+				const allTypes = new Set<string>();
+				worksSnapshot.docs.forEach((workDoc) => {
+					const workRelation = workDoc.data() as CreatorWorkRelation;
+					workRelation.roles?.forEach((r) => {
+						allTypes.add(r);
+					});
 				});
-			});
 
-			// primaryRoleが設定されていて、typesに含まれていない場合は追加
-			if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
-				allTypes.add(creatorData.primaryRole);
-			}
+				// primaryRoleが設定されていて、typesに含まれていない場合は追加
+				if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
+					allTypes.add(creatorData.primaryRole);
+				}
 
-			const creatorInfo: CreatorPageInfo = {
-				id: creatorData.creatorId,
-				name: creatorData.name,
-				types: Array.from(allTypes),
-				workCount: worksSnapshot.size,
-			};
-
-			allCreators.push(creatorInfo);
-		}
+				return {
+					id: creatorData.creatorId,
+					name: creatorData.name,
+					types: Array.from(allTypes),
+					workCount: worksSnapshot.size,
+				} satisfies CreatorPageInfo;
+			}),
+		);
 
 		// 役割でフィルタリング
 		let filteredCreators = allCreators;


### PR DESCRIPTION
## Summary

- [SPR-70](https://linear.app/nothink/issue/SPR-70) — PSI v5 が `/creators` を `UNKNOWN_ERROR: Could not find relevant puppeteer page` / `Lighthouse returned error: Something went wrong` で計測不能だった件の対処
- `getCreators` の N+1 直列 await を `Promise.all` に置き換え、subcollection 取得を並列化

## 背景

SPR-70 で報告されていた 5 ページの PSI v5 計測失敗を再検証したところ、4 ページ (`/buttons` mobile+desktop, `/search` mobile, `/works` desktop) は SPR-71 完了後に副次的に計測可能に戻っていた。残るは `/creators` mobile + desktop のみ。

curl での切り分けで以下を確認:

- 通常 UA → `x-nextjs-postponed: 1` (PPR shell) が返り TTFB 147ms
- `Chrome-Lighthouse` UA → PPR shell ヘッダが消失し full dynamic SSR となり TTFB **20-22 秒** (3 連続 + desktop UA でも再現)
- Cloudflare で UA ブロックされていないことを確認 (HTTP 200 / `cf-ray` 同一)
- Cloud Run の `max_instance_request_concurrency=50` / `min_instances=1` / `cpu_boost=true` も問題なし

## 根本原因

`apps/web/src/app/creators/actions.ts` の `getCreators` が、全 creator を取得した後で各 creator の `works` サブコレクションを `for-await` で**直列**に取得していたため、Firestore round-trip が N 回直列に積み上がり 20+ 秒の応答時間になっていた。通常 UA は PPR shell が即返るため体感されないが、Lighthouse のような bot UA では `isbot` 判定により full SSR を完了させてからレスポンスが返るため、Lighthouse の document timeout を超過していた。

## 変更

`for-await` を `Promise.all` + `map` に置き換え、各 creator の subcollection 取得を並列化。filter / sort / pagination のセマンティクスは変更なし。

## Test plan

- [x] `pnpm --filter @suzumina.click/web lint` — 触ったファイルにエラー無し
- [x] `pnpm --filter @suzumina.click/web typecheck` — pass
- [x] `pnpm --filter @suzumina.click/web test -- --run` — 688 passed / 1 skipped
- [ ] デプロイ後 PSI v5 で `/creators` mobile + desktop が計測完了することを確認 (要 API key 実測)
- [ ] 計測値が取得できれば SPR-70 close、引き続き失敗するなら CreatorDocument への workCount/types denormalization を検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)