### PR TITLE
chore(infra): production を唯一の環境にし死蔵 staging を除去（SPR-100）

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -5,20 +5,8 @@ locals {
   # var.gcp_project_id を参照し、他のリソース定義で利用します。
   project_id = var.gcp_project_id
 
-  # 環境固有の設定（個人開発向け2環境構成）
+  # 環境固有の設定（production 単一環境。staging は実体がなく SPR-100 で廃止）
   environment_config = {
-    staging = {
-      # テスト・プレビュー環境（超軽量・コスト重視）
-      cloud_run_min_instances = 0
-      cloud_run_max_instances = 1       # 最小限（テスト用）
-      cloud_run_cpu           = "1"     # 1vCPU（"1000m" と等価。表記を "1" に統一）
-      cloud_run_cpu_idle      = true    # コスト削減のためCPUアイドル有効
-      cloud_run_memory        = "512Mi" # 最小メモリ
-      # functions_* は ADR-009/SPR-92 で Actions 専管化。spec の正本は deploy-functions.yml
-      budget_amount        = 1000  # 約1000円（月）
-      enable_monitoring    = false # 基本監視のみ
-      enable_custom_domain = false # staging用ドメイン不要
-    }
     production = {
       # 本番環境（個人利用レベル・パフォーマンス改善）
       cloud_run_min_instances = 1        # LCP改善: コールドスタート排除

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,13 +44,14 @@ variable "youtube_api_key" {
 
 
 variable "environment" {
-  description = "環境名（staging, production）"
+  # staging は実体のない死蔵環境（state 0 リソース）だったため SPR-100 で廃止。production を唯一の環境とする。
+  description = "環境名（production のみ）"
   type        = string
-  default     = "staging"
+  default     = "production"
 
   validation {
-    condition     = contains(["staging", "production"], var.environment)
-    error_message = "環境は staging または production である必要があります。"
+    condition     = contains(["production"], var.environment)
+    error_message = "環境は production のみ有効です（staging は SPR-100 で廃止）。"
   }
 }
 


### PR DESCRIPTION
## 概要

SPR-99 の plan CI 偽 plan の根本原因だった「実体のない staging 環境を `var.environment` 既定が指す」footgun を解消する。staging は **state 0 リソース＝未デプロイの死蔵**（production=154 が唯一の実環境）。

## 変更
- `terraform/variables.tf`: `var.environment` の `default` を `staging`→**`production`**、`validation` を **production のみ**に。
- `terraform/locals.tf`: `environment_config` から **staging ブロックを除去**（production のみ）。
- **staging workspace を削除**（空のため安全。`Deleted workspace "staging"!` 実行済み）。

## 影響
- `current_env = environment_config["production"]` は不変。`resource_prefix` / `common_labels` の `environment` も production のまま（production の tfvars / CI は `environment` を明示指定済み）。
- **resource 変更なし＝apply 不要**（config 評価のみの変更）。`terraform validate` パス、残存 staging 参照なし（確認済み）。
- 本 PR の `Terraform Plan` CI チェックが production の full plan を実行し、変更が無い（既知の cosmetic dashboard×3 のみ）ことを検証する。

## 関連
- SPR-100（親 SPR-91 / 関連 SPR-99・ADR-010）。残る default workspace の stale state は SPR-101 で別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)