### PR TITLE
fix(infra): Resend SPF を単一 char-string に修正（Cloudflare DNS を cloudflare_record 管理化, SPR-93）

### DIFF
--- a/terraform/cloudflare_dns.tf
+++ b/terraform/cloudflare_dns.tf
@@ -1,0 +1,22 @@
+# ==============================================================================
+# Cloudflare DNS レコード（例外管理）
+# ==============================================================================
+# 原則 DNS レコードは Cloudflare 側で管理し Terraform では持たない（cloudflare.tf 参照）。
+# ただし以下は不具合是正のため例外的に Terraform 管理下に置く。
+#
+# SPF (send.suzumina.click TXT):
+#   既存レコードが複数 character-string（"v=spf1" "include:amazonses.com" "~all"）で
+#   保存されており、RFC 7208 §3.3 / RFC 1035 の連結規則で空白が消え
+#   `v=spf1include:amazonses.com~all` となり SPF が permerror になる（SPR-93）。
+#   単一 character-string へ是正するため既存レコードを import して管理する。
+# ==============================================================================
+
+resource "cloudflare_record" "resend_spf" {
+  count = local.current_env.enable_custom_domain ? 1 : 0
+
+  zone_id = data.cloudflare_zone.main[0].id
+  name    = "send" # Cloudflare はサブドメイン名を相対形で保持（= send.suzumina.click）。FQDN にすると replace 扱いになる
+  type    = "TXT"
+  content = "v=spf1 include:amazonses.com ~all"
+  ttl     = 1 # 1 = automatic
+}


### PR DESCRIPTION
## 背景 / 不具合

`send.suzumina.click` の SPF TXT レコードが**複数 character-string**で保存されていた:

```
"v=spf1" "include:amazonses.com" "~all"
```

DNS の TXT は複数 character-string を**スペース無しで連結**する（RFC 7208 §3.3 / RFC 1035）ため、実体は `v=spf1include:amazonses.com~all` となり mechanism が空白区切りされず **SPF が permerror**（SES が SPF 認可されない）になっていた。email は DKIM で到達していたが SPF 単独は degraded。

## 根本原因（DNS アーキテクチャ）

- `suzumina.click` の権威 NS は **Cloudflare**。公開 DNS は Cloudflare が配信し、DNS レコードは従来 **Terraform 管理外**だった（`cloudflare.tf` 参照）。
- Terraform の `google_dns_managed_zone` + `google_dns_record_set.resend_spf` は**非権威の死蔵ゾーン**で、apply しても live SPF は直らない（→ 調査・棚卸しは SPR-91）。

## 変更

`cloudflare_record.resend_spf` を新規追加（`terraform/cloudflare_dns.tf`）。既存レコードを **import** して Terraform 管理下に置き、`content` を単一文字列 `v=spf1 include:amazonses.com ~all` に是正。`name = "send"`（相対形）で in-place update（replace 回避）。

## 適用・検証（production workspace, 適用済み）

```
terraform apply  # 1 imported, 1 changed, 0 destroyed
```

- Cloudflare API `content`: `"v=spf1" "include:amazonses.com" "~all"` → **`v=spf1 include:amazonses.com ~all`**（単一文字列）
- `dig +short TXT send.suzumina.click`: 3トークン → **`"v=spf1 include:amazonses.com ~all"`（単一）**

## ⚠️ マージ注意（state 整合）

**本変更は production に apply 済み**（import により production state に `cloudflare_record.resend_spf` が登録済み）。**main へ未マージの間は config と state が不整合**で、main から `terraform apply` すると当リソースを destroy しようとする。**早めにマージ**して整合させること。

## スコープ外（→ SPR-91）

「DNS は Cloudflare 管理で Terraform 外」という現方針への例外。死蔵の Google Cloud DNS ゾーン整理、DNS の IaC 化方針は SPR-91 で別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)