### PR TITLE
fix(a11y): 非contrast 違反を解消し a11y.test を error ゲート化（SPR-132）

### DIFF
--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -16,7 +16,7 @@ const preview: Preview = {
 			// SPR-121 で story テストを CI 配線した際、初回 a11y 監査で大量の既存違反
 			// （主にブランド色の color-contrast < AA）が判明。まず play(interaction) を gate に常設し、
 			// a11y は "todo"（可視化のみ・非 fail）に。違反修正後に "error" へ戻す → SPR-129。
-			test: "todo",
+			test: "error",
 		},
 		backgrounds: {
 			options: {

--- a/packages/ui/src/components/custom/audio-player.stories.tsx
+++ b/packages/ui/src/components/custom/audio-player.stories.tsx
@@ -118,6 +118,7 @@ export const WithControls: Story = {
 						<label className="block text-sm font-medium">音量</label>
 						<input
 							type="range"
+							aria-label="音量"
 							min="0"
 							max="100"
 							defaultValue="75"

--- a/packages/ui/src/components/custom/list-page-layout.stories.tsx
+++ b/packages/ui/src/components/custom/list-page-layout.stories.tsx
@@ -131,7 +131,7 @@ export const AudioButtonListExample: Story = {
 								<div className="w-12 h-12 mx-auto mb-4 bg-blue-100 rounded-full flex items-center justify-center">
 									<Video className="h-6 w-6 text-blue-600" />
 								</div>
-								<h3 className="font-medium mb-2">音声ボタン {i + 1}</h3>
+								<h2 className="font-medium mb-2">音声ボタン {i + 1}</h2>
 								<p className="text-sm text-gray-600 mb-4">短い音声の説明</p>
 								<Button size="sm" className="w-full">
 									再生
@@ -367,7 +367,7 @@ export const ComponentsShowcase: Story = {
 			<ListPageContent>
 				<div className="space-y-8">
 					<div>
-						<h3 className="text-lg font-semibold mb-4">ListPageGrid - デフォルト設定</h3>
+						<h2 className="text-lg font-semibold mb-4">ListPageGrid - デフォルト設定</h2>
 						<ListPageGrid>
 							{Array.from({ length: 4 }, (_, i) => (
 								<div key={i} className="bg-white p-4 rounded-lg border text-center">
@@ -381,14 +381,14 @@ export const ComponentsShowcase: Story = {
 					</div>
 
 					<div>
-						<h3 className="text-lg font-semibold mb-4">ListPageStats - 統計情報</h3>
+						<h2 className="text-lg font-semibold mb-4">ListPageStats - 統計情報</h2>
 						<div className="bg-white p-4 rounded-lg border">
 							<ListPageStats currentPage={3} totalPages={12} totalCount={144} itemsPerPage={12} />
 						</div>
 					</div>
 
 					<div>
-						<h3 className="text-lg font-semibold mb-4">ListPageEmptyState - 空状態</h3>
+						<h2 className="text-lg font-semibold mb-4">ListPageEmptyState - 空状態</h2>
 						<div className="bg-white p-8 rounded-lg border">
 							<ListPageEmptyState
 								icon={<div className="text-4xl">📋</div>}

--- a/packages/ui/src/components/custom/validation-message.stories.tsx
+++ b/packages/ui/src/components/custom/validation-message.stories.tsx
@@ -195,6 +195,7 @@ export const Interactive: Story = {
 					<select
 						value={variant}
 						onChange={(e) => setVariant(e.target.value as "error" | "warning" | "info")}
+						aria-label="バリアント選択"
 						className="w-full p-2 border rounded"
 					>
 						<option value="error">Error</option>

--- a/packages/ui/src/components/ui/checkbox.stories.tsx
+++ b/packages/ui/src/components/ui/checkbox.stories.tsx
@@ -11,6 +11,8 @@ const meta = {
 		layout: "centered",
 	},
 	tags: ["autodocs"],
+	// ラベル無しの単体デモには既定のアクセシブル名を与える（a11y: button-name。SPR-132）
+	args: { "aria-label": "選択" },
 	argTypes: {
 		disabled: {
 			control: { type: "boolean" },

--- a/packages/ui/src/components/ui/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.stories.tsx
@@ -272,7 +272,7 @@ export const ContextMenu: Story = {
 			<p className="text-sm text-muted-foreground">音声ボタンのコンテキストメニュー例</p>
 			<DropdownMenu>
 				<DropdownMenuTrigger asChild>
-					<Button variant="outline" size="icon">
+					<Button variant="outline" size="icon" aria-label="操作メニュー">
 						<MoreHorizontal className="h-4 w-4" />
 					</Button>
 				</DropdownMenuTrigger>

--- a/packages/ui/src/components/ui/input.stories.tsx
+++ b/packages/ui/src/components/ui/input.stories.tsx
@@ -9,6 +9,8 @@ const meta = {
 		layout: "centered",
 	},
 	tags: ["autodocs"],
+	// ラベル無しの単体デモ（args ベース）に既定名（a11y: label。SPR-132）
+	args: { "aria-label": "入力" },
 	argTypes: {
 		type: {
 			control: { type: "select" },

--- a/packages/ui/src/components/ui/popover.stories.tsx
+++ b/packages/ui/src/components/ui/popover.stories.tsx
@@ -146,7 +146,7 @@ export const InfoPopover: Story = {
 			<span>ユーザー名</span>
 			<Popover>
 				<PopoverTrigger asChild>
-					<Button variant="ghost" size="sm" className="h-4 w-4 p-0">
+					<Button variant="ghost" size="sm" className="h-4 w-4 p-0" aria-label="詳細情報">
 						<InfoIcon className="h-3 w-3" />
 					</Button>
 				</PopoverTrigger>
@@ -264,7 +264,7 @@ export const OpenInteraction: Story = {
 			<PopoverTrigger asChild>
 				<Button variant="outline">ポップオーバーを開く</Button>
 			</PopoverTrigger>
-			<PopoverContent>
+			<PopoverContent aria-label="ポップオーバー">
 				<p className="text-sm">ポップオーバーの内容</p>
 			</PopoverContent>
 		</Popover>

--- a/packages/ui/src/components/ui/progress.stories.tsx
+++ b/packages/ui/src/components/ui/progress.stories.tsx
@@ -10,6 +10,8 @@ const meta = {
 		layout: "centered",
 	},
 	tags: ["autodocs"],
+	// args ベースの単体デモに既定のアクセシブル名（a11y: aria-progressbar-name。SPR-132）
+	args: { "aria-label": "進捗" },
 	argTypes: {
 		value: {
 			control: { type: "range", min: 0, max: 100, step: 1 },
@@ -39,7 +41,7 @@ export const BasicValues: Story = {
 					<span>0%</span>
 					<span>0/100</span>
 				</div>
-				<Progress value={0} />
+				<Progress aria-label="進捗" value={0} />
 			</div>
 
 			<div className="space-y-2">
@@ -47,7 +49,7 @@ export const BasicValues: Story = {
 					<span>25%</span>
 					<span>25/100</span>
 				</div>
-				<Progress value={25} />
+				<Progress aria-label="進捗" value={25} />
 			</div>
 
 			<div className="space-y-2">
@@ -55,7 +57,7 @@ export const BasicValues: Story = {
 					<span>50%</span>
 					<span>50/100</span>
 				</div>
-				<Progress value={50} />
+				<Progress aria-label="進捗" value={50} />
 			</div>
 
 			<div className="space-y-2">
@@ -63,7 +65,7 @@ export const BasicValues: Story = {
 					<span>75%</span>
 					<span>75/100</span>
 				</div>
-				<Progress value={75} />
+				<Progress aria-label="進捗" value={75} />
 			</div>
 
 			<div className="space-y-2">
@@ -71,7 +73,7 @@ export const BasicValues: Story = {
 					<span>100%</span>
 					<span>100/100</span>
 				</div>
-				<Progress value={100} />
+				<Progress aria-label="進捗" value={100} />
 			</div>
 		</div>
 	),
@@ -92,7 +94,7 @@ export const Animated: Story = {
 					<span>アニメーション付き進捗</span>
 					<span>{progress}%</span>
 				</div>
-				<Progress value={progress} />
+				<Progress aria-label="進捗" value={progress} />
 				<Button onClick={() => setProgress(Math.floor(Math.random() * 100))}>ランダムに更新</Button>
 			</div>
 		);
@@ -129,7 +131,7 @@ export const FileUploadProgress: Story = {
 						<span>sample-file.pdf</span>
 						<span>{Math.round(uploadProgress)}%</span>
 					</div>
-					<Progress value={uploadProgress} />
+					<Progress aria-label="進捗" value={uploadProgress} />
 					<div className="text-xs text-muted-foreground">
 						{isUploading
 							? "アップロード中..."
@@ -160,7 +162,7 @@ export const MultipleProgress: Story = {
 								<span>UI デザイン</span>
 								<span>90%</span>
 							</div>
-							<Progress value={90} />
+							<Progress aria-label="進捗" value={90} />
 						</div>
 
 						<div className="space-y-2">
@@ -168,7 +170,7 @@ export const MultipleProgress: Story = {
 								<span>フロントエンド開発</span>
 								<span>75%</span>
 							</div>
-							<Progress value={75} />
+							<Progress aria-label="進捗" value={75} />
 						</div>
 
 						<div className="space-y-2">
@@ -176,7 +178,7 @@ export const MultipleProgress: Story = {
 								<span>バックエンド開発</span>
 								<span>60%</span>
 							</div>
-							<Progress value={60} />
+							<Progress aria-label="進捗" value={60} />
 						</div>
 
 						<div className="space-y-2">
@@ -184,7 +186,7 @@ export const MultipleProgress: Story = {
 								<span>テスト</span>
 								<span>30%</span>
 							</div>
-							<Progress value={30} />
+							<Progress aria-label="進捗" value={30} />
 						</div>
 
 						<div className="space-y-2">
@@ -192,7 +194,7 @@ export const MultipleProgress: Story = {
 								<span>デプロイ</span>
 								<span>0%</span>
 							</div>
-							<Progress value={0} />
+							<Progress aria-label="進捗" value={0} />
 						</div>
 					</div>
 
@@ -201,7 +203,7 @@ export const MultipleProgress: Story = {
 							<span>全体進捗</span>
 							<span>51%</span>
 						</div>
-						<Progress value={51} className="mt-2" />
+						<Progress aria-label="進捗" value={51} className="mt-2" />
 					</div>
 				</div>
 			</div>
@@ -231,7 +233,7 @@ export const SkillProgress: Story = {
 								<span>{skill.name}</span>
 								<span>{skill.level}%</span>
 							</div>
-							<Progress value={skill.level} />
+							<Progress aria-label="進捗" value={skill.level} />
 						</div>
 					))}
 				</div>
@@ -280,7 +282,7 @@ export const LoadingSteps: Story = {
 						<span>{steps[currentStep]}</span>
 						<span>{Math.round(progress)}%</span>
 					</div>
-					<Progress value={progress} />
+					<Progress aria-label="進捗" value={progress} />
 					<div className="text-xs text-muted-foreground">
 						ステップ {currentStep + 1} / {steps.length}
 					</div>
@@ -299,27 +301,27 @@ export const CustomSizes: Story = {
 		<div className="w-[300px] space-y-6">
 			<div className="space-y-2">
 				<div className="text-sm font-medium">小（h-1）</div>
-				<Progress value={60} className="h-1" />
+				<Progress aria-label="進捗" value={60} className="h-1" />
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">デフォルト（h-2）</div>
-				<Progress value={60} />
+				<Progress aria-label="進捗" value={60} />
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">中（h-3）</div>
-				<Progress value={60} className="h-3" />
+				<Progress aria-label="進捗" value={60} className="h-3" />
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">大（h-4）</div>
-				<Progress value={60} className="h-4" />
+				<Progress aria-label="進捗" value={60} className="h-4" />
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">特大（h-6）</div>
-				<Progress value={60} className="h-6" />
+				<Progress aria-label="進捗" value={60} className="h-6" />
 			</div>
 		</div>
 	),
@@ -330,27 +332,43 @@ export const ColorVariants: Story = {
 		<div className="w-[300px] space-y-6">
 			<div className="space-y-2">
 				<div className="text-sm font-medium">デフォルト</div>
-				<Progress value={60} />
+				<Progress aria-label="進捗" value={60} />
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">成功（緑）</div>
-				<Progress value={60} className="[&>[data-slot=progress-indicator]]:bg-green-500" />
+				<Progress
+					aria-label="進捗"
+					value={60}
+					className="[&>[data-slot=progress-indicator]]:bg-green-500"
+				/>
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">警告（黄）</div>
-				<Progress value={60} className="[&>[data-slot=progress-indicator]]:bg-yellow-500" />
+				<Progress
+					aria-label="進捗"
+					value={60}
+					className="[&>[data-slot=progress-indicator]]:bg-yellow-500"
+				/>
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">エラー（赤）</div>
-				<Progress value={60} className="[&>[data-slot=progress-indicator]]:bg-red-500" />
+				<Progress
+					aria-label="進捗"
+					value={60}
+					className="[&>[data-slot=progress-indicator]]:bg-red-500"
+				/>
 			</div>
 
 			<div className="space-y-2">
 				<div className="text-sm font-medium">情報（青）</div>
-				<Progress value={60} className="[&>[data-slot=progress-indicator]]:bg-blue-500" />
+				<Progress
+					aria-label="進捗"
+					value={60}
+					className="[&>[data-slot=progress-indicator]]:bg-blue-500"
+				/>
 			</div>
 		</div>
 	),

--- a/packages/ui/src/components/ui/select.stories.tsx
+++ b/packages/ui/src/components/ui/select.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	render: () => (
 		<Select>
-			<SelectTrigger>
+			<SelectTrigger aria-label="選択肢">
 				<SelectValue placeholder="Select a fruit" />
 			</SelectTrigger>
 			<SelectContent>
@@ -41,7 +41,7 @@ export const Default: Story = {
 export const WithDefaultValue: Story = {
 	render: () => (
 		<Select defaultValue="banana">
-			<SelectTrigger>
+			<SelectTrigger aria-label="選択肢">
 				<SelectValue placeholder="Select a fruit" />
 			</SelectTrigger>
 			<SelectContent>
@@ -58,7 +58,7 @@ export const WithDefaultValue: Story = {
 export const Disabled: Story = {
 	render: () => (
 		<Select disabled>
-			<SelectTrigger>
+			<SelectTrigger aria-label="選択肢">
 				<SelectValue placeholder="Select a fruit" />
 			</SelectTrigger>
 			<SelectContent>

--- a/packages/ui/src/components/ui/separator.stories.tsx
+++ b/packages/ui/src/components/ui/separator.stories.tsx
@@ -183,6 +183,7 @@ export const InFormLayout: Story = {
 					<label className="text-sm font-medium">ユーザー名</label>
 					<input
 						type="text"
+						aria-label="ユーザー名"
 						className="w-full px-3 py-2 border rounded-md text-sm"
 						defaultValue="user123"
 					/>
@@ -192,6 +193,7 @@ export const InFormLayout: Story = {
 					<label className="text-sm font-medium">メールアドレス</label>
 					<input
 						type="email"
+						aria-label="メールアドレス"
 						className="w-full px-3 py-2 border rounded-md text-sm"
 						defaultValue="user@example.com"
 					/>

--- a/packages/ui/src/components/ui/sheet.stories.tsx
+++ b/packages/ui/src/components/ui/sheet.stories.tsx
@@ -121,7 +121,7 @@ export const MobileMenu: Story = {
 	render: () => (
 		<Sheet>
 			<SheetTrigger asChild>
-				<Button variant="outline" size="icon">
+				<Button variant="outline" size="icon" aria-label="メニューを開く">
 					<Menu className="h-4 w-4" />
 				</Button>
 			</SheetTrigger>

--- a/packages/ui/src/components/ui/switch.stories.tsx
+++ b/packages/ui/src/components/ui/switch.stories.tsx
@@ -16,6 +16,8 @@ const meta: Meta<typeof Switch> = {
 		},
 	},
 	tags: ["autodocs"],
+	// ラベル無しの単体デモ（args ベース story）に既定のアクセシブル名を与える（a11y: button-name。SPR-132）
+	args: { "aria-label": "スイッチ" },
 	argTypes: {
 		checked: {
 			control: "boolean",
@@ -84,7 +86,12 @@ export const Interactive: Story = {
 		return (
 			<div className="flex flex-col gap-4">
 				<div className="flex items-center gap-3">
-					<Switch checked={checked} onCheckedChange={setChecked} id="interactive-switch" />
+					<Switch
+						aria-label="スイッチ"
+						checked={checked}
+						onCheckedChange={setChecked}
+						id="interactive-switch"
+					/>
 					<label htmlFor="interactive-switch" className="text-sm font-medium">
 						状態: {checked ? "ON" : "OFF"}
 					</label>
@@ -111,7 +118,12 @@ export const WithLabels: Story = {
 						<Bell className="h-4 w-4 text-muted-foreground" />
 						<span className="text-sm font-medium">通知を受け取る</span>
 					</div>
-					<Switch checked={notifications} onCheckedChange={setNotifications} id="notifications" />
+					<Switch
+						aria-label="スイッチ"
+						checked={notifications}
+						onCheckedChange={setNotifications}
+						id="notifications"
+					/>
 				</div>
 
 				<div className="flex items-center justify-between">
@@ -119,7 +131,7 @@ export const WithLabels: Story = {
 						<Volume2 className="h-4 w-4 text-muted-foreground" />
 						<span className="text-sm font-medium">サウンドを再生</span>
 					</div>
-					<Switch checked={sound} onCheckedChange={setSound} id="sound" />
+					<Switch aria-label="スイッチ" checked={sound} onCheckedChange={setSound} id="sound" />
 				</div>
 
 				<div className="flex items-center justify-between">
@@ -127,7 +139,12 @@ export const WithLabels: Story = {
 						<Eye className="h-4 w-4 text-muted-foreground" />
 						<span className="text-sm font-medium">公開プロフィール</span>
 					</div>
-					<Switch checked={visibility} onCheckedChange={setVisibility} id="visibility" />
+					<Switch
+						aria-label="スイッチ"
+						checked={visibility}
+						onCheckedChange={setVisibility}
+						id="visibility"
+					/>
 				</div>
 			</div>
 		);
@@ -180,7 +197,7 @@ export const MultipleStates: Story = {
 				<div className="space-y-3">
 					<p className="text-sm font-medium text-foreground">デフォルト (OFF)</p>
 					<div className="flex items-center gap-3">
-						<Switch checked={false} />
+						<Switch aria-label="スイッチ" checked={false} />
 						<span className="text-xs text-muted-foreground">グレー背景</span>
 					</div>
 				</div>
@@ -188,7 +205,7 @@ export const MultipleStates: Story = {
 				<div className="space-y-3">
 					<p className="text-sm font-medium text-foreground">チェック済み (ON)</p>
 					<div className="flex items-center gap-3">
-						<Switch checked={true} />
+						<Switch aria-label="スイッチ" checked={true} />
 						<span className="text-xs text-suzuka-600">suzuka-500 背景</span>
 					</div>
 				</div>
@@ -196,7 +213,7 @@ export const MultipleStates: Story = {
 				<div className="space-y-3">
 					<p className="text-sm font-medium text-foreground">無効化 (OFF)</p>
 					<div className="flex items-center gap-3">
-						<Switch checked={false} disabled />
+						<Switch aria-label="スイッチ" checked={false} disabled />
 						<span className="text-xs text-muted-foreground">無効状態</span>
 					</div>
 				</div>
@@ -204,7 +221,7 @@ export const MultipleStates: Story = {
 				<div className="space-y-3">
 					<p className="text-sm font-medium text-foreground">無効化 (ON)</p>
 					<div className="flex items-center gap-3">
-						<Switch checked={true} disabled />
+						<Switch aria-label="スイッチ" checked={true} disabled />
 						<span className="text-xs text-muted-foreground">無効状態</span>
 					</div>
 				</div>
@@ -225,7 +242,11 @@ export const BrandColors: Story = {
 
 				<div className="space-y-4">
 					<div className="flex items-center gap-4">
-						<Switch checked={suzukaChecked} onCheckedChange={setSuzukaChecked} />
+						<Switch
+							aria-label="スイッチ"
+							checked={suzukaChecked}
+							onCheckedChange={setSuzukaChecked}
+						/>
 						<div>
 							<span className="text-sm font-medium">suzuka-500 (Primary)</span>
 							<p className="text-xs text-muted-foreground">デフォルトのプライマリカラー</p>
@@ -234,6 +255,7 @@ export const BrandColors: Story = {
 
 					<div className="flex items-center gap-4">
 						<Switch
+							aria-label="スイッチ"
 							checked={minaseChecked}
 							onCheckedChange={setMinaseChecked}
 							className="data-[state=checked]:bg-minase-500"

--- a/packages/ui/src/components/ui/table.tsx
+++ b/packages/ui/src/components/ui/table.tsx
@@ -4,8 +4,11 @@ import { cn } from "@suzumina.click/ui/lib/utils";
 import type * as React from "react";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
+	// 横スクロール領域はキーボードでもスクロールできるよう focusable にする（a11y: scrollable-region-focusable。SPR-132）
+	// biome の noNoninteractiveTabindex と axe の scrollable-region-focusable が衝突するため、後者を優先して suppress
 	return (
-		<div data-slot="table-container" className="relative w-full overflow-x-auto">
+		// biome-ignore lint/a11y/noNoninteractiveTabindex: スクロール領域をキーボードでスクロール可能にする（axe: scrollable-region-focusable）
+		<div data-slot="table-container" className="relative w-full overflow-x-auto" tabIndex={0}>
 			<table
 				data-slot="table"
 				className={cn("w-full caption-bottom text-sm", className)}

--- a/packages/ui/src/components/ui/textarea.stories.tsx
+++ b/packages/ui/src/components/ui/textarea.stories.tsx
@@ -10,6 +10,8 @@ const meta = {
 		layout: "centered",
 	},
 	tags: ["autodocs"],
+	// ラベル無しの単体デモ（args ベース）に既定名（a11y: label。SPR-132）
+	args: { "aria-label": "テキスト入力" },
 	argTypes: {
 		placeholder: {
 			control: "text",


### PR DESCRIPTION
[SPR-132](https://linear.app/nothink/issue/SPR-132) — Storybook a11y の**非contrast 違反を全解消**し、`a11y.test` を `"todo"→"error"` に戻して **CI で a11y をゲート化**する。

## 解消した違反（spike→0）
`button-name` / `aria-progressbar-name` / `label` / `select-name` / `heading-order` / `aria-dialog-name` / `scrollable-region-focusable`

## 変更（大半は demo story の名前付け。production 影響は table のみ）
- **単体デモのアクセシブル名**: progress/switch/checkbox/select/input/textarea に `aria-label`。args ベース story は **meta の既定 args** で一括付与
- **トリガ系アイコンボタン**: sheet/dropdown/popover の icon ボタンに `aria-label`、popover content に dialog 名
- **フォームデモ**: separator の入力 / validation-message の select に `aria-label`
- **見出し順**: list-page-layout の `h3→h2`（h1 からのレベル飛びを解消）
- **table.tsx（production）**: スクロール領域に `tabIndex`（`scrollable-region-focusable`）。**全スクロールテーブルの実 a11y 改善**。biome `noNoninteractiveTabindex` と axe が衝突するため axe 優先で suppress（理由コメント付き）

## ゲート化
- `packages/ui/.storybook/preview.ts`: `a11y.test` を **`"error"`** に
- **a11y=error で 41 files / 328 tests green（違反 0）** を確認。`pnpm verify` 通過。CI（Storybook Test）で a11y が常時 gate される

## 残り（別途・小）
- audio-button お気に入り系 play 2 件は `tags:["!test"]` で隔離継続（popover を開いて portal 内の FavoriteButton を取得する対応は別 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)