### PR TITLE
style(web): requireAuth の条件を optional chain に修正

### DIFF
--- a/apps/web/src/components/system/protected-route.tsx
+++ b/apps/web/src/components/system/protected-route.tsx
@@ -60,7 +60,7 @@ export default async function ProtectedRoute({
 export async function requireAuth(): Promise<UserSession> {
 	const session = await auth();
 
-	if (!session?.user || !session.user.isActive) {
+	if (!session?.user?.isActive) {
 		redirect("/auth/signin");
 	}
 


### PR DESCRIPTION
## 概要

[#495](https://github.com/nothink-jp/suzumina.click/pull/495)（SPR-116）のレビューで判明した、スコープ外だった既存の Biome lint 警告を解消する。

`protected-route.tsx` の `requireAuth` 内の条件式が `useOptionalChain` 警告を出していた（#495 がこのファイルを編集したことで pre-commit に表面化）。

## 変更

```diff
- if (!session?.user || !session.user.isActive) {
+ if (!session?.user?.isActive) {
```

ロジックは等価:
- user 無し → `!undefined` = true で redirect
- user ありで非アクティブ → redirect
- user ありでアクティブ → 通過

## 検証

- `pnpm verify` 通過（lint + typecheck + test）
- pre-commit の Biome 警告が解消されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)