### PR TITLE
feat(infra): Terraform apply 承認制 CI（Stage 2）（SPR-99 / ADR-010）

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,120 @@
+name: Terraform Apply
+
+# ADR-010 / SPR-99 Stage 2: main の terraform 変更を「plan 提示 → 承認 → apply」で適用する。
+# 二重ゲート: (1) WIF は terraform-apply-sa を main ブランチからのみ assume 可（iam.tf）。
+#            (2) apply job は GitHub Environment(production) の required reviewer 承認が必須。
+# plan は read-only SA、apply は強権限 SA に分離。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform-apply.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+# 全 apply を直列化（state lock と二重で安全。承認待ちを cancel しない）
+concurrency:
+  group: terraform-apply
+  cancel-in-progress: false
+
+env:
+  TF_IN_AUTOMATION: 'true'
+  TF_VAR_environment: production
+  TF_VAR_gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+  TF_VAR_project_number: ${{ secrets.GCP_PROJECT_NUMBER }}
+  TF_VAR_artifact_registry_repository_id: suzumina-click-web
+  TF_VAR_custom_domain: suzumina.click
+  TF_VAR_domain_name: suzumina.click
+  TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+  TF_VAR_admin_email: ${{ secrets.ADMIN_EMAIL }}
+  # app 機密は Terraform 管理外（secrets.tf の ignore_changes=[secret_data]）。placeholder で plan/apply 可能。
+  TF_VAR_youtube_api_key: 'ci-placeholder'
+  TF_VAR_discord_client_id: 'ci-placeholder'
+  TF_VAR_discord_client_secret: 'ci-placeholder'
+  TF_VAR_nextauth_secret: 'ci-placeholder'
+  TF_VAR_resend_api_key: 'ci-placeholder'
+  TF_VAR_contact_email_recipients: 'ci-placeholder@example.com'
+
+defaults:
+  run:
+    working-directory: terraform
+
+jobs:
+  plan:
+    name: plan (read-only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Authenticate (read-only plan SA)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'terraform-plan-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.13.5'
+          terraform_wrapper: false
+      - name: Init
+        run: terraform init -input=false
+      - name: Select production workspace
+        run: terraform workspace select production
+      - name: Plan (save to file)
+        run: |
+          set -o pipefail
+          # read-only SA は lock 書き込み不可のため plan は -lock=false。apply job 側で lock する。
+          terraform plan -input=false -lock=false -out=tfplan.bin -no-color 2>&1 | tee /tmp/plan.txt
+      - name: Plan summary
+        if: always()
+        run: |
+          {
+            echo '## Terraform Apply — plan（承認前にこの差分を確認）'
+            echo ''
+            echo '```hcl'
+            tail -c 60000 /tmp/plan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: terraform/tfplan.bin
+          retention-days: 1
+          if-no-files-found: error
+
+  apply:
+    name: apply (production / 承認ゲート)
+    needs: plan
+    runs-on: ubuntu-latest
+    # GitHub Environment(production) に required reviewer を設定しておくこと（未設定だとゲートが効かない）
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Authenticate (privileged apply SA / main 限定)
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'terraform-apply-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.13.5'
+          terraform_wrapper: false
+      - name: Init
+        run: terraform init -input=false
+      - name: Select production workspace
+        run: terraform workspace select production
+      - name: Download plan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+          path: terraform
+      - name: Apply saved plan
+        run: terraform apply -input=false tfplan.bin

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -307,6 +307,64 @@ resource "google_storage_bucket_iam_member" "terraform_plan_state_viewer" {
 }
 
 # ------------------------------------------------------------------------------
+# Terraform CI: apply 用 強権限サービスアカウント（ADR-010 / SPR-99 Stage 2）
+# ------------------------------------------------------------------------------
+# main へ merge された terraform 変更を apply する。WIF 連携は main ブランチからの assume のみに限定し、
+# さらに GitHub Environment(production) の required reviewer 承認を必須にする（二重ゲート）。
+# read-only の plan SA とは権限を分離する。
+
+resource "google_service_account" "terraform_apply_sa" {
+  project      = var.gcp_project_id
+  account_id   = "terraform-apply-sa"
+  display_name = "Terraform apply (privileged) SA"
+  description  = "main からの terraform apply を Environment 承認下で実行する CI SA（ADR-010 Stage 2）"
+}
+
+# WIF 連携: repo 限定（provider の attribute_condition）かつ main ブランチ限定（attribute.ref == refs/heads/main）。
+# PR ブランチ（refs/pull/*/merge）からは assume できない。
+resource "google_service_account_iam_binding" "terraform_apply_sa_wif" {
+  service_account_id = google_service_account.terraform_apply_sa.name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_pool.name}/attribute.ref/refs/heads/main"
+  ]
+
+  depends_on = [
+    google_service_account.terraform_apply_sa,
+    google_iam_workload_identity_pool.github_pool
+  ]
+}
+
+# curated strong: terraform が管理する全リソース＋その IAM をカバーする選定セット（roles/owner は回避）。
+# editor だけでは setIamPolicy（bucket/topic/secret/run/project/SA）・KMS・WIF・サービス有効化が不足するため
+# サービス別 admin を併用する。billing budget は billing.tf でコメントアウト済みのため billing 権限は不要。
+locals {
+  terraform_apply_sa_roles = [
+    "roles/editor",                          # 大半のリソース CRUD（run/scheduler/firestore/monitoring/logging/pubsub/AR/functions 等）
+    "roles/resourcemanager.projectIamAdmin", # google_project_iam_member（プロジェクト IAM、32件）
+    "roles/iam.serviceAccountAdmin",         # google_service_account + SA IAM binding
+    "roles/iam.roleAdmin",                   # google_project_iam_custom_role（カスタムロール 2件）
+    "roles/iam.workloadIdentityPoolAdmin",   # WIF pool / provider
+    "roles/storage.admin",                   # bucket IAM + lifecycle + tfstate の state 読み書き/ロック
+    "roles/pubsub.admin",                    # pubsub topic IAM
+    "roles/secretmanager.admin",             # secret 本体 + secret IAM
+    "roles/cloudkms.admin",                  # KMS keyring/key/IAM（editor 対象外）
+    "roles/run.admin",                       # Cloud Run service IAM binding（public_access）
+    "roles/serviceusage.serviceUsageAdmin",  # google_project_service の有効/無効化
+  ]
+}
+
+resource "google_project_iam_member" "terraform_apply_sa_roles" {
+  for_each = toset(local.terraform_apply_sa_roles)
+  project  = var.gcp_project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.terraform_apply_sa.email}"
+
+  depends_on = [google_service_account.terraform_apply_sa]
+}
+
+# ------------------------------------------------------------------------------
 # fetchYouTubeVideos関数用のサービスアカウントとIAM権限設定
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
## 概要

ADR-009 Phase 2 の **Stage 2（apply の CI 化）**。main の `terraform/**` 変更を「**plan 提示 → 承認 → apply**」で適用する。Stage 1（plan CI, #475/#476）に続く本丸。

## 二重ゲート（安全設計）
1. **WIF main 限定**: `terraform-apply-sa` は WIF で `attribute.ref == refs/heads/main` からのみ assume 可（PR ブランチからは不可）。
2. **GitHub Environment 承認**: `apply` job は `environment: production` の **required reviewer 承認**が必須。
- plan は read-only SA、apply は強権限 SA に分離（最小権限）。

## 変更
- `terraform/iam.tf`: **`terraform-apply-sa`** + main 限定 WIF binding + **curated strong ロール**（`for_each`）。`roles/owner` は回避し、terraform の管理フットプリント（IAM setIamPolicy / KMS / WIF / サービス有効化）を過不足なくカバー: `editor` + `resourcemanager.projectIamAdmin` + `iam.serviceAccountAdmin` + `iam.roleAdmin` + `iam.workloadIdentityPoolAdmin` + `storage.admin` + `pubsub.admin` + `secretmanager.admin` + `cloudkms.admin` + `run.admin` + `serviceusage.serviceUsageAdmin`。
- `.github/workflows/terraform-apply.yml`: 2-job（plan→gated apply、push main + workflow_dispatch、`concurrency` で直列化、保存 plan を apply）。

targeted plan: **13 to add**（apply SA + WIF + 11 roles）/ 0 change / 0 destroy。

## ⚠️ merge 後の bootstrap（順序が重要・安全のため）

> 安全性の根拠: apply SA は手順3まで**存在しない**ため、それまでに workflow が発火しても auth 失敗で安全に止まる。ゲート（Environment）を SA より先に用意することで、SA 使用可能時点では必ずゲートが効く。

1. **PR を merge**（workflow と iam.tf が入る。apply SA 未作成なので発火しても auth fail で無害）。
2. **GitHub Environment を設定**（UI・あなたの操作）: Settings → Environments → `production` を作成し **Required reviewers に自分を追加**。⚠️ これを設定しないと apply job がゲートなしで走るため、**SA を apply する前に必ず先に設定**すること。
3. **apply SA を適用**（私が `-target` で実行）:
   ```
   terraform -chdir=terraform apply \
     -target=google_service_account.terraform_apply_sa \
     -target=google_service_account_iam_binding.terraform_apply_sa_wif \
     -target=google_project_iam_member.terraform_apply_sa_roles
   ```
4. **動作確認**: `Terraform Apply` を workflow_dispatch → plan job で差分提示 → apply job が承認待ち → 承認 → apply 実行。初回は現状の cosmetic（dashboard×3）程度なので低リスクで検証可能。

## 備考
- 強権限 SA を CI に置くコストは ADR-010 で受容済み（WIF 短命 OIDC + main 限定 + 承認ゲートで緩和）。
- curated ロールに漏れがあれば初回 apply で判明 → 追加（反復）。billing budget は未管理（billing.tf コメントアウト）のため billing 権限は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)