### PR TITLE
perf(infra): _next/image を Cloudflare エッジでキャッシュ（SPR-86）

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -95,7 +95,17 @@ resource "cloudflare_ruleset" "cache_rules" {
     enabled     = true
   }
 
-  # 3. Next.js 画像最適化エンドポイント: 1日キャッシュ
+  # 3. Next.js 画像最適化エンドポイント (/_next/image?url=...): 1日キャッシュ
+  #
+  # 注意1: パスは末尾スラッシュ無しの "/_next/image"。
+  #   /_next/image はクエリ string 型エンドポイント (/_next/image?url=...) のため
+  #   http.request.uri.path は "/_next/image"。"/_next/image/" だと starts_with が
+  #   false になりルールが一致せず、最適化画像がエッジ未キャッシュ (cf-cache-status: DYNAMIC) になる。
+  #   ※ rule #2 の "/_next/static/" は直後に必ずサブパスが続くため末尾スラッシュでも一致する。
+  # 注意2: optimizer は Accept で形式ネゴ (Vary: Accept → AVIF/WebP/JPEG を出し分け)。
+  #   Cloudflare は Accept-Encoding 以外の Vary をデフォルトで非キャッシュ扱いにするため、
+  #   cache_key に Accept を含めて「形式ごとに別エントリ」でキャッシュする。これが無いと
+  #   最初にキャッシュした形式 (例: AVIF) を非対応ブラウザにも返し、画像が壊れる。
   rules {
     action = "set_cache_settings"
     action_parameters {
@@ -108,9 +118,16 @@ resource "cloudflare_ruleset" "cache_rules" {
         mode    = "override_origin"
         default = 86400
       }
+      cache_key {
+        custom_key {
+          header {
+            include = ["accept"]
+          }
+        }
+      }
     }
-    expression  = "(starts_with(http.request.uri.path, \"/_next/image/\"))"
-    description = "Next.js 画像最適化: 1日キャッシュ"
+    expression  = "(starts_with(http.request.uri.path, \"/_next/image\"))"
+    description = "Next.js 画像最適化: 1日キャッシュ (Accept 変種対応)"
     enabled     = true
   }
 


### PR DESCRIPTION
## 概要

list ページの Mobile LCP の支配項 **Resource Load Delay**（de-risk 計測: videos 48–69%、works も画像 bound）の主因 = `_next/image`（Next.js 画像最適化エンドポイント）が **Cloudflare エッジで未キャッシュ**だった問題を修正します。

Linear: **SPR-86**（de-risk は SPR-82 で実施、結論として ConfigurableList の Server Component 化は LCP no-go → Canceled）

## Root cause（本番ヘッダ実測）

- `_next/image?url=...` → `cf-cache-status: DYNAMIC`（2 回叩いても DYNAMIC＝origin 直行）。対照の `/_next/static/...css` は `HIT`（`age` 増加）。
- 原因①: cache rule 式が `/_next/image/`（末尾スラッシュ）。実エンドポイントの `http.request.uri.path` はクエリを除いた `/_next/image` なので `starts_with("/_next/image", "/_next/image/")` = false でルール不一致。
- 原因②: optimizer は `Vary: Accept` で AVIF/WebP/JPEG を出し分け（`Accept: image/avif…`→`image/avif` / `Accept: image/jpeg`→`image/jpeg` を実測）。Cloudflare は Accept-Encoding 以外の Vary をデフォルトで非キャッシュ扱いにする。

## 変更（`terraform/cloudflare.tf` rule #3）

1. `expression`: `/_next/image/` → `/_next/image`
2. `cache_key.custom_key.header.include = ["accept"]` を追加 — 形式ごとに別エントリでキャッシュし、format negotiation を保持（無いと最初にキャッシュした形式を全クライアントに返し非対応ブラウザで画像が壊れる）

## ⚠️ レビュー観点 / apply 前の注意

- **プラン依存**: Cache Rules の custom cache key は Cloudflare のプランによっては Enterprise 限定の可能性。`terraform plan` で弾かれる場合の代替:
  - (a) `cache_key` ブロックを外す（Accept 無視・AVIF ほぼ全対応という前提を受容、旧ブラウザに残リスク）
  - (b) Next 側で画像形式を単一化し `Vary` 自体を解消（`next.config` 変更、要検証）
- `terraform fmt`（差分なし）/ `terraform validate`（Success）はローカル通過済み。**apply は未実施**（Cloudflare 認証はインフラ側で実行）。

## apply 後の検証

```bash
U='https://suzumina.click/_next/image?url=...&w=750&q=75'
# 同一 Accept で 2 回 → 2 回目 HIT を期待
curl -sI -H 'Accept: image/avif,image/webp,*/*' "$U" | grep -i cf-cache-status
curl -sI -H 'Accept: image/avif,image/webp,*/*' "$U" | grep -i cf-cache-status
# 形式ネゴ維持（content-type が Accept で出し分くこと）
curl -sI -H 'Accept: image/avif,*/*' "$U" | grep -i content-type   # image/avif
curl -sI -H 'Accept: image/jpeg'     "$U" | grep -i content-type   # image/jpeg
```

その後、本番 PSI / Lighthouse mobile で `/works` `/videos` の LCP（特に Resource Load Delay）改善を計測。

## 関連

- SPR-86（本 PR）/ SPR-82（de-risk 元・Canceled）/ SPR-81・SPR-71（Mobile LCP・TTI epic）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
