### PR TITLE
fix(infra): Cloud Run web の恒久 plan 差分を解消（cpu 表記整合 + client/client_version を ignore）

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -244,11 +244,15 @@ resource "google_cloud_run_v2_service" "nextjs_app" {
 
   # 環境変数は GitHub Actions の `gcloud run deploy --set-env-vars/--set-secrets` が
   # 管理するため Terraform は無視する。
+  # client / client_version は gcloud run deploy が毎回付与する識別子メタデータで、
+  # Terraform config では未設定（null）。恒久的な "gcloud" -> null 差分を避けるため無視する。
   # image は ignore せず data source で live を追従する（SPR-67 恒久対策）。
   # 注意: refresh を伴わない apply（-refresh=false）は state を古くするため使用しない。
   lifecycle {
     ignore_changes = [
       template[0].containers[0].env,
+      client,
+      client_version,
     ]
   }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -11,7 +11,7 @@ locals {
       # テスト・プレビュー環境（超軽量・コスト重視）
       cloud_run_min_instances = 0
       cloud_run_max_instances = 1       # 最小限（テスト用）
-      cloud_run_cpu           = "1"     # 1vCPU（gcloud run deploy --cpu 1 の表記に整合）
+      cloud_run_cpu           = "1"     # 1vCPU（"1000m" と等価。表記を "1" に統一）
       cloud_run_cpu_idle      = true    # コスト削減のためCPUアイドル有効
       cloud_run_memory        = "512Mi" # 最小メモリ
       functions_memory        = "256Mi" # 最小メモリ

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -10,8 +10,8 @@ locals {
     staging = {
       # テスト・プレビュー環境（超軽量・コスト重視）
       cloud_run_min_instances = 0
-      cloud_run_max_instances = 1 # 最小限（テスト用）
-      cloud_run_cpu           = "1000m"
+      cloud_run_max_instances = 1       # 最小限（テスト用）
+      cloud_run_cpu           = "1"     # 1vCPU（gcloud run deploy --cpu 1 の表記に整合）
       cloud_run_cpu_idle      = true    # コスト削減のためCPUアイドル有効
       cloud_run_memory        = "512Mi" # 最小メモリ
       functions_memory        = "256Mi" # 最小メモリ
@@ -25,7 +25,7 @@ locals {
       # 本番環境（個人利用レベル・パフォーマンス改善）
       cloud_run_min_instances = 1        # LCP改善: コールドスタート排除
       cloud_run_max_instances = 2        # 最大インスタンス数を制限
-      cloud_run_cpu           = "1000m"  # 1vCPU: アイドル後レスポンス遅延を改善
+      cloud_run_cpu           = "1"      # 1vCPU: アイドル後レスポンス遅延を改善（gcloud --cpu 1 の表記に整合）
       cloud_run_cpu_idle      = false    # CPUを常時割り当て: アイドル後のスロットリング防止
       cloud_run_memory        = "1024Mi" # メモリ増強（1GB）でGC改善
       functions_memory        = "256Mi"  # YouTube API軽量処理用に最適化


### PR DESCRIPTION
## 背景 / 現象
`terraform/cloud_run.tf` の `google_cloud_run_v2_service.nextjs_app` を production workspace で plan すると、毎回 cosmetic な in-place 差分が出続け、apply のたびに web の revision が無駄に再作成されていた:

- `resources.limits.cpu = "1" -> "1000m"`（意味的に等価。1 vCPU = 1000m / **template 変更 → revision 再作成の主因**）
- `client = "gcloud" -> null` / `client_version = "..." -> null`（gcloud が付与するサービスレベルのメタデータ）

`.github/workflows/deploy-web.yml` が `gcloud run deploy --cpu 1` でデプロイするため live は `"1"` かつ client 系メタデータが付与される。一方 terraform config は cpu を `"1000m"`、client 系を未設定（null）にしているため、毎 plan で差分になっていた。

## 変更
1. **cpu 表記整合**: `locals.tf` の `cloud_run_cpu` を `"1000m"` → `"1"`（staging / production 両方、gcloud 表記に統一）。1 vCPU のまま機能変化なし。
2. **client/client_version の無視**: `cloud_run.tf` の `lifecycle.ignore_changes` に `client` / `client_version` を追加。既存の `env`（gcloud が `--set-env-vars` で管理）と同じ設計意図で、gcloud がデプロイ時に付与するメタデータを terraform が奪い合わないようにする。

## 検証（production workspace）
本番 state は `default` でなく `production` workspace。

```
terraform workspace select production
terraform plan -target=google_cloud_run_v2_service.nextjs_app -var-file=.../terraform.tfvars
```

結果: **cpu / client / client_version の差分がすべて消失**。web サービスの plan は意図した `description` 変更のみに収束（`Plan: 0 to add, 1 to change`）。

## 残差分の扱い
- `description`（live `"...Next.js 15..."` vs config `"...Next.js..."`）: config が正本の**一度きりの pending 変更**で、次回 apply で適用されれば解消する（恒久差分ではない）。本PRのスコープ外のため触れていない。

## スコープ
plan の cosmetic 恒久差分の解消のみ。image 周り（SPR-67 / data source 追従）は触れていない。本PRはその上に積む形。

🤖 Generated with [Claude Code](https://claude.com/claude-code)