### PR TITLE
perf(web): videos の総数取得を count() 集計化し全件スキャンを除去（SPR-88）

### DIFF
--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -9,6 +9,7 @@ const mockWhere = vi.fn();
 const mockOrderBy = vi.fn();
 const mockLimit = vi.fn();
 const mockStartAfter = vi.fn();
+const mockCount = vi.fn();
 
 vi.mock("@/lib/firestore", () => ({
 	getFirestore: () => ({
@@ -36,6 +37,7 @@ describe("Video Server Actions", () => {
 			limit: mockLimit,
 			startAfter: mockStartAfter,
 			get: mockGet,
+			count: mockCount,
 		};
 
 		mockCollection.mockReturnValue(mockQuery);
@@ -43,6 +45,10 @@ describe("Video Server Actions", () => {
 		mockOrderBy.mockReturnValue(mockQuery);
 		mockLimit.mockReturnValue(mockQuery);
 		mockStartAfter.mockReturnValue(mockQuery);
+		// count() は集計クエリを返す: query.count().get() → { data: () => ({ count }) }
+		mockCount.mockReturnValue({
+			get: vi.fn().mockResolvedValue({ data: () => ({ count: 0 }) }),
+		});
 	});
 
 	describe("getVideoTitles", () => {
@@ -127,6 +133,10 @@ describe("Video Server Actions", () => {
 			mockGet.mockResolvedValue({
 				docs: mockVideoDocs,
 				size: 2,
+			});
+			// デフォルトパスの総数は count() 集計から取得する（SPR-88）
+			mockCount.mockReturnValue({
+				get: vi.fn().mockResolvedValue({ data: () => ({ count: 2 }) }),
 			});
 
 			const result = await getVideoTitles();
@@ -285,6 +295,20 @@ describe("Video Server Actions", () => {
 
 			// getVideoTitlesが正しいパラメータで呼ばれることを確認
 			expect(mockGet).toHaveBeenCalled();
+		});
+
+		it("フィルタ無しのデフォルトパスは count() 集計で総数を取得する（全件スキャン回避, SPR-88）", async () => {
+			mockGet.mockResolvedValue({ docs: [], size: 0 });
+			mockCount.mockReturnValue({
+				get: vi.fn().mockResolvedValue({ data: () => ({ count: 99 }) }),
+			});
+
+			const result = await getVideosList({ page: 1, limit: 12 });
+
+			// count() + where(public) 集計が使われる
+			expect(mockWhere).toHaveBeenCalledWith("status.privacyStatus", "==", "public");
+			expect(mockCount).toHaveBeenCalled();
+			expect(result.totalCount).toBe(99);
 		});
 	});
 });

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -294,14 +294,16 @@ async function getVideosWithFiltering(
 	const plainVideos = videos; // すでにPlainObject
 	const _hasMore = snapshot.size > limit;
 
-	// publicな動画の総数を取得
-	// TODO: パフォーマンス最適化のため、メタデータコレクションでのキャッシュを検討
-	const countQuery = firestore.collection("videos");
-	const countSnapshot = await countQuery.get();
-	const total = countSnapshot.docs
-		.map((doc) => convertToVideo(doc))
-		.filter((video): video is VideoPlainObject => video !== null)
-		.filter((video) => video.status?.privacyStatus === "public" || !video.status).length;
+	// publicな動画の総数を count() 集計で取得（SPR-88: 毎リクエストの全件 .get()
+	// スキャンを回避。works/actions.ts と同じ count() パターン）。
+	// 注: 旧実装は (public || status未設定) を計上していたが、count()+where では status
+	// 未設定ドキュメントを拾えないため public のみ計上する（厳密化はメタデータ cache を検討）。
+	const countSnapshot = await firestore
+		.collection("videos")
+		.where("status.privacyStatus", "==", "public")
+		.count()
+		.get();
+	const total = countSnapshot.data().count;
 
 	return {
 		items: plainVideos,
@@ -402,18 +404,33 @@ export async function getTotalVideoCount(params?: {
 }) {
 	try {
 		const firestore = getFirestore();
-		const query = firestore.collection("videos");
 
-		// 全件を取得してメモリ上でフィルタリング（一時的な対応）
-		const snapshot = await query.get();
+		// フィルタが無い場合は count() 集計で取得し全件スキャンを回避（SPR-88）。
+		// 現状の唯一の呼び出し元 getVideosList は常にフィルタ無し ({}) で呼ぶため、
+		// この fast path が実質的なホットパス。
+		const hasFilters = !!(
+			params?.year ||
+			params?.search ||
+			params?.playlistTags?.length ||
+			params?.userTags?.length ||
+			params?.categoryNames?.length ||
+			params?.videoType
+		);
+		if (!hasFilters) {
+			const countSnapshot = await firestore
+				.collection("videos")
+				.where("status.privacyStatus", "==", "public")
+				.count()
+				.get();
+			return countSnapshot.data().count;
+		}
 
-		// Video Entityに変換してフィルタリング
+		// フィルタがある場合は全件取得してメモリ上でフィルタリング（暫定）
+		const snapshot = await firestore.collection("videos").get();
 		const videos = snapshot.docs
 			.map((doc) => convertToVideo(doc))
 			.filter((video): video is VideoPlainObject => video !== null)
 			.filter((video) => video.status?.privacyStatus === "public" || !video.status);
-
-		// フィルタリング処理をヘルパー関数に委譲
 		const filteredVideos = filterVideos(videos, params || {});
 
 		return filteredVideos.length;


### PR DESCRIPTION
## 概要

SPR-88 spike で特定した videos Mobile LCP の真因 — `getVideosList` の **no-filter 経路が総数算出のため videos コレクション全件を 2 回 `.get()` スキャン**していた問題を修正。Firestore `count()` 集計に置換しサーバ応答を短縮します。

Linear: **SPR-88**（WS-1）

## 背景（spike の計測）

- サーバ応答 total: **works ~0.3s vs videos ~0.8–1.2s**（TTFB は同等 ~0.18s）
- videos trace: LCP 画像マークアップが HTML stream 完了の **~1487ms** に届き、画像 load 自体は **26ms（edge HIT, SPR-86）**。→ videos LCP の支配項 Resource Load Delay は「画像/帯域」ではなく **サーバのデータ取得遅延**が律速
- 真因: no-filter の `getVideosList` 経路で 2 つの全件スキャンが走る:
  1. `getVideosWithFiltering` の count（filteredCount 用）
  2. `getTotalVideoCount({})`（totalCount 用、コメントに「一時的な対応」と明記）

## 変更（`apps/web/src/app/videos/actions.ts`）

- 上記 2 箇所の全件 `.get()` + in-memory count を **`where("status.privacyStatus","==","public").count().get()`** に置換（`works/actions.ts:58` と同じ既出パターン）
- `getTotalVideoCount` はフィルタ有り時のみ従来の in-memory フィルタにフォールバック（唯一の呼び出し元 `getVideosList` は常に `{}` で呼ぶため実質常に fast path）
- `getVideoTitles` 経由のため home（`app/actions.ts`）の動画取得にも効く

### ⚠️ 意味論の変更
旧実装は `privacyStatus === "public" || status未設定` を計上。`count() + where` では status 未設定ドキュメントを拾えないため **public のみ計上**します（方針合意済み）。status 未設定動画が多い場合は表示件数が下がるため、厳密化が必要ならメタデータ文書への total キャッシュを検討。

## 検証

- **web 全テスト: 62 files / 689 passed**（1 skipped）。videos actions / videos page / home actions すべて green。デフォルトパスの `count()` 利用を検証する新規テストを追加
- `biome check` clean / `tsc --noEmit --skipLibCheck` clean
- 期待効果: videos サーバ応答 ~1.1s → ~0.3s 相当 → LCP 画像マークアップが ~800ms 早着 → videos Mobile LCP の Resource Load Delay を直接削減。**マージ後に本番 PSI / Lighthouse mobile で実測**して確認

## 関連

- SPR-88（spike, WS-1）/ SPR-86（edge cache・画像 load は既に 26ms）/ SPR-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
