### PR TITLE
fix(infra): _next/image の cache_key から Accept を除去（apply 不可を解消, SPR-86）

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -102,10 +102,13 @@ resource "cloudflare_ruleset" "cache_rules" {
   #   http.request.uri.path は "/_next/image"。"/_next/image/" だと starts_with が
   #   false になりルールが一致せず、最適化画像がエッジ未キャッシュ (cf-cache-status: DYNAMIC) になる。
   #   ※ rule #2 の "/_next/static/" は直後に必ずサブパスが続くため末尾スラッシュでも一致する。
-  # 注意2: optimizer は Accept で形式ネゴ (Vary: Accept → AVIF/WebP/JPEG を出し分け)。
-  #   Cloudflare は Accept-Encoding 以外の Vary をデフォルトで非キャッシュ扱いにするため、
-  #   cache_key に Accept を含めて「形式ごとに別エントリ」でキャッシュする。これが無いと
-  #   最初にキャッシュした形式 (例: AVIF) を非対応ブラウザにも返し、画像が壊れる。
+  # 注意2: optimizer は Vary: Accept で AVIF/WebP/JPEG を出し分けるが、Cloudflare は
+  #   Accept をカスタムキャッシュキーに使えない (forbidden header / API err 20111)。
+  #   "Vary for Images" (Cache Variants) は拡張子ベースで /_next/image (拡張子なし) には効かない。
+  #   そのため Accept では分けず単一エントリでキャッシュする (cache=true で Vary を無視して
+  #   キャッシュし、最初にキャッシュした形式を全クライアントに返す)。AVIF/WebP は現行ブラウザで
+  #   ほぼ全対応のため実害は極小。形式別に厳密化する場合は Transform Rule で Accept を許可ヘッダ
+  #   (例 x-img-fmt: avif|webp|jpeg) に正規化し cache key に含める (SPR-86 フォロー)。
   rules {
     action = "set_cache_settings"
     action_parameters {
@@ -118,16 +121,9 @@ resource "cloudflare_ruleset" "cache_rules" {
         mode    = "override_origin"
         default = 86400
       }
-      cache_key {
-        custom_key {
-          header {
-            include = ["accept"]
-          }
-        }
-      }
     }
     expression  = "(starts_with(http.request.uri.path, \"/_next/image\"))"
-    description = "Next.js 画像最適化: 1日キャッシュ (Accept 変種対応)"
+    description = "Next.js 画像最適化: 1日キャッシュ"
     enabled     = true
   }
 


### PR DESCRIPTION
## 概要

[#459](https://github.com/nothink-jp/suzumina.click/pull/459) で追加した `cache_key.custom_key.header = ["accept"]` が **Cloudflare の forbidden header**（API err 20111）で `terraform apply` に失敗していたため、`cache_key` を削除します。`_next/image` のエッジキャッシュ化（cache rule の末尾スラッシュ修正）は #459 のまま維持。

Linear: **SPR-86**

## apply エラー

```
Error: error updating ruleset with ID "..."
  with cloudflare_ruleset.cache_rules[0]
  forbidden header (20111)
```

- `Accept` は Cloudflare のカスタムキャッシュキーに使えないヘッダ（`accept` / `accept-encoding` / `host` / `cookie` 等は禁止）。
- `terraform plan` は差分計算のみで CF API セマンティクスを検証しないため通過し、apply で拒否された。
- CF の Accept 形式ネゴ機能「Vary for Images（Cache Variants）」は拡張子ベースで、`/_next/image`（拡張子なし）には適用不可。

## 変更

- `cache_key` ブロックを削除（`expression` の末尾スラッシュ修正 `/_next/image` は維持）。
- `cache = true` により `_next/image` は `Vary: Accept` を無視してエッジキャッシュされる。

## 既知の制約（許容）

- 単一エントリでキャッシュ → 最初にキャッシュした形式（AVIF 等）を全クライアントに返す。AVIF/WebP は現行ブラウザでほぼ全対応のため実害は極小。
- 形式別に厳密化する場合は Transform Rule で Accept を許可ヘッダ（例 `x-img-fmt: avif|webp|jpeg`）に正規化し cache key に含める → **SPR-86 フォロー**。

## 検証

- `terraform fmt`（差分なし）/ `terraform validate`（Success）。
- **apply 後の本番検証**:
  1. 同一画像 URL を 2 回 → 2 回目以降 `cf-cache-status: HIT` を期待（万一 DYNAMIC のままなら `Vary` を落とす response Transform を追加）
  2. 異なる画像 URL 2 つがそれぞれ独立に HIT（クエリ string がキャッシュキーに保持されていること）
  3. PSI / Lighthouse mobile で `/works` `/videos` の LCP（Resource Load Delay）改善を実測

## 関連

- #459（slash 修正・本 PR の前段） / SPR-86 / SPR-82（Canceled）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
