### PR TITLE
chore(ci): 存在しない apps/admin 向け dead config を CI/Terraform から撤去（SPR-79）

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       web: ${{ steps.changes.outputs.web }}
-      admin: ${{ steps.changes.outputs.admin }}
       functions: ${{ steps.changes.outputs.functions }}
       shared-types: ${{ steps.changes.outputs.shared-types }}
       ui: ${{ steps.changes.outputs.ui }}
@@ -44,8 +43,6 @@ jobs:
           filters: |
             web:
               - 'apps/web/**'
-            admin:
-              - 'apps/admin/**'
             functions:
               - 'apps/functions/**'
             shared-types:
@@ -76,7 +73,7 @@ jobs:
     name: Parallel Quality Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.admin == 'true' || needs.changes.outputs.functions == 'true' || needs.changes.outputs.shared-types == 'true' || needs.changes.outputs.ui == 'true'
+    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.functions == 'true' || needs.changes.outputs.shared-types == 'true' || needs.changes.outputs.ui == 'true'
     timeout-minutes: 8
     
     steps:
@@ -117,19 +114,7 @@ jobs:
             pnpm --filter @suzumina.click/web test --run --passWithNoTests 2>&1 | sed 's/^/[web-test] /' &
             checks["web-test"]=$!
           fi
-          
-          # Admin app checks
-          if [[ "${{ needs.changes.outputs.admin }}" == "true" ]]; then
-            pnpm --filter @suzumina.click/admin lint 2>&1 | sed 's/^/[admin-lint] /' &
-            checks["admin-lint"]=$!
-            
-            pnpm --filter @suzumina.click/admin typecheck 2>&1 | sed 's/^/[admin-typecheck] /' &
-            checks["admin-typecheck"]=$!
-            
-            pnpm --filter @suzumina.click/admin test --run --passWithNoTests 2>&1 | sed 's/^/[admin-test] /' &
-            checks["admin-test"]=$!
-          fi
-          
+
           # Functions checks
           if [[ "${{ needs.changes.outputs.functions }}" == "true" ]]; then
             pnpm --filter @suzumina.click/functions build 2>&1 | sed 's/^/[functions-build] /' &
@@ -211,12 +196,7 @@ jobs:
             echo "Building web app..."
             pnpm --filter @suzumina.click/web build
           fi
-          
-          if [[ "${{ needs.changes.outputs.admin }}" == "true" ]]; then
-            echo "Building admin app..."
-            pnpm --filter @suzumina.click/admin build
-          fi
-          
+
           echo "✅ All builds verified successfully"
 
   docker-build-check:
@@ -319,7 +299,6 @@ jobs:
           
           echo "### 📁 Changed Components" >> $GITHUB_STEP_SUMMARY
           echo "- Web App: ${{ needs.changes.outputs.web == 'true' && '✅' || '⏭️' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Admin App: ${{ needs.changes.outputs.admin == 'true' && '✅' || '⏭️' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Functions: ${{ needs.changes.outputs.functions == 'true' && '✅' || '⏭️' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Shared Types: ${{ needs.changes.outputs.shared-types == 'true' && '✅' || '⏭️' }}" >> $GITHUB_STEP_SUMMARY
           echo "- UI Package: ${{ needs.changes.outputs.ui == 'true' && '✅' || '⏭️' }}" >> $GITHUB_STEP_SUMMARY

--- a/terraform/artifact-registry-lifecycle.tf
+++ b/terraform/artifact-registry-lifecycle.tf
@@ -17,15 +17,12 @@ output "enhanced_cleanup_info" {
   description = "Enhanced cleanup policies information"
   value = {
     existing_policies = {
-      keep_latest_web   = "5 images"
-      keep_latest_admin = "3 images"
-      delete_untagged   = "7 days"
+      keep_latest_web = "5 images"
+      delete_untagged = "7 days"
     }
     github_actions_cleanup = {
-      web_images      = "10 images kept"
-      web_revisions   = "5 revisions kept"
-      admin_images    = "5 images kept"
-      admin_revisions = "3 revisions kept"
+      web_images    = "10 images kept"
+      web_revisions = "5 revisions kept"
     }
     repository_url = "${var.region}-docker.pkg.dev/${var.gcp_project_id}/${var.artifact_registry_repository_id}"
   }

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -22,7 +22,7 @@ resource "google_artifact_registry_repository" "docker_repo" {
     condition {
       tag_state             = "ANY"
       tag_prefixes          = ["latest"]
-      package_name_prefixes = ["web", "suzumina-admin"]
+      package_name_prefixes = ["web"]
     }
   }
 
@@ -41,15 +41,6 @@ resource "google_artifact_registry_repository" "docker_repo" {
     most_recent_versions {
       keep_count            = 5
       package_name_prefixes = ["web"]
-    }
-  }
-
-  cleanup_policies {
-    id     = "keep-recent-admin-versions"
-    action = "KEEP"
-    most_recent_versions {
-      keep_count            = 3 # 管理者アプリは更新頻度が低いため3個まで
-      package_name_prefixes = ["suzumina-admin"]
     }
   }
 


### PR DESCRIPTION
## 概要

[SPR-79](https://linear.app/nothink/issue/SPR-79) — 存在しない `apps/admin` 向けの dead config を CI / Terraform から撤去する。

`apps/admin`（独立 Next.js 管理アプリ）は **2025-07-31 に完全削除済み**（commit `36303497` "feat: adminアプリの完全削除"）。現在 `apps/` 配下は `web` と `functions` のみ。にもかかわらず CI と Terraform に admin 向けの設定だけが残っており、CI/IaC の見通しを悪くしていた。

`deploy-web.yml` / `deploy-functions.yml` に admin のデプロイ参照はゼロ・`deploy-admin.yml` も存在しないため、`suzumina-admin` イメージは今後一切 push されない = **完全な dead config** と確定した上で撤去している。

## 方針（決定事項）

独立アプリ（`apps/admin`）は復活させない。将来 admin 機能が必要になれば `apps/web` の `/admin` 配下に置く。`pnpm-workspace.yaml` は `apps/*` glob なので、再構築が必要になった時点で CI を足し直せばよい。

## 変更内容

### `.github/workflows/pr-check.yml`（admin 参照 6 種を撤去）
- `changes` ジョブの `admin` output
- paths-filter の `apps/admin/**`
- `parallel-check` の `if` 条件から `admin`
- `parallel-check` 本体の "Admin app checks" ブロック
- `build-check` の admin ビルドブロック
- `pr-summary` の "Admin App" 表示行

### `terraform/artifact_registry.tf`
- `keep-minimum-versions` の `package_name_prefixes` から `suzumina-admin` を除去
- `keep-recent-admin-versions` cleanup policy ブロックを撤去

### `terraform/artifact-registry-lifecycle.tf`
- output `enhanced_cleanup_info` の admin 関連行を撤去

## スコープ外

- **docs の admin 参照**（`development.md` / `changelog.md` / `todo.md` / `database-schema.md`）→ [SPR-63](https://linear.app/nothink/issue/SPR-63)（ドキュメント運用整理）に委譲
- `apps/web/src/app/admin/recalculate-audio-button-counts/route.ts` → 削除アプリとは無関係の生きたルート。現状維持
- terraform の他の `admin` 参照（`storage.objectAdmin` / `run.admin` / `admin_email` 等）→ IAM/ロール由来で無関係。現状維持

## 検証

- `grep -ci admin .github/workflows/pr-check.yml` → **0**
- terraform に admin dead config の残存なし（`suzumina-admin` 等の grep が空）
- pr-check.yml の YAML パース OK
- `terraform fmt -check -recursive` clean
- アプリコード（TS）は無変更
- 本 PR 自身が新しい `pr-check.yml` で実行され、YAML の妥当性を実証する（`parallel-check` は web/functions 等が未変更のため skip。これは正常）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
