### PR TITLE
fix(ui): Chromatic で失敗する2 story を修正（SPR-130）

### DIFF
--- a/packages/ui/src/components/custom/audio-player.stories.tsx
+++ b/packages/ui/src/components/custom/audio-player.stories.tsx
@@ -15,6 +15,9 @@ const meta = {
 					"プール化された音声プレイヤー（DOM要素なし）。YouTube Player プールを使用してメモリ効率を向上させています。",
 			},
 		},
+		// ヘッドレスな音声プレイヤーで、YouTube iframe がオフスクリーンの巨大座標に描画され
+		// Chromatic のキャプチャ上限(25M px)を超える。視覚的回帰の対象として無意味なため snapshot を無効化（SPR-130）
+		chromatic: { disableSnapshot: true },
 	},
 	tags: ["autodocs"],
 } satisfies Meta<typeof AudioPlayer>;

--- a/packages/ui/src/components/ui/carousel.stories.tsx
+++ b/packages/ui/src/components/ui/carousel.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { Card, CardContent } from "./card";
 import {
 	Carousel,
@@ -233,9 +233,10 @@ export const NavigationInteraction: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const nextBtn = canvas.getByRole("button", { name: /next slide/i });
-		await expect(nextBtn).toBeEnabled();
+		// embla の初期化後に canScrollNext が立ち Next が enabled になる。描画タイミングに依存するため待つ
+		await waitFor(() => expect(nextBtn).toBeEnabled());
 		await userEvent.click(nextBtn);
 		const prevBtn = canvas.getByRole("button", { name: /previous slide/i });
-		await expect(prevBtn).toBeEnabled();
+		await waitFor(() => expect(prevBtn).toBeEnabled());
 	},
 };


### PR DESCRIPTION
## 概要

[#512](https://github.com/nothink-jp/suzumina.click/pull/512) マージ後の初回 Chromatic 実行で 2 件のエラーが発生したため修正。

## エラーと対応

### 1. `AudioPlayer / Auto Play` — capture limit 超過（Error）
> Your story couldn't be captured because it exceeds our 25,000,000px limit. Its dimensions are -9,998x-9,998px.

`AudioPlayer` は設計上「DOM要素なし」のヘッドレスなプール型プレイヤー。`autoPlay` で YouTube iframe がオフスクリーンの巨大座標に生成され、キャプチャ上限を超える。**視覚回帰の対象として無意味**なため、meta の `parameters.chromatic.disableSnapshot = true` で snapshot を無効化（play/interaction テストは従来通り実行される）。

### 2. `Carousel / Navigation Interaction` — play 失敗（Failed test）
> expect(element).toBeEnabled()

embla の初期化後に `canScrollNext` が立って Next/Prev ボタンが enabled になるが、play が `await` 無しで即 `toBeEnabled()` を assert していた。ローカル vitest では初期化が間に合い通るが、Chromatic の描画タイミングで fail。**`waitFor` で enabled を待つ**よう修正。

## 検証

- `pnpm test:storybook` → 328 passed（carousel play は waitFor 経由で green）
- `pnpm verify`（lint + typecheck + 全 unit test）→ green

マージ後の Chromatic 再実行で両エラーが解消される想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)