### PR TITLE
perf(web): Image priority に fetchpriority="high" を明示 + VideoList priority を 6→2 縮小（SPR-76）

### DIFF
--- a/apps/web/src/app/videos/components/VideoList.tsx
+++ b/apps/web/src/app/videos/components/VideoList.tsx
@@ -36,12 +36,10 @@ export default function VideoList({ initialData }: VideoListProps) {
 	}, []);
 
 	// レンダリング設定
+	// 先頭 2 件のみ priority。6 件は preload 並列で帯域競合 + TBT regression
+	// リスクがあり、LCP element は実測上いつも先頭 1 件目のため過剰。
 	const renderItem = (video: VideoPlainObject, index: number) => (
-		<VideoCard
-			video={video}
-			variant="grid"
-			priority={index < 6} // 最初の6枚をLCP最適化
-		/>
+		<VideoCard video={video} variant="grid" priority={index < 2} />
 	);
 
 	return (

--- a/apps/web/src/components/ui/thumbnail-image.tsx
+++ b/apps/web/src/components/ui/thumbnail-image.tsx
@@ -109,6 +109,10 @@ const ThumbnailImage = memo(function ThumbnailImage({
 				alt={alt}
 				fill
 				priority={priority}
+				// Next.js 16 では `priority` は preload + eager の発行までで、
+				// `fetchpriority="high"` 属性は自動付与しない。LCP 画像として
+				// 明示的にブラウザへ優先度を伝えるため `fetchPriority` を渡す。
+				fetchPriority={priority ? "high" : undefined}
 				sizes={sizes}
 				loading={priority ? "eager" : loading}
 				quality={quality}


### PR DESCRIPTION
## Summary

- [SPR-76](https://linear.app/nothink/issue/SPR-76) — Next.js 16 で `<Image priority>` が `fetchpriority="high"` 属性を自動付与しなくなった仕様変更に対応
- ThumbnailImage で priority=true 時に明示的に `fetchPriority="high"` を渡す
- VideoList の priority 範囲を `index<6` → `index<2` に縮小(WorksList と統一)
- 期待効果: /videos Mobile LCP **3,676ms → 2,500ms 級**(SPR-71 epic 受け入れ条件 LCP ≤ 2.5s 達成)、/works も同時改善

## 調査で判明した仕様変更

[apps/web/node_modules/next/dist/shared/lib/get-img-props.js:148](apps/web/node_modules/next/dist/shared/lib/get-img-props.js#L148) を読むと:

```js
function getImgProps({ ..., priority = false, ..., fetchPriority, ... }, _state) {
  let isLazy = !priority && !preload && (loading === 'lazy' || ...);  // priority → eager
  ...
  const props = { ..., loading: loadingFinal, fetchPriority, ... };   // fetchPriority はパススルーのみ
  const meta = { ..., preload: preload || priority, ... };             // priority → preload link 発行
}
```

- `priority` と `fetchPriority` は **別々の独立した prop** として destructure
- `priority=true` → preload link 発行 + `loading="eager"` ✓
- `priority=true` → **`fetchpriority="high"` 属性は自動付与されない** ❌
- 明示的に `fetchPriority="high"` を渡す必要がある

これは [SPR-73](https://linear.app/nothink/issue/SPR-73) で `/works` 修正後の PSI v5 `lcp-discovery-insight` audit が `priorityHinted: false` を返していた現象と完全に整合(`/works` curl HTML の img/preload の双方に `fetchpriority` 無しを実測確認済)。

## 現状の SSR HTML(curl, default UA)

```
=== /videos 12 img のうち先頭 6 件 ===
loading="eager" ✓
fetchpriority="high" 無し ❌  ← 本 PR で修正

=== /videos 6 個の <link rel="preload" as="image"> ===
fetchpriority="high" 無し ❌  ← 本 PR で修正
```

## 変更内容

### 1. [apps/web/src/components/ui/thumbnail-image.tsx](apps/web/src/components/ui/thumbnail-image.tsx)

`<Image>` に `fetchPriority={priority ? "high" : undefined}` を追加:

```tsx
<Image
  ...
  priority={priority}
+ fetchPriority={priority ? "high" : undefined}
  loading={priority ? "eager" : loading}
  ...
/>
```

ThumbnailImage は WorkCard / VideoCard / その他の image 共通コンポーネントなので、**/works /videos /home の Featured 系すべての LCP image に一括で適用**される。

### 2. [apps/web/src/app/videos/components/VideoList.tsx](apps/web/src/app/videos/components/VideoList.tsx)

`priority={index < 6}` → `priority={index < 2}`:

- 先頭 6 件の preload 並列は帯域競合(モバイル 4G 環境で顕著)+ TBT regression のリスク
- LCP element は実測上いつも先頭 1 件目([SPR-73 PSI breakdown](https://linear.app/nothink/issue/SPR-73))
- WorksList が既に `index<2` パターンを採用済 → 統一

## 期待効果

| Page | Metric | Before | After (想定) |
| -- | -- | -- | -- |
| /videos | Mobile LCP | 3,676ms | **~2,500ms** ✅ SPR-71 達成 |
| /videos | Mobile TBT | 529ms | ~400-450ms (preload 4 件減) |
| /works | Mobile LCP | 3,601ms | **~2,800-3,000ms**(fetchpriority hint 追加分) |
| /works | Mobile TBT | 725ms | 同程度(priority は元から 2) |

## 関連ページへの影響範囲

ThumbnailImage を使用しているコンポーネント([apps/web/src/components/ui/thumbnail-image.tsx](apps/web/src/components/ui/thumbnail-image.tsx) を経由):

- WorkCard (`/works`, `/works/[workId]`, 各種 Featured/Latest carousel)
- VideoCard (`/videos`, `/videos/[videoId]`, 各種 Featured/Latest carousel)
- その他の Thumbnail を出すページ全般

priority=true で render されている image すべてが対象。priority=false の場合は変化なし(fetchPriority=undefined のため Next.js Image はデフォルト挙動)。

## Test plan

- [x] `pnpm --filter @suzumina.click/web lint` — エラー無し
- [x] `pnpm --filter @suzumina.click/web typecheck` — pass
- [x] `pnpm --filter @suzumina.click/web test -- --run` — 688 passed / 1 skipped
- [ ] deploy 後 curl で `/videos` `/works` HTML の img と `<link rel="preload">` に `fetchpriority="high"` が含まれることを確認
- [ ] PSI v5 3 サンプル中央値で `/videos` Mobile LCP < 2.5s を達成
- [ ] `/works` Mobile LCP の追加改善も確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)