### PR TITLE
feat(web): ブランドフォント M PLUS Rounded 1c を next/font で復活（SPR-120）

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { M_PLUS_Rounded_1c } from "next/font/google";
 import "@suzumina.click/ui/globals.css";
 import { Toaster } from "@suzumina.click/ui/components/ui/sonner";
 import { Suspense } from "react";
@@ -14,6 +15,30 @@ import SiteHeader from "@/components/layout/site-header";
 import { DeferredGlobalEffects } from "@/components/system/deferred-global-effects";
 import { SessionProvider } from "@/components/user/session-provider";
 import { AgeVerificationProvider } from "@/contexts/age-verification-context";
+
+/**
+ * ブランドフォント M PLUS Rounded 1c（丸ゴシック）。
+ * next/font で self-host し、body に className として当てる（globals.css の既定 body フォントを上書き）。
+ * - CJK は巨大なため preload せず display:swap（初回はシステム丸ゴシックで即描画→差し替え）
+ * - weight は実使用に限定（400/500/700。600=semibold は最寄りで合成）
+ * - fallback は globals.css と同じシステム丸ゴシック系（未ロード/欠字/swap 中もブランド感を維持）
+ */
+const mPlusRounded = M_PLUS_Rounded_1c({
+	weight: ["400", "500", "700"],
+	subsets: ["latin"],
+	display: "swap",
+	preload: false,
+	adjustFontFallback: false,
+	fallback: [
+		"Hiragino Maru Gothic ProN",
+		"Meiryo",
+		"BIZ UDGothic",
+		"Hiragino Kaku Gothic ProN",
+		"YuGothic",
+		"system-ui",
+		"sans-serif",
+	],
+});
 
 export const metadata: Metadata = {
 	title: {
@@ -98,7 +123,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				<GoogleAnalyticsScript />
 				<GoogleTagManager />
 			</head>
-			<body className="min-h-screen flex flex-col antialiased gradient-bg">
+			<body
+				className={`${mPlusRounded.className} min-h-screen flex flex-col antialiased gradient-bg`}
+			>
 				<GoogleTagManagerNoscript />
 				<AgeVerificationProvider>
 					<SessionProvider>

--- a/packages/ui/.storybook/preview-head.html
+++ b/packages/ui/.storybook/preview-head.html
@@ -1,0 +1,17 @@
+<!-- Storybook でブランドフォント M PLUS Rounded 1c を実ロードする（SPR-120）。
+     本番(apps/web)は next/font で self-host するが、Storybook は dev ツールのため CDN で読み込み、
+     Design Tokens / Typography のプレビューを実フォントと一致させる。 -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700&display=swap"
+  rel="stylesheet"
+/>
+<style>
+  /* 本番と同じく M PLUS Rounded 1c を先頭にしてプレビュー全体を実態に合わせる */
+  body {
+    font-family:
+      "M PLUS Rounded 1c", "ヒラギノ丸ゴ ProN", "Hiragino Maru Gothic ProN", "メイリオ", Meiryo,
+      "BIZ UDゴシック", "BIZ UDGothic", system-ui, sans-serif;
+  }
+</style>

--- a/packages/ui/src/components/design-tokens/typography.mdx
+++ b/packages/ui/src/components/design-tokens/typography.mdx
@@ -10,10 +10,13 @@ import { Meta, Typeset, Title, Subtitle } from "@storybook/addon-docs/blocks";
 ## Font Family
 
 ```css
-font-family: "M PLUS Rounded 1c", sans-serif;
+font-family: "M PLUS Rounded 1c", "Hiragino Maru Gothic ProN", Meiryo, system-ui, sans-serif;
 ```
 
 丸みのあるサンセリフ書体。日本語と英数字の両方で柔らかい印象を与えます。
+
+本番（apps/web）では **next/font で M PLUS Rounded 1c を self-host**（weight 400/500/700・`display: swap`・CJK のため非 preload）。
+未ロード時・欠字時・swap 中は **OS のシステム丸ゴシック**（ヒラギノ丸ゴ / メイリオ / BIZ UD ゴシック等）にフォールバックする（SPR-120）。
 
 ## Font Scale
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -255,8 +255,9 @@
 		color: hsl(var(--foreground));
 	}
 
-	/* 日本語システムフォントスタック */
-	/* Web Fontを使用せず帯域を節約し、各OSネイティブフォントを活用 */
+	/* 日本語フォントスタック（既定 = システム丸ゴシック）。
+	 * apps/web では body に next/font の M PLUS Rounded 1c クラスが当たり、この既定を上書きする
+	 * (SPR-120)。Storybook 等 next/font 非適用の文脈ではこのスタックがそのまま効く。 */
 	body {
 		font-family:
 			/* 丸みのあるフォント優先 (macOS/iOS) */


### PR DESCRIPTION
[SPR-120](https://linear.app/nothink/issue/SPR-120) — デザイントークンが謳う **M PLUS Rounded 1c** が、過去の帯域最適化で配線が抜けて**一度もロードされていなかった**（doc と実態の乖離）。方針決定どおり復活させる。

## 変更
- **apps/web `layout.tsx`**: `next/font/google` で M PLUS Rounded 1c を self-host し `<body>` に適用
  - CJK のため **`preload: false` / `display: swap`**、weight は実使用の **400/500/700** に限定
  - `fallback` は globals.css と同じ**システム丸ゴシック系**（swap 中・欠字時・未ロード時もブランド感維持）
- **`globals.css`**: 既定 body フォント（システム丸ゴシック）の位置づけをコメントで明確化（apps/web では next/font クラスが上書き、Storybook 等では既定が効く）
- **Storybook `preview-head.html`（新規）**: M PLUS Rounded 1c を CDN ロードし、Design Tokens / Typography のプレビューを実態と一致
- **`typography.mdx`**: 実装手段（next/font self-host + system fallback）を注記

## 検証
- **dev / 本番ビルド（`next build && next start`）双方**で body computed font-family の先頭が `M PLUS Rounded 1c`、`document.fonts.check('700 24px "M PLUS Rounded 1c"')` = true を確認
- デスクトップ実描画で丸ゴシックに切り替わることをスクショ確認
- `pnpm verify` 通過

## 留意（トレードオフ）
- M PLUS Rounded 1c は CJK Web Font で容量が大きい。`preload:false` + `display:swap` で**初期表示はシステム丸ゴシック→差し替え**とし、LCP/CLS への影響を最小化。weight も3つに限定
- next/font はビルド時にフォントを取得・self-host する（CI/Docker ビルドにネットワークが必要。ローカル本番ビルドで取得成功を確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)