### PR TITLE
feat(videos): 動画一覧にタグ絞り込みUIを追加（SPR-110）

### DIFF
--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getVideosList, getVideoTitles } from "../actions";
+import { getPopularVideoTags, getVideosList, getVideoTitles } from "../actions";
 
 // Mock Firestore
 const mockGet = vi.fn();
@@ -309,6 +309,92 @@ describe("Video Server Actions", () => {
 			expect(mockWhere).toHaveBeenCalledWith("status.privacyStatus", "==", "public");
 			expect(mockCount).toHaveBeenCalled();
 			expect(result.totalCount).toBe(99);
+		});
+	});
+
+	describe("getPopularVideoTags", () => {
+		const makeVideoDoc = (id: string, playlistTags: string[]) => ({
+			id,
+			data: () => ({
+				id,
+				videoId: id,
+				title: `動画 ${id}`,
+				description: "説明",
+				channelId: "channel-1",
+				channelTitle: "チャンネル1",
+				publishedAt: new Date("2024-01-01").toISOString(),
+				duration: "PT5M",
+				thumbnailUrl: "https://example.com/thumb.jpg",
+				thumbnails: { high: { url: "https://example.com/thumb.jpg" } },
+				viewCount: 100,
+				likeCount: 10,
+				commentCount: 5,
+				hasAudioButtons: true,
+				audioButtonCount: 0,
+				categoryId: "10",
+				status: { privacyStatus: "public", uploadStatus: "processed" },
+				contentDetails: {
+					duration: "PT5M",
+					dimension: "2d",
+					definition: "hd",
+					caption: "false",
+					licensedContent: false,
+				},
+				statistics: { viewCount: "100", likeCount: "10", commentCount: "5" },
+				// 本番 mapper はネスト tags を正本として書き込む（video-mapper.ts）。
+				// filterVideos / getPopularVideoTags はともに video.tags.playlistTags を読む。
+				tags: { playlistTags, userTags: [], contentTags: [] },
+				playlistTags,
+				userTags: [],
+				lastFetchedAt: new Date().toISOString(),
+			}),
+		});
+
+		it("playlistTags を集計し件数の多い順に返す", async () => {
+			mockGet.mockResolvedValue({
+				docs: [
+					makeVideoDoc("v1", ["挨拶", "歌"]),
+					makeVideoDoc("v2", ["歌"]),
+					makeVideoDoc("v3", ["歌", "ゲーム"]),
+				],
+			});
+
+			const result = await getPopularVideoTags();
+
+			// public のみ対象とする where 条件で集計
+			expect(mockWhere).toHaveBeenCalledWith("status.privacyStatus", "==", "public");
+			expect(result[0]).toEqual({ tag: "歌", count: 3 });
+			const tags = result.map((t) => t.tag);
+			expect(tags).toContain("挨拶");
+			expect(tags).toContain("ゲーム");
+		});
+
+		it("limit で件数を制限する", async () => {
+			mockGet.mockResolvedValue({
+				docs: [makeVideoDoc("v1", ["a", "b", "c"])],
+			});
+
+			const result = await getPopularVideoTags(2);
+
+			expect(result).toHaveLength(2);
+		});
+
+		it("空文字タグは除外する", async () => {
+			mockGet.mockResolvedValue({
+				docs: [makeVideoDoc("v1", ["", "  ", "有効"])],
+			});
+
+			const result = await getPopularVideoTags();
+
+			expect(result).toEqual([{ tag: "有効", count: 1 }]);
+		});
+
+		it("エラー時は空配列を返す", async () => {
+			mockGet.mockRejectedValue(new Error("Firestore error"));
+
+			const result = await getPopularVideoTags();
+
+			expect(result).toEqual([]);
 		});
 	});
 });

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -365,6 +365,52 @@ export async function getVideoTitles(params?: {
 }
 
 /**
+ * 動画の人気タグ（playlistTags）を集計して取得する
+ *
+ * 一覧ページのタグ絞り込みUIの選択肢に使う。tags.playlistTags を正本とし、
+ * convertToVideo 経由で PlainObject 化してから集計する（Firestore raw 構造に依存しない）。
+ * 絞り込み自体は getVideosList の playlistTags フィルタ（filterVideos）が行う。
+ */
+export async function getPopularVideoTags(limit = 30): Promise<
+	Array<{
+		tag: string;
+		count: number;
+	}>
+> {
+	try {
+		const firestore = getFirestore();
+		const snapshot = await firestore
+			.collection("videos")
+			.where("status.privacyStatus", "==", "public")
+			.get();
+
+		const tagCounts = new Map<string, number>();
+		for (const doc of snapshot.docs) {
+			const video = convertToVideo(doc);
+			const playlistTags = video?.tags?.playlistTags;
+			if (Array.isArray(playlistTags)) {
+				for (const tag of playlistTags) {
+					if (typeof tag === "string" && tag.trim() !== "") {
+						tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+					}
+				}
+			}
+		}
+
+		return Array.from(tagCounts.entries())
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, limit)
+			.map(([tag, count]) => ({ tag, count }));
+	} catch (error) {
+		logger.error("動画の人気タグ取得に失敗", {
+			action: "getPopularVideoTags",
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
+}
+
+/**
  * Entity V2を使用した特定の動画IDで動画データを取得するServer Action
  * @param videoId - 動画ID
  * @returns 動画データまたはnull

--- a/apps/web/src/app/videos/components/VideoList.tsx
+++ b/apps/web/src/app/videos/components/VideoList.tsx
@@ -2,7 +2,7 @@
 
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { ConfigurableList } from "@suzumina.click/ui/components/custom";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ListWrapper } from "@/components/list/ListWrapper";
 import {
 	DEFAULT_ITEMS_PER_PAGE_OPTIONS,
@@ -10,7 +10,7 @@ import {
 	GRID_COLUMNS_4,
 	VIDEO_SORT_OPTIONS,
 } from "@/constants/list-options";
-import { getVideosList } from "../actions";
+import { getPopularVideoTags, getVideosList } from "../actions";
 import VideoCard from "./VideoCard";
 
 interface VideoListProps {
@@ -22,6 +22,21 @@ interface VideoListProps {
 }
 
 export default function VideoList({ initialData }: VideoListProps) {
+	// タグ絞り込み用の人気タグ（playlistTags）。取得失敗してもUIは動作する。
+	const [availableTags, setAvailableTags] = useState<Array<{ value: string; label: string }>>([]);
+
+	useEffect(() => {
+		const fetchTags = async () => {
+			try {
+				const tags = await getPopularVideoTags(30);
+				setAvailableTags(tags.map((t) => ({ value: t.tag, label: `${t.tag} (${t.count})` })));
+			} catch {
+				// タグ取得に失敗しても他のフィルタ・検索は動作するため握りつぶす
+			}
+		};
+		fetchTags();
+	}, []);
+
 	// 年代選択肢を生成（2018年から現在年まで）
 	const yearOptions = useMemo(() => {
 		const currentYear = new Date().getFullYear();
@@ -76,6 +91,19 @@ export default function VideoList({ initialData }: VideoListProps) {
 						showAll: true,
 						emptyValue: "all",
 					},
+					// key は playlistTags 固定: dataAdapter なしのため params.filters.playlistTags が
+					// そのまま getVideosList に渡り、filterVideos の playlistTags フィルタが処理する。
+					// 候補タグが無い間（取得前・取得失敗）はフィルタ自体を出さない。
+					...(availableTags.length > 0
+						? {
+								playlistTags: {
+									type: "tags" as const,
+									label: "タグ",
+									placeholder: "タグを選択",
+									options: availableTags,
+								},
+							}
+						: {}),
 				}}
 				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
 				emptyMessage="動画がありません"


### PR DESCRIPTION
## 概要

`/videos`（動画一覧）にタグ絞り込みUIを追加し、「動画のタグ検索が動いていない」を解消する。SPR-103 の方針（`/search` 廃止・各一覧ページへ集約）に伴う、壊れた挙動の修正（SPR-110）。

## 背景

`playlistTags` の URLパラメータ・Server Action・`filterVideos` ロジックは実装済みだったが、`VideoList` の ConfigurableList に filter 定義が無く **UIから選択できない**状態だった。これがタグ検索が動かない直接原因。

## 変更点

- `videos/actions.ts`: `getPopularVideoTags()` を追加（public 動画から `tags.playlistTags` を集計、`getPopularAudioButtonTags` と同型）
- `videos/components/VideoList.tsx`: filters に `playlistTags`（`type: "tags"`）を追加。候補タグが無い間はフィルタ非表示
- `videos/__tests__/actions.test.ts`: 集計のテスト4件

## 設計判断

- filter の **key を `playlistTags` に固定**。`dataAdapter` 省略時のデフォルト（`StandardListParams` 素通し）により `params.filters.playlistTags` がそのまま `getVideosList` に届くため、**`getVideosList`・`dataAdapter` ともに無変更**で既存挙動（年代/動画種別/件数）を壊さず配線できる
- 本番 mapper（`video-mapper.ts`）がネスト `tags.playlistTags` を書き込むことを確認済み。`filterVideos`・集計関数の読み取り先と一致するため、実データでも動作する
- `userTags` はデータ実態が不明なため今回スコープ外（同じ仕組みで後付け可能）

## 確認

- `pnpm verify` 通過（lint/typecheck/test）
- dev サーバでタグ選択→絞り込みの動作を目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)