### PR TITLE
a11y(ui)+refactor(web): タグ表示の ul/li 意味論化＋タグ遷移の SSOT 化（SPR-87 WS-3）

### DIFF
--- a/apps/web/src/app/search/search-page-content.tsx
+++ b/apps/web/src/app/search/search-page-content.tsx
@@ -25,6 +25,7 @@ import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useFavoriteStatusBulk } from "@/hooks/useFavoriteStatusBulk";
 import { useLikeDislikeStatusBulk } from "@/hooks/useLikeDislikeStatusBulk";
+import { buildTagSearchHref } from "@/lib/tag-search";
 
 interface UnifiedSearchResult {
 	audioButtons: AudioButtonPlainObject[];
@@ -352,12 +353,8 @@ function SearchResults({
 							</div>
 							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 								{searchResult.videos.slice(0, 6).map((video) => (
-									<Link
-										key={video.id}
-										href={`/videos/${video.id}`}
-										className="group block hover:shadow-lg transition-shadow"
-									>
-										<Card className="h-full">
+									<Card key={video.id} className="h-full group hover:shadow-lg transition-shadow">
+										<Link href={`/videos/${video.id}`} className="block">
 											<div className="aspect-[16/9] relative overflow-hidden rounded-t-lg bg-black">
 												<ThumbnailImage
 													src={video.thumbnailUrl}
@@ -365,7 +362,9 @@ function SearchResults({
 													className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-200"
 												/>
 											</div>
-											<CardContent className="p-4">
+										</Link>
+										<CardContent className="p-4">
+											<Link href={`/videos/${video.id}`} className="block">
 												<h3 className="font-medium line-clamp-2 group-hover:text-suzuka-600 transition-colors">
 													<HighlightText
 														text={video.title}
@@ -373,29 +372,30 @@ function SearchResults({
 														highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
 													/>
 												</h3>
-												<p className="text-sm text-muted-foreground mt-1">
-													{new Date(video.publishedAt).toLocaleDateString("ja-JP", {
-														timeZone: "Asia/Tokyo",
-													})}
-												</p>
-												{/* 3層タグハイライト表示 */}
-												<div className="mt-2">
-													<ThreeLayerTagDisplay
-														playlistTags={video.tags?.playlistTags || []}
-														userTags={video.tags?.userTags || []}
-														categoryId={video.categoryId}
-														categoryName={getYouTubeCategoryName(video.categoryId) || undefined}
-														searchQuery={searchQuery}
-														highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
-														size="sm"
-														maxTagsPerLayer={3}
-														showEmptyLayers={false}
-														showCategory={true}
-													/>
-												</div>
-											</CardContent>
-										</Card>
-									</Link>
+											</Link>
+											<p className="text-sm text-muted-foreground mt-1">
+												{new Date(video.publishedAt).toLocaleDateString("ja-JP", {
+													timeZone: "Asia/Tokyo",
+												})}
+											</p>
+											{/* 3層タグハイライト表示 */}
+											<div className="mt-2">
+												<ThreeLayerTagDisplay
+													playlistTags={video.tags?.playlistTags || []}
+													userTags={video.tags?.userTags || []}
+													categoryId={video.categoryId}
+													categoryName={getYouTubeCategoryName(video.categoryId) || undefined}
+													searchQuery={searchQuery}
+													highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
+													size="sm"
+													maxTagsPerLayer={3}
+													showEmptyLayers={false}
+													showCategory={true}
+													tagHref={buildTagSearchHref}
+												/>
+											</div>
+										</CardContent>
+									</Card>
 								))}
 							</div>
 							{searchResult.hasMore.videos && (
@@ -489,12 +489,8 @@ function SearchResults({
 				<TabsContent value="videos">
 					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 						{searchResult.videos.map((video) => (
-							<Link
-								key={video.id}
-								href={`/videos/${video.id}`}
-								className="group block hover:shadow-lg transition-shadow"
-							>
-								<Card className="h-full">
+							<Card key={video.id} className="h-full group hover:shadow-lg transition-shadow">
+								<Link href={`/videos/${video.id}`} className="block">
 									<div className="aspect-[16/9] relative overflow-hidden rounded-t-lg bg-black">
 										<ThumbnailImage
 											src={video.thumbnailUrl}
@@ -502,7 +498,9 @@ function SearchResults({
 											className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-200"
 										/>
 									</div>
-									<CardContent className="p-4">
+								</Link>
+								<CardContent className="p-4">
+									<Link href={`/videos/${video.id}`} className="block">
 										<h3 className="font-medium line-clamp-2 group-hover:text-suzuka-600 transition-colors">
 											<HighlightText
 												text={video.title}
@@ -510,29 +508,30 @@ function SearchResults({
 												highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
 											/>
 										</h3>
-										<p className="text-sm text-muted-foreground mt-1">
-											{new Date(video.publishedAt).toLocaleDateString("ja-JP", {
-												timeZone: "Asia/Tokyo",
-											})}
-										</p>
-										{/* 3層タグハイライト表示 */}
-										<div className="mt-2">
-											<ThreeLayerTagDisplay
-												playlistTags={video.tags?.playlistTags || []}
-												userTags={video.tags?.userTags || []}
-												categoryId={video.categoryId}
-												categoryName={getYouTubeCategoryName(video.categoryId) || undefined}
-												searchQuery={searchQuery}
-												highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
-												size="sm"
-												maxTagsPerLayer={3}
-												showEmptyLayers={false}
-												showCategory={true}
-											/>
-										</div>
-									</CardContent>
-								</Card>
-							</Link>
+									</Link>
+									<p className="text-sm text-muted-foreground mt-1">
+										{new Date(video.publishedAt).toLocaleDateString("ja-JP", {
+											timeZone: "Asia/Tokyo",
+										})}
+									</p>
+									{/* 3層タグハイライト表示 */}
+									<div className="mt-2">
+										<ThreeLayerTagDisplay
+											playlistTags={video.tags?.playlistTags || []}
+											userTags={video.tags?.userTags || []}
+											categoryId={video.categoryId}
+											categoryName={getYouTubeCategoryName(video.categoryId) || undefined}
+											searchQuery={searchQuery}
+											highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
+											size="sm"
+											maxTagsPerLayer={3}
+											showEmptyLayers={false}
+											showCategory={true}
+											tagHref={buildTagSearchHref}
+										/>
+									</div>
+								</CardContent>
+							</Card>
 						))}
 					</div>
 				</TabsContent>

--- a/apps/web/src/app/videos/components/VideoCard.tsx
+++ b/apps/web/src/app/videos/components/VideoCard.tsx
@@ -6,6 +6,7 @@ import { Calendar, Clock, Lock, Radio, Video } from "lucide-react";
 import Link from "next/link";
 import React from "react";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
+import { buildTagSearchHref } from "@/lib/tag-search";
 import VideoCardActions from "./VideoCardActions";
 
 // 動画タイプ別バッジ情報（純関数）
@@ -94,25 +95,6 @@ function getDisplayDate(video: VideoPlainObject) {
 		displayLabel: "公開日",
 		dateTimeValue: video.publishedAt,
 	};
-}
-
-// タグ → 検索ページの href ビルダー（純関数）。層に応じたフィルターパラメータを付与する
-function buildTagSearchHref(tag: string, layer: "playlist" | "user" | "category") {
-	const params = new URLSearchParams();
-	params.set("q", tag);
-	params.set("type", "videos");
-	switch (layer) {
-		case "playlist":
-			params.set("playlistTags", tag);
-			break;
-		case "user":
-			params.set("userTags", tag);
-			break;
-		case "category":
-			params.set("categoryNames", tag);
-			break;
-	}
-	return `/search?${params.toString()}`;
 }
 
 interface VideoCardProps {

--- a/apps/web/src/lib/__tests__/tag-search.test.ts
+++ b/apps/web/src/lib/__tests__/tag-search.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildTagSearchHref } from "../tag-search";
+
+describe("buildTagSearchHref", () => {
+	const parse = (href: string) => new URL(href, "http://localhost").searchParams;
+
+	it("playlist 層は playlistTags フィルターを付与する", () => {
+		const params = parse(buildTagSearchHref("配信", "playlist"));
+		expect(params.get("q")).toBe("配信");
+		expect(params.get("type")).toBe("videos");
+		expect(params.get("playlistTags")).toBe("配信");
+		expect(params.get("userTags")).toBeNull();
+		expect(params.get("categoryNames")).toBeNull();
+	});
+
+	it("user 層は userTags フィルターを付与する", () => {
+		const params = parse(buildTagSearchHref("可愛い", "user"));
+		expect(params.get("userTags")).toBe("可愛い");
+		expect(params.get("playlistTags")).toBeNull();
+	});
+
+	it("category 層は categoryNames フィルターを付与する", () => {
+		const params = parse(buildTagSearchHref("ゲーム", "category"));
+		expect(params.get("categoryNames")).toBe("ゲーム");
+	});
+
+	it("先頭は /search で、特殊文字はエンコードされる", () => {
+		const href = buildTagSearchHref("a&b c", "playlist");
+		expect(href.startsWith("/search?")).toBe(true);
+		expect(href).not.toContain("a&b c");
+		expect(parse(href).get("q")).toBe("a&b c");
+	});
+});

--- a/apps/web/src/lib/tag-search.ts
+++ b/apps/web/src/lib/tag-search.ts
@@ -1,0 +1,22 @@
+/**
+ * 3層タグ → 検索ページの href ビルダー（純関数）。
+ * 層に応じたフィルターパラメータを付与し、ThreeLayerTagDisplay の tagHref に渡す。
+ * VideoCard・検索結果のタグ遷移先を一元化する（正本）。
+ */
+export function buildTagSearchHref(tag: string, layer: "playlist" | "user" | "category") {
+	const params = new URLSearchParams();
+	params.set("q", tag);
+	params.set("type", "videos");
+	switch (layer) {
+		case "playlist":
+			params.set("playlistTags", tag);
+			break;
+		case "user":
+			params.set("userTags", tag);
+			break;
+		case "category":
+			params.set("categoryNames", tag);
+			break;
+	}
+	return `/search?${params.toString()}`;
+}

--- a/packages/ui/src/components/custom/__tests__/three-layer-tag-display.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/three-layer-tag-display.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ThreeLayerTagDisplay, VideoTagDisplay } from "../three-layer-tag-display";
@@ -258,6 +258,36 @@ describe("VideoTagDisplay", () => {
 			// ユーザータグはsuzuka-50色
 			const userBadge = screen.getByText("可愛い");
 			expect(userBadge).toHaveClass("bg-suzuka-50", "text-suzuka-700");
+		});
+
+		it("should render compact tags as a semantic list (ul/li)", () => {
+			render(
+				<VideoTagDisplay
+					playlistTags={["配信"]}
+					userTags={["可愛い"]}
+					categoryId="24"
+					categoryName="エンターテイメント"
+					compact={true}
+				/>,
+			);
+
+			const list = screen.getByRole("list", { name: "タグ" });
+			expect(list.tagName).toBe("UL");
+			expect(within(list).getAllByRole("listitem")).toHaveLength(3);
+		});
+
+		it("should render tagHref tags as links inside list items", () => {
+			render(
+				<VideoTagDisplay
+					playlistTags={["配信"]}
+					compact={true}
+					tagHref={(tag, layer) => `/search?q=${tag}&layer=${layer}`}
+				/>,
+			);
+
+			const link = screen.getByRole("link", { name: "配信" });
+			expect(link).toHaveAttribute("href", "/search?q=配信&layer=playlist");
+			expect(link.closest("li")).not.toBeNull();
 		});
 	});
 

--- a/packages/ui/src/components/custom/three-layer-tag-display/CompactTagDisplay.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/CompactTagDisplay.tsx
@@ -57,8 +57,10 @@ export function CompactTagDisplay({
 			text
 		);
 
+	if (allTags.length === 0) return null;
+
 	return (
-		<div className={cn("flex flex-wrap", sizeClasses.layerContainer, className)}>
+		<ul className={cn("flex flex-wrap", sizeClasses.layerContainer, className)} aria-label="タグ">
 			{allTags.map((tag, index) => {
 				const badgeClassName = cn(
 					sizeClasses.badge,
@@ -67,24 +69,23 @@ export function CompactTagDisplay({
 					"transition-all duration-200",
 				);
 
-				if (tagHref) {
-					return (
-						<Badge key={`${tag.type}-${tag.text}-${index}`} asChild className={badgeClassName}>
-							<Link href={tagHref(tag.text, tag.type)}>{renderContent(tag.text)}</Link>
-						</Badge>
-					);
-				}
-
 				return (
-					<Badge
-						key={`${tag.type}-${tag.text}-${index}`}
-						className={badgeClassName}
-						onClick={onTagClick ? (e) => handleTagClick(tag.text, tag.type, e) : undefined}
-					>
-						{renderContent(tag.text)}
-					</Badge>
+					<li key={`${tag.type}-${tag.text}-${index}`}>
+						{tagHref ? (
+							<Badge asChild className={badgeClassName}>
+								<Link href={tagHref(tag.text, tag.type)}>{renderContent(tag.text)}</Link>
+							</Badge>
+						) : (
+							<Badge
+								className={badgeClassName}
+								onClick={onTagClick ? (e) => handleTagClick(tag.text, tag.type, e) : undefined}
+							>
+								{renderContent(tag.text)}
+							</Badge>
+						)}
+					</li>
 				);
 			})}
-		</div>
+		</ul>
 	);
 }


### PR DESCRIPTION
## 概要
SPR-87 WS-3。**2つの関連テーマ**を含む（レビューで scope を実態に合わせて統合 = Plan A）。

### 1) WS-3 a11y: タグの意味論リスト化
- 共有 `CompactTagDisplay`（VideoCard が `compact=true` で使用）を **`<ul aria-label="タグ"><li>`** 構造に変更
  - 視覚は `flex flex-wrap` のまま不変（Tailwind preflight でブレット抑止。WorkCard が同パターンを本番使用済み）
  - スクリーンリーダーで「N個のリスト」として認識され WorkCard と一貫。空配列は `null` 返却

### 2) タグ遷移の SSOT 化（旧 spawn_task「死んだ onTagClick 整理」を統合）
- `buildTagSearchHref` を **`lib/tag-search.ts` に抽出して正本化**。VideoCard と検索結果で共有（重複解消）
- 検索結果の動画カードで**未配線だった `onTagClick` を `tagHref` に置換**（タグ遷移が実際に機能するように）
- これに伴い、タグ `<a>` が外側カード `<Link>` に**ネストしない**ようカード構造を再配置（サムネ/タイトル/タグ Link を兄弟化＝不正な anchor ネストを解消）

> ※この統合により、別途フラグしていた「search-page の死んだ onTagClick 整理」タスクは本 PR で消化済み。

## テスト / 検証
- `lib/__tests__/tag-search.test.ts`（新規）: href ビルダーの層別フィルター付与・エンコードを単体検証
- `three-layer-tag-display.test.tsx`: `role="list"`/`listitem`×3 と `tagHref` の `li>a` を検証
- `pnpm verify` 全パス（ui 334 / web 696）
- 実機 SSR HTML: `/videos` に `<ul aria-label="タグ"><li><a href="/search?...">` を12カード分出力

### テスト方針の注記（正直な開示）
検索フロー経由の**結果描画アサーションは既存 harness で脆い**（既存の人気タグテストも `searchUnified` 呼び出しのみ検証し描画は見ていない）。そのため search-page の結合テストは追加せず、(a) `tag-search` 単体テスト、(b) ui の `tagHref→li>a` テスト、(c) ネスト解消は構造的保証、でカバーしている。

## スコープ外（WS-3 棚卸しで発見 → 別Issue / 対応不要）
- **見出しレベル不整合**（VideoCard h3 / WorkCard h4・一覧で skip）→ カード横断 + 複数ページの問題のため別Issue [SPR-104](https://linear.app/nothink/issue/SPR-104) に切り出し
- アクション底揃えの技法差 / リンク aria-label の有無 → 機能的問題なし・現状で許容

## 関連
- SPR-87（WS-1 棚卸し → WS-2 shell+island 分解 #483 → 本 PR が WS-3）

🤖 Generated with [Claude Code](https://claude.com/claude-code)