### PR TITLE
fix(infra): plan CI を production 評価 + IAM read 権限で修正（SPR-99）

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -22,6 +22,10 @@ concurrency:
 env:
   TF_IN_AUTOMATION: 'true'
   # --- 非機密 config（CI plan 用に明示指定）---
+  # current_env は var.environment で引かれる（locals.tf:37）。production workspace の state と揃えるため
+  # 必ず production を指定する（未指定だと default "staging" 評価で enable_custom_domain=false 等になり、
+  # 本番限定リソースを destroy 扱いする偽 plan になる）。
+  TF_VAR_environment: production
   TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
   TF_VAR_project_number: ${{ secrets.GCP_PROJECT_NUMBER }}
   # default "suzumina-click" のままだと repo 名差で forces replacement の偽 plan になるため実値を渡す

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -287,6 +287,16 @@ resource "google_project_iam_member" "terraform_plan_viewer" {
   depends_on = [google_service_account.terraform_plan_sa]
 }
 
+# plan の refresh は IAM ポリシー（getIamPolicy）も読む。roles/viewer には getIamPolicy が無く
+# google_*_iam_member / iam_binding の refresh が 403 になるため、read-only の securityReviewer を付与する。
+resource "google_project_iam_member" "terraform_plan_security_reviewer" {
+  project = var.gcp_project_id
+  role    = "roles/iam.securityReviewer"
+  member  = "serviceAccount:${google_service_account.terraform_plan_sa.email}"
+
+  depends_on = [google_service_account.terraform_plan_sa]
+}
+
 # tfstate バケットの read（state 読み取り。plan は -lock=false で lock 書き込み不要）
 resource "google_storage_bucket_iam_member" "terraform_plan_state_viewer" {
   bucket = google_storage_bucket.tfstate.name


### PR DESCRIPTION
## 概要

#475 の bootstrap 後、`Terraform Plan` CI が失敗した（`2 to add / 7 to change / 7 to destroy` の **偽 plan** + `getIamPolicy` 403）。原因は 2 点で、いずれも **read-only SA による plan 評価の問題**＝本番リソースは未変更（apply していない）。

## 原因と修正

1. **環境評価のズレ（偽の destroy plan）**
   `local.current_env = local.environment_config[var.environment]`（`locals.tf:37`）＝config は **`var.environment`** で引かれる（workspace ではない）。CI は production workspace の state を選択したが `TF_VAR_environment` 未指定で default `"staging"` 評価になり、`enable_custom_domain=false` 等で cloudflare×3 / domain mapping / dashboard を **destroy 扱い**していた。
   → workflow に **`TF_VAR_environment: production`** を追加（state と config 環境を一致）。

2. **`getIamPolicy` 403**
   plan の refresh は `google_*_iam_member` / `iam_binding` の IAM ポリシーも読むが、`roles/viewer` に `*.getIamPolicy` が無く pubsub topic / storage bucket の refresh が 403 → plan exit 1。
   → terraform-plan-sa に **`roles/iam.securityReviewer`**（read-only の IAM ポリシー閲覧）を付与。

## 検証
- `terraform validate` パス。
- targeted plan: securityReviewer member = **1 to add**。
- 修正後は production 評価になり、偽の destroy は消え、既知の cosmetic（dashboard×3）程度に収束する想定（merge → SA 権限 apply → workflow 再実行で green を確認する）。

## merge 後
1. 追加権限を apply: `terraform -chdir=terraform apply -target=google_project_iam_member.terraform_plan_security_reviewer`
2. `Terraform Plan` を再実行（workflow_dispatch）して green を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)