### PR TITLE
fix(a11y): ConfigurableList セレクタ + 本番 Progress にアクセシブル名（SPR-132 component分）

### DIFF
--- a/apps/web/src/components/audio/create-button-limit.tsx
+++ b/apps/web/src/components/audio/create-button-limit.tsx
@@ -65,6 +65,7 @@ export function CreateButtonLimit({ userId }: CreateButtonLimitProps) {
 
 			<Progress
 				value={percentage}
+				aria-label={`本日の音声ボタン作成数 ${limit.current}/${limit.limit}`}
 				className={`h-2 ${isNearLimit ? "[&>div]:bg-orange-500" : ""} ${
 					isAtLimit ? "[&>div]:bg-destructive" : ""
 				}`}

--- a/apps/web/src/components/content/characteristic-evaluation.tsx
+++ b/apps/web/src/components/content/characteristic-evaluation.tsx
@@ -86,7 +86,12 @@ function CharacteristicAxisDisplay({ label, leftLabel, rightLabel, value }: Axis
 
 			{/* プログレスバー */}
 			<div className="relative">
-				<Progress value={percentage} className="h-3" style={{ opacity }} />
+				<Progress
+					value={percentage}
+					className="h-3"
+					style={{ opacity }}
+					aria-label={`${leftLabel}〜${rightLabel}の評価`}
+				/>
 				{/* 中央線 */}
 				<div className="absolute top-0 left-1/2 transform -translate-x-px h-3 w-0.5 bg-border opacity-50" />
 				{/* 値のインジケーター */}

--- a/packages/ui/src/components/custom/configurable-list.tsx
+++ b/packages/ui/src/components/custom/configurable-list.tsx
@@ -53,7 +53,7 @@ function SelectFilter({
 	const options = generateOptions(config);
 	return (
 		<Select value={value?.toString() || ""} onValueChange={onChange}>
-			<SelectTrigger className="w-[180px]">
+			<SelectTrigger className="w-[180px]" aria-label={config.label || "絞り込み"}>
 				<SelectValue placeholder={config.placeholder || `${config.label}を選択`} />
 			</SelectTrigger>
 			<SelectContent>

--- a/packages/ui/src/components/custom/configurable-list/ConfigurableListControls.tsx
+++ b/packages/ui/src/components/custom/configurable-list/ConfigurableListControls.tsx
@@ -61,7 +61,7 @@ export function ConfigurableListControls({
 				{/* ソート選択 */}
 				{sortOptions.length > 0 && (
 					<Select value={currentSort} onValueChange={onSortChange}>
-						<SelectTrigger className="h-8 w-[140px]">
+						<SelectTrigger className="h-8 w-[140px]" aria-label="並び順">
 							<SelectValue placeholder="並び順" />
 						</SelectTrigger>
 						<SelectContent>
@@ -79,7 +79,7 @@ export function ConfigurableListControls({
 					itemsPerPageOptions.length > 0 &&
 					(actualTotal > 0 || (initialTotal && initialTotal > 0)) && (
 						<Select value={currentItemsPerPage.toString()} onValueChange={onItemsPerPageChange}>
-							<SelectTrigger className="h-8 w-[140px]">
+							<SelectTrigger className="h-8 w-[140px]" aria-label="表示件数">
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>


### PR DESCRIPTION
[SPR-132](https://linear.app/nothink/issue/SPR-132) のうち、**本番に影響する component レベルの名前欠落**を先行解消（スクリーンリーダー体験に直結）。

## 背景
SPR-121 の a11y 監査で `button-name`(38) / `aria-progressbar-name`(28) 等の非contrast 違反が判明。多くは story の label 不足だが、一部は **production component の実欠落**だった。

## 変更（component / production）
- **ConfigurableList**: ソート/表示件数/フィルタの `SelectTrigger` に `aria-label` を付与（`ConfigurableListControls` の2つ + `configurable-list.tsx` のフィルタ select）。**8つの一覧ページで使用**＝実ユーザー影響。`button-name` 違反 8 件を解消
- **本番 Progress に `aria-label`**:
  - `characteristic-evaluation`: 「{left}〜{right}の評価」
  - `create-button-limit`: 「本日の音声ボタン作成数 {current}/{limit}」

## 検証
- configurable-list を targeted `a11y=error` で実行し **button-name 解消を確認**（残り4は color-contrast=SPR-131 領域）
- `pnpm verify` 通過。`a11y.test` は **"todo" 据え置き**（全違反解消後に Phase で error 化）

## 残り（SPR-132 継続・別 PR）
- 各 story の form control ラベル付け（switch/checkbox/select/progress/input）
- sheet/popover/dropdown トリガ名、heading-order、select-name 等
- 完了 + SPR-131(contrast) 完了後に `a11y.test` を "error" 化 + audio-button play 修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)