### PR TITLE
perf(infra): Cloud Run を cpu_idle=true に戻してコスト最適化（SPR-83）

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -9,11 +9,14 @@ locals {
   environment_config = {
     production = {
       # 本番環境（個人利用レベル・パフォーマンス改善）
-      cloud_run_min_instances = 1        # LCP改善: コールドスタート排除
-      cloud_run_max_instances = 2        # 最大インスタンス数を制限
-      cloud_run_cpu           = "1"      # 1vCPU: アイドル後レスポンス遅延を改善（gcloud --cpu 1 の表記に整合）
-      cloud_run_cpu_idle      = false    # CPUを常時割り当て: アイドル後のスロットリング防止
-      cloud_run_memory        = "1024Mi" # メモリ増強（1GB）でGC改善
+      cloud_run_min_instances = 1   # LCP改善: コールドスタート排除
+      cloud_run_max_instances = 2   # 最大インスタンス数を制限
+      cloud_run_cpu           = "1" # 1vCPU: アイドル後レスポンス遅延を改善（gcloud --cpu 1 の表記に整合）
+      # SPR-83: cpu_idle=false は billable_instance_time を約28倍に増やす主因（+~¥8,700/月）。
+      # この規模（~0.1 req/s）では min_instances=1 の常時ウォーム + warm-up scheduler の
+      # `/` ping（JIT維持）で体感速度は確保でき、24/7フルレート課金は過剰なため true に戻す。
+      cloud_run_cpu_idle = true     # アイドル時はCPU課金を停止（min_instances=1 でウォームは維持）
+      cloud_run_memory   = "1024Mi" # メモリ増強（1GB）でGC改善
       # functions_* は ADR-009/SPR-92 で Actions 専管化。spec の正本は deploy-functions.yml
       budget_amount        = 5000 # 月額5000円制限
       enable_monitoring    = true # フル監視


### PR DESCRIPTION
## 背景（SPR-83）
perf 対応後の GCP 課金増を Cloud Monitoring で計測した結果、**5/24 の `cpu_idle=false` 切替が課金急増の単独主因**と判明した。

| メトリクス | Before（~5/22） | After（5/24~） | 倍率 |
|---|---|---|---|
| Cloud Run 課金対象インスタンス時間 | ~3,650 秒/日 | ~104,000 秒/日 | **約28倍** |

- `min_instances=1` は SPR-3 より前から設定済みで、変更前は 3,650秒/日 しか課金されていなかった → 急増は `cpu_idle=false`（CPU常時割当＝24/7フルレート課金）が主因。
- コスト試算（list price 概算）：Cloud Run compute が **~$1.6/月 → ~$60/月（+~¥8,700/月）**。

## 変更
`terraform/locals.tf` の production ブロック：`cloud_run_cpu_idle = false → true`（1点のみ）。

- `min_instances=1` と `startup_cpu_boost` は維持 → **コールドスタート排除（UXの主便益）はそのまま**。
- この規模（~0.1 req/s）では warm-up scheduler の `/` ping（JIT維持）が cpu_idle=false を代替できる。

## 反映後の確認
反映後 `billable_instance_time` を **3〜5日実測**し、コスト低下と体感速度の維持を確認する。

## plan（targeted, 確認済み）
\`\`\`
~ resources {
    ~ cpu_idle = false -> true
  }
Plan: 0 to add, 1 to change, 0 to destroy.
\`\`\`

Linear: [SPR-83](https://linear.app/nothink/issue/SPR-83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)