### PR TITLE
fix(infra): warmup の UA 恒久 diff と firestore_rules の provider 表現差を解消（SPR-98）

### DIFF
--- a/terraform/firestore_rules.tf
+++ b/terraform/firestore_rules.tf
@@ -9,9 +9,11 @@ resource "google_firestore_document" "firestore_rules" {
   project     = var.gcp_project_id
   collection  = "_firestore_rules"
   document_id = "firestore_rules"
+  # fields は Firestore REST API の Value 表現（camelCase）で記述する。
+  # snake_case（string_value）にすると live(stringValue) と恒久 diff になる（ADR-009 / SPR-98）。
   fields = jsonencode({
     rules = {
-      string_value = <<-EOT
+      stringValue = <<-EOT
         rules_version = '2';
         service cloud.firestore {
           // 基本設定 - デフォルトはすべての読み書きを拒否

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -65,10 +65,8 @@ resource "google_cloud_scheduler_job" "cloud_run_warmup" {
     uri         = google_cloud_run_v2_service.nextjs_app.uri
     http_method = "GET"
 
-    # タイムアウト設定
-    headers = {
-      "User-Agent" = "Google-Cloud-Scheduler"
-    }
+    # User-Agent ヘッダは指定しない: "Google-Cloud-Scheduler" は Scheduler の既定 UA で
+    # API が headers に保存せず、明示すると毎 plan で恒久 diff になるため（ADR-009 / SPR-98）。
 
     # Cloud Runサービスへのアクセス認証
     oidc_token {


### PR DESCRIPTION
## 概要
ADR-009 Phase 1。SPR-98 の cosmetic/低リスク drift のうち **warmup** と **firestore_rules** を **config 整合のみで解消**（apply 不要・live 非変更）。

## 変更
- `scheduler.tf`: cloud_run_warmup の `headers` から `User-Agent` を削除。"Google-Cloud-Scheduler" は Scheduler 既定 UA で API が headers に保存せず、明示すると毎 plan で `+User-Agent` の恒久 diff になっていた。config から外して live(headers なし)と一致。
- `firestore_rules.tf`: `string_value`(snake) → `stringValue`(camel)。`google_firestore_document.fields` は Firestore REST API の Value 表現（camelCase）を期待し、live state も `stringValue`。snake_case が provider 表現差で恒久 diff を生んでいた。API 表現に整合させ live と一致。

## dashboard ×3 は許容（このPRでは触らない）
`google_monitoring_dashboard` の座標/etag 恒久 diff は、(1) dashboard_json の座標編集が provider 正規化挙動依存で脆い、(2) `ignore_changes=[dashboard_json]` は dashboard の実変更を阻害する、ため **cosmetic として許容**（実害なし）。SPR-98 issue でも「除去または許容」と想定済み。

## 検証
- `terraform validate`: ✅
- `terraform plan`（production）: 修正前 `7 to change` → 修正後 **`0 to add, 5 to change, 0 to destroy`**。warmup と firestore_rules が plan から消失。残る 5 = dns×2（resend_spf/dmarc = SPR-94 dead-zone）+ dashboard×3（許容）。
- **apply 不要**: 両修正とも config を live 実態に整合させるもので、plan が消える＝既に live と一致。

## 関連
- ADR-009（`docs/decisions/infrastructure/ADR-009-deploy-iac-responsibility-split.md`）
- Closes SPR-98（dashboard は許容として記載）

🤖 Generated with [Claude Code](https://claude.com/claude-code)