### PR TITLE
fix(ui): Chromatic 差分の安定化（フィクスチャ決定論化 + 動画 iframe の snapshot 無効化）

### DIFF
--- a/packages/ui/src/components/custom/configurable-list.stories.tsx
+++ b/packages/ui/src/components/custom/configurable-list.stories.tsx
@@ -18,6 +18,9 @@ interface Product {
 	createdAt: string;
 }
 
+// 視覚回帰(Chromatic)の差分を防ぐため、乱数や現在時刻は使わず index 由来の決定論的な値で生成する
+const FIXTURE_BASE_MS = Date.parse("2024-06-01T00:00:00.000Z");
+
 // サンプルデータ生成
 const generateProducts = (count: number): Product[] => {
 	const categories = ["Electronics", "Books", "Clothing", "Food", "Toys"];
@@ -27,12 +30,12 @@ const generateProducts = (count: number): Product[] => {
 		id: i + 1,
 		name: `Product ${i + 1}`,
 		category: categories[i % categories.length],
-		price: Math.floor(Math.random() * 10000) + 1000,
-		inStock: Math.random() > 0.3,
+		price: ((i * 1373) % 9000) + 1000,
+		inStock: i % 10 < 7,
 		releaseYear: (2020 + (i % 5)).toString(),
-		rating: Math.floor(Math.random() * 5) + 1,
-		tags: tags.filter(() => Math.random() > 0.6),
-		createdAt: new Date(Date.now() - i * 86400000).toISOString(),
+		rating: (i % 5) + 1,
+		tags: tags.filter((_, t) => (i + t) % 3 === 0),
+		createdAt: new Date(FIXTURE_BASE_MS - i * 86400000).toISOString(),
 	}));
 };
 
@@ -282,7 +285,7 @@ const generateTags = (count: number): Tag[] => {
 		id: i + 1,
 		name: categories[i % categories.length],
 		color: colors[i % colors.length],
-		count: Math.floor(Math.random() * 100) + 1,
+		count: ((i * 37) % 100) + 1,
 	}));
 };
 

--- a/packages/ui/src/components/custom/youtube-player.stories.tsx
+++ b/packages/ui/src/components/custom/youtube-player.stories.tsx
@@ -7,6 +7,9 @@ const meta = {
 	component: YouTubePlayer,
 	parameters: {
 		layout: "padded",
+		// 実 YouTube iframe を埋め込むため、再生フレーム/ポスター/読み込み状態が毎回変わり
+		// Chromatic で安定したスナップショットが撮れない。視覚回帰の対象外として無効化（SPR-130）
+		chromatic: { disableSnapshot: true },
 	},
 	tags: ["autodocs"],
 } satisfies Meta<typeof YouTubePlayer>;


### PR DESCRIPTION
## 概要

Chromatic で毎ビルド差分が出ていた story を 2 系統まとめて安定化する。原因が異なる 2 件：

### 1. ConfigurableList — 非決定的フィクスチャ（決定論化で対応）

[configurable-list.stories.tsx](packages/ui/src/components/custom/configurable-list.stories.tsx) の `generateProducts` / `generateTags` が**モジュール読み込み時に `Math.random()` と `Date.now()`** で表示データ（¥価格・在庫・★評価・タグ・件数・作成日）を生成 → ビルドごとに変化。

→ **index 由来の決定論的な値**（+ 固定基準日 `FIXTURE_BASE_MS`）に置換。多様性は保ちつつ安定化。

### 2. YouTubePlayer — ライブ動画 iframe（snapshot 無効化で対応）

[youtube-player.stories.tsx](packages/ui/src/components/custom/youtube-player.stories.tsx) は実 YouTube iframe を埋め込むため、再生フレーム/ポスター/読み込み状態が毎回変わり安定撮影不可（AudioPlayer と同クラス）。

→ meta に `chromatic.disableSnapshot: true`。視覚回帰の対象外に（play/render は従来通り）。

## 補足

`progress.stories.tsx` の `Math.random()` は onClick / setInterval 内（操作起点）のみで、Chromatic は初期状態をキャプチャするため差分要因にならず変更不要。

## 検証

- `pnpm test:storybook` → 330 passed
- `pnpm verify` → green
- フィクスチャから `Math.random` / `Date.now` を除去済みを確認

これらは TurboSnap warmup とは別の、story 自体の非決定性。TurboSnap が効いても残るため先に解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)