### PR TITLE
perf(web): CreatorDocument に workCount/types を denormalize（SPR-74 Phase B）

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -19,6 +19,7 @@
 		"tools:stats": "dotenv -e .env -- tsx src/tools/run-tools.ts stats",
 		"tools:report": "dotenv -e .env -- tsx src/tools/run-tools.ts report",
 		"tools:reset": "dotenv -e .env -- tsx src/tools/run-tools.ts reset",
+		"tools:backfill-creators": "dotenv -e .env -- tsx src/tools/run-tools.ts backfill-creators",
 		"tools:help": "dotenv -e .env -- tsx src/tools/run-tools.ts help",
 		"check:integrity": "dotenv -e .env -- tsx src/tools/core/run-data-integrity-check.ts",
 		"check:price-history": "dotenv -e .env -- tsx src/tools/check-price-history.ts",

--- a/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
@@ -12,6 +12,7 @@ import * as logger from "../../../shared/logger";
 import {
 	getCreatorWithWorks,
 	getCreatorWorkCount,
+	recomputeCreatorStats,
 	removeCreatorMappings,
 	updateCreatorPrimaryRole,
 	updateCreatorWorkMapping,
@@ -468,6 +469,46 @@ describe("creator-firestore", () => {
 
 			expect(result.creator).toBeNull();
 			expect(result.works).toEqual([]);
+		});
+	});
+
+	describe("recomputeCreatorStats", () => {
+		it("works から workCount/types/primaryRole を計算して update する", async () => {
+			mockGet.mockResolvedValueOnce({
+				empty: false,
+				size: 3,
+				docs: [
+					{ data: () => ({ workId: "RJ001", roles: ["voice"] }) },
+					{ data: () => ({ workId: "RJ002", roles: ["voice", "other"] }) },
+					{ data: () => ({ workId: "RJ003", roles: ["illustration"] }) },
+				],
+			});
+
+			await recomputeCreatorStats("VA001");
+
+			expect(mockUpdate).toHaveBeenCalledTimes(1);
+			const updateArg = mockUpdate.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(updateArg.workCount).toBe(3);
+			expect(new Set(updateArg.types as string[])).toEqual(
+				new Set(["voice", "other", "illustration"]),
+			);
+			expect(updateArg.primaryRole).toBe("voice");
+		});
+
+		it("works が空の場合は workCount=0, types=[] で update する", async () => {
+			mockGet.mockResolvedValueOnce({
+				empty: true,
+				size: 0,
+				docs: [],
+			});
+
+			await recomputeCreatorStats("VA001");
+
+			expect(mockUpdate).toHaveBeenCalledTimes(1);
+			const updateArg = mockUpdate.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(updateArg.workCount).toBe(0);
+			expect(updateArg.types).toEqual([]);
+			expect(updateArg.primaryRole).toBeUndefined();
 		});
 	});
 });

--- a/apps/functions/src/services/dlsite/creator-firestore.ts
+++ b/apps/functions/src/services/dlsite/creator-firestore.ts
@@ -221,6 +221,20 @@ export async function updateCreatorWorkMapping(
 			});
 		}
 
+		// SPR-74 Phase B: 影響を受けたクリエイターの workCount/types/primaryRole を再計算。
+		// マッピングの batch.commit は成功しているので、失敗しても処理結果は success のまま。
+		const affectedCreators = new Set<string>([
+			...processedCreators,
+			...Array.from(existingMappings.keys()),
+		]);
+		const results = await Promise.allSettled(
+			Array.from(affectedCreators).map((creatorId) => recomputeCreatorStats(creatorId)),
+		);
+		const failed = results.filter((r) => r.status === "rejected").length;
+		if (failed > 0) {
+			logger.warn(`クリエイター集計再計算で ${failed} 件失敗`, { workId });
+		}
+
 		return { success: true };
 	} catch (error) {
 		logger.error(`クリエイターマッピング更新エラー: ${workId}`, {
@@ -291,6 +305,63 @@ export async function getCreatorWorkCount(creatorId: string): Promise<number> {
 		});
 		return 0;
 	}
+}
+
+/**
+ * クリエイターの集計フィールド（workCount / types / primaryRole）を
+ * works サブコレクションから再計算して creator doc に書き戻す。
+ *
+ * SPR-74 Phase B で導入。/creators の読み込みパスがこれらの denormalized
+ * フィールドを使うため、書き込み時に必ず同期する必要がある。
+ *
+ * @param creatorId クリエイターID
+ */
+export async function recomputeCreatorStats(creatorId: string): Promise<void> {
+	const worksSnapshot = await firestore
+		.collection(CREATORS_COLLECTION)
+		.doc(creatorId)
+		.collection("works")
+		.get();
+
+	if (worksSnapshot.empty) {
+		await firestore.collection(CREATORS_COLLECTION).doc(creatorId).update({
+			workCount: 0,
+			types: [],
+			updatedAt: Timestamp.now(),
+		});
+		return;
+	}
+
+	const typesSet = new Set<CreatorType>();
+	const roleCount = new Map<CreatorType, number>();
+
+	worksSnapshot.docs.forEach((doc) => {
+		const relation = doc.data() as CreatorWorkRelation;
+		relation.roles?.forEach((role: CreatorType) => {
+			typesSet.add(role);
+			roleCount.set(role, (roleCount.get(role) || 0) + 1);
+		});
+	});
+
+	let primaryRole: CreatorType | undefined;
+	let maxCount = 0;
+	for (const [role, count] of roleCount) {
+		if (count > maxCount) {
+			maxCount = count;
+			primaryRole = role;
+		}
+	}
+
+	const update: Record<string, unknown> = {
+		workCount: worksSnapshot.size,
+		types: Array.from(typesSet),
+		updatedAt: Timestamp.now(),
+	};
+	if (primaryRole) {
+		update.primaryRole = primaryRole;
+	}
+
+	await firestore.collection(CREATORS_COLLECTION).doc(creatorId).update(update);
 }
 
 /**

--- a/apps/functions/src/tools/backfill-creator-stats.ts
+++ b/apps/functions/src/tools/backfill-creator-stats.ts
@@ -1,0 +1,38 @@
+/**
+ * Creator 集計フィールド (workCount / types / primaryRole) backfill ツール
+ *
+ * SPR-74 Phase B で導入された denormalize フィールドを既存 creator docs に
+ * 一括反映する一回限りのスクリプト。
+ *
+ * 使い方:
+ *   pnpm --filter @suzumina.click/functions tools:backfill-creators
+ */
+
+import firestore from "../infrastructure/database/firestore";
+import { recomputeCreatorStats } from "../services/dlsite/creator-firestore";
+import * as logger from "../shared/logger";
+
+const CONCURRENCY = 20;
+
+export async function backfillCreatorStats(): Promise<void> {
+	logger.info("クリエイター集計フィールド backfill 開始");
+
+	const creatorsSnapshot = await firestore.collection("creators").get();
+	const docs = creatorsSnapshot.docs;
+	const total = docs.length;
+
+	let processed = 0;
+	let failed = 0;
+
+	for (let i = 0; i < docs.length; i += CONCURRENCY) {
+		const chunk = docs.slice(i, i + CONCURRENCY);
+		const results = await Promise.allSettled(chunk.map((doc) => recomputeCreatorStats(doc.id)));
+		for (const r of results) {
+			if (r.status === "fulfilled") processed++;
+			else failed++;
+		}
+		logger.info(`進捗: ${i + chunk.length}/${total} (success=${processed}, failed=${failed})`);
+	}
+
+	logger.info(`backfill 完了: success=${processed}, failed=${failed}, total=${total}`);
+}

--- a/apps/functions/src/tools/run-tools.ts
+++ b/apps/functions/src/tools/run-tools.ts
@@ -176,6 +176,22 @@ export async function runWeeklyReport(): Promise<void> {
 }
 
 /**
+ * Creator 集計フィールドの backfill (SPR-74 Phase B 移行用)
+ */
+export async function backfillCreators(): Promise<void> {
+	try {
+		logger.info("🔄 クリエイター集計 backfill 開始");
+		const { backfillCreatorStats } = await import("./backfill-creator-stats.js");
+		await backfillCreatorStats();
+	} catch (error) {
+		logger.error("クリエイター集計 backfill エラー:", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		throw error;
+	}
+}
+
+/**
  * リセットツール（メタデータリセット）
  */
 export async function resetMetadata(): Promise<void> {
@@ -203,14 +219,16 @@ DLsite Functions 運用ツール
   pnpm tools:<command>
 
 コマンド:
-  stats   失敗統計を表示
-  report  週次健全性レポートを生成
-  reset   メタデータをリセット
-  help    このヘルプを表示
+  stats              失敗統計を表示
+  report             週次健全性レポートを生成
+  reset              メタデータをリセット
+  backfill-creators  Creator workCount/types を一括再計算 (SPR-74 Phase B)
+  help               このヘルプを表示
 
 例:
   pnpm tools:stats
   pnpm tools:report
+  pnpm tools:backfill-creators
 `;
 	process.stdout.write(helpText);
 }
@@ -229,6 +247,9 @@ if (require.main === module) {
 				break;
 			case "reset":
 				await resetMetadata();
+				break;
+			case "backfill-creators":
+				await backfillCreators();
 				break;
 			case "help":
 			case "--help":

--- a/apps/web/src/app/creators/actions.ts
+++ b/apps/web/src/app/creators/actions.ts
@@ -34,10 +34,25 @@ async function fetchCreators(params: GetCreatorsParams): Promise<GetCreatorsResu
 		// 全クリエイターを取得
 		const creatorsSnapshot = await firestore.collection("creators").get();
 
-		// 各クリエイターの works サブコレクションを並列取得して N+1 直列待ちを回避
+		// SPR-74 Phase B: denormalized な workCount/types があれば subcollection 読み込みを省略。
+		// backfill 未完了の旧データは fallback で従来の Promise.all 並列読みに退避する。
 		const allCreators: CreatorPageInfo[] = await Promise.all(
 			creatorsSnapshot.docs.map(async (doc) => {
 				const creatorData = doc.data() as CreatorDocument;
+
+				if (typeof creatorData.workCount === "number" && Array.isArray(creatorData.types)) {
+					const allTypes = new Set<string>(creatorData.types);
+					if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
+						allTypes.add(creatorData.primaryRole);
+					}
+					return {
+						id: creatorData.creatorId,
+						name: creatorData.name,
+						types: Array.from(allTypes),
+						workCount: creatorData.workCount,
+					} satisfies CreatorPageInfo;
+				}
+
 				const worksSnapshot = await doc.ref.collection("works").get();
 
 				const allTypes = new Set<string>();
@@ -48,7 +63,6 @@ async function fetchCreators(params: GetCreatorsParams): Promise<GetCreatorsResu
 					});
 				});
 
-				// primaryRoleが設定されていて、typesに含まれていない場合は追加
 				if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
 					allTypes.add(creatorData.primaryRole);
 				}

--- a/packages/shared-types/src/types/firestore/creator.ts
+++ b/packages/shared-types/src/types/firestore/creator.ts
@@ -30,6 +30,20 @@ export interface CreatorDocument {
 
 	/** 更新日時 */
 	updatedAt: Timestamp;
+
+	/**
+	 * 作品数（works サブコレクションのサイズを denormalize）。
+	 * SPR-74 Phase B で導入。recomputeCreatorStats / backfill で同期される。
+	 * 旧データには未設定のため optional。
+	 */
+	workCount?: number;
+
+	/**
+	 * このクリエイターが関わるすべての役割（works サブコレクションから集約）。
+	 * SPR-74 Phase B で導入。recomputeCreatorStats / backfill で同期される。
+	 * 旧データには未設定のため optional。
+	 */
+	types?: CreatorType[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- [SPR-74](https://linear.app/nothink/issue/SPR-74) Phase B — CreatorDocument に集計フィールド (`workCount`, `types`) を denormalize し、`/creators` の read 経路から **N+1 subcollection 読み込みを完全撤廃**
- bot UA cache miss TTFB: **2.4s → ~200ms 想定** (N+1 → 1 collection.get())
- per-Cloud-Run-instance cache(Phase A)の制約を回避、PSI v5 の一貫性向上

## 背景

[Phase A](https://github.com/nothink-jp/suzumina.click/pull/445) (`unstable_cache(60s)`) で cache hit 時 TTFB は ~150ms まで短縮されたが、PSI v5 検証で以下が判明:

- `unstable_cache` は per-Cloud-Run-instance のため、Lighthouse 経路から PSI が叩く request は cache miss しがち
- cache miss 時 TTFB は 2.4s 残存(N parallel reads が支配)
- 結果 PSI v5 reliability は限定改善 (mobile では intermittent UNKNOWN_ERROR が残る)

Phase B で **cache 層に依存しない安定改善**を実現する。

## 変更内容

### 1. shared-types: CreatorDocument 型拡張

[packages/shared-types/src/types/firestore/creator.ts](packages/shared-types/src/types/firestore/creator.ts):

```ts
interface CreatorDocument {
  // existing
  creatorId, name, primaryRole?, createdAt, updatedAt;

  // 追加 (旧データ互換のため optional)
  workCount?: number;
  types?: CreatorType[];
}
```

### 2. Cloud Functions: write path に集計の自動同期

[apps/functions/src/services/dlsite/creator-firestore.ts](apps/functions/src/services/dlsite/creator-firestore.ts):

- `recomputeCreatorStats(creatorId)` を新設 — works サブコレクションから workCount/types/primaryRole を計算して creator doc に書き戻す
- `updateCreatorWorkMapping` の `batch.commit()` 後に、影響を受けたクリエイター(追加+削除両方)について `Promise.allSettled` で `recomputeCreatorStats` を呼ぶ
- best-effort 設計 — recomputeCreatorStats が失敗してもマッピング自体は成功扱いで warn ログのみ

### 3. Backfill ツール

[apps/functions/src/tools/backfill-creator-stats.ts](apps/functions/src/tools/backfill-creator-stats.ts): 既存 ~500 creator docs に集計フィールドを一括反映する一回限りのスクリプト。CONCURRENCY=20 で chunk 実行、進捗ログあり。

実行: `pnpm --filter @suzumina.click/functions tools:backfill-creators`

### 4. Web: read path の fast path

[apps/web/src/app/creators/actions.ts](apps/web/src/app/creators/actions.ts):

- denormalized フィールドがあれば subcollection 読み込みをスキップ (fast path)
- 旧データ(backfill 前 + バッファ作成直後の race)には既存 Promise.all 並列読みにフォールバック

## 移行手順

1. **本 PR を deploy** — この時点で `updateCreatorWorkMapping` は新規 creators に集計を populate。read path は旧データを subcollection fallback で処理
2. **backfill 実行** — `pnpm --filter @suzumina.click/functions tools:backfill-creators` で全 creator docs に集計を埋める
3. 以降は自動で維持(2h cron の updateCreatorWorkMapping が同期、週次 data-integrity-check は将来追加候補)

## 期待効果

| 項目 | Phase A 後 | Phase A + B 後 (backfill 完了) |
| -- | -- | -- |
| bot UA cache hit TTFB | ~150ms | ~150ms |
| bot UA cache miss TTFB | 2.4s | **~200ms** |
| PSI v5 mobile reliability | 1/3 success | 想定 3/3 success |
| Firestore reads / request | N+1 | **1** |

## トレードオフ / 既知の制約

- `updateCreatorWorkMapping` で 1 work ごとに 影響 creator 数 ぶんの追加 read+write 発生(典型 2-10 creators/work)。2h cron + バッチ処理なのでコスト許容範囲内。
- `updateCreatorPrimaryRole` (既存 export だが外部呼び出しなし) は recomputeCreatorStats が役割を tracker するため将来削除候補。本 PR では dead code として残す。
- `data-integrity-check` への workCount/types 整合性検証は将来追加候補。

## Test plan

- [x] `pnpm --filter @suzumina.click/shared-types typecheck` / `lint` / `test` (913 passed)
- [x] `pnpm --filter @suzumina.click/functions typecheck` / `lint` / `test` (340 passed / 24 skipped, recomputeCreatorStats の 2 ケース追加)
- [x] `pnpm --filter @suzumina.click/web typecheck` / `lint` / `test` (688 passed / 1 skipped)
- [ ] deploy 後 `pnpm tools:backfill-creators` 実行
- [ ] backfill 完了後 curl Chrome-Lighthouse UA で TTFB ~200ms 確認(現状 2.4s)
- [ ] PSI v5 で `/creators` mobile + desktop 3 サンプル成功率向上を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)