### PR TITLE
perf(web): /contact ContactForm を dynamic 化して Zod chunk を初期ロードから排除（SPR-72）

### DIFF
--- a/apps/web/src/app/contact/components/ContactFormClient.tsx
+++ b/apps/web/src/app/contact/components/ContactFormClient.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Skeleton } from "@suzumina.click/ui/components/ui/skeleton";
+import dynamic from "next/dynamic";
+
+/**
+ * ContactForm の遅延読み込みフォールバック。
+ * 実フォーム (種別 select / 件名 / 内容 textarea / メール / 送信ボタン) の
+ * 構造と高さに近づけて CLS を抑える。
+ */
+function ContactFormSkeleton() {
+	return (
+		<div className="space-y-6" data-testid="contact-form-skeleton" aria-hidden>
+			{/* お問い合わせ種別 */}
+			<div className="space-y-2">
+				<Skeleton className="h-5 w-32" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+			{/* 件名 */}
+			<div className="space-y-2">
+				<Skeleton className="h-5 w-16" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+			{/* 内容 (rows=8) */}
+			<div className="space-y-2">
+				<Skeleton className="h-5 w-16" />
+				<Skeleton className="h-48 w-full" />
+			</div>
+			{/* メールアドレス */}
+			<div className="space-y-2">
+				<Skeleton className="h-5 w-40" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+			{/* 送信ボタン */}
+			<div className="pt-4">
+				<Skeleton className="h-10 w-full" />
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Server Component の page.tsx からは `next/dynamic({ ssr: false })` を直接呼べない
+ * (`ssr: false is not allowed in Server Components`) ため、client wrapper 経由で
+ * ContactForm を動的読み込みする。これにより Zod / react-hook-form を含む chunk が
+ * /contact の First Load JS から外れる (SPR-72)。
+ */
+const ContactForm = dynamic(() => import("./ContactForm").then((m) => m.ContactForm), {
+	ssr: false,
+	loading: () => <ContactFormSkeleton />,
+});
+
+export function ContactFormClient() {
+	return <ContactForm />;
+}

--- a/apps/web/src/app/contact/page.tsx
+++ b/apps/web/src/app/contact/page.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
 import { AlertTriangle, Bug, HelpCircle, Lightbulb, MessageSquare } from "lucide-react";
 import type { Metadata } from "next";
-import { ContactForm } from "./components/ContactForm";
+import { ContactFormClient as ContactForm } from "./components/ContactFormClient";
 
 export const metadata: Metadata = {
 	title: "お問い合わせ",


### PR DESCRIPTION
## 概要

[SPR-72](https://linear.app/nothink/issue/SPR-72) — Zod chunk を含む最後の 1 ページ `/contact` から、Zod / `@hookform/resolvers/zod` / `react-hook-form` を含む chunk を初期ロード（First Load JS）から排除する。

PR #437 で 14 ページ中 13 ページの Zod chunk を排除済みだったが、`/contact` だけは `ContactForm.tsx` が `@hookform/resolvers/zod`（→ `zod/v4/core`）を直接 import しているため残存していた。

## アプローチ

Server Component の `page.tsx` からは `next/dynamic({ ssr: false })` を直接呼べない（`ssr: false is not allowed in Server Components`）ため、client wrapper `ContactFormClient` を新設し、その内部で `ContactForm` を遅延読み込みする。CLS 配慮のため実フォーム構造に近い skeleton を表示。

- `apps/web/src/app/contact/components/ContactFormClient.tsx`（新規, `"use client"`）
- `apps/web/src/app/contact/page.tsx`（import を 1 行差し替え）

フォーム送信は Server Action 経由のため、`ssr: false` 化による機能 regression はない。

## 計測（prerendered HTML の script chunks = 実 First Load JS）

| ページ | First Load JS | chunk 数 |
| --- | --- | --- |
| **/contact** | **885.1 KB** | 19 |
| /about | 880.1 KB | 18 |
| /privacy | 880.1 KB | 18 |
| /terms | 880.1 KB | 18 |

- `/contact` が Zod-free な兄弟ページと **~5KB 差で同水準**に到達（ドキュメント基準値 1117.7KB から約 -232KB）
- Zod ライブラリ chunk（285.4KB）は `/contact` 初期ロードから排除
- `ContactForm` は独立した遅延 chunk（34.1KB）に分離され、初期ロード外に

> 絶対値はチケット記載時（目標 828KB）からコード増で drift しているが、受け入れ条件「他ページと同程度」は満たしている。

## 受け入れ条件

- [x] `/contact` の First Load JS が他ページと同程度（Zod chunk 排除）
- [x] Zod chunk が含まれるページが 14 → 0
- [x] フォーム送信機能が変わらず動作（Server Action 経由・ロジック不変）
- [x] typecheck / lint / test（62 files, 688 passed）pass
- [ ] production deploy 後の PSI v5 mobile で `/contact` LCP 改善を確認（デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
