### PR TITLE
refactor(infra): Cloud Run web の spec/invoker を terraform 専管化（deploy-web.yml から削除）（SPR-97）

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -160,21 +160,17 @@ jobs:
           echo "🚀 Deploying to Cloud Run..."
           
           # Deploy and let Cloud Run handle traffic migration automatically
+          # spec（cpu/memory/min-max-instances/timeout/port/cpu-throttling）と invoker（--allow-unauthenticated）は
+          # Terraform が正本（cloud_run.tf）。ADR-009/SPR-97 に基づき deploy からは外し、二重管理を解消する。
+          # gcloud run deploy は update セマンティクスで、指定しないフラグは既存 revision の値を保持するため、
+          # ここでは image / env / secret のみ更新する（spec は terraform apply 時のみ変更）。
           gcloud run deploy ${{ env.SERVICE_NAME }} \
             --image $IMAGE_TAG \
             --region ${{ env.REGION }} \
             --platform managed \
-            --allow-unauthenticated \
             --service-account="cloud-run-nextjs@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
             --set-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,GOOGLE_CLOUD_PROJECT=${{ env.PROJECT_ID }},NEXTAUTH_URL=https://suzumina.click,AUTH_TRUST_HOST=true,NEXT_PUBLIC_GA_MEASUREMENT_ID=G-9SYZ48LBPH,NEXT_PUBLIC_GTM_ID=GTM-W7QT5PCR" \
-            --set-secrets="DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,NEXTAUTH_SECRET=NEXTAUTH_SECRET:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest,RESEND_API_KEY=RESEND_API_KEY:latest,CONTACT_EMAIL_RECIPIENTS=CONTACT_EMAIL_RECIPIENTS:latest" \
-            --memory 1024Mi \
-            --cpu 1 \
-            --no-cpu-throttling \
-            --min-instances 1 \
-            --max-instances 2 \
-            --timeout 300 \
-            --port 8080
+            --set-secrets="DISCORD_CLIENT_ID=DISCORD_CLIENT_ID:latest,DISCORD_CLIENT_SECRET=DISCORD_CLIENT_SECRET:latest,NEXTAUTH_SECRET=NEXTAUTH_SECRET:latest,YOUTUBE_API_KEY=YOUTUBE_API_KEY:latest,RESEND_API_KEY=RESEND_API_KEY:latest,CONTACT_EMAIL_RECIPIENTS=CONTACT_EMAIL_RECIPIENTS:latest"
           
           echo "✅ Deployment completed successfully"
       


### PR DESCRIPTION
## 概要
ADR-009 Phase 1。**最初に問題提起された「web Cloud Run を二箇所で一致させた二重管理」**を解消。deploy-web.yml から spec/invoker フラグを削除し、cloud_run.tf を正本にする。

## 変更
- `deploy-web.yml` の `gcloud run deploy` から削除:
  - spec: `--memory` / `--cpu` / `--no-cpu-throttling` / `--min-instances` / `--max-instances` / `--timeout` / `--port`
  - invoker: `--allow-unauthenticated`
  - 残す: `--image` / `--region` / `--platform` / `--service-account` / `--set-env-vars` / `--set-secrets`
- terraform（cloud_run.tf）は**変更なし**: spec は locals/cloud_run.tf で既に宣言、invoker は `google_cloud_run_v2_service_iam_binding.public_access`（allUsers）で既に管理。

## 正本の整理（変更後）
| 属性 | 正本 |
|---|---|
| spec（cpu/mem/instances/timeout/port/cpu_idle/concurrency/probe） | **terraform** |
| invoker（allUsers） | **terraform**（binding） |
| image / env / secret | **workflow**（terraform は data source / ignore_changes で委譲済み） |

## patch 挙動の前提と検証
`gcloud run deploy` は update セマンティクスで、指定しないフラグは既存 revision の値を保持する（CI で `--image` のみ更新は一般的パターン）。

⚠️ **マージ後の初回 web デプロイ後に検証**（万一 reset されたら revert + `terraform apply` で復旧）:
```
gcloud run services describe suzumina-click-web --region=asia-northeast1 \
  --format="yaml(spec.template.spec.containerConcurrency, spec.template.spec.timeoutSeconds, spec.template.spec.containers[0].resources, spec.template.metadata.annotations)"
```
**ベースライン（現 live = terraform 宣言値、describe で確認済み）**: cpu `1` / memory `1024Mi` / minScale `1` / maxScale `2` / timeout `300` / concurrency `50`。デプロイ後もこの値が維持されていれば OK。

## 検証済み
- 現 live spec が terraform 宣言値と**全一致**（二重管理の実証 + ベースライン記録）
- workflow のみの変更で terraform plan には影響なし（web は既に drift なし）

## 関連
- ADR-009 / Closes SPR-97

🤖 Generated with [Claude Code](https://claude.com/claude-code)