### PR TITLE
ci(ui): Chromatic 視覚回帰を CI 導入（PR+TurboSnap / 段階的）（SPR-130）

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,81 @@
+name: Chromatic
+
+# packages/ui の Storybook を Chromatic にアップロードし視覚回帰(visual regression)を検出する（SPR-130）。
+# コスト設計: ui 変更時のみ実行 + TurboSnap(--only-changed) で変更 story だけスナップショットし無料枠を節約。
+# - pull_request: マージ前に視覚差分をレビュー（exitZeroOnChanges で GH チェックはブロックしない＝段階的導入）。
+# - push(main): マージ後のベースライン確立。autoAcceptChanges で main の見た目を新ベースラインに自動採用。
+# play/a11y は storybook-test.yml、本番ビルド回帰は e2e-smoke.yml が担い、本 workflow は見た目の差分のみ担保する。
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      ui: ${{ steps.changes.outputs.ui }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            ui:
+              - 'packages/ui/**'
+              - 'packages/shared-types/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/chromatic.yml'
+
+  chromatic:
+    name: Visual regression (Chromatic)
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.ui == 'true'
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # TurboSnap は変更検出に git 履歴を使うため全履歴を取得する
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.16.0'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Chromatic
+        uses: chromaui/action@v17
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/ui
+          buildScriptName: build-storybook
+          # TurboSnap: 変更に関係する story のみスナップショット
+          onlyChanged: true
+          # 視覚差分があっても GH チェックは成功させる（差分は Chromatic 上でレビュー＝段階的導入）
+          exitZeroOnChanges: true
+          # main では差分を新ベースラインとして自動採用（PR で既にレビュー済みのため）
+          autoAcceptChanges: main

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -110,8 +110,11 @@ pnpm test
 pnpm test:coverage
 
 # Storybook の story を play(interaction)/a11y テストとして browser モードで実行
-# （vitest + playwright。a11y は現状 "todo"＝可視化のみ。CI: storybook-test.yml）
+# （vitest + playwright。a11y 違反は CI fail＝"error" ゲート。CI: storybook-test.yml）
 pnpm test:storybook
+
+# Chromatic 視覚回帰（要 CHROMATIC_PROJECT_TOKEN。--only-changed で変更 story のみ）
+pnpm chromatic
 
 # 型チェック
 pnpm typecheck
@@ -209,7 +212,7 @@ pnpm exec biome check --write src/components/ui
 - **デザイントークン変更**: 対応する Storybook を必ず更新
 - **新規コンポーネント**: Storybook ストーリー作成を推奨
 - **ブランドカラー**: suzuka/minase colors の一貫性維持
-- **Chromatic**: 視覚的回帰テスト対象（段階的導入）
+- **Chromatic**: 視覚回帰を CI 導入済み（`chromatic.yml`）。ui 変更時のみ + TurboSnap(`--only-changed`) で無料枠を節約。PR では差分をレビュー（GH チェックはブロックしない段階的導入）、main push で新ベースラインを自動採用。ハード gate 化は将来 `exitZeroOnChanges` を外して切替可能
 
 ## 📚 関連ドキュメント
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,8 @@
 		"test:critical": "vitest run --reporter=verbose button.test.tsx dialog.test.tsx",
 		"clean": "rimraf coverage storybook-static node_modules/.cache .vitest",
 		"storybook": "storybook dev -p 6006",
-		"build-storybook": "storybook build"
+		"build-storybook": "storybook build",
+		"chromatic": "chromatic --build-script-name=build-storybook --only-changed"
 	},
 	"dependencies": {
 		"@suzumina.click/shared-types": "workspace:*",
@@ -54,6 +55,7 @@
 		"@vitest/browser": "^4.1.8",
 		"@vitest/browser-playwright": "^4.1.8",
 		"@vitest/coverage-v8": "^4.1.8",
+		"chromatic": "^17.2.0",
 		"happy-dom": "^20.9.0",
 		"next": "^16.2.7",
 		"playwright": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      chromatic:
+        specifier: ^17.2.0
+        version: 17.2.0
       happy-dom:
         specifier: ^20.9.0
         version: 20.9.0
@@ -3039,6 +3042,22 @@ packages:
 
   chromatic@16.10.0:
     resolution: {integrity: sha512-nFsztmnu7rFiGafUJgXvLUNpqmRylz92eNvzBoJNTKKQj4EQUyxznwnfpf1dTs7hXtWD8JwcH92jADydaHA1sw==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
+        optional: true
+
+  chromatic@17.2.0:
+    resolution: {integrity: sha512-jxuFtNNMuxbVcM2oAAPsa1fDuygt5e1SVJpvTmvSPkVXFQGylFvApsbhDP9a94qI8QMJeUMmts4bXMqrBotWjg==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
@@ -7561,6 +7580,10 @@ snapshots:
   check-error@2.1.3: {}
 
   chromatic@16.10.0:
+    dependencies:
+      semver: 7.8.1
+
+  chromatic@17.2.0:
     dependencies:
       semver: 7.8.1
 


### PR DESCRIPTION
## 概要

SPR-130。`@chromatic-com/storybook` アドオンは導入済みだが `chromatic` script も CI step も無く**一度も実行されていなかった**ため、Chromatic 視覚回帰を CI に本配線する。

トリガー方針は **PR(ui変更時) + TurboSnap**（無料枠節約・マージ前レビュー優先）を選択。

## 変更

- **`.github/workflows/chromatic.yml`（新規）**
  - `changes` ジョブで **ui 変更時のみ**実行（`storybook-test.yml` と同じ paths-filter）
  - `pull_request`（main 宛）: マージ前に視覚差分をレビュー。`exitZeroOnChanges: true` で **GH チェックはブロックしない**（段階的導入。差分は Chromatic UI で確認）
  - `push`（main）: マージ後のベースライン確立。`autoAcceptChanges: main` で main の見た目を新ベースラインに自動採用
  - `onlyChanged: true`（**TurboSnap**）で変更に関係する story だけスナップショット。`fetch-depth: 0` で履歴取得
  - `chromaui/action@v17`（chromatic CLI と連動。最新 17.2.0）
- **`packages/ui/package.json`**: `chromatic` CLI を devDependency 追加 + `pnpm chromatic`（`--only-changed`）script
- **`packages/ui/README.md`**: 「Chromatic: 段階的導入」を実態に更新。あわせて a11y ゲートの古い `"todo"` 記述を `"error"`（SPR-132 で達成済み）に修正

## ⚠️ オーナー作業（マージ前に必要）

`CHROMATIC_PROJECT_TOKEN` を **GitHub Secret に登録**してください（取得済みトークン）。未登録だと chromatic step のみ失敗します。他の step / 他 workflow には影響しません。

```
gh secret set CHROMATIC_PROJECT_TOKEN
```

## 検証

- `pnpm verify`（lint + typecheck + 全 unit test）→ green
- workflow YAML パース OK / `chromatic --version` → 17.2.0
- 初回ビルドで全 story がベースライン化される想定（その後は TurboSnap で差分のみ）

## 留意 / 将来

- 外部 SaaS・無料枠前提。ui 変更時のみ + TurboSnap でスナップショット数を抑制
- ハード gate 化したい場合は `exitZeroOnChanges` を外せば視覚差分で PR をブロックできる

🤖 Generated with [Claude Code](https://claude.com/claude-code)