### PR TITLE
refactor(infra): Cloud Functions を Actions 専管化し terraform から関数リソースを除去（SPR-92）

### DIFF
--- a/terraform/function_dlsite_individual_info_api.tf
+++ b/terraform/function_dlsite_individual_info_api.tf
@@ -8,95 +8,22 @@
 # Individual Info API専用関数の設定
 locals {
   dlsite_individual_api_function_name = "fetchDLsiteUnifiedData"
-  dlsite_individual_api_runtime       = "nodejs22"
-  dlsite_individual_api_entry_point   = "fetchDLsiteUnifiedData"
-  dlsite_individual_api_memory        = "512Mi" # Memory increased due to 260 MiB usage
-  dlsite_individual_api_timeout       = 300     # 5分タイムアウト（API集約処理最適化）
 }
 
-# Individual Info API専用作品取得関数（Gen2）
-# GitHub Actionsと連携してデプロイされる統合データ収集システム
-resource "google_cloudfunctions2_function" "fetch_dlsite_works_individual_api" {
-  # 100% API-Only アーキテクチャを有効化
-
-  project  = var.gcp_project_id
-  name     = local.dlsite_individual_api_function_name
-  location = var.region
-
-  # ビルド設定
-  build_config {
-    runtime     = local.dlsite_individual_api_runtime
-    entry_point = local.dlsite_individual_api_entry_point
-    # 初回デプロイ用にダミーのソースコードを設定
-    # GitHub Actionsによる実際のデプロイでは上書きされる
-    source {
-      storage_source {
-        bucket = google_storage_bucket.functions_deployment.name
-        object = "function-source-dummy.zip"
-      }
-    }
-  }
-
-  # サービス設定
-  service_config {
-    max_instance_count = 1 # リソース削減のため1に制限
-    min_instance_count = 0 # コールドスタートを許容
-    available_memory   = local.dlsite_individual_api_memory
-    timeout_seconds    = local.dlsite_individual_api_timeout
-
-    # 専用のサービスアカウントを使用
-    service_account_email = google_service_account.fetch_dlsite_individual_api_sa.email
-
-    # Individual Info API処理用環境変数
-    environment_variables = {
-      FUNCTION_SIGNATURE_TYPE = "cloudevent"
-      FUNCTION_TARGET         = local.dlsite_individual_api_entry_point
-
-      # Individual Info API設定
-      INDIVIDUAL_INFO_API_ENABLED = "true"
-      API_ONLY_MODE               = "true"
-      MAX_CONCURRENT_API_REQUESTS = "5"
-      API_REQUEST_DELAY_MS        = "500"
-
-      # データ品質設定
-      ENABLE_DATA_VALIDATION = "true"
-      MINIMUM_QUALITY_SCORE  = "80"
-
-      # 時系列データ統合
-      ENABLE_TIMESERIES_INTEGRATION = "true"
-
-      # ログレベル
-      LOG_LEVEL = "info"
-    }
-  }
-
-  # Pub/Subトリガー設定
-  event_trigger {
-    trigger_region        = var.region
-    event_type            = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic          = google_pubsub_topic.dlsite_individual_api_trigger.id
-    retry_policy          = "RETRY_POLICY_DO_NOT_RETRY"
-    service_account_email = google_service_account.fetch_dlsite_individual_api_sa.email
-  }
-
-  # GitHub Actions からのデプロイとの競合を避けるため、
-  # ソースコードと環境変数は GitHub Actions が管理し、Terraform は無視する
-  lifecycle {
-    ignore_changes = [
-      build_config,
-      service_config[0].environment_variables,
-    ]
-    create_before_destroy = false
-  }
-
-  depends_on = [
-    google_firestore_database.database,
-    google_pubsub_topic.dlsite_individual_api_trigger,
-    google_project_iam_member.fetch_dlsite_individual_api_firestore_user,
-    google_project_iam_member.fetch_dlsite_individual_api_log_writer,
-    google_service_account.fetch_dlsite_individual_api_sa,
-  ]
-}
+# Individual Info API専用作品取得関数 (Gen2) は GitHub Actions でデプロイされるため、
+# Terraform では google_cloudfunctions2_function リソースを管理しない（ADR-009 / SPR-92）。
+#
+# spec の正本（deploy-functions.yml の gcloud functions deploy）:
+#   runtime=nodejs24 / memory=512Mi / timeout=300s / max-instances=1
+#   entry-point=fetchDLsiteUnifiedData / trigger-topic=dlsite-individual-api-trigger
+#
+# デプロイ手順:
+#   1. terraform apply で SA / Pub/Sub トピック / Scheduler / IAM を作成
+#   2. GitHub Actions（deploy-functions.yml）が関数本体をデプロイ
+#
+# resource "google_cloudfunctions2_function" "fetch_dlsite_works_individual_api" {
+#   # GitHub Actions によるデプロイとの競合を避けるためコメントアウト（ADR-009 / SPR-92）。
+# }
 
 # Individual Info API専用のPub/Subトピック
 resource "google_pubsub_topic" "dlsite_individual_api_trigger" {

--- a/terraform/function_youtube_videos.tf
+++ b/terraform/function_youtube_videos.tf
@@ -2,16 +2,15 @@
 # YouTube動画取得関数 (v2 - Pub/Subトリガー)
 # ==============================================================================
 # 概要: YouTubeから最新の動画情報を定期的に取得しFirestoreに保存する関数
-# GitHub Actions移行完了に伴い、ソースコード管理部分は削除済み
+#
+# ADR-009: 関数本体（spec/source/runtime/env）は GitHub Actions が正本（deploy-functions.yml）。
+# Terraform は SA / Pub/Sub / Scheduler / IAM の土台のみを管理し、
+# google_cloudfunctions2_function リソースは持たない（checkDataIntegrity 方式に統一）。
+# これにより live(540s/3) ↔ config(120s/1) の二重管理 drift を解消する（SPR-92）。
 # ==============================================================================
 
-# デプロイの共通設定
 locals {
   youtube_function_name = "fetchYouTubeVideos"
-  youtube_runtime       = "nodejs22"
-  youtube_entry_point   = "fetchYouTubeVideos" # 注: これをindex.tsで登録した関数名と一致させる
-  youtube_memory        = local.current_env.functions_memory
-  youtube_timeout       = local.current_env.functions_timeout
 
   # この関数が必要とする環境変数（シークレット）のリスト
   youtube_secrets = [
@@ -19,87 +18,20 @@ locals {
   ]
 }
 
-# YouTube動画取得関数 (v2 - Pub/Subトリガー)（環境設定により条件付き作成）
-resource "google_cloudfunctions2_function" "fetch_youtube_videos" {
-  count = local.current_env.functions_enabled ? 1 : 0
-
-  project  = var.gcp_project_id
-  name     = local.youtube_function_name
-  location = var.region
-
-  # ビルド設定
-  build_config {
-    runtime     = local.youtube_runtime
-    entry_point = local.youtube_entry_point
-    # 初回デプロイ用にダミーのソースコードを設定
-    # GitHub Actionsによる実際のデプロイでは上書きされる
-    source {
-      storage_source {
-        bucket = google_storage_bucket.functions_deployment.name
-        object = "function-source-dummy.zip"
-      }
-    }
-  }
-
-  # サービス設定
-  service_config {
-    max_instance_count = 1 # スケジュールタスクのため低めに設定
-    min_instance_count = 0 # コールドスタートを許容
-    available_memory   = local.youtube_memory
-    timeout_seconds    = local.youtube_timeout
-    # 専用のサービスアカウントを使用
-    service_account_email = google_service_account.fetch_youtube_videos_sa.email
-
-    # シークレット環境変数を動的に設定
-    dynamic "secret_environment_variables" {
-      for_each = local.youtube_secrets
-      content {
-        key        = secret_environment_variables.value
-        secret     = google_secret_manager_secret.secrets[secret_environment_variables.value].secret_id
-        version    = "latest"
-        project_id = var.gcp_project_id
-      }
-    }
-
-    # CloudEventトリガーのための環境変数設定
-    environment_variables = {
-      FUNCTION_SIGNATURE_TYPE = "cloudevent"              # CloudEvent形式であることを明示
-      FUNCTION_TARGET         = local.youtube_entry_point # エントリポイント名を指定
-    }
-  }
-
-  # イベントトリガー設定 (Pub/Sub)
-  event_trigger {
-    trigger_region = var.region # 関数のリージョンと一致させる
-    event_type     = "google.cloud.pubsub.topic.v1.messagePublished"
-    pubsub_topic   = google_pubsub_topic.youtube_video_fetch_trigger.id
-    retry_policy   = "RETRY_POLICY_DO_NOT_RETRY"
-    # トリガー用にも同じ専用サービスアカウントを使用
-    service_account_email = google_service_account.fetch_youtube_videos_sa.email
-  }
-
-  # GitHub Actions からのデプロイとの競合を避けるため、
-  # ソースコードと環境変数は GitHub Actions が管理し、Terraform は無視する
-  lifecycle {
-    ignore_changes = [
-      build_config,                            # ビルド設定全体を無視（GitHub Actionsが管理）
-      service_config[0].environment_variables, # 環境変数もGitHub Actionsが管理
-    ]
-    # 既存のリソースとの競合を避けるため、作成失敗時は手動で解決する
-    create_before_destroy = false
-  }
-
-  depends_on = [
-    # この関数に必要なFirestore DB、Pub/Subトピック、シークレット
-    google_firestore_database.database,
-    google_pubsub_topic.youtube_video_fetch_trigger,
-    google_secret_manager_secret.secrets,
-    google_project_iam_member.fetch_youtube_videos_firestore_user,
-    google_project_iam_member.fetch_youtube_videos_log_writer,
-    # サービスアカウントが存在することを確認
-    google_service_account.fetch_youtube_videos_sa,
-  ]
-}
+# YouTube動画取得関数 (Gen2) は GitHub Actions でデプロイされるため、
+# Terraform では google_cloudfunctions2_function リソースを管理しない（ADR-009 / SPR-92）。
+#
+# spec の正本（deploy-functions.yml の gcloud functions deploy）:
+#   runtime=nodejs24 / memory=256Mi / timeout=540s / max-instances=3
+#   entry-point=fetchYouTubeVideos / trigger-topic=youtube-video-fetch-trigger
+#
+# デプロイ手順:
+#   1. terraform apply で SA / Pub/Sub トピック / Scheduler / IAM を作成
+#   2. GitHub Actions（deploy-functions.yml）が関数本体をデプロイ
+#
+# resource "google_cloudfunctions2_function" "fetch_youtube_videos" {
+#   # GitHub Actions によるデプロイとの競合を避けるためコメントアウト（ADR-009 / SPR-92）。
+# }
 
 # YouTube動画取得関数用のサービスアカウントにシークレットアクセス権限を付与
 resource "google_secret_manager_secret_iam_member" "youtube_video_secret_accessor" {
@@ -118,11 +50,11 @@ resource "google_secret_manager_secret_iam_member" "youtube_video_secret_accesso
 }
 
 # Cloud Function のリソース情報を出力
+# 関数は GitHub Actions でデプロイされるため、名前のみ出力（checkDataIntegrity 方式）
 output "fetch_youtube_videos_function_info" {
-  value = local.current_env.functions_enabled ? {
-    name     = google_cloudfunctions2_function.fetch_youtube_videos[0].name
-    location = google_cloudfunctions2_function.fetch_youtube_videos[0].location
-    state    = google_cloudfunctions2_function.fetch_youtube_videos[0].state
-  } : null
+  value = {
+    name = local.youtube_function_name
+    note = "Function will be deployed via GitHub Actions (ADR-009)"
+  }
   description = "YouTube動画取得関数の情報"
 }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -14,9 +14,7 @@ locals {
       cloud_run_cpu           = "1"     # 1vCPU（"1000m" と等価。表記を "1" に統一）
       cloud_run_cpu_idle      = true    # コスト削減のためCPUアイドル有効
       cloud_run_memory        = "512Mi" # 最小メモリ
-      functions_memory        = "256Mi" # 最小メモリ
-      functions_timeout       = 120     # 短いタイムアウト
-      functions_enabled       = false   # staging環境ではfunctions無効化（コスト削減）
+      # functions_* は ADR-009/SPR-92 で Actions 専管化。spec の正本は deploy-functions.yml
       budget_amount           = 1000    # 約1000円（月）
       enable_monitoring       = false   # 基本監視のみ
       enable_custom_domain    = false   # staging用ドメイン不要
@@ -28,9 +26,7 @@ locals {
       cloud_run_cpu           = "1"      # 1vCPU: アイドル後レスポンス遅延を改善（gcloud --cpu 1 の表記に整合）
       cloud_run_cpu_idle      = false    # CPUを常時割り当て: アイドル後のスロットリング防止
       cloud_run_memory        = "1024Mi" # メモリ増強（1GB）でGC改善
-      functions_memory        = "256Mi"  # YouTube API軽量処理用に最適化
-      functions_timeout       = 120      # API呼び出し最適化
-      functions_enabled       = true     # 本番では有効
+      # functions_* は ADR-009/SPR-92 で Actions 専管化。spec の正本は deploy-functions.yml
       budget_amount           = 5000     # 月額5000円制限
       enable_monitoring       = true     # フル監視
       enable_custom_domain    = true     # 本番ドメイン


### PR DESCRIPTION
## 概要
ADR-009 Phase 1 の実装。Cloud Functions（youtube/dlsite）を **Actions 専管化**し、terraform から `google_cloudfunctions2_function` リソースを除去（既存の checkDataIntegrity 方式に全関数を統一）。

SPR-92（youtube の live 540s/3 ↔ config 120s/1 の ping-pong drift）を**原理的に解消**する。spec の正本は deploy-functions.yml（GitHub Actions）に一本化。

## 変更
- `function_youtube_videos.tf`: 関数 resource をコメントアウト、locals を function_name/secrets のみに整理、output を local ベース化。spec 実体値（nodejs24/256Mi/540s/max3）をコメント記録。secret_iam_member は土台として維持。
- `function_dlsite_individual_info_api.tf`: 同様に関数 resource を除去、locals 整理。topic/scheduler/IAM は維持。
- `locals.tf`: dead 化した `functions_memory/timeout/enabled` を environment_config から削除。
- SPR-95（runtime 版ズレ nodejs22→24）も本 PR の spec コメント統一で解消。

## ⚠️ 反映手順（state rm のみ。SPR-92 では apply しない）
**マージ後**、state から関数を除去する（config からも除去済みなので、terraform が関数を管理しなくなる。live 関数は GitHub Actions 管理で残る）:
```
cd terraform
terraform workspace select production
terraform state rm 'google_cloudfunctions2_function.fetch_youtube_videos[0]'
terraform state rm 'google_cloudfunctions2_function.fetch_dlsite_works_individual_api'
terraform plan -var-file=terraform.tfvars   # 関数の destroy(2件) が消えることを確認
```
⚠️ この plan には既存 drift 7件（warmup/dns/firestore/dashboard）が "to change" で残るが、これらは SPR-96/97/98 のスコープ。**SPR-92 では apply しない**（blanket apply は既存 drift を巻き込むため＝SPR-91 の -target 必須方針）。state rm だけで二重管理の解消は完了する。

## 検証
- `terraform validate`: ✅ 成功（関数除去による参照切れなし）
- `terraform plan`（production）: `0 to add, 7 to change, 2 to destroy`。関数2つが destroy 検出＝state rm の必要性を確認。

## レビュー反映（/review）
- 指摘1[中]: 「state rm のみで完了、SPR-92 では apply しない」を明確化（blanket apply で既存 drift を巻き込まないため）。
- 指摘2[軽]: output `fetch_youtube_videos_function_info` の構造変更（location/state 削除）→ .github/scripts に参照なし・terraform output の CI 利用なしを確認済み、安全。

## 関連
- ADR-009（`docs/decisions/infrastructure/ADR-009-deploy-iac-responsibility-split.md`）
- Closes SPR-92, SPR-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)