### PR TITLE
docs: README のバージョン記述を package.json に SSOT 化（SPR-80）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # suzumina.click
 
-[![Version](https://img.shields.io/badge/version-v0.3.11-blue)](https://suzumina.click)
+[![Version](https://img.shields.io/github/package-json/v/nothink-jp/suzumina.click)](https://suzumina.click)
 [![Status](https://img.shields.io/badge/status-production-green)](https://suzumina.click)
 
 声優「涼花みなせ」ファンコミュニティの非公式ファンサイト
@@ -66,4 +66,4 @@ pnpm build
 
 ## ライセンス
 
-MIT License - 個人運営の非公式ファンサイト（v0.3.11）
+MIT License - 個人運営の非公式ファンサイト


### PR DESCRIPTION
## 概要

[SPR-80](https://linear.app/nothink/issue/SPR-80) 対応。ドキュメント間のバージョン記述の不整合を解消し、バージョンの正本（SSOT）を `package.json` に一本化する。

## 背景

調査の結果、SPR-80 が指摘していた不整合の大半は SPR-63 (#465) で既に解消済みだった（README 技術スタック／CLAUDE.md は「正確なバージョンは package.json を正とする」へ修正済み）。

残っていた唯一の矛盾が **README の `v0.3.11` ハードコード2箇所**。package.json は全て `0.3.12`、docs/ 配下も `v0.3.12` で一致しており、README だけが陳腐化していた。

## 変更内容（README.md）

- version バッジを静的な `badge/version-v0.3.11` → 動的な `github/package-json/v/nothink-jp/suzumina.click` に変更。**リポジトリの package.json を直接読むため、バンプ時に自動追従し二度と陳腐化しない**。
- ライセンス行の冗長な版数記述 `（v0.3.11）` を削除。

## 完了の定義

- [x] ドキュメント間でバージョン記述の矛盾がない
- [x] バージョンのハードコードが最小化され、SSOT が package.json に寄っている

## スコープ外

`docs/operations/{todo,changelog}.md` 等の「Next.js 16 / v0.3.12」記述はリリース時点の変更履歴（point-in-time の記録）であり、意図的に凍結すべき値のため変更しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)