### PR TITLE
perf(tags): 人気タグ集計を unstable_cache でキャッシュ化（SPR-112）

### DIFF
--- a/apps/web/src/app/buttons/__tests__/actions.test.ts
+++ b/apps/web/src/app/buttons/__tests__/actions.test.ts
@@ -56,6 +56,9 @@ vi.mock("next/headers", () => ({
 // Mock cache revalidation
 vi.mock("next/cache", () => ({
 	revalidatePath: vi.fn(),
+	// getPopularAudioButtonTags が unstable_cache 経由になったため、テストでは
+	// ラップ対象の関数をそのまま返すパススルーにする（Next ランタイム外で動かすため）。
+	unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
 }));
 
 // Mock auth

--- a/apps/web/src/app/buttons/__tests__/tag-filter.test.ts
+++ b/apps/web/src/app/buttons/__tests__/tag-filter.test.ts
@@ -6,6 +6,12 @@ vi.mock("@/auth", () => ({
 	auth: vi.fn(),
 }));
 
+// getPopularAudioButtonTags が unstable_cache 経由になったため、Next ランタイム外では
+// ラップ対象の関数をそのまま返すパススルーにする。
+vi.mock("next/cache", () => ({
+	unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
 // Mock Firestore
 const mockFirestoreDocs = [
 	{

--- a/apps/web/src/app/buttons/lib/audio-button-stats.ts
+++ b/apps/web/src/app/buttons/lib/audio-button-stats.ts
@@ -1,7 +1,15 @@
 "use server";
 
+import { unstable_cache } from "next/cache";
 import { getFirestore } from "@/lib/firestore";
 import * as logger from "@/lib/logger";
+
+/**
+ * 人気タグ集計は全件スキャンを伴うため、revalidate でキャッシュして
+ * ページ訪問ごとの全件 .get() を回避する（SPR-112 / SPR-88 と整合）。
+ * タグは緩やかにしか変化しないので長めの TTL を採用する。
+ */
+const POPULAR_TAGS_REVALIDATE_SECONDS = 60 * 60;
 
 /**
  * 動画の音声ボタン数を取得
@@ -48,14 +56,12 @@ export async function getAudioButtonCount(videoId: string): Promise<number> {
 }
 
 /**
- * 人気タグリストを取得する
+ * 音声ボタンの人気タグを集計する内部実装。
+ * 全件 .get() を伴うため、公開 API はキャッシュ経由で呼ぶ（getPopularAudioButtonTags）。
  */
-export async function getPopularAudioButtonTags(limit = 30): Promise<
-	Array<{
-		tag: string;
-		count: number;
-	}>
-> {
+async function fetchPopularAudioButtonTags(
+	limit: number,
+): Promise<Array<{ tag: string; count: number }>> {
 	try {
 		const firestore = getFirestore();
 		const snapshot = await firestore.collection("audioButtons").where("isPublic", "==", true).get();
@@ -81,6 +87,26 @@ export async function getPopularAudioButtonTags(limit = 30): Promise<
 		logger.error("人気タグの取得に失敗", { error });
 		return [];
 	}
+}
+
+// limit は unstable_cache が引数として自動でキー化する。
+const getPopularAudioButtonTagsCached = unstable_cache(
+	fetchPopularAudioButtonTags,
+	["popular-audio-button-tags"],
+	{ revalidate: POPULAR_TAGS_REVALIDATE_SECONDS, tags: ["popular-audio-button-tags"] },
+);
+
+/**
+ * 人気タグリストを取得する。
+ * 一覧ページのタグ絞り込みUIの選択肢に使う。全件スキャンを避けるため revalidate キャッシュ経由。
+ */
+export async function getPopularAudioButtonTags(limit = 30): Promise<
+	Array<{
+		tag: string;
+		count: number;
+	}>
+> {
+	return getPopularAudioButtonTagsCached(limit);
 }
 
 /**

--- a/apps/web/src/app/buttons/lib/audio-button-stats.ts
+++ b/apps/web/src/app/buttons/lib/audio-button-stats.ts
@@ -58,35 +58,33 @@ export async function getAudioButtonCount(videoId: string): Promise<number> {
 /**
  * 音声ボタンの人気タグを集計する内部実装。
  * 全件 .get() を伴うため、公開 API はキャッシュ経由で呼ぶ（getPopularAudioButtonTags）。
+ *
+ * エラーはここで握りつぶさず throw する。unstable_cache は throw をキャッシュしないため、
+ * 一過性の Firestore 障害で空配列が revalidate 窓の間キャッシュされるのを避ける。
  */
 async function fetchPopularAudioButtonTags(
 	limit: number,
 ): Promise<Array<{ tag: string; count: number }>> {
-	try {
-		const firestore = getFirestore();
-		const snapshot = await firestore.collection("audioButtons").where("isPublic", "==", true).get();
+	const firestore = getFirestore();
+	const snapshot = await firestore.collection("audioButtons").where("isPublic", "==", true).get();
 
-		const tagCounts = new Map<string, number>();
+	const tagCounts = new Map<string, number>();
 
-		for (const doc of snapshot.docs) {
-			const data = doc.data();
-			if (data && Array.isArray(data.tags)) {
-				for (const tag of data.tags) {
-					if (typeof tag === "string" && tag.trim() !== "") {
-						tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
-					}
+	for (const doc of snapshot.docs) {
+		const data = doc.data();
+		if (data && Array.isArray(data.tags)) {
+			for (const tag of data.tags) {
+				if (typeof tag === "string" && tag.trim() !== "") {
+					tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
 				}
 			}
 		}
-
-		return Array.from(tagCounts.entries())
-			.sort((a, b) => b[1] - a[1])
-			.slice(0, limit)
-			.map(([tag, count]) => ({ tag, count }));
-	} catch (error) {
-		logger.error("人気タグの取得に失敗", { error });
-		return [];
 	}
+
+	return Array.from(tagCounts.entries())
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, limit)
+		.map(([tag, count]) => ({ tag, count }));
 }
 
 // limit は unstable_cache が引数として自動でキー化する。
@@ -99,6 +97,7 @@ const getPopularAudioButtonTagsCached = unstable_cache(
 /**
  * 人気タグリストを取得する。
  * 一覧ページのタグ絞り込みUIの選択肢に使う。全件スキャンを避けるため revalidate キャッシュ経由。
+ * エラー時は空配列を返す（キャッシュ層には正常結果のみ載る）。
  */
 export async function getPopularAudioButtonTags(limit = 30): Promise<
 	Array<{
@@ -106,7 +105,12 @@ export async function getPopularAudioButtonTags(limit = 30): Promise<
 		count: number;
 	}>
 > {
-	return getPopularAudioButtonTagsCached(limit);
+	try {
+		return await getPopularAudioButtonTagsCached(limit);
+	} catch (error) {
+		logger.error("人気タグの取得に失敗", { error });
+		return [];
+	}
 }
 
 /**

--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -25,6 +25,12 @@ vi.mock("@/lib/logger", () => ({
 	debug: vi.fn(),
 }));
 
+// getPopularVideoTags が unstable_cache 経由になったため、Next ランタイム外では
+// ラップ対象の関数をそのまま返すパススルーにする。
+vi.mock("next/cache", () => ({
+	unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
 describe("Video Server Actions", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -389,41 +389,36 @@ export async function getVideoTitles(params?: {
  * tags.playlistTags を正本とし、convertToVideo 経由で PlainObject 化してから集計する
  * （Firestore raw 構造に依存しない）。絞り込み自体は getVideosList の filterVideos が行う。
  * 全件 .get() を伴うため、公開 API はキャッシュ経由で呼ぶ（getPopularVideoTags）。
+ *
+ * エラーはここで握りつぶさず throw する。unstable_cache は throw をキャッシュしないため、
+ * 一過性の Firestore 障害で空配列が revalidate 窓の間キャッシュされるのを避ける。
  */
 async function fetchPopularVideoTags(
 	limit: number,
 ): Promise<Array<{ tag: string; count: number }>> {
-	try {
-		const firestore = getFirestore();
-		const snapshot = await firestore
-			.collection("videos")
-			.where("status.privacyStatus", "==", "public")
-			.get();
+	const firestore = getFirestore();
+	const snapshot = await firestore
+		.collection("videos")
+		.where("status.privacyStatus", "==", "public")
+		.get();
 
-		const tagCounts = new Map<string, number>();
-		for (const doc of snapshot.docs) {
-			const video = convertToVideo(doc);
-			const playlistTags = video?.tags?.playlistTags;
-			if (Array.isArray(playlistTags)) {
-				for (const tag of playlistTags) {
-					if (typeof tag === "string" && tag.trim() !== "") {
-						tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
-					}
+	const tagCounts = new Map<string, number>();
+	for (const doc of snapshot.docs) {
+		const video = convertToVideo(doc);
+		const playlistTags = video?.tags?.playlistTags;
+		if (Array.isArray(playlistTags)) {
+			for (const tag of playlistTags) {
+				if (typeof tag === "string" && tag.trim() !== "") {
+					tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
 				}
 			}
 		}
-
-		return Array.from(tagCounts.entries())
-			.sort((a, b) => b[1] - a[1])
-			.slice(0, limit)
-			.map(([tag, count]) => ({ tag, count }));
-	} catch (error) {
-		logger.error("動画の人気タグ取得に失敗", {
-			action: "getPopularVideoTags",
-			error: error instanceof Error ? error.message : String(error),
-		});
-		return [];
 	}
+
+	return Array.from(tagCounts.entries())
+		.sort((a, b) => b[1] - a[1])
+		.slice(0, limit)
+		.map(([tag, count]) => ({ tag, count }));
 }
 
 // limit は unstable_cache が引数として自動でキー化する。
@@ -435,6 +430,7 @@ const getPopularVideoTagsCached = unstable_cache(fetchPopularVideoTags, ["popula
 /**
  * 動画の人気タグ（playlistTags）を取得する。
  * 一覧ページのタグ絞り込みUIの選択肢に使う。全件スキャンを避けるため revalidate キャッシュ経由。
+ * エラー時は空配列を返す（キャッシュ層には正常結果のみ載る）。
  */
 export async function getPopularVideoTags(limit = 30): Promise<
 	Array<{
@@ -442,7 +438,15 @@ export async function getPopularVideoTags(limit = 30): Promise<
 		count: number;
 	}>
 > {
-	return getPopularVideoTagsCached(limit);
+	try {
+		return await getPopularVideoTagsCached(limit);
+	} catch (error) {
+		logger.error("動画の人気タグ取得に失敗", {
+			action: "getPopularVideoTags",
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return [];
+	}
 }
 
 /**

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -8,8 +8,16 @@ import {
 	videoTransformers,
 } from "@suzumina.click/shared-types";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
+import { unstable_cache } from "next/cache";
 import { getFirestore } from "@/lib/firestore";
 import * as logger from "@/lib/logger";
+
+/**
+ * 人気タグ集計は全件スキャンを伴うため、revalidate でキャッシュして
+ * ページ訪問ごとの全件 .get() を回避する（SPR-112 / SPR-88 と整合）。
+ * タグは緩やかにしか変化しないので長めの TTL を採用する。
+ */
+const POPULAR_TAGS_REVALIDATE_SECONDS = 60 * 60;
 
 /**
  * ビデオフィルタリングパラメータの型
@@ -376,18 +384,15 @@ export async function getVideoTitles(params?: {
 }
 
 /**
- * 動画の人気タグ（playlistTags）を集計して取得する
+ * 動画の人気タグ（playlistTags）を集計する内部実装。
  *
- * 一覧ページのタグ絞り込みUIの選択肢に使う。tags.playlistTags を正本とし、
- * convertToVideo 経由で PlainObject 化してから集計する（Firestore raw 構造に依存しない）。
- * 絞り込み自体は getVideosList の playlistTags フィルタ（filterVideos）が行う。
+ * tags.playlistTags を正本とし、convertToVideo 経由で PlainObject 化してから集計する
+ * （Firestore raw 構造に依存しない）。絞り込み自体は getVideosList の filterVideos が行う。
+ * 全件 .get() を伴うため、公開 API はキャッシュ経由で呼ぶ（getPopularVideoTags）。
  */
-export async function getPopularVideoTags(limit = 30): Promise<
-	Array<{
-		tag: string;
-		count: number;
-	}>
-> {
+async function fetchPopularVideoTags(
+	limit: number,
+): Promise<Array<{ tag: string; count: number }>> {
 	try {
 		const firestore = getFirestore();
 		const snapshot = await firestore
@@ -419,6 +424,25 @@ export async function getPopularVideoTags(limit = 30): Promise<
 		});
 		return [];
 	}
+}
+
+// limit は unstable_cache が引数として自動でキー化する。
+const getPopularVideoTagsCached = unstable_cache(fetchPopularVideoTags, ["popular-video-tags"], {
+	revalidate: POPULAR_TAGS_REVALIDATE_SECONDS,
+	tags: ["popular-video-tags"],
+});
+
+/**
+ * 動画の人気タグ（playlistTags）を取得する。
+ * 一覧ページのタグ絞り込みUIの選択肢に使う。全件スキャンを避けるため revalidate キャッシュ経由。
+ */
+export async function getPopularVideoTags(limit = 30): Promise<
+	Array<{
+		tag: string;
+		count: number;
+	}>
+> {
+	return getPopularVideoTagsCached(limit);
 }
 
 /**


### PR DESCRIPTION
## 概要

`getPopularVideoTags` / `getPopularAudioButtonTags` を `unstable_cache` でキャッシュ化し、一覧ページ訪問ごとの**コレクション全件 `.get()`** を解消する。SPR-112（PR #489 レビュー指摘のフォローアップ）。

## 背景

両関数はタグ絞り込みUIの候補取得のため、`/videos` `/buttons` を開く・クライアント遷移するたびに `videos` / `audioButtons` コレクションを全件取得して集計していた。`videos` は SPR-88 で全件スキャンを明示的に回避した経緯があり、これに逆行していた。

## 変更点

- `creators/actions.ts`（SPR-74）と同じ書式を踏襲：
  - 内部 `fetchPopularVideoTags` / `fetchPopularAudioButtonTags`（raw 集計）
  - `unstable_cache(fetch, [key], { revalidate, tags })` でラップ
  - 公開 API（`getPopularVideoTags` / `getPopularAudioButtonTags`）は委譲のみ。**シグネチャ・呼び出し側は変更なし**
- `revalidate` は **1 時間**（タグは緩やかにしか変化しない）。`tags`（`popular-video-tags` / `popular-audio-button-tags`）を付与し、将来 `revalidateTag` で明示無効化も可能
- `limit` は `unstable_cache` が引数として自動キー化
- 既存テスト3ファイルに `next/cache` のパススルー mock を追加（Next ランタイム外で動かすため。sitemap/creators テストと同じ手法）

## 確認

- `pnpm verify` 通過（lint/typecheck/test、web 629 件）
- 挙動は不変（集計結果は同じ。キャッシュ層を挟むのみ）

## 補足 / フォロー候補

- TTL=1h は妥当な既定値だが調整可。コンテンツ投入が cron バッチのため、必要なら ingestion 後に `revalidateTag` で即時反映する選択肢もある（今回は導入せず）
- sitemap.test.ts のような「固定キー・revalidate・tag の回帰検知テスト」までは入れていない（必要なら追加可）

## 関連

- 指摘元: SPR-110（#489）/ 整合: SPR-88（全件スキャン回避）
- 残フォロー: SPR-113（shared-types 孤立型）, SPR-115（packages/ui 未使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)