### PR TITLE
fix(a11y): component 個別の color-contrast を AA 適合（SPR-131 / Phase2）

### DIFF
--- a/packages/ui/src/components/custom/__tests__/validation-message.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/validation-message.test.tsx
@@ -46,7 +46,7 @@ describe("ValidationMessage", () => {
 			const { container } = render(
 				<ValidationMessage variant="warning" message="Warning message" isVisible={true} />,
 			);
-			expect(container.firstChild).toHaveClass("text-minase-600");
+			expect(container.firstChild).toHaveClass("text-minase-700");
 		});
 
 		it("applies info variant styles", () => {

--- a/packages/ui/src/components/custom/audio-player.stories.tsx
+++ b/packages/ui/src/components/custom/audio-player.stories.tsx
@@ -94,21 +94,21 @@ export const WithControls: Story = {
 						<button
 							type="button"
 							onClick={() => audioRef.current?.play()}
-							className="px-3 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+							className="px-3 py-2 bg-blue-700 text-white rounded hover:bg-blue-800"
 						>
 							再生
 						</button>
 						<button
 							type="button"
 							onClick={() => audioRef.current?.pause()}
-							className="px-3 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600"
+							className="px-3 py-2 bg-yellow-400 text-gray-900 rounded hover:bg-yellow-500"
 						>
 							一時停止
 						</button>
 						<button
 							type="button"
 							onClick={() => audioRef.current?.stop()}
-							className="px-3 py-2 bg-red-500 text-white rounded hover:bg-red-600"
+							className="px-3 py-2 bg-red-700 text-white rounded hover:bg-red-800"
 						>
 							停止
 						</button>

--- a/packages/ui/src/components/custom/configurable-list/ConfigurableListPagination.tsx
+++ b/packages/ui/src/components/custom/configurable-list/ConfigurableListPagination.tsx
@@ -46,6 +46,7 @@ export function ConfigurableListPagination({
 				<PaginationItem>
 					<PaginationPrevious
 						href="#"
+						aria-disabled={!hasPrev}
 						onClick={(e) => {
 							e.preventDefault();
 							if (hasPrev) {
@@ -118,6 +119,7 @@ export function ConfigurableListPagination({
 				<PaginationItem>
 					<PaginationNext
 						href="#"
+						aria-disabled={!hasNext}
 						onClick={(e) => {
 							e.preventDefault();
 							if (hasNext) {

--- a/packages/ui/src/components/custom/tag-list.tsx
+++ b/packages/ui/src/components/custom/tag-list.tsx
@@ -136,8 +136,10 @@ export function TagList({
 					)}
 				</Badge>
 			))}
+			{/* secondary(オレンジ)上は secondary-foreground(暗色) を使う。text-muted-foreground だと
+				グレー文字でコントラスト 2.29 になり AA 未満（SPR-131） */}
 			{hasMoreTags && (
-				<Badge variant="secondary" className={cn(sizeClasses.badge, "text-muted-foreground")}>
+				<Badge variant="secondary" className={sizeClasses.badge}>
 					+{tags.length - maxTags}個
 				</Badge>
 			)}

--- a/packages/ui/src/components/custom/time-display.stories.tsx
+++ b/packages/ui/src/components/custom/time-display.stories.tsx
@@ -154,7 +154,8 @@ export const CustomLabel: Story = {
 export const Styled: Story = {
 	args: {
 		time: 156.8,
-		className: "text-lg text-primary bg-primary/10 px-2 py-1 rounded",
+		// primary 文字 × primary/10 背景は 4.27（AA 未満）。文字を suzuka-700 に濃くして 4.5:1（SPR-131）
+		className: "text-lg text-suzuka-700 bg-primary/10 px-2 py-1 rounded",
 		showLabel: true,
 		label: "切り抜き時間",
 	},

--- a/packages/ui/src/components/custom/validation-message.tsx
+++ b/packages/ui/src/components/custom/validation-message.tsx
@@ -75,7 +75,8 @@ export function ValidationMessage({
 			icon: AlertCircle,
 		},
 		warning: {
-			container: "text-minase-600",
+			// minase-600 は白背景で 3.3:1（AA 未満）。minase-700 で 4.5:1 を満たす（SPR-131）
+			container: "text-minase-700",
 			icon: AlertTriangle,
 		},
 		info: {

--- a/packages/ui/src/components/ui/button.stories.tsx
+++ b/packages/ui/src/components/ui/button.stories.tsx
@@ -111,7 +111,8 @@ export const CustomSuzuka: Story = {
 export const CustomMinase: Story = {
 	args: {
 		children: "Minase Style",
-		className: "bg-minase-500 hover:bg-minase-600 text-white",
+		// minase(オレンジ)は明色のため白文字は AA 未満（2.32）。暗色文字で 4.5:1 を満たす（SPR-131）
+		className: "bg-minase-500 hover:bg-minase-600 text-minase-950",
 	},
 };
 

--- a/packages/ui/src/components/ui/textarea.stories.tsx
+++ b/packages/ui/src/components/ui/textarea.stories.tsx
@@ -177,9 +177,10 @@ export const ErrorState: Story = {
 				id="error-textarea"
 				placeholder="コメントを入力してください"
 				aria-invalid="true"
-				className="border-red-500 focus-visible:border-red-500 focus-visible:ring-red-500/20"
+				className="border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20"
 			/>
-			<p className="text-sm text-red-500">このフィールドは必須です。</p>
+			{/* red-500 直書きは白背景で 3.8（AA 未満）。AA 適合の destructive トークンを使う（SPR-131） */}
+			<p className="text-sm text-destructive">このフィールドは必須です。</p>
 		</div>
 	),
 };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -53,7 +53,7 @@
 		--accent: 24 6% 94%; /* 暖色ニュートラル - border(20°)/foreground(28°) と整合（旧値は青系デフォルト残り） */
 		--accent-foreground: 28 25% 8%; /* foreground と同値（旧値は青系 navy 残り） */
 
-		--destructive: 0 75% 50%; /* Updated for WCAG AA: 4.60:1 contrast ratio */
+		--destructive: 0 72% 45%; /* WCAG AA: 白との相互で 4.5:1（旧 50% は 4.36 で未満。fg/bg 両用のため SPR-131 で darken） */
 		--destructive-foreground: 60 9% 98%;
 
 		--border: 20 6% 90%;


### PR DESCRIPTION
[SPR-131](https://linear.app/nothink/issue/SPR-131) — SPR-129 Phase1(トークン)後に残った **component/story 個別の color-contrast 違反を解消**（実測 15 → **0**）。

## component / token（本番影響）
- **validation-message** warning: `text-minase-600`(3.3) → `text-minase-700`（AA）。実フォームの警告表示
- **tag-list** overflow バッジ: `text-muted-foreground` 上書き（グレー on オレンジ 2.29）を除去し secondary-foreground(暗色)に
- **ConfigurableListPagination**: disabled の Prev/Next に `aria-disabled` 付与（`opacity-50` の faded 文字 3.43 が AA 未満。**disabled 化で axe 対象外＝実 a11y も改善**）
- **`--destructive`** トークン: `0 75% 50%`→`0 72% 45%`（白との相互 4.36→4.5:1。fg/bg 両用＝error テキスト＆ボタン両方が AA に）

## story デモの直書き色
- button `CustomMinase`: 白文字→`text-minase-950` ／ textarea `ErrorState`: `red-500`→`destructive`
- audio-player デモ操作: blue/red を 700 シェード、yellow は暗色文字 ／ time-display `Styled`: 文字を `suzuka-700`

## 検証
- targeted `a11y=error` 実行で **color-contrast 0** を確認（残る非contrast: button-name/aria-progressbar-name/label 等 = [SPR-132](https://linear.app/nothink/issue/SPR-132)）
- `pnpm verify` 通過（validation-message の単体テストのクラス期待も 700 に更新）
- `a11y.test` は **"todo" 据え置き**（SPR-132 完了後にまとめて "error" 化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)