### PR TITLE
chore(web): 未使用の環境変数を整理し .env.example を整備

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -15,6 +15,12 @@ GOOGLE_CLOUD_PROJECT=suzumina-click
 # 通常は `pnpm dev:local` が自動設定するため手動指定は不要。本番では絶対に設定しない。
 # FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
 
+# ── サイト / アクセス制御（任意）──
+# robots.txt / sitemap.xml の canonical URL。未設定なら https://suzumina.click
+# NEXT_PUBLIC_APP_URL=https://suzumina.click
+# 本番のみ有効な host 許可リスト（カンマ区切り）。未設定なら検証しない。ローカルでは不要。
+# ALLOWED_HOSTS=suzumina.click,www.suzumina.click
+
 # ── 外部 API ──
 # YouTube Data API（動画情報の取得）
 YOUTUBE_API_KEY=your_youtube_api_key_here

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,38 +1,31 @@
-# Discord OAuth Application Settings
-# Create at: https://discord.com/developers/applications
+# apps/web 環境変数テンプレート
+# 値を埋めて .env / .env.local にコピーして使う。NEXT_PUBLIC_* はブラウザに露出する。
+
+# ── 認証（Discord OAuth + NextAuth）──
+# Discord App: https://discord.com/developers/applications
 DISCORD_CLIENT_ID=your_discord_client_id_here
 DISCORD_CLIENT_SECRET=your_discord_client_secret_here
-
-
-# NextAuth Secret
-# Generate with: openssl rand -base64 32
+# NEXTAUTH_SECRET の生成: openssl rand -base64 32
 NEXTAUTH_SECRET=your_nextauth_secret_here
-
-# NextAuth URL
 NEXTAUTH_URL=http://localhost:3000
 
-# Google Cloud Configuration
+# ── Google Cloud / Firestore ──
 GOOGLE_CLOUD_PROJECT=suzumina-click
-
-# Firestore Emulator (ローカル開発)
-# 設定すると @google-cloud/firestore SDK が Emulator に接続し、ADC 不要・本番に触れない。
-# 通常は `pnpm dev:local`（Emulator 起動 + シード + dev 起動）が自動で設定するため、
-# 手動で .env.local に置く必要はない。本番では絶対に設定しないこと。
+# Firestore Emulator 接続先。設定すると ADC 不要・本番に触れない（ローカル専用）。
+# 通常は `pnpm dev:local` が自動設定するため手動指定は不要。本番では絶対に設定しない。
 # FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
 
-# YouTube API (for video information)
+# ── 外部 API ──
+# YouTube Data API（動画情報の取得）
 YOUTUBE_API_KEY=your_youtube_api_key_here
-
-# Google Analytics Configuration
-# Get your Measurement ID from Google Analytics 4
-NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
-
-
-# Email Configuration (Resend)
-# Get your API key from: https://resend.com/api-keys
+# Resend（お問い合わせメール送信）: https://resend.com/api-keys
 RESEND_API_KEY=re_your_resend_api_key_here
 
-# Email Recipients for Contact Form
-# Comma-separated list of email addresses to receive contact form notifications
-CONTACT_EMAIL_RECIPIENTS=your-email@example.com,another-email@example.com
+# ── 計測・解析（任意）──
+# GA4 Measurement ID / Google Tag Manager Container ID
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+NEXT_PUBLIC_GTM_ID=GTM-XXXXXXX
 
+# ── お問い合わせ ──
+# 通知先メールアドレス（カンマ区切りで複数指定可）
+CONTACT_EMAIL_RECIPIENTS=your-email@example.com,another-email@example.com


### PR DESCRIPTION
## 概要
`apps/web` の環境変数を網羅調査（ソース / テスト / Terraform / CI）し、参照のない dead 変数を整理。あわせて `.env.example` の可読性を向上した。

## 削除した dead 環境変数
ローカルの `.env` / `.env.local` から削除（いずれも gitignore 対象のため本 PR の差分には含まれない。手元の作業ツリーで反映済み）。

| 変数 | 削除理由 |
|---|---|
| `DEFAULT_ADMIN_DISCORD_IDS` | admin role は Firestore 取得（`getUserRoleFromFirestore`）へ移行済み。changelog にも「完全削除」と記録あり |
| `NEXT_PUBLIC_ADSENSE_CLIENT_ID` | AdSense 関連の実装が一切存在しない |
| `NEXT_PUBLIC_AMAZON_ASSOCIATE_ID` | コメントアウト済・未使用 |
| `ENABLE_ENTITY_V2` | フラグを読むコードがなく Entity V2 は常時有効 |

## `.env.example`（本 PR の差分）
- 用途別セクション（認証 / Google Cloud・Firestore / 外部 API / 計測・解析 / お問い合わせ）へ再構成
- 使用中なのに記載漏れだった `NEXT_PUBLIC_GTM_ID` を追記
- 冗長なコメントを削り、生成コマンドや Emulator の本番禁止注意など判断に効く情報のみ残した

## 確認
- 残した変数（`DISCORD_*` / `NEXTAUTH_*` / `GOOGLE_CLOUD_PROJECT` / `YOUTUBE_API_KEY` / `NEXT_PUBLIC_GA_MEASUREMENT_ID` / `NEXT_PUBLIC_GTM_ID` / `RESEND_API_KEY` / `CONTACT_EMAIL_RECIPIENTS` / `FIRESTORE_EMULATOR_HOST`）はすべてコード参照を確認済み
- pre-commit（secretlint）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)