### PR TITLE
perf(web): /works の AgeVerification spinner gate を撤廃して SSR で <img> を出力（SPR-73）

### DIFF
--- a/apps/web/src/components/content/works-page-client.tsx
+++ b/apps/web/src/components/content/works-page-client.tsx
@@ -15,24 +15,10 @@ interface WorksPageClientProps {
 }
 
 export function WorksPageClient({ initialData }: WorksPageClientProps) {
-	const { showR18Content, isLoading: ageVerificationLoading } = useAgeVerification();
-
-	if (ageVerificationLoading) {
-		return (
-			<ListPageLayout>
-				<ListPageHeader
-					title="作品一覧"
-					description="涼花みなせさんの音声作品情報を参照・表示。DLsite公式サイトであなたにぴったりの作品を見つけよう"
-				/>
-				<ListPageContent>
-					<div className="text-center py-12">
-						<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-						<p className="mt-2 text-muted-foreground">読み込み中...</p>
-					</div>
-				</ListPageContent>
-			</ListPageLayout>
-		);
-	}
+	// isLoading で early return しない: AgeVerificationOverlay 側が
+	// fixed inset-0 + body scroll lock で未確認ユーザーを覆う設計のため、
+	// ここでさらに gate するとコンテンツ render が遅れるだけで意味がない。
+	const { showR18Content } = useAgeVerification();
 
 	return (
 		<ListPageLayout>


### PR DESCRIPTION
## Summary

- [SPR-73](https://linear.app/nothink/issue/SPR-73) の根本原因を特定: `/works` の LCP element (`<img>`) が **SSR HTML に一切含まれていなかった**
- `WorksPageClient` の `isLoading` early return を削除して SSR で `<img>` を出力できるようにする
- 期待効果: Mobile LCP **4.57s → 2.5s 級**(SPR-71 受け入れ条件 LCP ≤ 2.5s を達成)

## 調査で判明したこと

### prod HTML の比較

| Page | `<img>` in SSR | `_next/image` | preload as=image | spinner |
| -- | -- | -- | -- | -- |
| `/` | 20 | 280 | あり | 0 |
| `/videos` | 12 | 192 | 6 | 0 |
| **`/works`** | **0** | **0** | **0** | **1** ⚠️ |
| `/buttons` | 0 | 0 | 0 | 2 (構造的に img 無し) |

`/works` だけ SSR で `<img>` が出力されておらず、HTML 内の DLsite 画像 URL (`doujin/` × 83 件) は **すべて RSC payload のシリアライズデータ**として埋め込まれていた。

### 原因

[apps/web/src/components/content/works-page-client.tsx:18-35](apps/web/src/components/content/works-page-client.tsx):

```tsx
const { ..., isLoading: ageVerificationLoading } = useAgeVerification();
if (ageVerificationLoading) {
  return <ListPageLayout>...spinner...</ListPageLayout>;
}
```

[apps/web/src/contexts/age-verification-context.tsx:27](apps/web/src/contexts/age-verification-context.tsx#L27):

```tsx
const [isLoading, setIsLoading] = useState(true);
useEffect(() => { /* localStorage 読込 */ setIsLoading(false); }, []);
```

- SSR では `useEffect` が走らない → `isLoading: true` のまま
- `WorksPageClient` が spinner だけ返す → **WorksList が SSR されない**
- `<img>` が初期 HTML に出ない → `priority` prop は無効、`fetchpriority` / preload も emit されない
- Lighthouse の LCP element は hydration + localStorage 読込完了後に初めて DOM に現れる

これで [PR #439](https://github.com/nothink-jp/suzumina.click/pull/439)(先頭 6 件に `priority` 設定)、[PR #440](https://github.com/nothink-jp/suzumina.click/pull/440)(6→2 に絞り) が PSI で LCP を改善できなかった理由が完全に説明できる(priority 対象の `<img>` が SSR HTML に存在しなかった)。

### なぜ削除して良いか

[apps/web/src/components/consent/age-verification-overlay.tsx:55-58](apps/web/src/components/consent/age-verification-overlay.tsx#L55) の JSDoc:

> Client-side overlay that prompts age verification **without blocking content render**.
> Renders nothing until the provider's localStorage check resolves, then either
> stays hidden (verified / bot) or shows a fixed-position confirmation card.

設計上、**コンテンツ render はブロックしない**前提。未確認ユーザーには overlay が `fixed inset-0 z-50` + `document.body.style.overflow = "hidden"`(同ファイル L82-90)で viewport 全体を覆い、scroll もロックする。WorksPageClient の追加 gate は overlay と役割が重複しており、LCP を悪化させるだけ。

他の list 系ページ(`/`, `/videos`, `/buttons`)はこの gate を持たず、すべて SSR で正しく content を出力している。

## 変更

[apps/web/src/components/content/works-page-client.tsx](apps/web/src/components/content/works-page-client.tsx):

- `if (ageVerificationLoading) ...` early return ブロックを削除
- `useAgeVerification` の destructure から `isLoading` を除去
- `showR18Content` の description 分岐は維持(SSR 時は `false` で「全年齢」description、hydration 後に確定。hydration mismatch は発生しない、文字列の差し替えのみ)

## 想定 R18 表示挙動

- 未確認ユーザーが `/works` を開く: SSR で R18 含む全件が初期 HTML に出力される
- 直後の hydration で overlay が mount され `fixed inset-0` で全画面を覆う + body scroll lock
- ユーザーは overlay を dismiss(年齢確認)するまで content を視認・操作できない

→ overlay mount まで < 100ms の窓で R18 サムネが見える可能性はあるが、**現状の spinner 経由でも overlay mount 後に同じ window が存在** するため UX 上の regression なし。

## Test plan

- [x] `pnpm --filter @suzumina.click/web lint` — 触ったファイルにエラー無し
- [x] `pnpm --filter @suzumina.click/web typecheck` — pass
- [x] `pnpm --filter @suzumina.click/web test -- --run` — 688 passed / 1 skipped (`works/__tests__/page.test.tsx` は `WorksPageClient` をモックしているため影響なし)
- [ ] deploy 後 curl で `/works` HTML に `<img>` および `<link rel="preload" as="image" fetchpriority="high">` が出力されているか確認
- [ ] PSI v5 で `/works` Mobile LCP が 4.57s → 2.5s 級に改善するか 3 サンプルで確認

## Follow-up

- `/videos` LCP 3.60s の改善は別途調査が必要(`<img>` は SSR で出力されているが `fetchpriority="high"` 属性が img 自体には付与されていない、ただし `<link rel="preload">` は emit 済)
- /buttons mobile TBT=1500ms、/search mobile TBT=4180ms 等の TBT 過大ケースは [SPR-75](https://linear.app/nothink/issue/SPR-75) や別 issue で扱う

🤖 Generated with [Claude Code](https://claude.com/claude-code)