### PR TITLE
a11y(web): カード見出しレベルの skip を中間 h2 で解消（SPR-104）

### DIFF
--- a/apps/web/src/app/circles/[circleId]/components/CircleWorksList.tsx
+++ b/apps/web/src/app/circles/[circleId]/components/CircleWorksList.tsx
@@ -56,6 +56,7 @@ export default function CircleWorksList({ circleId, initialData }: CircleWorksLi
 				items={transformedInitialData?.items || []}
 				initialTotal={transformedInitialData?.total || 0}
 				renderItem={(work) => <WorkListItem work={work} />}
+				listHeading="作品一覧"
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}

--- a/apps/web/src/app/circles/components/CirclesList.tsx
+++ b/apps/web/src/app/circles/components/CirclesList.tsx
@@ -85,6 +85,7 @@ export default function CirclesList({ initialData }: CirclesListProps) {
 				items={initialItems}
 				initialTotal={initialTotal}
 				renderItem={(circle) => <CircleListItem circle={circle} />}
+				listHeading="サークル一覧"
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}

--- a/apps/web/src/app/creators/[creatorId]/components/CreatorWorksList.tsx
+++ b/apps/web/src/app/creators/[creatorId]/components/CreatorWorksList.tsx
@@ -59,6 +59,7 @@ export default function CreatorWorksList({ creatorId, initialData }: CreatorWork
 				items={transformedInitialData?.items || []}
 				initialTotal={transformedInitialData?.total || 0}
 				renderItem={(work) => <WorkListItem work={work} />}
+				listHeading="作品一覧"
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}

--- a/apps/web/src/app/creators/components/CreatorsList.tsx
+++ b/apps/web/src/app/creators/components/CreatorsList.tsx
@@ -107,6 +107,7 @@ export default function CreatorsList({ initialData }: CreatorsListProps) {
 				items={initialItems}
 				initialTotal={initialTotal}
 				renderItem={(creator) => <CreatorListItem creator={creator} />}
+				listHeading="クリエイター一覧"
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}

--- a/apps/web/src/app/videos/components/VideoList.tsx
+++ b/apps/web/src/app/videos/components/VideoList.tsx
@@ -48,6 +48,7 @@ export default function VideoList({ initialData }: VideoListProps) {
 				items={initialData.items}
 				initialTotal={initialData.totalCount}
 				renderItem={renderItem}
+				listHeading="動画一覧"
 				fetchFn={getVideosList as (params: unknown) => Promise<unknown>}
 				{...DEFAULT_LIST_PROPS}
 				layout="grid"

--- a/apps/web/src/app/works/components/WorkCard.tsx
+++ b/apps/web/src/app/works/components/WorkCard.tsx
@@ -180,14 +180,14 @@ export default function WorkCard({ work, variant = "default", priority = false }
 						className="block group"
 						aria-label={`${work.title}の詳細を見る`}
 					>
-						<h4
+						<h3
 							id={`work-title-${work.id}`}
 							className={`font-semibold mb-1 line-clamp-2 group-hover:text-foreground/80 transition-colors text-foreground ${
 								isCompact ? "text-base" : "text-sm"
 							}`}
 						>
 							{work.title}
-						</h4>
+						</h3>
 					</Link>
 					{work.circleId ? (
 						<Link

--- a/apps/web/src/app/works/components/WorksList.tsx
+++ b/apps/web/src/app/works/components/WorksList.tsx
@@ -85,6 +85,7 @@ export default function WorksList({ initialData }: WorksListProps) {
 				// 画像 (~250x250) は decode コストが高く、6 並列で TBT +210ms regression
 				// (SPR-9 / 2026-05-28 PSI 3 サンプル中央値で確認) したため縮小。
 				renderItem={(work, index) => <WorkListItem work={work} priority={index < 2} />}
+				listHeading="作品一覧"
 				fetchFn={fetchFn}
 				dataAdapter={dataAdapter}
 				{...DEFAULT_LIST_PROPS}

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-sidebar.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-sidebar.tsx
@@ -21,6 +21,8 @@ export function AudioButtonDetailSidebar({
 		<div className="lg:col-span-1">
 			<div className="space-y-6">
 				{/* 動画カード */}
+				{/* ページ h1 と VideoCard の見出し(h3)の間を埋める中間見出し（sr-only） */}
+				<h2 className="sr-only">元動画</h2>
 				<Suspense
 					fallback={
 						<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-sidebar.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-sidebar.tsx
@@ -38,6 +38,8 @@ export function AudioButtonDetailSidebar({
 				</Suspense>
 
 				{/* ユーザーカード */}
+				{/* 作成者セクションの見出し（sr-only）。UserCard 内の h3 の親見出しを補う */}
+				<h2 className="sr-only">作成者</h2>
 				<Suspense
 					fallback={
 						<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">

--- a/apps/web/src/components/layout/site-footer.tsx
+++ b/apps/web/src/components/layout/site-footer.tsx
@@ -42,7 +42,7 @@ export default function SiteFooter() {
 					{/* 下段：サイト名と説明文 */}
 					<div className="text-center space-y-4">
 						<div>
-							<h4 className="font-bold text-lg mb-2 text-minase-50">suzumina.click</h4>
+							<h2 className="font-bold text-lg mb-2 text-minase-50">suzumina.click</h2>
 							<p className="text-minase-200 text-sm">
 								ファンによる、ファンのためのコミュニティサイト
 							</p>

--- a/packages/ui/src/components/custom/__tests__/configurable-list.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/configurable-list.test.tsx
@@ -51,6 +51,19 @@ describe("ConfigurableList", () => {
 		});
 	});
 
+	it("listHeading 指定時に sr-only な h2 を描画する（見出しレベル skip 防止）", () => {
+		render(<ConfigurableList items={sampleItems} renderItem={renderItem} listHeading="動画一覧" />);
+
+		const heading = screen.getByRole("heading", { level: 2, name: "動画一覧" });
+		expect(heading.tagName).toBe("H2");
+		expect(heading).toHaveClass("sr-only");
+	});
+
+	it("listHeading 未指定時は h2 を描画しない", () => {
+		render(<ConfigurableList items={sampleItems} renderItem={renderItem} />);
+		expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+	});
+
 	it("filters items by category", async () => {
 		render(
 			<ConfigurableList

--- a/packages/ui/src/components/custom/configurable-list.tsx
+++ b/packages/ui/src/components/custom/configurable-list.tsx
@@ -395,6 +395,7 @@ export function ConfigurableList<T>({
 	},
 	itemsPerPageOptions,
 	initialTotal,
+	listHeading,
 }: ConfigurableListProps<T>) {
 	// URLパラメータとの同期
 	const urlHook = useListUrl({
@@ -618,6 +619,8 @@ export function ConfigurableList<T>({
 			/>
 
 			{/* リスト本体 */}
+			{/* ページ h1 と各カード見出し(h3)の間を埋める中間見出し（sr-only）。見出しレベル skip を防ぐ */}
+			{listHeading && <h2 className="sr-only">{listHeading}</h2>}
 			{currentItems.length > 0 ? (
 				<ConfigurableListItems
 					items={currentItems}

--- a/packages/ui/src/components/custom/configurable-list/types.ts
+++ b/packages/ui/src/components/custom/configurable-list/types.ts
@@ -152,6 +152,11 @@ export interface ConfigurableListProps<T> {
 
 	// 初期総数（サーバーサイドレンダリング時）
 	initialTotal?: number;
+
+	// リスト本体の見出し（スクリーンリーダー向け）。
+	// ページ h1 と各カードの見出し（h3）の間を埋める中間 h2 として sr-only で描画し、
+	// 見出しレベルの skip を防ぐ。指定時のみ描画。
+	listHeading?: string;
 }
 
 /**


### PR DESCRIPTION
## 概要
SPR-104。カードのタイトル見出しが固定レベルで、配置文脈に対し見出しレベルが skip していた問題を是正。

**方針**: 固定レベルでは文脈ごとに正しくできないため、**カードを一律 h3 に揃え、h1 直下の文脈に中間 h2（sr-only）を補う**。

## 変更点
- **WorkCard**: タイトル `h4` → `h3`（VideoCard と統一）
- **ConfigurableList**: 任意の sr-only 中間見出し prop `listHeading` を追加（items 直前に `<h2 class="sr-only">`）→ 一覧の `h1→[h2]→h3` を確立
- **`listHeading` 設定（ConfigurableList 利用の全該当一覧）**:
  - VideoList「動画一覧」/ WorksList「作品一覧」/ CircleWorksList・CreatorWorksList「作品一覧」
  - **CirclesList「サークル一覧」/ CreatorsList「クリエイター一覧」**（レビュー指摘1で追加 — CircleListItem/CreatorListItem も h3 カードで h1→h3 skip だった）
- **audio-button-detail サイドバー**:
  - VideoCard(sidebar) 前に sr-only `<h2>`「元動画」
  - 作成者カード（UserCardWrapper 内 h3）前に sr-only `<h2>`「作成者」（h3→h3 で skip ではないがセクション親見出しを補完）

## 是正後の階層（skip ゼロ）
| 文脈 | After |
|---|---|
| トップ各セクション（h2） | h2 → h3(card) |
| /videos・/works・/creators・/circles・creator-works・circle-works 一覧 | h1 → h2(sr-only) → h3 |
| audio-button-detail サイドバー | h1 → h2(sr-only:元動画/作成者) → h3 |

→ **ConfigurableList 8箇所すべて**とサイドバーで skip 解消。

## 調査で判明した範囲の訂正（正直な開示）
- **AudioButtonCard は対象外で正しい**: `/buttons`・`/favorites` は `AudioButtonListItem`（再生ボタン系）で**見出し要素を持たず** skip なし。想定の `AudioButtonCard`(h3) は**デッドコード**。
- **フッターの `h4`「suzumina.click」** はカード無関係の既存事象でスコープ外。

## テスト / 検証
- `configurable-list.test.tsx`: `listHeading` の描画（sr-only h2）/ 未指定時の非描画を検証
- `pnpm verify` 全パス（ui 336 / web 696）
- 実機 SSR HTML 確認: /videos・/works・/circles・/creators で `h1 → h2(sr-only) → h3`、トップで `h2 → h3`、WorkCard が h3 描画

## 関連
SPR-87（VideoCard 整理）/ SPR-105（検索ページ VideoCard 再利用＝同種の見出し集約と連動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: heading-order 実ブラウザ監査 + フッター修正
レビュー指摘（axe/Lighthouse 未実施）に対応し、Preview 実ブラウザでハイドレート後の見出し列を取得して level skip を検査。

- 監査で **フッターの h4「suzumina.click」が site-wide の skip 原因**と判明（`<footer>` 内ブランド見出しが h4 で、直前の h2 から h2→h4）。カードとは無関係の既存事象。
- **対応**: `site-footer.tsx` の当該見出しを **h4 → h2**（`<footer>` はページ h1 直下の領域＝h2 が適切。h2→h2 / h3→h2 は skip でない）。
- **監査結果（ハイドレート後）**: `/`・`/videos`・`/works`・`/circles`・`/creators` すべてで **heading-order violation 0**。WorkCard が実描画で h3、各一覧で sr-only h2 を確認。

→ SPR-104 の AC「各ページで heading-order 警告ゼロ」を実測で達成。
