### PR TITLE
chore(infra): dashboard の cosmetic 永久 diff を ignore_changes で解消（SPR-102）

### DIFF
--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -88,6 +88,12 @@ data "google_project" "current" {
 resource "google_monitoring_dashboard" "cost_overview" {
   count = local.current_env.enable_monitoring ? 1 : 0
 
+  # dashboard_json は API が etag/name を付与し xPos/yPos=0 を省略するため config と恒久 diff になりうる（SPR-98 既知）。
+  # apply CI の承認ノイズ削減のため内容変更を無視する（更新時は一時的に ignore_changes を外す / console で編集）。
+  lifecycle {
+    ignore_changes = [dashboard_json]
+  }
+
   dashboard_json = jsonencode({
     displayName = "${var.gcp_project_id} コスト概要ダッシュボード"
     mosaicLayout = {

--- a/terraform/logging.tf
+++ b/terraform/logging.tf
@@ -144,6 +144,12 @@ resource "google_monitoring_alert_policy" "high_error_rate_logs" {
 
 # アプリケーションログ閲覧用のカスタムダッシュボード
 resource "google_monitoring_dashboard" "logging_dashboard" {
+  # dashboard_json は API が etag/name を付与し xPos/yPos=0 を省略するため config と恒久 diff になる（SPR-98 既知）。
+  # apply CI の承認ノイズ削減のため内容変更を無視する（更新時は一時的に ignore_changes を外す / console で編集）。
+  lifecycle {
+    ignore_changes = [dashboard_json]
+  }
+
   dashboard_json = <<EOF
 {
   "displayName": "suzumina.click ログ分析ダッシュボード",

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -5,6 +5,13 @@
 
 # メトリクスダッシュボード
 resource "google_monitoring_dashboard" "service_overview" {
+  # dashboard_json は API が etag/name を付与し xPos/yPos=0 を省略するため config と恒久 diff になる（SPR-98 既知）。
+  # config 側では match 不能（etag/name は server 採番）なので、apply CI の承認ノイズ削減のため内容変更を無視する。
+  # ダッシュボード定義の更新時は一時的に ignore_changes を外す（または console で編集）。
+  lifecycle {
+    ignore_changes = [dashboard_json]
+  }
+
   dashboard_json = <<EOF
 {
   "displayName": "suzumina.click サービス概要ダッシュボード",

--- a/terraform/monitoring_performance.tf
+++ b/terraform/monitoring_performance.tf
@@ -5,6 +5,12 @@
 
 # Next.js パフォーマンス専用ダッシュボード
 resource "google_monitoring_dashboard" "nextjs_performance" {
+  # dashboard_json は API が etag/name を付与し xPos/yPos=0 を省略するため config と恒久 diff になる（SPR-98 既知）。
+  # apply CI の承認ノイズ削減のため内容変更を無視する（更新時は一時的に ignore_changes を外す / console で編集）。
+  lifecycle {
+    ignore_changes = [dashboard_json]
+  }
+
   dashboard_json = <<EOF
 {
   "displayName": "Next.js パフォーマンス監視ダッシュボード",


### PR DESCRIPTION
## 概要

SPR-98 が「許容」とした monitoring dashboard×3 の cosmetic 永久 diff を解消する。SPR-99 Stage 2（apply 承認制 CI）導入後、apply CI が毎回この 3 件（`0 add / 3 change / 0 destroy`）を承認対象に出すノイズになっていたため。

## 原因（config では match 不能）
`google_monitoring_dashboard.dashboard_json` は API が `etag` / `name`（server 採番）を付与し `xPos/yPos=0` を省略するため、config をどう書いても恒久 diff になる。0 座標除去だけでは etag/name が残り解消しない。

## 変更
4 dashboard（`service_overview` / `nextjs_performance` / `logging_dashboard` / `cost_overview`）に **`lifecycle { ignore_changes = [dashboard_json] }`** を付与。`secret_data`（ADR-010）と同型の「TF 管理外＝bootstrap 一回化」。

## 検証
- `terraform validate` パス。
- targeted plan（3 dashboard）→ **`No changes`**（恒久 diff 消滅）。
- **config 評価のみ＝apply 不要**。本 PR の `Terraform Plan` CI が full plan で確認する（dashboard 由来の change が消える想定）。

## トレードオフ
- dashboard 定義の更新は一時的に `ignore_changes` を外す or console 編集（変更頻度は低く許容）。

SPR-102（親 SPR-91 / 関連 SPR-98・SPR-99）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)