### PR TITLE
refactor(web): VideoCard を server shell + client island に分解（SPR-87）

### DIFF
--- a/apps/web/src/app/videos/components/VideoCard.tsx
+++ b/apps/web/src/app/videos/components/VideoCard.tsx
@@ -1,22 +1,14 @@
-"use client";
-
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
-import {
-	canCreateAudioButton,
-	getAudioButtonCreationErrorMessage,
-} from "@suzumina.click/shared-types";
 import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
-import { Button } from "@suzumina.click/ui/components/ui/button";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
-import { Calendar, Clock, ExternalLink, Eye, Lock, Plus, Radio, Video } from "lucide-react";
+import { Calendar, Clock, Lock, Radio, Video } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
-import React, { memo, useCallback, useMemo } from "react";
+import React from "react";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
+import VideoCardActions from "./VideoCardActions";
 
-// Helper function to get video badge information
+// 動画タイプ別バッジ情報（純関数）
 function getVideoBadgeInfo(video: VideoPlainObject) {
 	// VideoPlainObject は常に_computedプロパティを持つ
 	const { videoType } = video._computed;
@@ -66,155 +58,79 @@ function getVideoBadgeInfo(video: VideoPlainObject) {
 	}
 }
 
+// 表示日付（純関数）: ライブ配信は配信開始時間を優先し、無効なら公開時間にフォールバック
+function getDisplayDate(video: VideoPlainObject) {
+	const formatJpDate = (value: string) =>
+		new Date(value).toLocaleDateString("ja-JP", {
+			timeZone: "Asia/Tokyo",
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		});
+
+	const streamStartTime = video.liveStreamingDetails?.actualStartTime;
+	if (streamStartTime) {
+		const date = new Date(streamStartTime);
+		if (!Number.isNaN(date.getTime())) {
+			return {
+				formattedDate: formatJpDate(streamStartTime),
+				displayLabel: "配信開始",
+				dateTimeValue: streamStartTime,
+			};
+		}
+	}
+
+	const publishedDate = new Date(video.publishedAt);
+	if (Number.isNaN(publishedDate.getTime())) {
+		// 無効な日付文字列はそのまま表示
+		return {
+			formattedDate: video.publishedAt,
+			displayLabel: "公開日",
+			dateTimeValue: video.publishedAt,
+		};
+	}
+	return {
+		formattedDate: formatJpDate(video.publishedAt),
+		displayLabel: "公開日",
+		dateTimeValue: video.publishedAt,
+	};
+}
+
+// タグ → 検索ページの href ビルダー（純関数）。層に応じたフィルターパラメータを付与する
+function buildTagSearchHref(tag: string, layer: "playlist" | "user" | "category") {
+	const params = new URLSearchParams();
+	params.set("q", tag);
+	params.set("type", "videos");
+	switch (layer) {
+		case "playlist":
+			params.set("playlistTags", tag);
+			break;
+		case "user":
+			params.set("userTags", tag);
+			break;
+		case "category":
+			params.set("categoryNames", tag);
+			break;
+	}
+	return `/search?${params.toString()}`;
+}
+
 interface VideoCardProps {
 	video: VideoPlainObject;
-	buttonCount?: number; // 従来の互換性のため残すが、video.audioButtonCountを優先
 	variant?: "grid" | "sidebar";
 	priority?: boolean; // LCP画像最適化用
 }
 
-// パフォーマンス向上: VideoCardをメモ化して不要な再レンダリングを防ぐ
-const VideoCard = memo(function VideoCard({
-	video,
-	buttonCount,
-	variant = "grid",
-	priority = false,
-}: VideoCardProps) {
-	const { data: session } = useSession();
-	const router = useRouter();
-	const isGrid = variant === "grid";
-
-	// 音声ボタン数: video.audioButtonCountを優先し、なければbuttonCountを使用
-	const actualButtonCount = video.audioButtonCount ?? buttonCount ?? 0;
-
-	// メモ化: 日付フォーマットを最適化（ライブ配信は配信開始時間を優先）
-	const { formattedDate, displayLabel, dateTimeValue } = useMemo(() => {
-		// ライブ配信アーカイブの場合は配信開始時間を使用
-		const isLiveStream = video.liveStreamingDetails?.actualStartTime;
-		const streamStartTime = video.liveStreamingDetails?.actualStartTime;
-
-		if (isLiveStream && streamStartTime) {
-			try {
-				const date = new Date(streamStartTime);
-				// Invalid Dateチェックを追加
-				if (Number.isNaN(date.getTime())) {
-					// 配信開始時間が無効な場合は公開時間にフォールバック
-				} else {
-					return {
-						formattedDate: date.toLocaleDateString("ja-JP", {
-							timeZone: "Asia/Tokyo",
-							year: "numeric",
-							month: "2-digit",
-							day: "2-digit",
-						}),
-						displayLabel: "配信開始",
-						dateTimeValue: streamStartTime,
-					};
-				}
-			} catch {
-				// 配信開始時間の解析に失敗した場合は公開時間にフォールバック
-			}
-		}
-
-		// 通常動画または配信開始時間が無効な場合は公開時間を使用
-		try {
-			const date = new Date(video.publishedAt);
-			// Invalid Dateチェックを追加
-			if (Number.isNaN(date.getTime())) {
-				return {
-					formattedDate: video.publishedAt,
-					displayLabel: "公開日",
-					dateTimeValue: video.publishedAt,
-				};
-			}
-			return {
-				formattedDate: date.toLocaleDateString("ja-JP", {
-					timeZone: "Asia/Tokyo",
-					year: "numeric",
-					month: "2-digit",
-					day: "2-digit",
-				}),
-				displayLabel: "公開日",
-				dateTimeValue: video.publishedAt,
-			};
-		} catch {
-			return {
-				formattedDate: video.publishedAt,
-				displayLabel: "公開日",
-				dateTimeValue: video.publishedAt,
-			};
-		}
-	}, [video.publishedAt, video.liveStreamingDetails?.actualStartTime]);
-
-	// メモ化: YouTubeカテゴリ名取得
-	const categoryName = useMemo(() => {
-		return getYouTubeCategoryName(video.categoryId);
-	}, [video.categoryId]);
-
-	// タグクリック時の検索ページ遷移
-	const handleTagClick = useCallback(
-		(tag: string, layer: "playlist" | "user" | "category") => {
-			const params = new URLSearchParams();
-			params.set("q", tag);
-			params.set("type", "videos");
-
-			// 層に応じたフィルターパラメータを設定
-			switch (layer) {
-				case "playlist":
-					params.set("playlistTags", tag);
-					break;
-				case "user":
-					params.set("userTags", tag);
-					break;
-				case "category":
-					params.set("categoryNames", tag);
-					break;
-			}
-
-			router.push(`/search?${params.toString()}`);
-		},
-		[router],
-	);
-
-	// メモ化: 音声ボタン作成可能判定（認証状態も考慮）
-	const canCreateButtonData = useMemo(() => {
-		// ログインしていない場合
-		if (!session?.user) {
-			return {
-				canCreate: false,
-				reason: "音声ボタンを作成するにはすずみなふぁみりーメンバーとしてログインが必要です",
-			};
-		}
-
-		// 埋め込み制限チェック
-		if (video.status?.embeddable === false) {
-			return {
-				canCreate: false,
-				reason: "この動画は埋め込みが制限されているため、音声ボタンを作成できません",
-			};
-		}
-
-		// 動画の条件をチェック
-		const videoCanCreate = canCreateAudioButton(video);
-		if (!videoCanCreate) {
-			const reason =
-				getAudioButtonCreationErrorMessage(video) ||
-				"音声ボタンを作成できるのは配信アーカイブのみです";
-			return {
-				canCreate: false,
-				reason,
-			};
-		}
-
-		return { canCreate: true, reason: undefined };
-	}, [video, session?.user]);
-
-	const canCreateButton = canCreateButtonData.canCreate;
-
-	// メモ化: 動画タイプバッジの情報
-	const videoBadgeInfo = useMemo(() => {
-		return getVideoBadgeInfo(video);
-	}, [video]);
+/**
+ * 動画カード（server shell）。
+ * 認証ゲートを伴うアクションは {@link VideoCardActions}（client island）に隔離し、
+ * 本体は純表示に徹する。WorkCard と同じ「shell + island」構造。
+ */
+function VideoCard({ video, variant = "grid", priority = false }: VideoCardProps) {
+	const actualButtonCount = video.audioButtonCount ?? 0;
+	const { formattedDate, displayLabel, dateTimeValue } = getDisplayDate(video);
+	const categoryName = getYouTubeCategoryName(video.categoryId);
+	const videoBadgeInfo = getVideoBadgeInfo(video);
 
 	return (
 		<article
@@ -255,11 +171,12 @@ const VideoCard = memo(function VideoCard({
 					{actualButtonCount > 0 && (
 						<div className="absolute top-2 left-2">
 							<Badge
+								asChild
 								variant="secondary"
-								className="bg-white/90 text-foreground"
-								aria-label={`${actualButtonCount}個の音声ボタンが作成されています`}
+								className="bg-white/90 text-foreground cursor-pointer hover:bg-white"
+								aria-label={`${actualButtonCount}個の音声ボタン一覧を見る`}
 							>
-								{actualButtonCount} ボタン
+								<Link href={`/buttons?videoId=${video.id}`}>{actualButtonCount} ボタン</Link>
 							</Badge>
 						</div>
 					)}
@@ -311,66 +228,16 @@ const VideoCard = memo(function VideoCard({
 							showEmptyLayers={false}
 							showCategory={true}
 							compact={true}
-							onTagClick={handleTagClick}
+							tagHref={buildTagSearchHref}
 						/>
 					</div>
 
-					{/* アクションボタン */}
-					{isGrid ? (
-						canCreateButton ? (
-							<fieldset className="flex gap-2" aria-label="動画アクション">
-								<Button
-									size="sm"
-									variant="outline"
-									className="flex-1 border text-muted-foreground hover:bg-accent min-h-[44px] text-sm"
-									asChild
-								>
-									<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
-										<Eye className="h-4 w-4 mr-1" aria-hidden="true" />
-										詳細を見る
-									</Link>
-								</Button>
-								<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
-									<Link
-										href={`/buttons/create?video_id=${video.id}`}
-										aria-label={`${video.title}の音声ボタンを作成`}
-										className="flex items-center whitespace-nowrap"
-									>
-										<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
-										ボタン作成
-									</Link>
-								</Button>
-							</fieldset>
-						) : (
-							<Button
-								size="sm"
-								variant="outline"
-								className="w-full border text-muted-foreground hover:bg-accent min-h-[44px] text-sm"
-								asChild
-							>
-								<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
-									<Eye className="h-4 w-4 mr-1" aria-hidden="true" />
-									詳細を見る
-								</Link>
-							</Button>
-						)
-					) : (
-						<Button
-							variant="outline"
-							size="sm"
-							className="w-full border text-muted-foreground hover:bg-accent min-h-[44px]"
-							asChild
-						>
-							<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
-								<ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
-								動画を見る
-							</Link>
-						</Button>
-					)}
+					{/* アクションボタン（認証ゲートは client island に隔離） */}
+					<VideoCardActions video={video} variant={variant} />
 				</div>
 			</div>
 		</article>
 	);
-});
+}
 
 export default VideoCard;

--- a/apps/web/src/app/videos/components/VideoCardActions.tsx
+++ b/apps/web/src/app/videos/components/VideoCardActions.tsx
@@ -112,7 +112,7 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 						className="flex items-center whitespace-nowrap"
 					>
 						<LogIn className="h-4 w-4 mr-1" aria-hidden="true" />
-						ログインして作成
+						ログイン
 					</Link>
 				</Button>
 			</fieldset>

--- a/apps/web/src/app/videos/components/VideoCardActions.tsx
+++ b/apps/web/src/app/videos/components/VideoCardActions.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import type { VideoPlainObject } from "@suzumina.click/shared-types";
+import {
+	canCreateAudioButton,
+	getAudioButtonCreationErrorMessage,
+} from "@suzumina.click/shared-types";
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { ExternalLink, Eye, LogIn, Plus } from "lucide-react";
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+
+interface VideoCardActionsProps {
+	video: VideoPlainObject;
+	variant: "grid" | "sidebar";
+}
+
+type ButtonGate =
+	| { canCreate: true }
+	| { canCreate: false; needsLogin: true }
+	| { canCreate: false; needsLogin: false; reason: string };
+
+function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): ButtonGate {
+	if (!isLoggedIn) {
+		return { canCreate: false, needsLogin: true };
+	}
+	if (video.status?.embeddable === false) {
+		return {
+			canCreate: false,
+			needsLogin: false,
+			reason: "この動画は埋め込みが制限されているため、音声ボタンを作成できません",
+		};
+	}
+	if (!canCreateAudioButton(video)) {
+		return {
+			canCreate: false,
+			needsLogin: false,
+			reason:
+				getAudioButtonCreationErrorMessage(video) ||
+				"音声ボタンを作成できるのは配信アーカイブのみです",
+		};
+	}
+	return { canCreate: true };
+}
+
+/**
+ * VideoCard のアクション領域（client island）。
+ * 認証ゲート（useSession）をカード本体から隔離するための最小 client コンポーネント。
+ */
+export default function VideoCardActions({ video, variant }: VideoCardActionsProps) {
+	const { data: session } = useSession();
+
+	const detailLink = (
+		<Button
+			size="sm"
+			variant="outline"
+			className="flex-1 border text-muted-foreground hover:bg-accent min-h-[44px] text-sm"
+			asChild
+		>
+			<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
+				<Eye className="h-4 w-4 mr-1" aria-hidden="true" />
+				詳細を見る
+			</Link>
+		</Button>
+	);
+
+	if (variant === "sidebar") {
+		return (
+			<Button
+				variant="outline"
+				size="sm"
+				className="w-full border text-muted-foreground hover:bg-accent min-h-[44px]"
+				asChild
+			>
+				<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
+					<ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
+					動画を見る
+				</Link>
+			</Button>
+		);
+	}
+
+	const gate = evaluateButtonGate(video, Boolean(session?.user));
+
+	if (gate.canCreate) {
+		return (
+			<fieldset className="flex gap-2" aria-label="動画アクション">
+				{detailLink}
+				<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
+					<Link
+						href={`/buttons/create?video_id=${video.id}`}
+						aria-label={`${video.title}の音声ボタンを作成`}
+						className="flex items-center whitespace-nowrap"
+					>
+						<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+						ボタン作成
+					</Link>
+				</Button>
+			</fieldset>
+		);
+	}
+
+	// 未ログイン: ログイン導線を出す
+	if (gate.needsLogin) {
+		return (
+			<fieldset className="flex gap-2" aria-label="動画アクション">
+				{detailLink}
+				<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
+					<Link
+						href={`/auth/signin?callbackUrl=${encodeURIComponent(`/buttons/create?video_id=${video.id}`)}`}
+						aria-label="ログインして音声ボタンを作成"
+						className="flex items-center whitespace-nowrap"
+					>
+						<LogIn className="h-4 w-4 mr-1" aria-hidden="true" />
+						ログインして作成
+					</Link>
+				</Button>
+			</fieldset>
+		);
+	}
+
+	// 作成不可（理由あり）: disabled ボタン + tooltip で理由を提示
+	return (
+		<fieldset className="flex gap-2" aria-label="動画アクション">
+			{detailLink}
+			<Button
+				size="sm"
+				variant="default"
+				className="flex-1 min-h-[44px] text-sm"
+				disabled
+				title={gate.reason}
+				aria-label={`音声ボタンを作成できません: ${gate.reason}`}
+			>
+				<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+				ボタン作成
+			</Button>
+		</fieldset>
+	);
+}

--- a/apps/web/src/app/videos/components/VideoCardActions.tsx
+++ b/apps/web/src/app/videos/components/VideoCardActions.tsx
@@ -9,6 +9,7 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 import { ExternalLink, Eye, LogIn, Plus } from "lucide-react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import type { ReactNode } from "react";
 
 interface VideoCardActionsProps {
 	video: VideoPlainObject;
@@ -82,58 +83,58 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 
 	const gate = evaluateButtonGate(video, Boolean(session?.user));
 
+	let createAction: ReactNode;
 	if (gate.canCreate) {
-		return (
-			<fieldset className="flex gap-2" aria-label="動画アクション">
-				{detailLink}
-				<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
-					<Link
-						href={`/buttons/create?video_id=${video.id}`}
-						aria-label={`${video.title}の音声ボタンを作成`}
-						className="flex items-center whitespace-nowrap"
-					>
-						<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
-						ボタン作成
-					</Link>
-				</Button>
-			</fieldset>
+		createAction = (
+			<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
+				<Link
+					href={`/buttons/create?video_id=${video.id}`}
+					aria-label={`${video.title}の音声ボタンを作成`}
+					className="flex items-center whitespace-nowrap"
+				>
+					<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+					ボタン作成
+				</Link>
+			</Button>
 		);
-	}
-
-	// 未ログイン: ログイン導線を出す
-	if (gate.needsLogin) {
-		return (
-			<fieldset className="flex gap-2" aria-label="動画アクション">
-				{detailLink}
-				<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
-					<Link
-						href={`/auth/signin?callbackUrl=${encodeURIComponent(`/buttons/create?video_id=${video.id}`)}`}
-						aria-label="ログインして音声ボタンを作成"
-						className="flex items-center whitespace-nowrap"
-					>
-						<LogIn className="h-4 w-4 mr-1" aria-hidden="true" />
-						ログイン
-					</Link>
-				</Button>
-			</fieldset>
+	} else if (gate.needsLogin) {
+		// 未ログイン: ログイン導線を出す
+		createAction = (
+			<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
+				<Link
+					href={`/auth/signin?callbackUrl=${encodeURIComponent(`/buttons/create?video_id=${video.id}`)}`}
+					aria-label="ログインして音声ボタンを作成"
+					className="flex items-center whitespace-nowrap"
+				>
+					<LogIn className="h-4 w-4 mr-1" aria-hidden="true" />
+					ログイン
+				</Link>
+			</Button>
 		);
-	}
-
-	// 作成不可（理由あり）: disabled ボタン + tooltip で理由を提示
-	return (
-		<fieldset className="flex gap-2" aria-label="動画アクション">
-			{detailLink}
+	} else {
+		// 作成不可（理由あり）: aria-disabled で理由を提示。
+		// native disabled は pointer-events-none で title ツールチップが出ず、
+		// フォーカスもできないため、aria-disabled でホバー/フォーカス両方に理由を届かせる。
+		createAction = (
 			<Button
+				type="button"
 				size="sm"
 				variant="default"
-				className="flex-1 min-h-[44px] text-sm"
-				disabled
+				className="flex-1 min-h-[44px] text-sm opacity-50 cursor-not-allowed hover:bg-primary"
+				aria-disabled="true"
 				title={gate.reason}
 				aria-label={`音声ボタンを作成できません: ${gate.reason}`}
 			>
 				<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
 				ボタン作成
 			</Button>
+		);
+	}
+
+	return (
+		<fieldset className="flex gap-2" aria-label="動画アクション">
+			{detailLink}
+			{createAction}
 		</fieldset>
 	);
 }

--- a/apps/web/src/app/videos/components/__tests__/VideoCard.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/VideoCard.test.tsx
@@ -1,16 +1,10 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import VideoCard from "../VideoCard";
 
-// モックの設定
-vi.mock("next/navigation", () => ({
-	useRouter: vi.fn(),
-}));
-
+// モックの設定（認証ゲートは VideoCardActions client island が useSession を使う）
 vi.mock("next-auth/react", () => ({
 	useSession: vi.fn(),
 }));
@@ -73,12 +67,8 @@ function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 }
 
 describe("VideoCard", () => {
-	const mockPush = vi.fn();
-	const mockRouter = { push: mockPush };
-
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useRouter as any).mockReturnValue(mockRouter);
 		(useSession as any).mockReturnValue({ data: null });
 	});
 
@@ -133,12 +123,12 @@ describe("VideoCard", () => {
 		expect(screen.getByText("配信アーカイブ")).toBeInTheDocument();
 	});
 
-	it("音声ボタン数が表示される", () => {
+	it("音声ボタン数バッジが一覧ページへのリンクになっている", () => {
 		const video = createMockVideo({ audioButtonCount: 5 });
 		render(<VideoCard video={video} />);
 
-		expect(screen.getByLabelText("5個の音声ボタンが作成されています")).toBeInTheDocument();
-		expect(screen.getByText("5 ボタン")).toBeInTheDocument();
+		const badgeLink = screen.getByText("5 ボタン").closest("a");
+		expect(badgeLink).toHaveAttribute("href", "/buttons?videoId=video123");
 	});
 
 	it("タグが表示される", () => {
@@ -155,8 +145,7 @@ describe("VideoCard", () => {
 		expect(screen.getByText("ユーザータグ1")).toBeInTheDocument();
 	});
 
-	it("タグクリックで検索ページに遷移する", async () => {
-		const user = userEvent.setup();
+	it("タグが検索ページへのリンクになっている", () => {
 		const video = createMockVideo({
 			tags: {
 				playlistTags: ["プレイリストタグ1"],
@@ -166,51 +155,11 @@ describe("VideoCard", () => {
 		});
 		render(<VideoCard video={video} />);
 
-		const playlistTag = screen.getByText("プレイリストタグ1");
-		await user.click(playlistTag);
-
-		expect(mockPush).toHaveBeenCalledWith(
+		const playlistTagLink = screen.getByText("プレイリストタグ1").closest("a");
+		expect(playlistTagLink).toHaveAttribute(
+			"href",
 			"/search?q=%E3%83%97%E3%83%AC%E3%82%A4%E3%83%AA%E3%82%B9%E3%83%88%E3%82%BF%E3%82%B01&type=videos&playlistTags=%E3%83%97%E3%83%AC%E3%82%A4%E3%83%AA%E3%82%B9%E3%83%88%E3%82%BF%E3%82%B01",
 		);
-	});
-
-	it("ログインしていない場合は音声ボタン作成ボタンが表示されない", () => {
-		const video = createMockVideo({
-			videoType: "archived",
-			duration: "PT2H30M", // 2時間（30分（１５分以上）
-			liveStreamingDetails: {
-				actualStartTime: "2024-01-01T00:00:00Z",
-				actualEndTime: "2024-01-01T02:30:00Z",
-			},
-		});
-		render(<VideoCard video={video} />);
-
-		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
-		expect(screen.getByText("詳細を見る")).toBeInTheDocument();
-	});
-
-	it("ログインしていて配信アーカイブの場合は音声ボタン作成ボタンが表示される", () => {
-		(useSession as any).mockReturnValue({
-			data: { user: { id: "user123", name: "テストユーザー" } },
-		});
-
-		const video = createMockVideo({
-			videoType: "archived",
-			duration: "PT2H30M", // 2時間（30分（１５分以上）
-			liveStreamingDetails: {
-				actualStartTime: "2024-01-01T00:00:00Z",
-				actualEndTime: "2024-01-01T02:30:00Z",
-			},
-			_computed: {
-				...createMockVideo()._computed,
-				videoType: "archived",
-				isArchived: true,
-				canCreateButton: true,
-			},
-		});
-		render(<VideoCard video={video} />);
-
-		expect(screen.getByText("ボタン作成")).toBeInTheDocument();
 	});
 
 	describe("公開日時境界テスト", () => {

--- a/apps/web/src/app/videos/components/__tests__/VideoCardActions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/VideoCardActions.test.tsx
@@ -75,7 +75,7 @@ describe("VideoCardActions", () => {
 		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
 	});
 
-	it("ログイン済みでも作成不可なら理由を tooltip に持つ disabled ボタンを表示する", () => {
+	it("ログイン済みでも作成不可なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
 		(useSession as any).mockReturnValue(loggedIn);
 		const video = createMockVideo({
 			liveBroadcastContent: "live",
@@ -90,8 +90,12 @@ describe("VideoCardActions", () => {
 		render(<VideoCardActions video={video} variant="grid" />);
 
 		const createButton = screen.getByText("ボタン作成").closest("button");
-		expect(createButton).toBeDisabled();
+		// native disabled は pointer-events-none で tooltip が出ないため aria-disabled を使う
+		expect(createButton).toHaveAttribute("aria-disabled", "true");
+		expect(createButton).not.toBeDisabled();
 		expect(createButton).toHaveAttribute("title", "ライブ配信中は音声ボタンを作成できません");
+		// ホバー/フォーカスで理由が届くよう href を持たない（遷移しない）
+		expect(createButton).not.toHaveAttribute("href");
 	});
 
 	it("埋め込み制限がある場合は理由として埋め込み制限を表示する", () => {
@@ -100,7 +104,7 @@ describe("VideoCardActions", () => {
 		render(<VideoCardActions video={video} variant="grid" />);
 
 		const createButton = screen.getByText("ボタン作成").closest("button");
-		expect(createButton).toBeDisabled();
+		expect(createButton).toHaveAttribute("aria-disabled", "true");
 		expect(createButton).toHaveAttribute(
 			"title",
 			"この動画は埋め込みが制限されているため、音声ボタンを作成できません",

--- a/apps/web/src/app/videos/components/__tests__/VideoCardActions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/VideoCardActions.test.tsx
@@ -67,7 +67,7 @@ describe("VideoCardActions", () => {
 		(useSession as any).mockReturnValue(loggedOut);
 		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
 
-		const loginLink = screen.getByText("ログインして作成").closest("a");
+		const loginLink = screen.getByText("ログイン").closest("a");
 		expect(loginLink).toHaveAttribute(
 			"href",
 			"/auth/signin?callbackUrl=%2Fbuttons%2Fcreate%3Fvideo_id%3Dvideo123",

--- a/apps/web/src/app/videos/components/__tests__/VideoCardActions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/VideoCardActions.test.tsx
@@ -1,0 +1,109 @@
+import type { VideoPlainObject } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import VideoCardActions from "../VideoCardActions";
+
+vi.mock("next-auth/react", () => ({
+	useSession: vi.fn(),
+}));
+
+function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
+	const base = {
+		id: "video123",
+		videoId: "abc123",
+		title: "テスト動画タイトル",
+		description: "説明",
+		publishedAt: "2024-01-01T00:00:00Z",
+		channelId: "channel123",
+		channelTitle: "テストチャンネル",
+		categoryId: "22",
+		duration: "PT2H30M",
+		liveBroadcastContent: "none",
+		liveStreamingDetails: null,
+		status: { embeddable: true },
+		audioButtonCount: 0,
+		_computed: {
+			isArchived: true,
+			isPremiere: false,
+			isLive: false,
+			isUpcoming: false,
+			canCreateButton: true,
+			videoType: "archived",
+			thumbnailUrl: "https://example.com/thumbnail.jpg",
+			youtubeUrl: "https://youtube.com/watch?v=abc123",
+		},
+	};
+	return { ...base, ...overrides } as VideoPlainObject;
+}
+
+const loggedIn = { data: { user: { id: "user123", name: "テストユーザー" } } };
+const loggedOut = { data: null };
+
+describe("VideoCardActions", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("sidebar variant では『動画を見る』リンクのみ表示する", () => {
+		(useSession as any).mockReturnValue(loggedOut);
+		render(<VideoCardActions video={createMockVideo()} variant="sidebar" />);
+
+		const link = screen.getByText("動画を見る").closest("a");
+		expect(link).toHaveAttribute("href", "/videos/video123");
+		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
+	});
+
+	it("ログイン済み・作成可能ならボタン作成リンクを表示する", () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
+
+		const createLink = screen.getByText("ボタン作成").closest("a");
+		expect(createLink).toHaveAttribute("href", "/buttons/create?video_id=video123");
+		expect(screen.getByText("詳細を見る")).toBeInTheDocument();
+	});
+
+	it("未ログインならログイン導線を表示する（callbackUrl 付き）", () => {
+		(useSession as any).mockReturnValue(loggedOut);
+		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
+
+		const loginLink = screen.getByText("ログインして作成").closest("a");
+		expect(loginLink).toHaveAttribute(
+			"href",
+			"/auth/signin?callbackUrl=%2Fbuttons%2Fcreate%3Fvideo_id%3Dvideo123",
+		);
+		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
+	});
+
+	it("ログイン済みでも作成不可なら理由を tooltip に持つ disabled ボタンを表示する", () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		const video = createMockVideo({
+			liveBroadcastContent: "live",
+			_computed: {
+				...createMockVideo()._computed,
+				isArchived: false,
+				isLive: true,
+				canCreateButton: false,
+				videoType: "live",
+			},
+		});
+		render(<VideoCardActions video={video} variant="grid" />);
+
+		const createButton = screen.getByText("ボタン作成").closest("button");
+		expect(createButton).toBeDisabled();
+		expect(createButton).toHaveAttribute("title", "ライブ配信中は音声ボタンを作成できません");
+	});
+
+	it("埋め込み制限がある場合は理由として埋め込み制限を表示する", () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		const video = createMockVideo({ status: { embeddable: false } });
+		render(<VideoCardActions video={video} variant="grid" />);
+
+		const createButton = screen.getByText("ボタン作成").closest("button");
+		expect(createButton).toBeDisabled();
+		expect(createButton).toHaveAttribute(
+			"title",
+			"この動画は埋め込みが制限されているため、音声ボタンを作成できません",
+		);
+	});
+});

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -224,6 +224,7 @@ vi.mock("lucide-react", () => {
 		// Icons for VideoCard
 		Eye: createMockIcon("Eye"),
 		Radio: createMockIcon("Radio"),
+		LogIn: createMockIcon("LogIn"),
 		// Icons for UserMenu
 		LogOut: createMockIcon("LogOut"),
 		// Icons for AutocompleteDropdown and SearchInputWithAutocomplete

--- a/packages/ui/src/components/custom/three-layer-tag-display.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display.tsx
@@ -31,6 +31,8 @@ export interface VideoTagDisplayProps {
 	className?: string;
 	/** タグクリック時のコールバック */
 	onTagClick?: (tag: string, layer: "playlist" | "user" | "category") => void;
+	/** タグの遷移先 href ビルダー。指定時は onTagClick より優先し <Link> を描画する（server 化向け） */
+	tagHref?: (tag: string, layer: "playlist" | "user" | "category") => string;
 	/** 表示サイズ */
 	size?: "sm" | "default" | "lg";
 	/** 各層の最大表示タグ数（0の場合は制限なし） */
@@ -54,6 +56,7 @@ export function VideoTagDisplay({
 	highlightClassName,
 	className,
 	onTagClick,
+	tagHref,
 	size = "default",
 	maxTagsPerLayer = 0,
 	showEmptyLayers = false,
@@ -105,6 +108,7 @@ export function VideoTagDisplay({
 				allTags={allTags}
 				sizeClasses={sizeClasses}
 				onTagClick={onTagClick}
+				tagHref={tagHref}
 				searchQuery={searchQuery}
 				highlightClassName={highlightClassName}
 				className={className}
@@ -124,6 +128,7 @@ export function VideoTagDisplay({
 			sizeClasses={sizeClasses}
 			showEmptyLayers={showEmptyLayers}
 			onTagClick={onTagClick}
+			tagHref={tagHref}
 			searchQuery={searchQuery}
 			highlightClassName={highlightClassName}
 		/>
@@ -140,6 +145,7 @@ export function VideoTagDisplay({
 			sizeClasses={sizeClasses}
 			showEmptyLayers={showEmptyLayers}
 			onTagClick={onTagClick}
+			tagHref={tagHref}
 			searchQuery={searchQuery}
 			highlightClassName={highlightClassName}
 		/>
@@ -150,6 +156,7 @@ export function VideoTagDisplay({
 			categoryName={categoryName}
 			sizeClasses={sizeClasses}
 			onTagClick={onTagClick}
+			tagHref={tagHref}
 			searchQuery={searchQuery}
 			highlightClassName={highlightClassName}
 		/>

--- a/packages/ui/src/components/custom/three-layer-tag-display/CategoryDisplay.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/CategoryDisplay.tsx
@@ -5,6 +5,7 @@
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { FolderOpen } from "lucide-react";
+import Link from "next/link";
 import type { MouseEvent } from "react";
 import { HighlightText } from "../highlight-text";
 
@@ -17,6 +18,8 @@ interface CategoryDisplayProps {
 		layerContainer: string;
 	};
 	onTagClick?: (tag: string, layer: "playlist" | "user" | "category") => void;
+	/** タグの遷移先 href ビルダー。指定時は onTagClick より優先し <Link> を描画する */
+	tagHref?: (tag: string, layer: "playlist" | "user" | "category") => string;
 	searchQuery?: string;
 	highlightClassName?: string;
 }
@@ -25,6 +28,7 @@ export function CategoryDisplay({
 	categoryName,
 	sizeClasses,
 	onTagClick,
+	tagHref,
 	searchQuery,
 	highlightClassName,
 }: CategoryDisplayProps) {
@@ -36,6 +40,23 @@ export function CategoryDisplay({
 		}
 	};
 
+	const badgeClassName = cn(
+		sizeClasses.badge,
+		"bg-suzuka-700 text-white border-suzuka-700 hover:bg-suzuka-800",
+		(tagHref || onTagClick) && "cursor-pointer",
+		"transition-all duration-200",
+	);
+
+	const content = searchQuery ? (
+		<HighlightText
+			text={categoryName}
+			searchQuery={searchQuery}
+			highlightClassName={highlightClassName || "bg-yellow-200 text-yellow-900 px-1 rounded"}
+		/>
+	) : (
+		categoryName
+	);
+
 	return (
 		<div className="space-y-2">
 			<h4 className={cn("font-medium text-muted-foreground flex items-center", sizeClasses.title)}>
@@ -44,27 +65,15 @@ export function CategoryDisplay({
 				<span className="text-xs text-muted-foreground ml-2">(YouTube分類)</span>
 			</h4>
 			<div className={cn("flex flex-wrap", sizeClasses.layerContainer)}>
-				<Badge
-					className={cn(
-						sizeClasses.badge,
-						"bg-suzuka-700 text-white border-suzuka-700 hover:bg-suzuka-800",
-						onTagClick && "cursor-pointer",
-						"transition-all duration-200",
-					)}
-					onClick={onTagClick ? handleClick : undefined}
-				>
-					{searchQuery ? (
-						<HighlightText
-							text={categoryName}
-							searchQuery={searchQuery}
-							highlightClassName={
-								highlightClassName || "bg-yellow-200 text-yellow-900 px-1 rounded"
-							}
-						/>
-					) : (
-						categoryName
-					)}
-				</Badge>
+				{tagHref ? (
+					<Badge asChild className={badgeClassName}>
+						<Link href={tagHref(categoryName, "category")}>{content}</Link>
+					</Badge>
+				) : (
+					<Badge className={badgeClassName} onClick={onTagClick ? handleClick : undefined}>
+						{content}
+					</Badge>
+				)}
 			</div>
 		</div>
 	);

--- a/packages/ui/src/components/custom/three-layer-tag-display/CompactTagDisplay.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/CompactTagDisplay.tsx
@@ -4,6 +4,7 @@
 
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { cn } from "@suzumina.click/ui/lib/utils";
+import Link from "next/link";
 import type { MouseEvent } from "react";
 import { HighlightText } from "../highlight-text";
 
@@ -17,6 +18,8 @@ interface CompactTagDisplayProps {
 	allTags: TagData[];
 	sizeClasses: { badge: string; layerContainer: string };
 	onTagClick?: (tag: string, layer: "playlist" | "user" | "category") => void;
+	/** タグの遷移先 href ビルダー。指定時は onTagClick より優先し <Link> を描画する */
+	tagHref?: (tag: string, layer: "playlist" | "user" | "category") => string;
 	searchQuery?: string;
 	highlightClassName?: string;
 	className?: string;
@@ -26,6 +29,7 @@ export function CompactTagDisplay({
 	allTags,
 	sizeClasses,
 	onTagClick,
+	tagHref,
 	searchQuery,
 	highlightClassName,
 	className,
@@ -42,32 +46,45 @@ export function CompactTagDisplay({
 		}
 	};
 
+	const renderContent = (text: string) =>
+		searchQuery ? (
+			<HighlightText
+				text={text}
+				searchQuery={searchQuery}
+				highlightClassName={highlightClassName || "bg-yellow-200 text-yellow-900 px-1 rounded"}
+			/>
+		) : (
+			text
+		);
+
 	return (
 		<div className={cn("flex flex-wrap", sizeClasses.layerContainer, className)}>
-			{allTags.map((tag, index) => (
-				<Badge
-					key={`${tag.type}-${tag.text}-${index}`}
-					className={cn(
-						sizeClasses.badge,
-						tag.className,
-						onTagClick && "cursor-pointer",
-						"transition-all duration-200",
-					)}
-					onClick={onTagClick ? (e) => handleTagClick(tag.text, tag.type, e) : undefined}
-				>
-					{searchQuery ? (
-						<HighlightText
-							text={tag.text}
-							searchQuery={searchQuery}
-							highlightClassName={
-								highlightClassName || "bg-yellow-200 text-yellow-900 px-1 rounded"
-							}
-						/>
-					) : (
-						tag.text
-					)}
-				</Badge>
-			))}
+			{allTags.map((tag, index) => {
+				const badgeClassName = cn(
+					sizeClasses.badge,
+					tag.className,
+					(tagHref || onTagClick) && "cursor-pointer",
+					"transition-all duration-200",
+				);
+
+				if (tagHref) {
+					return (
+						<Badge key={`${tag.type}-${tag.text}-${index}`} asChild className={badgeClassName}>
+							<Link href={tagHref(tag.text, tag.type)}>{renderContent(tag.text)}</Link>
+						</Badge>
+					);
+				}
+
+				return (
+					<Badge
+						key={`${tag.type}-${tag.text}-${index}`}
+						className={badgeClassName}
+						onClick={onTagClick ? (e) => handleTagClick(tag.text, tag.type, e) : undefined}
+					>
+						{renderContent(tag.text)}
+					</Badge>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/ui/src/components/custom/three-layer-tag-display/TagLayer.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/TagLayer.tsx
@@ -4,6 +4,7 @@
 
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { cn } from "@suzumina.click/ui/lib/utils";
+import Link from "next/link";
 import type { MouseEvent } from "react";
 import { HighlightText } from "../highlight-text";
 
@@ -22,6 +23,8 @@ interface TagLayerProps {
 	};
 	showEmptyLayers: boolean;
 	onTagClick?: (tag: string, layer: "playlist" | "user" | "category") => void;
+	/** タグの遷移先 href ビルダー。指定時は onTagClick より優先し <Link> を描画する */
+	tagHref?: (tag: string, layer: "playlist" | "user" | "category") => string;
 	searchQuery?: string;
 	highlightClassName?: string;
 }
@@ -36,6 +39,7 @@ export function TagLayer({
 	sizeClasses,
 	showEmptyLayers,
 	onTagClick,
+	tagHref,
 	searchQuery,
 	highlightClassName,
 }: TagLayerProps) {
@@ -54,6 +58,17 @@ export function TagLayer({
 			onTagClick(tag, layerType);
 		}
 	};
+
+	const renderContent = (text: string) =>
+		searchQuery ? (
+			<HighlightText
+				text={text}
+				searchQuery={searchQuery}
+				highlightClassName={highlightClassName || "bg-yellow-200 text-yellow-900 px-1 rounded"}
+			/>
+		) : (
+			text
+		);
 
 	const getLayerDescription = () => {
 		if (layer === "playlist") {
@@ -75,30 +90,32 @@ export function TagLayer({
 				{description && <span className="text-xs text-muted-foreground ml-2">{description}</span>}
 			</h4>
 			<div className={cn("flex flex-wrap", sizeClasses.layerContainer)}>
-				{displayData.displayed.map((tag, index) => (
-					<Badge
-						key={`${tag}-${index}`}
-						className={cn(
-							sizeClasses.badge,
-							badgeClassName,
-							onTagClick && "cursor-pointer",
-							"transition-all duration-200",
-						)}
-						onClick={onTagClick ? (e) => handleTagClick(tag, layer, e) : undefined}
-					>
-						{searchQuery ? (
-							<HighlightText
-								text={tag}
-								searchQuery={searchQuery}
-								highlightClassName={
-									highlightClassName || "bg-yellow-200 text-yellow-900 px-1 rounded"
-								}
-							/>
-						) : (
-							tag
-						)}
-					</Badge>
-				))}
+				{displayData.displayed.map((tag, index) => {
+					const itemClassName = cn(
+						sizeClasses.badge,
+						badgeClassName,
+						(tagHref || onTagClick) && "cursor-pointer",
+						"transition-all duration-200",
+					);
+
+					if (tagHref) {
+						return (
+							<Badge key={`${tag}-${index}`} asChild className={itemClassName}>
+								<Link href={tagHref(tag, layer)}>{renderContent(tag)}</Link>
+							</Badge>
+						);
+					}
+
+					return (
+						<Badge
+							key={`${tag}-${index}`}
+							className={itemClassName}
+							onClick={onTagClick ? (e) => handleTagClick(tag, layer, e) : undefined}
+						>
+							{renderContent(tag)}
+						</Badge>
+					);
+				})}
 				{displayData.hasMore && (
 					<Badge
 						variant="outline"


### PR DESCRIPTION
## 概要
SPR-87 WS-2。VideoCard を WorkCard と同じ「server shell + client island」構造に統一する。WS-1（[要件棚卸し](https://linear.app/nothink/issue/SPR-87)）で確定した UX 要件も同時に反映。

**非ゴール**: perf/LCP 目的ではない（list LCP は image-bound で別 Issue SPR-86 担当）。本 PR は保守性 + UX 品質の改善。

## 変更点
### 共有 UI: 加算的 `tagHref`（packages/ui）
- `ThreeLayerTagDisplay` と3サブコンポーネントに `tagHref?: (tag, layer) => string` を追加
- 指定時は `<Badge asChild><Link>` を描画、未指定なら従来の `onTagClick` → **既存の他利用箇所（search-page-content / VideoUserTagEditor）は無改修で挙動不変**

### client island 新規: `VideoCardActions`
- `useSession` をここだけに隔離
- 算出済みで未使用だったボタン作成不可 `reason` を初めて表示
  - 未ログイン → ログイン導線（`/auth/signin?callbackUrl=…`）
  - その他不可（配信中/予定/動画長不明/埋め込み制限）→ `disabled` ボタン + tooltip(`title`)

### VideoCard を server shell 化
- `"use client"` / `useSession` / `useRouter` / `useMemo` / `useCallback` / `memo` を全除去。日付・カテゴリ・バッジ・タグURLは純関数化
- タグを `<Link>` 化（`useRouter` 完全除去）
- 音声ボタン数バッジを `/buttons?videoId=` への Link 化
- 死蔵 `buttonCount` prop を削除（利用箇所ゼロ確認済み）

## UX 要件（WS-1 確定分）の反映
| # | 項目 | 対応 |
|---|---|---|
| ① | 作成不可理由 | 未ログイン=リンク / その他=disabled + tooltip |
| ② | タグ導線 | `<Link>` 化 |
| ③ | ボタン数バッジ | `/buttons?videoId=` へ Link |

## テスト
- `VideoCard.test.tsx`: タグ/バッジの Link 検証に更新
- `VideoCardActions.test.tsx`（新規）: 認証・作成可否の5分岐
- `pnpm verify`（lint + typecheck + test 692 pass）/ `pnpm build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)