### PR TITLE
fix(web): ヘッダーの「動画一覧」が本番で消える不具合を修正（SPR-124）

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,20 @@
 			"runtimeArgs": ["--filter", "@suzumina.click/ui", "storybook"],
 			"port": 6006,
 			"autoPort": false
+		},
+		{
+			"name": "web",
+			"runtimeExecutable": "pnpm",
+			"runtimeArgs": ["--filter", "@suzumina.click/web", "dev"],
+			"port": 3000,
+			"autoPort": false
+		},
+		{
+			"name": "web-prod",
+			"runtimeExecutable": "pnpm",
+			"runtimeArgs": ["--filter", "@suzumina.click/web", "start", "--port", "3001"],
+			"port": 3001,
+			"autoPort": false
 		}
 	]
 }

--- a/apps/web/src/components/layout/site-header.tsx
+++ b/apps/web/src/components/layout/site-header.tsx
@@ -1,14 +1,14 @@
-import {
-	NavigationMenu,
-	NavigationMenuItem,
-	NavigationMenuLink,
-	NavigationMenuList,
-} from "@suzumina.click/ui/components/ui/navigation-menu";
 import Link from "next/link";
 import { Suspense } from "react";
 import { auth } from "@/auth";
 import AuthButton from "../user/auth-button";
 import MobileMenu from "./mobile-menu";
+
+const NAV_LINKS = [
+	{ href: "/videos", label: "動画一覧" },
+	{ href: "/buttons", label: "ボタン検索" },
+	{ href: "/works", label: "作品一覧" },
+] as const;
 
 export default function SiteHeader() {
 	return (
@@ -31,26 +31,24 @@ export default function SiteHeader() {
 							</Link>
 						</div>
 
-						{/* デスクトップナビゲーション */}
-						<NavigationMenu className="hidden md:flex">
-							<NavigationMenuList>
-								<NavigationMenuItem>
-									<NavigationMenuLink asChild>
-										<Link href="/videos">動画一覧</Link>
-									</NavigationMenuLink>
-								</NavigationMenuItem>
-								<NavigationMenuItem>
-									<NavigationMenuLink asChild>
-										<Link href="/buttons">ボタン検索</Link>
-									</NavigationMenuLink>
-								</NavigationMenuItem>
-								<NavigationMenuItem>
-									<NavigationMenuLink asChild>
-										<Link href="/works">作品一覧</Link>
-									</NavigationMenuLink>
-								</NavigationMenuItem>
-							</NavigationMenuList>
-						</NavigationMenu>
+						{/* デスクトップナビゲーション。
+							ドロップダウンの無い静的リンクのため radix NavigationMenu は使わず素の nav にする。
+							radix NavigationMenu(Collection 機構)は本番ビルド(cacheComponents/PPR)で
+							先頭 collection item の anchor を prerender/hydration 時に脱落させる不具合があった（SPR-124 系）。 */}
+						<nav className="hidden md:flex" aria-label="メインナビゲーション">
+							<ul className="flex list-none items-center gap-1">
+								{NAV_LINKS.map((item) => (
+									<li key={item.href}>
+										<Link
+											href={item.href}
+											className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+										>
+											{item.label}
+										</Link>
+									</li>
+								))}
+							</ul>
+						</nav>
 
 						{/* 認証関連: wrapper の min-h で UserMenu (desktop ~52px) と
 							MobileMenu (mobile 44px) と同じ高さを常に確保する。これにより


### PR DESCRIPTION
[SPR-124](https://linear.app/nothink/issue/SPR-124) — 本番でグローバルヘッダーの先頭ナビ項目「動画一覧」(/videos) が消失する不具合の修正。

## 症状
- デスクトップヘッダーが「ボタン検索 / 作品一覧」のみで **動画一覧 が欠落**
- レンダリング時に**一瞬表示されてから消える**（SSR では描画される）

## 原因（再現・切り分け済み）
radix `NavigationMenu`（`NavigationMenuList`/`NavigationMenuItem`/`NavigationMenuLink asChild > Link`）の **Collection 機構が本番ビルドで先頭 collection item の `<a>` を prerender/hydration 時に脱落**させていた。

- **`next dev` では再現せず**、`next build && next start`（本番ビルド）で再現
- ローカル本番ビルドで：`navigation-menu-item` は3個あるが先頭の `<a>` が空（リンク2個のみ）
- 切り分け：`reactCompiler: false` でも再現 / `cacheComponents: false`(PPR) でも再現 → どちらも主因ではなく、**radix NavigationMenu(Collection) × React 19 / Next 16 本番サーバ描画の相性問題**

## 修正
ドロップダウンの無い静的リンク3つに radix `NavigationMenu`（Collection/Viewport/focus-proxy 付き）は過剰。**素の `<nav><ul><li><Link>` に置換**し、トリガとなる最適化フラグに依存しない堅牢な形にした（軽量化も兼ねる）。

## 検証（next.config は本番同一 = reactCompiler/cacheComponents 両 ON のまま）
- `next build && next start` の **SSR HTML**：動画一覧・ボタン検索・作品一覧 の3リンク出力 ✓
- **ハイドレーション後 DOM**：`linkCount: 3` ✓
- デスクトップ幅スクリーンショットで3項目表示を確認 ✓
- web `lint` / `typecheck` / `site-header` テスト（2件）pass ✓

## 影響範囲・備考
- `mobile-menu` は素の Link 実装で影響なし。radix NavigationMenu の利用は SiteHeader が唯一だったため、副次的に `packages/ui` の `navigation-menu` はアプリ未使用に（別途掃除候補）
- `.claude/launch.json` に web/web-prod の preview 起動設定を追加（本検証で使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)