### PR TITLE
test(web): ヘッダー nav の prod-build スモーク + 実コンポーネントテスト（SPR-125）

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,0 +1,90 @@
+name: E2E Smoke (prod build)
+
+# SPR-124（radix NavigationMenu がヘッダーの先頭ナビ項目を本番ビルドでのみ脱落）のような
+# 「next dev / jsdom では再現せず next build でのみ顕在化する回帰」を CI で捕捉する。
+# 本番ビルド(next build → next start)に対して最小スモーク(e2e/smoke.spec.ts)を実行する。
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      ui_or_web: ${{ steps.changes.outputs.ui_or_web }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            ui_or_web:
+              - 'apps/web/**'
+              - 'packages/ui/**'
+              - 'packages/shared-types/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/e2e-smoke.yml'
+
+  smoke:
+    name: Header smoke (prod build)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.ui_or_web == 'true'
+    timeout-minutes: 15
+    env:
+      # ブート用のダミー値（実認証は行わない。/ は header を含む layout が描画されれば十分）
+      NEXTAUTH_URL: http://127.0.0.1:3000
+      AUTH_TRUST_HOST: "true"
+      AUTH_SECRET: ci-smoke-dummy-not-a-real-secret
+      NEXTAUTH_SECRET: ci-smoke-dummy-not-a-real-secret
+      DISCORD_CLIENT_ID: dummy
+      DISCORD_CLIENT_SECRET: dummy
+      NEXT_PUBLIC_GA_MEASUREMENT_ID: ""
+      NEXT_PUBLIC_GTM_ID: ""
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.16.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright (chromium)
+        run: pnpm --filter @suzumina.click/web exec playwright install --with-deps chromium
+
+      - name: Build web (production)
+        run: pnpm --filter @suzumina.click/web build
+
+      - name: Run header smoke against prod server
+        env:
+          PLAYWRIGHT_PROD: "1"
+        run: pnpm --filter @suzumina.click/web test:e2e:smoke
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 本番ビルド限定の回帰を捕捉するためのスモーク。
+ * SPR-124（radix NavigationMenu が本番ビルドで先頭ナビ項目を脱落させた不具合）は
+ * `next dev` では再現せず `next build && next start` でのみ顕在化したため、
+ * このスモークは本番ビルドに対して実行する（PLAYWRIGHT_PROD / CI 経由、SPR-125）。
+ */
+test.describe("@smoke グローバルヘッダー", () => {
+	test("デスクトップヘッダーに 3 つのナビリンクが揃っている", async ({ page }) => {
+		// デスクトップ幅（md 以上）で nav を表示させる
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.goto("/");
+
+		await expect(page.getByRole("banner")).toBeVisible();
+
+		const nav = page.getByRole("navigation", { name: "メインナビゲーション" });
+		await expect(nav).toBeVisible();
+
+		// SPR-124 の回帰（先頭 動画一覧 の脱落）を確実に検出する
+		await expect(nav.getByRole("link", { name: "動画一覧" })).toBeVisible();
+		await expect(nav.getByRole("link", { name: "ボタン検索" })).toBeVisible();
+		await expect(nav.getByRole("link", { name: "作品一覧" })).toBeVisible();
+		await expect(nav.getByRole("link")).toHaveCount(3);
+
+		// href も検証（順序・リンク先の固定）
+		await expect(nav.getByRole("link", { name: "動画一覧" })).toHaveAttribute("href", "/videos");
+	});
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,8 @@
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",
 		"test:e2e:debug": "playwright test --debug",
+		"test:e2e:smoke": "playwright test smoke --project=chromium",
+		"test:smoke:prod": "next build && PLAYWRIGHT_PROD=1 playwright test smoke --project=chromium",
 		"clean": "rimraf .next coverage node_modules/.cache .vitest test-results playwright-report",
 		"deploy:build": "cd ../.. && docker build -f apps/web/Dockerfile -t suzumina-web .",
 		"deploy:test": "docker run --rm -p 8080:8080 suzumina-web",
@@ -49,7 +51,7 @@
 	},
 	"devDependencies": {
 		"@next/bundle-analyzer": "^16.2.6",
-		"@playwright/test": "^1.58.2",
+		"@playwright/test": "^1.60.0",
 		"@suzumina.click/typescript-config": "workspace:*",
 		"@tailwindcss/postcss": "^4.3.0",
 		"@testing-library/jest-dom": "^6.9.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -68,11 +68,15 @@ export default defineConfig({
 		// },
 	],
 
-	/* Run your local dev server before starting the tests */
+	/* テスト前にローカルサーバを起動する。
+	 * PLAYWRIGHT_PROD=1 のときは本番ビルド(next start)に対して実行する。
+	 * SPR-124 のような「本番ビルドでのみ顕在化する回帰」は dev では捕捉できないため、
+	 * スモーク(@smoke / e2e/smoke.spec.ts)はこのモードで回す（事前に `next build` 済みであること）。 */
 	webServer: {
-		command: "pnpm dev",
+		command: process.env.PLAYWRIGHT_PROD ? "pnpm start" : "pnpm dev",
 		url: "http://127.0.0.1:3000",
 		reuseExistingServer: !process.env.CI,
-		timeout: 120 * 1000,
+		// 本番モードは起動のみ(ビルドは事前)だが余裕を持たせる
+		timeout: (process.env.PLAYWRIGHT_PROD ? 180 : 120) * 1000,
 	},
 });

--- a/apps/web/src/components/layout/__tests__/desktop-nav.test.tsx
+++ b/apps/web/src/components/layout/__tests__/desktop-nav.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DesktopNav } from "../desktop-nav";
+
+// next/link を素の <a> に置換（DesktopNav の唯一の外部依存）
+vi.mock("next/link", () => ({
+	default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+describe("DesktopNav（実コンポーネント）", () => {
+	it("3つのナビリンクを正しい href で描画する", () => {
+		render(<DesktopNav />);
+
+		const nav = screen.getByRole("navigation", { name: "メインナビゲーション" });
+		const links = screen.getAllByRole("link");
+
+		// SPR-124 の回帰（先頭リンク欠落）を検出: 3リンク・順序・href を固定で検証
+		expect(links).toHaveLength(3);
+		expect(links.map((a) => [a.textContent, a.getAttribute("href")])).toEqual([
+			["動画一覧", "/videos"],
+			["ボタン検索", "/buttons"],
+			["作品一覧", "/works"],
+		]);
+		// 先頭の動画一覧が nav 内に存在すること（SPR-124 で消えた項目）
+		expect(nav).toContainElement(screen.getByRole("link", { name: "動画一覧" }));
+	});
+});

--- a/apps/web/src/components/layout/desktop-nav.tsx
+++ b/apps/web/src/components/layout/desktop-nav.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+const NAV_LINKS = [
+	{ href: "/videos", label: "動画一覧" },
+	{ href: "/buttons", label: "ボタン検索" },
+	{ href: "/works", label: "作品一覧" },
+] as const;
+
+/**
+ * デスクトップのグローバルナビゲーション。
+ * ドロップダウンの無い静的リンクのため radix NavigationMenu は使わず素の nav にする。
+ * radix NavigationMenu(Collection 機構)は本番ビルド(cacheComponents/PPR)で先頭 collection item の
+ * anchor を prerender/hydration 時に脱落させる不具合があった（SPR-124）。
+ * site-header から切り出して単体テストで実コードを描画できるようにしている（SPR-125）。
+ */
+export function DesktopNav() {
+	return (
+		<nav className="hidden md:flex" aria-label="メインナビゲーション">
+			<ul className="flex list-none items-center gap-1">
+				{NAV_LINKS.map((item) => (
+					<li key={item.href}>
+						<Link
+							href={item.href}
+							className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+						>
+							{item.label}
+						</Link>
+					</li>
+				))}
+			</ul>
+		</nav>
+	);
+}

--- a/apps/web/src/components/layout/site-header.tsx
+++ b/apps/web/src/components/layout/site-header.tsx
@@ -2,13 +2,8 @@ import Link from "next/link";
 import { Suspense } from "react";
 import { auth } from "@/auth";
 import AuthButton from "../user/auth-button";
+import { DesktopNav } from "./desktop-nav";
 import MobileMenu from "./mobile-menu";
-
-const NAV_LINKS = [
-	{ href: "/videos", label: "動画一覧" },
-	{ href: "/buttons", label: "ボタン検索" },
-	{ href: "/works", label: "作品一覧" },
-] as const;
 
 export default function SiteHeader() {
 	return (
@@ -31,24 +26,7 @@ export default function SiteHeader() {
 							</Link>
 						</div>
 
-						{/* デスクトップナビゲーション。
-							ドロップダウンの無い静的リンクのため radix NavigationMenu は使わず素の nav にする。
-							radix NavigationMenu(Collection 機構)は本番ビルド(cacheComponents/PPR)で
-							先頭 collection item の anchor を prerender/hydration 時に脱落させる不具合があった（SPR-124 系）。 */}
-						<nav className="hidden md:flex" aria-label="メインナビゲーション">
-							<ul className="flex list-none items-center gap-1">
-								{NAV_LINKS.map((item) => (
-									<li key={item.href}>
-										<Link
-											href={item.href}
-											className="inline-flex h-9 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
-										>
-											{item.label}
-										</Link>
-									</li>
-								))}
-							</ul>
-						</nav>
+						<DesktopNav />
 
 						{/* 認証関連: wrapper の min-h で UserMenu (desktop ~52px) と
 							MobileMenu (mobile 44px) と同じ高さを常に確保する。これにより

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,10 +120,10 @@ importers:
         version: 1.17.0(react@19.2.7)
       next:
         specifier: ^16.2.7
-        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.7(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 5.0.0-beta.30(next@16.2.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -156,8 +156,8 @@ importers:
         specifier: ^16.2.6
         version: 16.2.6
       '@playwright/test':
-        specifier: ^1.58.2
-        version: 1.58.2
+        specifier: ^1.60.0
+        version: 1.60.0
       '@suzumina.click/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
@@ -262,7 +262,7 @@ importers:
         version: 1.17.0(react@19.2.7)
       next:
         specifier: ^16.2.7
-        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1441,8 +1441,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4255,18 +4255,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.58.2:
-    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.58.2:
-    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5901,9 +5891,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -8755,10 +8745,10 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.59.0
 
-  next-auth@5.0.0-beta.30(next@16.2.7(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  next-auth@5.0.0-beta.30(next@16.2.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -8766,7 +8756,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.7
       '@swc/helpers': 0.5.15
@@ -8786,7 +8776,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.7
       '@next/swc-win32-x64-msvc': 16.2.7
       '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.58.2
+      '@playwright/test': 1.60.0
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -8934,15 +8924,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  playwright-core@1.58.2: {}
-
   playwright-core@1.60.0: {}
-
-  playwright@1.58.2:
-    dependencies:
-      playwright-core: 1.58.2
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.60.0:
     dependencies:


### PR DESCRIPTION
[SPR-125](https://linear.app/nothink/issue/SPR-125) — [SPR-124](https://linear.app/nothink/issue/SPR-124)（ヘッダー先頭ナビが本番ビルドで脱落）が**テスト緑のまま本番に出た再発防止**。

## なぜすり抜けたか
- `site-header.test.tsx` は**実コンポーネントを描画せず、テスト内に同等マークアップを自前再現**して検証するトートロジー → 実装が壊れても緑
- 既存 e2e（`home.spec.ts`）は3リンクを検証**済み**だが、① `webServer: pnpm dev`（dev サーバ）で走るため本番限定バグを再現できず、② **e2e が CI で未実行**
- さらに `@playwright/test ^1.58.2` ↔ `playwright ^1.60.0` の**バージョン不整合**で e2e は起動不能だった（`test.describe() not expected` エラー）

## 変更
- **DesktopNav を `desktop-nav.tsx` に切り出し**、実コードを描画する単体テストを追加（トートロジー解消・`next/link` のみ依存で隔離可能）
- **本番ビルド限定回帰を捕捉する最小スモーク** `e2e/smoke.spec.ts`（ヘッダーの 動画一覧/ボタン検索/作品一覧 の3リンク・href・件数を検証）
- `playwright.config.ts` に **`PLAYWRIGHT_PROD` モード**追加（`next start` に対して実行）
- **依存不整合を解消**: `@playwright/test` を `^1.60.0` に統一（e2e 起動不能の根本原因）
- **CI**: `e2e-smoke.yml` 追加 — web/ui 変更時に `next build` → 本番起動 → スモーク実行（ブート用 dummy auth env）
- scripts: `test:e2e:smoke` / `test:smoke:prod`

## 検証
- **ローカルで `next build && next start` に対しスモーク pass を確認**（修正前の挙動なら3リンク検証で fail する設計）
- `pnpm verify` 通過（web 単体テスト +1）
- この PR の CI で `E2E Smoke (prod build)` ワークフローが実走する

## スコープ外（別途）
- `site-header.test.tsx` のモックパス不整合（`./AuthButton` 等が実パスと不一致＝dead mock）は本 PR では触れず温存。トートロジー型テストの全体棚卸しは別タスク

🤖 Generated with [Claude Code](https://claude.com/claude-code)