### PR TITLE
chore(harness): ローカル検証ループを本物にする（pnpm verify 新設 + pre-push 修正, SPR-77）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,8 @@ For detailed project documentation, see [Documentation Index](docs/README.md).
 - NO automatic documentation generation (*.md, README, etc.)
 
 ### 3. TESTING REQUIREMENTS
-- **ALWAYS run tests after code changes**: `pnpm test`
-- **ALWAYS run linting**: `pnpm lint`
-- **ALWAYS run typecheck**: `pnpm typecheck`
+- **完了前に必ず `pnpm verify` を通す** - lint + typecheck + test を一括実行（ローカル pre-push / CI と同じ判定）。失敗時は非ゼロで停止する
+- 個別に確認したい場合のみ: `pnpm lint` / `pnpm typecheck` / `pnpm test`
 - **ALWAYS place test files in `__tests__` directories** - not co-located with source files
 
 ### 4. CODE QUALITY STANDARDS
@@ -80,7 +79,10 @@ For detailed project documentation, see [Documentation Index](docs/README.md).
 # Development
 pnpm --filter @suzumina.click/web dev
 
-# Testing
+# Verify (CI と同じ判定: lint + typecheck + test)
+pnpm verify
+
+# 個別実行
 pnpm test
 pnpm lint
 pnpm typecheck

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -25,12 +25,13 @@ pre-push:
     typecheck-changed:
       glob: "*.{ts,tsx}"
       run: |
-        # 変更ファイルが属するパッケージを特定して型チェック
-        for file in {staged_files}
-        do
-          if [[ $file == apps/* ]] || [[ $file == packages/* ]]; then
-            pkg_dir=$(echo $file | cut -d'/' -f1-2)
-            pnpm --filter "./$pkg_dir" typecheck 2>/dev/null || true
-          fi
+        set -e
+        # push 対象ファイルが属するパッケージを特定して型チェック（重複排除）
+        # `case` を $() 内に書くと sh(bash 互換) がパターンの ) を $( の閉じと誤認するため grep で抽出する
+        pkgs=$(printf "%s\n" {push_files} | grep -E "^(apps|packages)/" | cut -d/ -f1-2 | sort -u)
+        if [ -z "$pkgs" ]; then echo "型チェック対象のパッケージ変更なし"; exit 0; fi
+        for pkg in $pkgs; do
+          echo "▶ typecheck: $pkg"
+          pnpm --filter "./$pkg" typecheck
         done
-      fail_text: "変更ファイルの型チェックに失敗しました"
+      fail_text: "変更パッケージの型チェックに失敗しました"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"secretlint:sarif": "secretlint --format @secretlint/secretlint-formatter-sarif --output secretlint-results.sarif \"**/*\"",
 		"typecheck": "pnpm -r typecheck",
 		"test": "pnpm -r test",
+		"verify": "pnpm lint && pnpm typecheck && pnpm test",
 		"test:coverage": "pnpm -r test:coverage",
 		"clean": "pnpm -r clean && rimraf node_modules/.cache coverage",
 		"clean:all": "pnpm clean && rimraf node_modules **/node_modules"


### PR DESCRIPTION
## 概要

harness の観点で**ローカル検証ループを「本物」にする**（Linear: SPR-77）。CI（pr-check.yml）は lint / typecheck / test を実際に落とす本物のゲートだが、ローカルの自己修正ループが弱く、エージェントが確実なフィードバックを得るには「push → PR → CI 待ち」になっていた。これをローカルに前倒しする。

## 変更

- **package.json**: 単一ゲート `verify` を新設（`pnpm lint && pnpm typecheck && pnpm test`）。`&&` 連結で最初の失敗時に非ゼロ終了。
- **lefthook.yml (pre-push)**: 型チェックが実質機能していなかったのを修正
  - `{staged_files}` → `{push_files}`（pre-push 時点では staged が空になりがち）
  - `2>/dev/null || true` を撤去（失敗の握り潰しを解消）＋ `set -e`
  - 対象パッケージを `sort -u` で重複排除
- **CLAUDE.md**: 「ALWAYS run test/lint/typecheck」の口約束を `pnpm verify`（pre-push / CI と同じ判定）への参照に集約。Quick Command にも追記。

## 適用差分にあった潜在バグを修正

Linear に用意されていた提案差分（構文パースのみ・完全実行は未実施）は、pre-push のパッケージ抽出を `case "$file" in ... esac` で書いていた。これは `$(...)` コマンド置換の中に置くと **macOS の `/bin/sh`（POSIX モードの bash）で `syntax error near ';;'`** を起こす（case パターン末尾の `)` を `$(` の閉じと誤認する移植性の罠）。`dash`（Linux/CI）では通るため CI では発覚せず、**ローカル pre-push だけが必ず壊れる**＝直したいループそのものが壊れる状態だった。`case` を使わない `printf | grep | cut | sort` に書き換えて解消。

## 検証（完了の定義）

- ✅ `pnpm verify` → **exit 0**、lint → typecheck → test の順で全 2273 テスト pass
- ✅ pre-push: 型エラーを含むファイル → **exit 1** + 実 `TS2322` 検出 + fail_text 表示。正常ファイル → exit 0、apps/packages 外の変更 → graceful skip（実フックで確認）
- ✅ `/bin/sh`・`dash` 両方でフックのシェルロジックを「マッチあり / ルートのみ / 空」の3ケース検証
- ✅ 本 PR の push 自体も修正後 pre-push を通過（非 .ts 変更につき typecheck は正しく skip）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
