### PR TITLE
test(ui): AudioButton お気に入り play テストを popover 経由に修正し隔離解除（SPR-132）

### DIFF
--- a/packages/ui/src/components/custom/audio-button.stories.tsx
+++ b/packages/ui/src/components/custom/audio-button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { AudioButton as AudioButtonType } from "@suzumina.click/shared-types";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, fn, screen, userEvent, within } from "storybook/test";
 import { AudioButton } from "./audio-button";
 
 const meta = {
@@ -129,12 +129,9 @@ export const AuthenticatedWithLikes: Story = {
 	},
 };
 
-// FIXME(SPR-129): お気に入りボタン(FavoriteButton)は detail popover(PopoverActions)内にあり、
-// この play は「詳細を表示」を開かずに探すため見つけられず fail する。修正にはまず popover を開く必要があり、
-// radix popover は portal 描画のため within(canvasElement) では拾えず within(document.body)/screen が要る。
-// 正しいテストに直すまで CI から除外（実装/props は現存。機能欠落ではない）。
+// FavoriteButton は詳細 popover(PopoverActions)内にあるため、まず「詳細を表示」を開いてから取得する。
+// radix popover は portal 描画なので within(canvasElement) では拾えず、screen(document.body) で探す。
 export const FavoriteToggleInteraction: Story = {
-	tags: ["!test"],
 	args: {
 		audioButton: mockAudioButton,
 		onPlay: fn(),
@@ -144,16 +141,15 @@ export const FavoriteToggleInteraction: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const favoriteBtn = canvas.getByRole("button", { name: "お気に入りに追加" });
+		await userEvent.click(canvas.getByRole("button", { name: "詳細を表示" }));
+		const favoriteBtn = await screen.findByRole("button", { name: "お気に入りに追加" });
 		await userEvent.click(favoriteBtn);
 		await expect(args.onFavoriteToggle).toHaveBeenCalledOnce();
 	},
 };
 
-// FIXME(SPR-129): 同上。FavoriteButton は popover 内のため、popover を開いてから取得するよう
-// 直すまで CI から除外（機能欠落ではない）。
+// 同上。未認証時は popover 内の FavoriteButton が disabled になることを確認する。
 export const UnauthenticatedFavoriteDisabled: Story = {
-	tags: ["!test"],
 	args: {
 		audioButton: mockAudioButton,
 		onPlay: fn(),
@@ -163,7 +159,8 @@ export const UnauthenticatedFavoriteDisabled: Story = {
 	},
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
-		const favoriteBtn = canvas.getByRole("button", { name: "お気に入りに追加" });
+		await userEvent.click(canvas.getByRole("button", { name: "詳細を表示" }));
+		const favoriteBtn = await screen.findByRole("button", { name: "お気に入りに追加" });
 		await expect(favoriteBtn).toBeDisabled();
 		await userEvent.click(favoriteBtn);
 		await expect(args.onFavoriteToggle).not.toHaveBeenCalled();

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -557,7 +557,11 @@ export function AudioButton({
 					</PopoverTrigger>
 				</div>
 
-				<PopoverContent className="w-96 p-0 border-suzuka-200" align="start">
+				<PopoverContent
+					className="w-96 p-0 border-suzuka-200"
+					align="start"
+					aria-label={`${audioButton.buttonText} の詳細`}
+				>
 					<AudioButtonPopoverContent
 						audioButton={audioButton}
 						duration={duration}


### PR DESCRIPTION
## 概要

SPR-132 の残作業。隔離していた `AudioButton` のお気に入り play テスト2本を正しく直し、CI（storybook play tests）に復帰させる。

## 背景

`FavoriteButton` は詳細 popover（`PopoverActions`）内にあり、旧 play は「詳細を表示」を開かずに `within(canvasElement)` で探していたため見つけられず、`tags:["!test"]` で CI から除外していた（[#510](https://github.com/nothink-jp/suzumina.click/pull/510) 時点の FIXME）。機能欠落ではなくテストの不備。

## 変更

- `audio-button.stories.tsx`
  - `FavoriteToggleInteraction` / `UnauthenticatedFavoriteDisabled` の play を、**まず「詳細を表示」トリガーを開いてから** `screen.findByRole`（radix popover は portal 描画のため `within(canvasElement)` では拾えない）でお気に入りボタンを取得する形に修正
  - 両 story の隔離 `tags:["!test"]` を解除
- `audio-button.tsx`
  - popover を開くと radix `PopoverContent`（`role="dialog"`）が accessible name 欠如で **axe `aria-dialog-name` に違反**したため、`aria-label` を付与（本番コンポーネントの a11y 改善）

## 検証

- `pnpm test:storybook` → 330 passed（隔離解除後の2本含め全 play green）
- `pnpm verify`（lint + typecheck + 全 unit test）→ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)