### PR TITLE
fix(works): セール終了後も「セール中」が残る不具合を修正

### DIFF
--- a/apps/functions/src/services/dlsite/__tests__/dlsite-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/dlsite-firestore.test.ts
@@ -3,6 +3,7 @@
  * 重要な機能に絞った簡潔なテスト
  */
 
+import { FieldValue } from "@google-cloud/firestore";
 import type { WorkDocument } from "@suzumina.click/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -112,6 +113,39 @@ describe("dlsite-firestore", () => {
 
 			expect(mockBatch.set).not.toHaveBeenCalled();
 			expect(mockBatch.commit).not.toHaveBeenCalled();
+		});
+
+		it("セール終了時（discount/original/point が不在）は FieldValue.delete() で旧値を消す", async () => {
+			// merge 書き込み + ignoreUndefinedProperties では undefined はスキップされ古い割引が残る。
+			// 不在の任意価格フィールドは明示削除されることを保証する（セール中表示が解除されない回帰の防止）。
+			const workAfterSale: WorkDocument = {
+				...sampleWork,
+				price: { current: 1650, currency: "JPY" },
+			};
+			mockQuery.get.mockResolvedValue({ empty: true, docs: [] });
+
+			await saveWorksToFirestore([workAfterSale]);
+
+			const payload = mockBatch.set.mock.calls[0][1] as { price: Record<string, unknown> };
+			expect((payload.price.discount as any).isEqual(FieldValue.delete())).toBe(true);
+			expect((payload.price.original as any).isEqual(FieldValue.delete())).toBe(true);
+			expect((payload.price.point as any).isEqual(FieldValue.delete())).toBe(true);
+			expect(payload.price.current).toBe(1650);
+		});
+
+		it("セール中（discount/original あり）はその値を保持する", async () => {
+			const workOnSale: WorkDocument = {
+				...sampleWork,
+				price: { current: 1320, original: 1650, discount: 20, currency: "JPY" },
+			};
+			mockQuery.get.mockResolvedValue({ empty: true, docs: [] });
+
+			await saveWorksToFirestore([workOnSale]);
+
+			const payload = mockBatch.set.mock.calls[0][1] as { price: Record<string, unknown> };
+			expect(payload.price.discount).toBe(20);
+			expect(payload.price.original).toBe(1650);
+			expect(payload.price.current).toBe(1320);
 		});
 
 		it("最適化構造では全データを保存する（バリデーションはマッパー段階で実行）", async () => {

--- a/apps/functions/src/services/dlsite/dlsite-firestore.ts
+++ b/apps/functions/src/services/dlsite/dlsite-firestore.ts
@@ -4,7 +4,7 @@
  * YouTube実装パターンに従い、DLsite作品データのFirestore保存・取得・更新を行います。
  */
 
-import type { Query } from "@google-cloud/firestore";
+import { FieldValue, type Query } from "@google-cloud/firestore";
 import type { WorkDocument } from "@suzumina.click/shared-types";
 import firestore from "../../infrastructure/database/firestore";
 import { chunkArray } from "../../shared/array-utils";
@@ -15,6 +15,32 @@ import { FAILURE_REASONS, trackMultipleFailedWorks } from "./failure-tracker";
 
 // Firestore関連の定数
 const DLSITE_WORKS_COLLECTION = "works";
+
+/**
+ * Firestore 書き込み用にドキュメントを正規化する。
+ *
+ * クライアントは `ignoreUndefinedProperties: true`、書き込みは `set(..., { merge: true })`。
+ * この組み合わせでは値が undefined のフィールドは「スキップ」されるだけで「削除」されず、
+ * 既存の値が温存される。結果、セール終了で discount / original が消えても古い割引が残り続け、
+ * 「セール中」表示が解除されない（不在＝状態、なのに不在を書き込めない問題）。
+ *
+ * price の任意フィールド（original / discount / point）は不在時に FieldValue.delete() を
+ * 明示し、セール終了などの状態遷移を Firestore 上の正本へ確実に反映する。
+ */
+function toWorkWriteData(work: WorkDocument): WorkDocument {
+	const { original, discount, point } = work.price;
+	// FieldValue.delete() は型上 number ではないため、書き込み専用の値として cast する。
+	const del = FieldValue.delete() as unknown as undefined;
+	return {
+		...work,
+		price: {
+			...work.price,
+			original: original ?? del,
+			discount: discount ?? del,
+			point: point ?? del,
+		},
+	};
+}
 
 /**
  * 単一チャンクのバッチ処理
@@ -29,7 +55,7 @@ async function processChunk(
 
 	for (const work of chunk) {
 		const docRef = collection.doc(work.productId);
-		chunkBatch.set(docRef, work, { merge: true });
+		chunkBatch.set(docRef, toWorkWriteData(work), { merge: true });
 	}
 
 	const startTime = Date.now();
@@ -120,7 +146,7 @@ async function processSingleBatch(works: WorkDocument[]): Promise<void> {
 
 	for (const work of works) {
 		const docRef = collection.doc(work.productId);
-		batch.set(docRef, work, { merge: true });
+		batch.set(docRef, toWorkWriteData(work), { merge: true });
 	}
 
 	await batch.commit();

--- a/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
+++ b/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
@@ -66,14 +66,10 @@ function StarRating({ rating }: { rating: number }) {
 // 価格情報を計算
 function calculatePriceInfo(work: WorkPlainObject) {
 	const currentPrice = work.price.current;
-	// 元の価格を取得、もしくは割引率から計算
-	const originalPrice =
-		work.price.original ||
-		(work.price.discount !== undefined && work.price.discount > 0
-			? Math.round(currentPrice / (1 - work.price.discount / 100))
-			: undefined);
-	// NOTE: 将来的にはWorkPrice.isDiscounted()を使用することを推奨
-	const isOnSale = work.price.discount !== undefined && work.price.discount > 0;
+	// セール判定は「実割引（current < original）」を正本とする。
+	// discount フィールドはセール終了後も古い値が残りうるため判定にも逆算にも使わない（軸3: 正本の整合性）。
+	const isOnSale = work.price.isDiscounted;
+	const originalPrice = isOnSale ? work.price.original : undefined;
 
 	return { currentPrice, originalPrice, isOnSale };
 }

--- a/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
+++ b/apps/web/src/app/works/[workId]/components/WorkDetail.tsx
@@ -67,11 +67,16 @@ function StarRating({ rating }: { rating: number }) {
 function calculatePriceInfo(work: WorkPlainObject) {
 	const currentPrice = work.price.current;
 	// セール判定は「実割引（current < original）」を正本とする。
-	// discount フィールドはセール終了後も古い値が残りうるため判定にも逆算にも使わない（軸3: 正本の整合性）。
+	// discount フィールドはセール終了後も古い値が残りうるため判定にも表示にも使わない（軸3: 正本の整合性）。
 	const isOnSale = work.price.isDiscounted;
 	const originalPrice = isOnSale ? work.price.original : undefined;
+	// 割引率も current/original から算出し、判定と表示の正本を揃える。
+	const discountRate =
+		isOnSale && originalPrice
+			? Math.round(((originalPrice - currentPrice) / originalPrice) * 100)
+			: undefined;
 
-	return { currentPrice, originalPrice, isOnSale };
+	return { currentPrice, originalPrice, isOnSale, discountRate };
 }
 
 // シェア処理
@@ -103,7 +108,10 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 	}, [work.ageRating]);
 
 	// 価格情報の計算
-	const { currentPrice, originalPrice, isOnSale } = useMemo(() => calculatePriceInfo(work), [work]);
+	const { currentPrice, originalPrice, isOnSale, discountRate } = useMemo(
+		() => calculatePriceInfo(work),
+		[work],
+	);
 
 	// ランキング情報は現在利用できません
 	const latestRank = undefined;
@@ -194,7 +202,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 										¥{originalPrice.toLocaleString("ja-JP")}
 									</span>
 									<Badge className="bg-destructive/10 text-destructive text-lg px-3 py-1">
-										{work.price.discount}% OFF
+										{discountRate}% OFF
 									</Badge>
 								</div>
 							) : (

--- a/apps/web/src/app/works/components/WorkCard.tsx
+++ b/apps/web/src/app/works/components/WorkCard.tsx
@@ -125,8 +125,9 @@ export default function WorkCard({ work, variant = "default", priority = false }
 	// 価格表示の計算
 	const currentPrice = work.price?.current ?? 0;
 	const originalPrice = work.price?.original ?? 0;
-	// NOTE: 将来的にはWorkPrice.isDiscounted()を使用することを推奨
-	const isOnSale = work.price?.discount !== undefined && work.price.discount > 0;
+	// セール判定は「実割引（current < original）」を正本とする。
+	// discount フィールドはセール終了後も古い値が残りうるため判定に使わない（軸3: 正本の整合性）。
+	const isOnSale = work.price?.isDiscounted ?? false;
 
 	// ランキング情報は現在利用できません
 	const latestRank = undefined;


### PR DESCRIPTION
## 概要
作品一覧・作品詳細で、セールが終了した作品にも「セール中」バッジと割引表示が残り続ける不具合を修正する。

スクリーンショットの症状（**現在価格 ¥1,650 = 取り消し線価格 ¥1,650（同額）かつ 20% OFF**）は、修正前ロジックで算出される値と完全一致しており、原因を確定済み。

## 原因
Firestore の `merge: true`（`works` への書き込み）+ `ignoreUndefinedProperties: true`（クライアント設定）の組み合わせでは、値が `undefined` のフィールドは**削除されずスキップ**される。

セール終了時、マッパーは `price.discount` / `price.original` を `undefined` にするが、上記により Firestore 上の旧値が削除されず残存（sticky 化）。UI のセール判定が `discount > 0` だったため「セール中」が解除されなかった。

> 非正規化そのものより、「派生フィールドの“不在”が状態を意味するのに、書き込み層が不在を表現できない」点が真因。

## 修正（2層）
### ① 書き込み層（根治）
- `dlsite-firestore.ts` に `toWorkWriteData` を追加。不在の任意価格フィールド（`original` / `discount` / `point`）を `FieldValue.delete()` で明示削除し、2つの書き込み箇所に適用。
- セール終了が Firestore 上の正本へ正しく反映される。

### ② UI 層（防御 + 既存汚染データの即時救済）
- セール判定を `discount > 0` から実割引 `current < original`（既存の computed プロパティ `work.price.isDiscounted`）に変更。
- `WorkCard.tsx` / `WorkDetail.tsx`（`WorkDetail` は割引率からの逆算も廃止）。
- 既に汚染されたデータも再デプロイ時点で即座にバッジが消える（再フェッチ待ち不要）。

## 効果
- 既存汚染データ：②でデプロイ即解消。
- 正本データ：①で次回取得 cron（2時間ごと）に `discount`/`original` が削除され Firestore も整合。
- 整合性 cron への事後修復追加は不要（CLAUDE.md「設計で守る」方針に沿う）。

## テスト
- `pnpm verify` 全パス（lint + typecheck + test）。
- 回帰防止テスト2件を追加（セール終了時に `FieldValue.delete()` が書かれること／セール中は値が保持されること）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)