### PR TITLE
fix(ci): shared-types / ui 単独変更がノーチェックで緑になる穴を塞ぐ（SPR-78）

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -94,72 +94,97 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       
-      # shared-types / ui は no-build（src を直接公開）のため事前ビルド不要
-      # 完全並列実行による品質チェック
+      # shared-types / ui は no-build（src を直接公開）のため事前ビルド不要。
+      # 変更されたパッケージごとに lint / typecheck / test を並列実行する。
+      # shared-types / ui はモノレポ全体の型の土台なので、変更時は依存先
+      # （web / functions）の typecheck も走らせて破壊的変更を検出する。
       - name: Run all quality checks in parallel
+        env:
+          WEB: ${{ needs.changes.outputs.web }}
+          FUNCTIONS: ${{ needs.changes.outputs.functions }}
+          SHARED_TYPES: ${{ needs.changes.outputs.shared-types }}
+          UI: ${{ needs.changes.outputs.ui }}
         run: |
+          # 各チェックは `pnpm ... | sed` のパイプで実行する。pipefail がないと
+          # pnpm 側の失敗が末尾の sed の終了コード 0 にマスクされて緑になるため、
+          # GitHub Actions のデフォルトと同じく明示的に有効化する。
+          set -eo pipefail
           echo "🧪 Running quality checks in parallel..."
-          
-          # 実行するチェックを管理
+
           declare -A checks
-          
-          # Web app checks
-          if [[ "${{ needs.changes.outputs.web }}" == "true" ]]; then
-            pnpm --filter @suzumina.click/web lint 2>&1 | sed 's/^/[web-lint] /' &
-            checks["web-lint"]=$!
-            
-            pnpm --filter @suzumina.click/web typecheck 2>&1 | sed 's/^/[web-typecheck] /' &
-            checks["web-typecheck"]=$!
-            
-            pnpm --filter @suzumina.click/web test --run --passWithNoTests 2>&1 | sed 's/^/[web-test] /' &
-            checks["web-test"]=$!
+
+          # <label> のチェックをバックグラウンドで起動し、PID を記録する。
+          run_check() {
+            local label="$1"; shift
+            "$@" 2>&1 | sed "s/^/[$label] /" &
+            checks["$label"]=$!
+          }
+
+          # --- web ---------------------------------------------------------
+          # web 変更時は web 自身を検査。web 未変更でも依存（shared-types / ui）が
+          # 変わったら typecheck だけ走らせ、破壊的変更を検出する。
+          if [[ "$WEB" == "true" ]]; then
+            run_check web-lint      pnpm --filter @suzumina.click/web lint
+            run_check web-typecheck pnpm --filter @suzumina.click/web typecheck
+            run_check web-test      pnpm --filter @suzumina.click/web test --run --passWithNoTests
+          elif [[ "$SHARED_TYPES" == "true" || "$UI" == "true" ]]; then
+            run_check web-typecheck pnpm --filter @suzumina.click/web typecheck
           fi
 
-          # Functions checks
-          if [[ "${{ needs.changes.outputs.functions }}" == "true" ]]; then
-            pnpm --filter @suzumina.click/functions build 2>&1 | sed 's/^/[functions-build] /' &
-            checks["functions-build"]=$!
-            
-            # ビルドの完了を待ってからlint/typecheck/testを実行
-            wait ${checks["functions-build"]}
-            build_result=$?
-            
-            if [ $build_result -eq 0 ]; then
+          # --- shared-types ------------------------------------------------
+          if [[ "$SHARED_TYPES" == "true" ]]; then
+            run_check shared-types-lint      pnpm --filter @suzumina.click/shared-types lint
+            run_check shared-types-typecheck pnpm --filter @suzumina.click/shared-types typecheck
+            run_check shared-types-test      pnpm --filter @suzumina.click/shared-types test
+          fi
+
+          # --- ui ----------------------------------------------------------
+          if [[ "$UI" == "true" ]]; then
+            run_check ui-lint      pnpm --filter @suzumina.click/ui lint
+            run_check ui-typecheck pnpm --filter @suzumina.click/ui typecheck
+            run_check ui-test      pnpm --filter @suzumina.click/ui test
+          fi
+
+          # --- functions ---------------------------------------------------
+          # functions は esbuild バンドルのため build を fail-fast ゲートにし、
+          # 成功後に lint / typecheck / test を並列起動する。functions 未変更でも
+          # shared-types が変わったら typecheck だけ走らせる（build 非依存）。
+          if [[ "$FUNCTIONS" == "true" ]]; then
+            if pnpm --filter @suzumina.click/functions build 2>&1 | sed 's/^/[functions-build] /'; then
               echo "✅ functions-build completed"
-              
-              pnpm --filter @suzumina.click/functions lint 2>&1 | sed 's/^/[functions-lint] /' &
-              checks["functions-lint"]=$!
-              
-              pnpm --filter @suzumina.click/functions typecheck 2>&1 | sed 's/^/[functions-typecheck] /' &
-              checks["functions-typecheck"]=$!
-              
-              pnpm --filter @suzumina.click/functions test --run 2>&1 | sed 's/^/[functions-test] /' &
-              checks["functions-test"]=$!
+              run_check functions-lint      pnpm --filter @suzumina.click/functions lint
+              run_check functions-typecheck pnpm --filter @suzumina.click/functions typecheck
+              run_check functions-test      pnpm --filter @suzumina.click/functions test --run
             else
               echo "❌ functions-build failed"
               exit 1
             fi
+          elif [[ "$SHARED_TYPES" == "true" ]]; then
+            run_check functions-typecheck pnpm --filter @suzumina.click/functions typecheck
           fi
-          
-          # 全チェックの完了を待つ
+
+          # --- 全チェックの完了を待ち、ひとつでも失敗したらジョブを fail させる ---
+          # 1 件も選ばれなければ「無検査で緑」になるので、ここで明示的に落とす。
+          if [[ ${#checks[@]} -eq 0 ]]; then
+            echo "⚠️ No quality checks were selected for the changed files"
+            exit 1
+          fi
+
           failed=false
-          for check_name in "${!checks[@]}"; do
-            if [[ $check_name != "functions-build" ]]; then  # already handled
-              if wait ${checks[$check_name]}; then
-                echo "✅ $check_name completed"
-              else
-                echo "❌ $check_name failed"
-                failed=true
-              fi
+          for label in "${!checks[@]}"; do
+            if wait "${checks[$label]}"; then
+              echo "✅ $label completed"
+            else
+              echo "❌ $label failed"
+              failed=true
             fi
           done
-          
+
           if $failed; then
             echo "❌ Some checks failed"
             exit 1
-          else
-            echo "🎉 All checks completed successfully"
           fi
+          echo "🎉 All checks completed successfully"
 
   build-check:
     name: Build Verification


### PR DESCRIPTION
## 背景 / 穴の正体

`parallel-check` の起動条件(`if`)は shared-types / ui 変更でもジョブを起動するが、ステップ本体には web / functions のブロックしか無かった。そのため `packages/shared-types/**` / `packages/ui/**` **単独変更**の PR は、何も実行せず `🎉 All checks completed successfully` で**緑**になっていた（緑＝安全が崩れていた）。shared-types はモノレポ全体の型の土台のため、無検査通過はリスクが高い。

Closes SPR-78

## 変更点

- **4 パッケージそれぞれに lint / typecheck / test を追加**（`run_check` ヘルパで重複排除）
- **破壊的変更検出**: shared-types 変更時は依存先 **web / functions の typecheck** も、ui 変更時は **web typecheck** も起動。web / functions 自身が変更済みなら `elif` で**二重起動を回避**
- **pipefail を明示**: 既存実装は GHA デフォルトの pipefail に暗黙依存していた（無いと `pnpm` の失敗が末尾 `sed` の exit 0 に**マスクされて緑**になる）
- **「チェック 0 件なら fail」ガード**を追加し「無検査で緑」を**構造的に再発防止**
- functions の build-first fail-fast は維持（背景+wait → 前景 `if`、pipefail 下で等価）

admin は SPR-79 で既に除去済みのため対象外。

## 検証

**実パッケージ（本番と同一コマンド）**: `pnpm --filter` で shared-types / ui の lint・typecheck・test 全 6 件 → **exit 0**

**ディスパッチ模擬**（YAML から抽出した実 run スクリプトを `pnpm` だけモックして実行）:

| 変更セット | 選ばれたチェック | exit |
|---|---|---|
| shared-types のみ | shared-types 3種 + web-typecheck + functions-typecheck | 0 |
| ui のみ | ui 3種 + web-typecheck | 0 |
| web + shared-types | web 3種 + shared-types 3種 + functions-typecheck（重複なし） | 0 |
| functions + shared-types | functions 4種 + shared-types 3種 + web-typecheck（重複なし） | 0 |
| 変更なし（ガード） | （空）→ 明示 fail | 1 |
| shared-types test 失敗 | — | 1（赤） |
| functions build 失敗 | functions-build のみ（fail-fast） | 1 |

## スコープ外メモ

- `build-check` は未変更。shared-types / ui は no-build で、下流 `web next build` の型破壊は依存先 typecheck が捕捉するため（PR ループ最重量の web ビルドは毎回回さず、post-merge `deploy-web.yml` がバックストップ）。
- `packages/typescript-config/**` 単独変更は `parallel-check` の `if` に含まれず**ジョブごとスキップ**される別の小さな穴あり（本 PR のスコープ外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
