### PR TITLE
perf(web): 非クリティカルな全ページ client を hydration 後に遅延ロード（SPR-81 WS-A）

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,13 +7,11 @@ import {
 	GoogleTagManager,
 	GoogleTagManagerNoscript,
 } from "@/components/analytics/google-tag-manager";
-import { PageViewTracker } from "@/components/analytics/page-view-tracker";
-import { AgeVerificationOverlay } from "@/components/consent/age-verification-overlay";
+import { AgeVerificationOverlayDeferred } from "@/components/consent/age-verification-overlay-deferred";
 import { ConsentModeScript } from "@/components/consent/consent-mode-script";
-import { CookieConsentBanner } from "@/components/consent/cookie-consent-banner";
 import SiteFooter from "@/components/layout/site-footer";
 import SiteHeader from "@/components/layout/site-header";
-import PerformanceMonitor from "@/components/system/performance-monitor";
+import { DeferredGlobalEffects } from "@/components/system/deferred-global-effects";
 import { SessionProvider } from "@/components/user/session-provider";
 import { AgeVerificationProvider } from "@/contexts/age-verification-context";
 
@@ -104,11 +102,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				<GoogleTagManagerNoscript />
 				<AgeVerificationProvider>
 					<SessionProvider>
-						<PerformanceMonitor />
-						{/* useSearchParams を含むため、static prerender 時の CSR bailout エラーを回避 */}
-						<Suspense fallback={null}>
-							<PageViewTracker />
-						</Suspense>
 						{/* SiteHeader 自体は静的シェル。auth() 解決は内部の Suspense 境界で局所化されている */}
 						<SiteHeader />
 						<main id="main-content" className="flex-1 min-h-screen">
@@ -122,9 +115,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 						</main>
 						<SiteFooter />
 						<Toaster />
-						<CookieConsentBanner />
+						{/* 非クリティカルな全ページ client 副作用/UI を hydration 後に遅延ロード (SPR-81 WS-A) */}
+						<DeferredGlobalEffects />
 					</SessionProvider>
-					<AgeVerificationOverlay />
+					<AgeVerificationOverlayDeferred />
 				</AgeVerificationProvider>
 			</body>
 		</html>

--- a/apps/web/src/components/consent/age-verification-overlay-deferred.tsx
+++ b/apps/web/src/components/consent/age-verification-overlay-deferred.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { lazy, Suspense, useEffect, useState } from "react";
+
+/**
+ * AgeVerificationOverlay を hydration 後に遅延ロードする wrapper (SPR-81 WS-A)。
+ *
+ * SPR-7 で overlay 方式に変更されコンテンツを非ブロック化済みのため、first paint 後の
+ * 表示で UX 上の問題はない。`React.lazy` で初期 bundle から overlay の chunk を分離し、
+ * mounted gate で hydration 後にのみ import + hydration することで、初期 hydration の
+ * main-thread 占有を削減する。
+ *
+ * 注: `useAgeVerification` を参照するため、本コンポーネントは引き続き
+ * AgeVerificationProvider の配下に配置する必要がある。
+ */
+
+const AgeVerificationOverlay = lazy(() =>
+	import("@/components/consent/age-verification-overlay").then((m) => ({
+		default: m.AgeVerificationOverlay,
+	})),
+);
+
+export function AgeVerificationOverlayDeferred() {
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	if (!mounted) return null;
+
+	return (
+		<Suspense fallback={null}>
+			<AgeVerificationOverlay />
+		</Suspense>
+	);
+}

--- a/apps/web/src/components/system/deferred-global-effects.tsx
+++ b/apps/web/src/components/system/deferred-global-effects.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { lazy, Suspense, useEffect, useState } from "react";
+
+/**
+ * 全ページで mount される非クリティカルな client 副作用 / UI を、hydration 後
+ * (first paint 後) に遅延ロード・遅延 hydration するための wrapper (SPR-81 WS-A)。
+ *
+ * 対象:
+ * - PerformanceMonitor: web-vitals 初期化 (buffered PerformanceObserver のため遅延後でも計測可)
+ * - PageViewTracker: GA ページビュー送信 (視覚出力なし)
+ * - CookieConsentBanner: 同意未取得時のみ表示する banner (元々 isLoading で自己遅延)
+ *
+ * いずれも `React.lazy` で初期 bundle から chunk を分離し、`useEffect` の mounted gate で
+ * hydration 後にのみ chunk import + hydration を開始する。これにより初期 hydration の
+ * main-thread 占有を減らし、LCP 要素の描画を前倒しする。
+ * 視覚出力が無いか自己遅延型のため CLS 影響なし。
+ */
+
+const PerformanceMonitor = lazy(() => import("@/components/system/performance-monitor"));
+
+const PageViewTracker = lazy(() =>
+	import("@/components/analytics/page-view-tracker").then((m) => ({ default: m.PageViewTracker })),
+);
+
+const CookieConsentBanner = lazy(() =>
+	import("@/components/consent/cookie-consent-banner").then((m) => ({
+		default: m.CookieConsentBanner,
+	})),
+);
+
+export function DeferredGlobalEffects() {
+	const [mounted, setMounted] = useState(false);
+
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+
+	if (!mounted) return null;
+
+	return (
+		<Suspense fallback={null}>
+			<PerformanceMonitor />
+			<PageViewTracker />
+			<CookieConsentBanner />
+		</Suspense>
+	);
+}


### PR DESCRIPTION
## 概要

[SPR-81](https://linear.app/nothink/issue/SPR-81)（Mobile JS hydration / TTI 改善 epic）の **WS-A 初回 small-batch**。全ページで mount される非クリティカルな client コンポーネント4つを `React.lazy` + mounted gate で **hydration 後に遅延ロード**し、初期 bundle から chunk を分離する。

## baseline 診断（本番 PSI mobile）

| ページ | LCP | TBT | TTI | 主因 |
| --- | --- | --- | --- | --- |
| / | 3.3s | 80ms | 8.3s | critical window の hydration が LCP 描画を後ろ倒し |
| /videos | 4.8s | 330ms | 7.3s | 同上 |
| /works | 4.5s | 320ms | 7.1s | 同上 |

- **TBT は既に低い**（SPR-74 等の効果）。残る課題は **LCP（3.3-4.8s）と TTI（7-8s）**。
- 共有 app チャンク（全ページ最大の JS 実行 exec 354-434ms）＝ framework + 全ページ mount の client provider 群の hydration。
- GTM/GA は既に `lazyOnload`（SPR-9）で load 後ロード済 ＝ LCP 非ブロック。WS-D は実施済。

## 変更

`PerformanceMonitor` / `PageViewTracker` / `CookieConsentBanner` / `AgeVerificationOverlay` を遅延化（既存 `audio-buttons-carousel-deferred` パターン踏襲）:

- `components/system/deferred-global-effects.tsx`（新規）— PerformanceMonitor / PageViewTracker / CookieConsentBanner（provider 依存なし、grouping）
- `components/consent/age-verification-overlay-deferred.tsx`（新規）— AgeVerificationOverlay（`useAgeVerification` 参照のため Provider 配下に残置）
- `app/layout.tsx` — 上記を deferred wrapper に差し替え

## 計測（ローカル before/after, raw First Load JS）

| ページ | before | after | Δ |
| --- | --- | --- | --- |
| / | 897.4 KB | 883.7 KB | **-13.7 KB** |
| /videos | 1047.2 KB | 1037.6 KB | **-9.6 KB** |
| /works | 1047.2 KB | 1037.6 KB | **-9.6 KB** |

- CookieConsentBanner（5.5KB）・AgeVerificationOverlay（7.6KB）が**遅延チャンクに分離**され初期ロードから除外を確認。
- **byte 削減は modest（~10-14KB）**。本バッチの主眼は byte 数より「4コンポーネントの hydration を critical window から外す **main-thread 占有削減**」で、LCP 描画前倒し効果は **デプロイ後の本番 PSI（LCP/TTI）でクロスチェック**する。

## リスク / 受け入れ

- リスク **低**: いずれも視覚出力なし（Monitor/Tracker）or 自己遅延型（banner の `isLoading`）or overlay 非ブロック（SPR-7）→ **CLS 影響なし**。typecheck / lint / test（688 passed）/ build 全 pass。
- 本 PR は epic の「small batch → 計測 → 続行/pivot」の**de-risk な第一歩**。LCP ≤ 2.5s 達成には後続バッチ（ConfigurableList の項目 server 描画＝spike P1）が必要な見込み。デプロイ後の本番計測で効果を見て次バッチを判断する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
