### PR TITLE
fix(infra): Cloud Run の image state 乖離を data source 追従で解消（SPR-67）

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -73,6 +73,41 @@ gsutil rm gs://suzumina-click-tfstate/terraform/state/production.tflock
 sleep 30 && terraform apply
 ```
 
+#### 3. "Revision ... is not ready" / "Image '...web:<sha>' not found" (SPR-67)
+
+Cloud Run の image は **GitHub Actions（`deploy-web.yml`）が `gcloud run deploy` でデプロイ**し、
+Terraform は `data.google_cloud_run_v2_service.current` 経由で稼働中サービスの image を
+読み取って追従する（`terraform/cloud_run.tf`）。これにより state に古い image SHA は残らず、
+通常運用でこのエラーは発生しない。
+
+万一発生した場合（例: `-refresh=false` で apply した／state が長期間古いまま）の復旧:
+
+```bash
+# 1. state を実体に同期（最優先。これだけで解消することが多い）
+terraform apply -refresh-only
+
+# 2. 差分を確認してから適用
+terraform plan
+terraform apply
+```
+
+> ⚠️ `terraform apply -refresh=false` は state を古いままにし image 乖離を再発させるため使用しない。
+
+### 初回 apply / 災害復旧（サービス未作成）
+
+Cloud Run サービスがまだ存在しない状態では上記 data source が読めず `plan` が失敗する。
+その場合は **一度だけ** bootstrap モードで `:latest` 起動する:
+
+```bash
+# 1. サービスを :latest で新規作成
+terraform apply -var="cloud_run_bootstrap=true"
+
+# 2. GitHub Actions（Deploy Web）でアプリ image を本デプロイ
+
+# 3. 以降は通常運用（bootstrap=false がデフォルト）に戻す
+terraform plan
+```
+
 ### ログ確認方法
 ```bash
 # Cloud Storageのロックファイル確認

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -25,10 +25,11 @@ data "google_cloud_run_v2_service" "current" {
 }
 
 locals {
-  # 通常運用では live の image を踏襲し、bootstrap 時は :latest にフォールバックする。
-  # try() は count=0（bootstrap）時のインデックスエラーを捕捉するためのもの。
-  cloud_run_image = try(
-    data.google_cloud_run_v2_service.current[0].template[0].containers[0].image,
+  # 通常運用では live の image を踏襲し、bootstrap（count=0）時は :latest にフォールバックする。
+  # splat + one() で count=0 を null 化してフォールバックさせ、count=1 だが構造が想定外の
+  # 場合は黙殺せずエラーにする（try() のような握り潰しを避ける）。
+  cloud_run_image = coalesce(
+    one(data.google_cloud_run_v2_service.current[*].template[0].containers[0].image),
     "${var.region}-docker.pkg.dev/${local.project_id}/${var.artifact_registry_repository_id}/web:latest"
   )
 }

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -4,6 +4,35 @@
  * Next.js 15 App RouterアプリケーションをCloud Runにデプロイする設定
  */
 
+# 現在稼働中の Cloud Run サービスを参照し、GitHub Actions がデプロイした
+# 「実体の image」を読み取る（SPR-67 恒久対策）。
+#
+# 背景: GitHub Actions は `gcloud run deploy --image web:<sha>` で image を更新するが、
+# 以前は lifecycle.ignore_changes で image を無視していたため state に古い SHA が残り、
+# labels 等の差分契機で revision が新規作成されると、cleanup policy で既に削除済みの
+# image を参照して起動失敗していた（"Image ... not found"）。
+# この data source で実体の image を毎回読み取り resource に渡すことで、
+# Terraform 側の image を常に live へ追従させ、古い SHA が state に残らないようにする。
+#
+# 初回 apply / DR 時（サービス未作成）は var.cloud_run_bootstrap = true にして
+# data source の参照を無効化し、:latest で起動する。
+data "google_cloud_run_v2_service" "current" {
+  count = var.cloud_run_bootstrap ? 0 : 1
+
+  provider = google
+  name     = var.cloud_run_service_name
+  location = var.region
+}
+
+locals {
+  # 通常運用では live の image を踏襲し、bootstrap 時は :latest にフォールバックする。
+  # try() は count=0（bootstrap）時のインデックスエラーを捕捉するためのもの。
+  cloud_run_image = try(
+    data.google_cloud_run_v2_service.current[0].template[0].containers[0].image,
+    "${var.region}-docker.pkg.dev/${local.project_id}/${var.artifact_registry_repository_id}/web:latest"
+  )
+}
+
 # Cloud Runサービス（全環境で有効）
 resource "google_cloud_run_v2_service" "nextjs_app" {
 
@@ -30,8 +59,9 @@ resource "google_cloud_run_v2_service" "nextjs_app" {
 
     # コンテナ設定
     containers {
-      # Artifact Registryのイメージを参照
-      image = "${var.region}-docker.pkg.dev/${local.project_id}/${var.artifact_registry_repository_id}/web:latest"
+      # 稼働中サービスの image を踏襲する（SPR-67: 古い SHA の混入防止）。
+      # 実体の追跡は data.google_cloud_run_v2_service.current 経由（local.cloud_run_image）。
+      image = local.cloud_run_image
 
       # リソース制限（環境別・コスト最適化）
       resources {
@@ -211,11 +241,12 @@ resource "google_cloud_run_v2_service" "nextjs_app" {
     type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
 
-  # GitHub Actions からのデプロイとの競合を避けるため、
-  # 画像参照と環境変数は GitHub Actions が管理し、Terraform は無視する
+  # 環境変数は GitHub Actions の `gcloud run deploy --set-env-vars/--set-secrets` が
+  # 管理するため Terraform は無視する。
+  # image は ignore せず data source で live を追従する（SPR-67 恒久対策）。
+  # 注意: refresh を伴わない apply（-refresh=false）は state を古くするため使用しない。
   lifecycle {
     ignore_changes = [
-      template[0].containers[0].image,
       template[0].containers[0].env,
     ]
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,6 +79,12 @@ variable "cloud_run_service_name" {
   default     = "suzumina-click-web"
 }
 
+variable "cloud_run_bootstrap" {
+  description = "初回 apply（サービス未作成）や DR 時に true。稼働中サービスの image を参照する data source を無効化し、:latest で起動する。通常運用では false。"
+  type        = bool
+  default     = false
+}
+
 # ==========================================================
 # 監視・アラート設定用変数
 # ==========================================================


### PR DESCRIPTION
## 概要

[SPR-67](https://linear.app/nothink/issue/SPR-67) — Cloud Run の image state 乖離問題への恒久対策。

## 根本原因

- `terraform/cloud_run.tf` の `lifecycle.ignore_changes = [image]` により、GitHub Actions が `gcloud run deploy --image web:<sha>` で更新する image が Terraform state に反映されない
- state には古い SHA が残り続け、`labels` 等の差分契機で revision が新規作成されると state の古い SHA を使う
- その SHA は Artifact Registry の cleanup policy（`keep-recent-versions = 5`）で既に削除済みのことが多く、revision 起動失敗（`Error: ... Image '...web:<sha>' not found`）に至る（SPR-66 で発生）

## 対応（案2: data source で現行 image を動的取得）

- `data "google_cloud_run_v2_service" "current"` で稼働中サービスの image を読み取り、resource の image を常に live へ追従させる（state に古い SHA が残らない）
- `lifecycle.ignore_changes` から `image` を除去（`env` は GitHub Actions 管理のため残置）
- 初回 apply / DR 用に `cloud_run_bootstrap` 変数を追加（サービス未作成時は `:latest` 起動にフォールバック）
- `terraform/README.md` に「Image not found」復旧手順と bootstrap 手順を追記

案3（CI で `terraform refresh`）は GitHub Actions への tfstate 書き込み権限付与と state ロック競合が必要なため不採用。案2 は宣言的に完結し新たな IAM 権限も CI 結合も不要。

## 検証

`production` workspace に対し `terraform plan`（Cloud Run サービスに `-target`、読み取り専用）を実機実行:

```
data.google_cloud_run_v2_service.current[0]: Read complete [id=...services/suzumina-click-web]
Plan: 0 to add, 1 to change, 0 to destroy
```

- **`image` の差分なし** → live image を踏襲し、古い SHA への巻き戻しが起きないことを実機確認
- 残る `1 to change` は本変更と無関係の既存 cosmetic 差分（`cpu "1" -> "1000m"` の等価整形、gcloud の `client`/`client_version` メタデータ → null）
- この差分契機で revision が再作成されても、image は live（存在する）を使うため起動失敗しない

## 受け入れ条件

- [x] `terraform apply` 単独で image 由来の deploy エラーが発生しない仕組み（data source 追従）
- [x] 運用ドキュメントに復旧手順を記載（セーフティネット）

## 補足（範囲外）

- `cpu "1" vs "1000m"` の恒久差分が残る。`locals.tf` の production `cloud_run_cpu` を `"1"` に揃えれば消せるが SPR-67 の範囲外
- ローカル ADC ではフル plan 時に別プロジェクト（`suzumina-click-firebase`）のカスタムロール / KMS で `iam.roles.get` 403 が出る（権限ギャップ・別件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
