### PR TITLE
refactor(web): 検索ページの動画結果を VideoCard 再利用に統一（SPR-105）

### DIFF
--- a/apps/web/src/app/search/search-page-content.tsx
+++ b/apps/web/src/app/search/search-page-content.tsx
@@ -7,17 +7,16 @@ import type {
 	WorkPlainObject,
 } from "@suzumina.click/shared-types";
 import { HighlightText } from "@suzumina.click/ui/components/custom/highlight-text";
-import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent } from "@suzumina.click/ui/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@suzumina.click/ui/components/ui/tabs";
-import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
 import { BookOpen, ChevronRight, Filter, Loader2, Music, Search, Video, X } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { searchUnified } from "@/app/actions";
+import VideoCard from "@/app/videos/components/VideoCard";
 import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
 import { SearchFilters } from "@/components/search/search-filters";
 import { SearchInputWithAutocomplete } from "@/components/search/search-input-with-autocomplete";
@@ -25,7 +24,6 @@ import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useFavoriteStatusBulk } from "@/hooks/useFavoriteStatusBulk";
 import { useLikeDislikeStatusBulk } from "@/hooks/useLikeDislikeStatusBulk";
-import { buildTagSearchHref } from "@/lib/tag-search";
 
 interface UnifiedSearchResult {
 	audioButtons: AudioButtonPlainObject[];
@@ -353,49 +351,7 @@ function SearchResults({
 							</div>
 							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 								{searchResult.videos.slice(0, 6).map((video) => (
-									<Card key={video.id} className="h-full group hover:shadow-lg transition-shadow">
-										<Link href={`/videos/${video.id}`} className="block">
-											<div className="aspect-[16/9] relative overflow-hidden rounded-t-lg bg-black">
-												<ThumbnailImage
-													src={video.thumbnailUrl}
-													alt={video.title}
-													className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-200"
-												/>
-											</div>
-										</Link>
-										<CardContent className="p-4">
-											<Link href={`/videos/${video.id}`} className="block">
-												<h3 className="font-medium line-clamp-2 group-hover:text-suzuka-600 transition-colors">
-													<HighlightText
-														text={video.title}
-														searchQuery={searchQuery}
-														highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
-													/>
-												</h3>
-											</Link>
-											<p className="text-sm text-muted-foreground mt-1">
-												{new Date(video.publishedAt).toLocaleDateString("ja-JP", {
-													timeZone: "Asia/Tokyo",
-												})}
-											</p>
-											{/* 3層タグハイライト表示 */}
-											<div className="mt-2">
-												<ThreeLayerTagDisplay
-													playlistTags={video.tags?.playlistTags || []}
-													userTags={video.tags?.userTags || []}
-													categoryId={video.categoryId}
-													categoryName={getYouTubeCategoryName(video.categoryId) || undefined}
-													searchQuery={searchQuery}
-													highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
-													size="sm"
-													maxTagsPerLayer={3}
-													showEmptyLayers={false}
-													showCategory={true}
-													tagHref={buildTagSearchHref}
-												/>
-											</div>
-										</CardContent>
-									</Card>
+									<VideoCard key={video.id} video={video} searchQuery={searchQuery} />
 								))}
 							</div>
 							{searchResult.hasMore.videos && (
@@ -489,49 +445,7 @@ function SearchResults({
 				<TabsContent value="videos">
 					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 						{searchResult.videos.map((video) => (
-							<Card key={video.id} className="h-full group hover:shadow-lg transition-shadow">
-								<Link href={`/videos/${video.id}`} className="block">
-									<div className="aspect-[16/9] relative overflow-hidden rounded-t-lg bg-black">
-										<ThumbnailImage
-											src={video.thumbnailUrl}
-											alt={video.title}
-											className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-200"
-										/>
-									</div>
-								</Link>
-								<CardContent className="p-4">
-									<Link href={`/videos/${video.id}`} className="block">
-										<h3 className="font-medium line-clamp-2 group-hover:text-suzuka-600 transition-colors">
-											<HighlightText
-												text={video.title}
-												searchQuery={searchQuery}
-												highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
-											/>
-										</h3>
-									</Link>
-									<p className="text-sm text-muted-foreground mt-1">
-										{new Date(video.publishedAt).toLocaleDateString("ja-JP", {
-											timeZone: "Asia/Tokyo",
-										})}
-									</p>
-									{/* 3層タグハイライト表示 */}
-									<div className="mt-2">
-										<ThreeLayerTagDisplay
-											playlistTags={video.tags?.playlistTags || []}
-											userTags={video.tags?.userTags || []}
-											categoryId={video.categoryId}
-											categoryName={getYouTubeCategoryName(video.categoryId) || undefined}
-											searchQuery={searchQuery}
-											highlightClassName="bg-yellow-200 text-yellow-900 font-medium px-0.5 rounded"
-											size="sm"
-											maxTagsPerLayer={3}
-											showEmptyLayers={false}
-											showCategory={true}
-											tagHref={buildTagSearchHref}
-										/>
-									</div>
-								</CardContent>
-							</Card>
+							<VideoCard key={video.id} video={video} searchQuery={searchQuery} />
 						))}
 					</div>
 				</TabsContent>

--- a/apps/web/src/app/videos/components/VideoCard.tsx
+++ b/apps/web/src/app/videos/components/VideoCard.tsx
@@ -1,4 +1,5 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
+import { HighlightText } from "@suzumina.click/ui/components/custom/highlight-text";
 import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
@@ -101,6 +102,8 @@ interface VideoCardProps {
 	video: VideoPlainObject;
 	variant?: "grid" | "sidebar";
 	priority?: boolean; // LCP画像最適化用
+	/** 検索語。指定時はタイトル・タグでマッチ語をハイライトする（検索結果での再利用向け） */
+	searchQuery?: string;
 }
 
 /**
@@ -108,7 +111,7 @@ interface VideoCardProps {
  * 認証ゲートを伴うアクションは {@link VideoCardActions}（client island）に隔離し、
  * 本体は純表示に徹する。WorkCard と同じ「shell + island」構造。
  */
-function VideoCard({ video, variant = "grid", priority = false }: VideoCardProps) {
+function VideoCard({ video, variant = "grid", priority = false, searchQuery }: VideoCardProps) {
 	const actualButtonCount = video.audioButtonCount ?? 0;
 	const { formattedDate, displayLabel, dateTimeValue } = getDisplayDate(video);
 	const categoryName = getYouTubeCategoryName(video.categoryId);
@@ -182,7 +185,15 @@ function VideoCard({ video, variant = "grid", priority = false }: VideoCardProps
 							id={`video-title-${video.id}`}
 							className="font-semibold text-lg mb-2 line-clamp-2 group-hover:text-foreground/80 transition-colors text-foreground"
 						>
-							{video.title}
+							{searchQuery ? (
+								<HighlightText
+									text={video.title}
+									searchQuery={searchQuery}
+									highlightClassName="bg-yellow-200 text-yellow-900 px-0.5 rounded"
+								/>
+							) : (
+								video.title
+							)}
 						</h3>
 					</Link>
 					<p
@@ -211,6 +222,7 @@ function VideoCard({ video, variant = "grid", priority = false }: VideoCardProps
 							showCategory={true}
 							compact={true}
 							tagHref={buildTagSearchHref}
+							searchQuery={searchQuery}
 						/>
 					</div>
 

--- a/apps/web/src/app/videos/components/__tests__/VideoCard.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/VideoCard.test.tsx
@@ -162,6 +162,23 @@ describe("VideoCard", () => {
 		);
 	});
 
+	it("searchQuery 指定時にタイトルのマッチ語をハイライトする", () => {
+		const video = createMockVideo();
+		const { container } = render(<VideoCard video={video} searchQuery="動画" />);
+
+		const marks = [...container.querySelectorAll("mark")];
+		expect(marks.some((m) => m.textContent === "動画")).toBe(true);
+		// ハイライトはタイトル（video-title）内に存在する
+		const titleHeading = container.querySelector('[id^="video-title-"]');
+		expect(titleHeading?.querySelector("mark")).not.toBeNull();
+	});
+
+	it("searchQuery 未指定時はタイトルをハイライトしない", () => {
+		const video = createMockVideo();
+		const { container } = render(<VideoCard video={video} />);
+		expect(container.querySelector("mark")).toBeNull();
+	});
+
 	describe("公開日時境界テスト", () => {
 		it("年末年始をまたぐ日時が正しくJSTで表示される", () => {
 			const video = createMockVideo({


### PR DESCRIPTION
## 概要
SPR-105。検索ページ `SearchResults` が独自インライン動画カードを**2箇所で重複**（overview の `videos.slice(0,6)` と videos タブの `videos.map`）していたのを、clean な **VideoCard**（server shell + client island）の再利用に統一。

## 変更点
- **VideoCard に任意 prop `searchQuery` を追加**。指定時のみタイトルを `HighlightText` で包み、`ThreeLayerTagDisplay` にも `searchQuery` を渡してマッチ語をハイライト。
  - 未指定時は `HighlightText` を描画しない → 通常利用（/videos・トップ等）は不変、**server shell のまま**（HighlightText は client だが子としてのみ描画）
- **search-page-content** の2ブロックを `<VideoCard video={video} searchQuery={searchQuery} />` に置換し **~75行の重複を削除**
- 不要 import（`ThreeLayerTagDisplay` / `getYouTubeCategoryName` / `buildTagSearchHref`）を削除

## 決定事項（issue のトレードオフ）
- **searchQuery ハイライト**: 「VideoCard に searchQuery を足して維持」を採用（検索 UX を落とさない）。`ThreeLayerTagDisplay` は元々 searchQuery 対応のため、タグハイライトもそのまま維持。

## 効果
- 検索結果が**タグ(ul/li 化済み)・アクション・各バッジ・見出し(h3)**で他ページと一貫
- 検索結果動画タイトルが **h3**（SPR-104 と同種の固定 h3 を VideoCard 側に集約）
- カード全体を1つの `<Link>` で包む旧構造を解消し **anchor ネスト risk も消滅**

## 型適合
`searchVideos → getVideoTitles` は `videoTransformers.fromFirestore` で完全な `VideoPlainObject`（`_computed` 付き）を返し、`UnifiedSearchResult.videos: VideoPlainObject[]`。VideoList が VideoCard に渡すのと同一経路＝**ドロップイン適合**。

## テスト / 検証
- `VideoCard.test.tsx`: `searchQuery` ハイライトの描画（`<mark>`）/ 未指定時の非描画を追加
- `pnpm verify` 全パス（ui 336 / web 698）
- **実ブラウザ確認**（`/search?q=マイクラ&type=videos`）: VideoCard **12枚**描画 / ハイライト維持（"マイクラ"）/ タイトル **h3** / **nested anchor 0**

## 補足（companion の扱い）
issue の「アンカー非ネストの lint 担保」は、**VideoCard 再利用により検索ページの手書きネスト構造自体が消滅**したため risk は構造的に解消。Biome には nested-anchor の組込ルールがなく、専用 lint 追加はツール変更が大きいため本PRでは見送り（必要なら別Issue）。

## 関連
SPR-87（VideoCard 整理）/ SPR-104（見出しレベル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)