### PR TITLE
chore(ui): next/react を peerDependencies 化 + sonner の next-themes 撤去（SPR-122）

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,16 +24,17 @@
 		"clsx": "^2.1.1",
 		"embla-carousel-react": "8.6.0",
 		"lucide-react": "^1.17.0",
-		"next": "^16.2.7",
-		"next-themes": "^0.4.6",
 		"radix-ui": "1.4.3",
-		"react": "^19.2.7",
-		"react-dom": "^19.2.7",
 		"react-hook-form": "^7.77.0",
 		"recharts": "3.8.1",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.6.0",
 		"tw-animate-css": "^1.4.0"
+	},
+	"peerDependencies": {
+		"next": "^16.0.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0"
 	},
 	"devDependencies": {
 		"@chromatic-com/storybook": "^5.2.1",
@@ -51,6 +52,9 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitest/coverage-v8": "^4.1.8",
 		"happy-dom": "^20.9.0",
+		"next": "^16.2.7",
+		"react": "^19.2.7",
+		"react-dom": "^19.2.7",
 		"remark-gfm": "^4.0.1",
 		"rimraf": "^6.1.3",
 		"storybook": "^10.4.1",

--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -7,15 +7,15 @@ import {
 	OctagonXIcon,
 	TriangleAlertIcon,
 } from "lucide-react";
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+// サイトは light-only（ADR-011: ThemeProvider 無し / darkreader-lock）。
+// next-themes の useTheme は ThemeProvider 不在で "system" を返し、OS がダークだと
+// トーストだけダーク化する不整合を生むため、theme は "light" に固定する（props で上書き可）。
 const Toaster = ({ ...props }: ToasterProps) => {
-	const { theme = "system" } = useTheme();
-
 	return (
 		<Sonner
-			theme={theme as ToasterProps["theme"]}
+			theme="light"
 			className="toaster group"
 			icons={{
 				success: <CircleCheckIcon className="size-4" />,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,21 +257,9 @@ importers:
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)
-      next:
-        specifier: ^16.2.7
-        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       radix-ui:
         specifier: 1.4.3
         version: 1.4.3(patch_hash=485a085c0b1ad0e53117b9bfe90784b64d918aad086e7ad7f87dfd0169f300ae)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react:
-        specifier: ^19.2.7
-        version: 19.2.7
-      react-dom:
-        specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
       react-hook-form:
         specifier: ^7.77.0
         version: 7.77.0(react@19.2.7)
@@ -333,6 +321,15 @@ importers:
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
+      next:
+        specifier: ^16.2.7
+        version: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -4104,12 +4101,6 @@ packages:
         optional: true
       nodemailer:
         optional: true
-
-  next-themes@0.4.6:
-    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.2.7:
     resolution: {integrity: sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==}
@@ -8724,11 +8715,6 @@ snapshots:
       '@auth/core': 0.41.0
       next: 16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
-
-  next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   next@16.2.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:


### PR DESCRIPTION
[SPR-122](https://linear.app/nothink/issue/SPR-122) — UI パッケージの Next/React 結合を明示し、light-only サイトで無効な `next-themes` を外す。

## 変更
### next/react の peerDependencies 化
- `next` / `react` / `react-dom` を `dependencies` → **`peerDependencies`**（`^16.0.0` / `^19.0.0`）へ移動
  - アプリの単一 Next/React に解決させ、**二重インストール・dual-React（hooks 破壊）を防止**。結合を宣言で明示
  - パッケージ自身の Storybook/vitest/tsc 用に **`devDependencies` にも保持**（standalone で解決可能）
- 唯一の消費元 apps/web が peer を満たすため install で peer 警告なし

### sonner の next-themes 撤去
- `useTheme()`（ThemeProvider 不在で `"system"` を返し、OS がダークだと**トーストだけダーク化**）を撤去し **`theme="light"` に固定**（props で上書き可）
- light-only サイト（ADR-011: ThemeProvider 無し / darkreader-lock）との不整合を解消
- `next-themes` を依存から削除（唯一の利用元が sonner。lockfile **-2**）

## 検証
- `pnpm install` クリーン（peer 警告なし）
- `pnpm verify` 通過
- 本番ビルド `✓ Compiled successfully`（peer 解決 OK）

## スコープ外（issue 記載どおり）
- 純粋ライブラリ化（Link/router の props 注入）は大工事のため見送り（custom はプロジェクト専用前提で許容）

🤖 Generated with [Claude Code](https://claude.com/claude-code)