### PR TITLE
feat(functions): 整合性チェックに dry-run とエミュレータ注入テストを追加（SPR-138）

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -14,6 +14,7 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
+		"test:integration": "vitest run src/endpoints/__tests__/data-integrity-check.integration.test.ts",
 		"seed:dump": "dotenv -e .env -- tsx src/tools/firestore-local/dump.ts",
 		"seed:load": "tsx src/tools/firestore-local/seed.ts",
 		"collect:work-ids": "dotenv -e .env -- tsx src/tools/core/collect-work-ids.ts",

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * データ整合性チェックのインテグレーションテスト（Firestore Emulator 実機）
+ *
+ * 既知の壊れデータを Emulator に注入 → runIntegrityCheck を実行 →
+ * 「検出件数・修正件数」と「修復後の Firestore 実体」を assert する。
+ * モックでは検証できない実際の集計ロジックの正しさを確認するのが目的（SPR-138）。
+ *
+ * 実行（専用ポートで Emulator を起動して回す）:
+ *   pnpm test:integration            （リポジトリルート）
+ *
+ * 安全装置:
+ *   - RUN_INTEGRATION_TESTS と FIRESTORE_EMULATOR_HOST の両方が無いと describe ごとスキップ。
+ *     → 通常の `pnpm test` / CI（Emulator 無し）では実行されない。
+ *   - 各テスト前に Emulator のデータを全消去するため、dev:local(8080) とは別ポートを使うこと。
+ *   - NODE_ENV=test でも Emulator に接続できるよう ALLOW_TEST_FIRESTORE を有効化する。
+ */
+
+import type { Firestore } from "@google-cloud/firestore";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { runIntegrityCheck as RunIntegrityCheck } from "../data-integrity-check";
+
+const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST;
+const RUN = Boolean(process.env.RUN_INTEGRATION_TESTS) && Boolean(EMULATOR_HOST);
+const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || "suzumina-click";
+
+let getFirestore: () => Firestore;
+let resetFirestoreInstance: () => void;
+let runIntegrityCheck: typeof RunIntegrityCheck;
+
+/** Emulator の全ドキュメントを消去する（REST 管理エンドポイント） */
+async function clearEmulator(): Promise<void> {
+	const url = `http://${EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
+	const res = await fetch(url, { method: "DELETE" });
+	if (!res.ok) {
+		throw new Error(`Emulator のデータ消去に失敗: ${res.status} ${await res.text()}`);
+	}
+}
+
+describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", () => {
+	beforeAll(async () => {
+		// 本番接続ブロック（NODE_ENV=test）を回避し Emulator へ向ける
+		process.env.ALLOW_TEST_FIRESTORE = "true";
+		process.env.GOOGLE_CLOUD_PROJECT = PROJECT_ID;
+
+		const firestoreModule = await import("../../infrastructure/database/firestore");
+		getFirestore = firestoreModule.getFirestore;
+		resetFirestoreInstance = firestoreModule.resetFirestoreInstance;
+		({ runIntegrityCheck } = await import("../data-integrity-check"));
+	});
+
+	beforeEach(async () => {
+		await clearEmulator();
+		resetFirestoreInstance();
+	});
+
+	afterAll(async () => {
+		await clearEmulator();
+	});
+
+	it("Circle workIds の重複と存在しない作品IDを除去する", async () => {
+		const db = getFirestore();
+		await db.collection("works").doc("RJ001").set({ title: "w1", circleId: "RG001" });
+		await db.collection("works").doc("RJ002").set({ title: "w2", circleId: "RG001" });
+		// 重複(RJ001) + 存在しない作品(RJ999)
+		await db
+			.collection("circles")
+			.doc("RG001")
+			.set({
+				workIds: ["RJ001", "RJ001", "RJ002", "RJ999"],
+			});
+
+		const result = await runIntegrityCheck();
+
+		expect(result.checks.circleWorkCounts.checked).toBe(1);
+		expect(result.checks.circleWorkCounts.fixed).toBeGreaterThan(0);
+
+		const circle = await db.collection("circles").doc("RG001").get();
+		expect((circle.data()?.workIds as string[]).sort()).toEqual(["RJ001", "RJ002"]);
+	});
+
+	it("孤立した Creator マッピングと空 Creator を削除する", async () => {
+		const db = getFirestore();
+		await db.collection("works").doc("RJ001").set({ title: "w1", circleId: "RG001" });
+
+		// CR1: 有効(RJ001) + 孤立(RJ999)
+		await db.collection("creators").doc("CR1").set({ name: "c1" });
+		await db
+			.collection("creators")
+			.doc("CR1")
+			.collection("works")
+			.doc("RJ001")
+			.set({ workId: "RJ001" });
+		await db
+			.collection("creators")
+			.doc("CR1")
+			.collection("works")
+			.doc("RJ999")
+			.set({ workId: "RJ999" });
+		// CR2: 孤立のみ → Creator ごと削除
+		await db.collection("creators").doc("CR2").set({ name: "c2" });
+		await db
+			.collection("creators")
+			.doc("CR2")
+			.collection("works")
+			.doc("RJ888")
+			.set({ workId: "RJ888" });
+
+		const result = await runIntegrityCheck();
+
+		expect(result.checks.orphanedCreators.found).toBeGreaterThanOrEqual(2);
+
+		// 孤立マッピングは消え、有効マッピングは残る
+		expect(
+			(await db.collection("creators").doc("CR1").collection("works").doc("RJ999").get()).exists,
+		).toBe(false);
+		expect(
+			(await db.collection("creators").doc("CR1").collection("works").doc("RJ001").get()).exists,
+		).toBe(true);
+		// 全孤立の Creator ドキュメントは削除される
+		expect((await db.collection("creators").doc("CR2").get()).exists).toBe(false);
+	});
+
+	it("Work-Circle 相互参照のずれ（circle.workIds に未登録）を補う", async () => {
+		const db = getFirestore();
+		await db.collection("circles").doc("RG001").set({ workIds: [] });
+		await db.collection("works").doc("RJ001").set({ title: "w1", circleId: "RG001" });
+
+		const result = await runIntegrityCheck();
+
+		expect(result.checks.workCircleConsistency.fixed).toBeGreaterThanOrEqual(1);
+		const circle = await db.collection("circles").doc("RG001").get();
+		expect(circle.data()?.workIds as string[]).toContain("RJ001");
+	});
+
+	it("作品の creators から失われた Creator-Work マッピングを復元する", async () => {
+		const db = getFirestore();
+		await db
+			.collection("circles")
+			.doc("RG001")
+			.set({ workIds: ["RJ001"] });
+		await db
+			.collection("works")
+			.doc("RJ001")
+			.set({
+				title: "w1",
+				circleId: "RG001",
+				circle: "サークル名",
+				creators: { voice_by: [{ id: "CR1", name: "声優1" }] },
+			});
+
+		const result = await runIntegrityCheck();
+
+		expect(result.checks.creatorWorkRestore?.restored).toBeGreaterThanOrEqual(1);
+		expect(result.checks.creatorWorkRestore?.creatorsCreated).toBeGreaterThanOrEqual(1);
+
+		expect((await db.collection("creators").doc("CR1").get()).exists).toBe(true);
+		expect(
+			(await db.collection("creators").doc("CR1").collection("works").doc("RJ001").get()).exists,
+		).toBe(true);
+	});
+
+	it("dry-run では不整合を検出するが Firestore を変更しない", async () => {
+		const db = getFirestore();
+		await db.collection("works").doc("RJ001").set({ title: "w1", circleId: "RG001" });
+		await db
+			.collection("circles")
+			.doc("RG001")
+			.set({ workIds: ["RJ001", "RJ001"] }); // 重複
+
+		const result = await runIntegrityCheck({ dryRun: true });
+
+		// 要修正としてカウントはされる
+		expect(result.dryRun).toBe(true);
+		expect(result.checks.circleWorkCounts.fixed).toBeGreaterThan(0);
+
+		// 実体は変更されていない（重複が残っている）
+		const circle = await db.collection("circles").doc("RG001").get();
+		expect(circle.data()?.workIds as string[]).toEqual(["RJ001", "RJ001"]);
+
+		// 結果ドキュメントも書かれていない
+		expect((await db.collection("dlsiteMetadata").doc("dataIntegrityCheck").get()).exists).toBe(
+			false,
+		);
+	});
+});

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
@@ -27,6 +27,18 @@ let getFirestore: () => Firestore;
 let resetFirestoreInstance: () => void;
 let runIntegrityCheck: typeof RunIntegrityCheck;
 
+// 変更前の env を退避し、afterAll で復元する（プロセスグローバルの汚染防止）
+let prevAllowTestFirestore: string | undefined;
+let prevProjectId: string | undefined;
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+	} else {
+		process.env[key] = value;
+	}
+}
+
 /** Emulator の全ドキュメントを消去する（REST 管理エンドポイント） */
 async function clearEmulator(): Promise<void> {
 	const url = `http://${EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
@@ -39,6 +51,8 @@ async function clearEmulator(): Promise<void> {
 describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", () => {
 	beforeAll(async () => {
 		// 本番接続ブロック（NODE_ENV=test）を回避し Emulator へ向ける
+		prevAllowTestFirestore = process.env.ALLOW_TEST_FIRESTORE;
+		prevProjectId = process.env.GOOGLE_CLOUD_PROJECT;
 		process.env.ALLOW_TEST_FIRESTORE = "true";
 		process.env.GOOGLE_CLOUD_PROJECT = PROJECT_ID;
 
@@ -55,6 +69,9 @@ describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", (
 
 	afterAll(async () => {
 		await clearEmulator();
+		// env を元に戻し、他テストの本番接続ブロックを緩めたままにしない
+		restoreEnv("ALLOW_TEST_FIRESTORE", prevAllowTestFirestore);
+		restoreEnv("GOOGLE_CLOUD_PROJECT", prevProjectId);
 	});
 
 	it("Circle workIds の重複と存在しない作品IDを除去する", async () => {

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../shared/logger", () => ({
 
 import firestore from "../../infrastructure/database/firestore";
 // テスト対象をインポート（モックの後）
-import { checkDataIntegrity } from "../data-integrity-check";
+import { checkDataIntegrity, runIntegrityCheck } from "../data-integrity-check";
 
 // モック関数をvitestから取得
 const mockCollection = vi.mocked(firestore.collection);
@@ -397,5 +397,47 @@ describe("checkDataIntegrity", () => {
 				}),
 			}),
 		});
+	});
+
+	it("dry-run では不整合を検出するが Firestore へ書き込まない", async () => {
+		// 重複作品IDを持つサークル（要修正のケース）
+		const mockCircles = {
+			size: 1,
+			docs: [
+				{
+					id: "circle1",
+					data: () => ({
+						workIds: ["work1", "work1", "work2"], // 重複あり
+					}),
+					ref: { update: mockUpdate },
+				},
+			],
+		};
+		const mockWorkDoc = { get: vi.fn().mockResolvedValue({ exists: true }) };
+		const emptySnapshot = { size: 0, docs: [] };
+
+		mockCollection.mockImplementation((collName: string) => {
+			if (collName === "circles") {
+				return { get: vi.fn().mockResolvedValue(mockCircles), doc: mockDoc };
+			}
+			if (collName === "creators" || collName === "works") {
+				return { get: vi.fn().mockResolvedValue(emptySnapshot), doc: vi.fn(() => mockWorkDoc) };
+			}
+			// dlsiteMetadata に触れたら書き込み扱いなので最小限で返す
+			return {
+				doc: vi.fn(() => ({ set: mockSet, collection: vi.fn() })),
+			};
+		});
+
+		const result = await runIntegrityCheck({ dryRun: true });
+
+		// 検出・集計は行われる
+		expect(result.dryRun).toBe(true);
+		expect(result.checks.circleWorkCounts.fixed).toBeGreaterThan(0);
+		expect(result.totalFixed).toBeGreaterThan(0);
+
+		// 書き込み系は一切呼ばれない（commit / 結果保存の set）
+		expect(mockCommit).not.toHaveBeenCalled();
+		expect(mockSet).not.toHaveBeenCalled();
 	});
 });

--- a/apps/functions/src/endpoints/data-integrity-check.ts
+++ b/apps/functions/src/endpoints/data-integrity-check.ts
@@ -5,6 +5,11 @@
  * - CircleのworkIds配列の整合性
  * - 孤立したCreatorマッピングのクリーンアップ
  * - Work-Circle相互参照の整合性
+ *
+ * dryRun（report-only）モード:
+ *   集計・検出は通常どおり行い「修正したであろう件数」をカウントするが、
+ *   Firestore への書き込み（batch.commit / 結果保存）は一切行わない。
+ *   本番データを汚さずに「整合性関数が何を直すか」を確認するための観測専用モード。
  */
 
 import type {
@@ -25,10 +30,23 @@ const INTEGRITY_CHECK_DOC_ID = "dataIntegrityCheck";
 const FIRESTORE_BATCH_LIMIT = 400;
 
 /**
+ * 整合性チェックの実行オプション
+ */
+export interface IntegrityCheckOptions {
+	/**
+	 * true の場合、検出・集計のみ行い Firestore への書き込みを一切行わない（report-only）。
+	 * 既定は false（＝従来どおり修正を書き込む）。本番スケジュール実行は false。
+	 */
+	dryRun?: boolean;
+}
+
+/**
  * 整合性チェック結果の型定義
  */
-interface IntegrityCheckResult {
+export interface IntegrityCheckResult {
 	timestamp: string;
+	/** report-only モードで実行されたか（書き込みをスキップしたか） */
+	dryRun: boolean;
 	checks: {
 		circleWorkCounts: {
 			checked: number;
@@ -59,7 +77,7 @@ interface IntegrityCheckResult {
 /**
  * CircleのworkIds配列の整合性をチェック
  */
-async function checkCircleWorkCounts(result: IntegrityCheckResult): Promise<void> {
+async function checkCircleWorkCounts(result: IntegrityCheckResult, dryRun: boolean): Promise<void> {
 	logger.info("CircleのworkIds配列の整合性チェックを開始");
 
 	const circlesSnapshot = await firestore.collection("circles").get();
@@ -91,7 +109,7 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult): Promise<void
 			batchCount++;
 
 			// バッチサイズ制限
-			if (batchCount >= FIRESTORE_BATCH_LIMIT) {
+			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
 				await batch.commit();
 				batchCount = 0;
 			}
@@ -121,26 +139,26 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult): Promise<void
 			result.checks.circleWorkCounts.fixed++;
 			batchCount++;
 
-			if (batchCount >= FIRESTORE_BATCH_LIMIT) {
+			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
 				await batch.commit();
 				batchCount = 0;
 			}
 		}
 	}
 
-	if (batchCount > 0) {
+	if (!dryRun && batchCount > 0) {
 		await batch.commit();
 	}
 
 	logger.info(
-		`CircleのworkIds配列チェック完了: ${result.checks.circleWorkCounts.checked}件チェック、${result.checks.circleWorkCounts.fixed}件修正`,
+		`CircleのworkIds配列チェック完了: ${result.checks.circleWorkCounts.checked}件チェック、${result.checks.circleWorkCounts.fixed}件${dryRun ? "要修正" : "修正"}`,
 	);
 }
 
 /**
  * 孤立したCreatorマッピングをチェック
  */
-async function checkOrphanedCreators(result: IntegrityCheckResult): Promise<void> {
+async function checkOrphanedCreators(result: IntegrityCheckResult, dryRun: boolean): Promise<void> {
 	logger.info("孤立したCreatorマッピングのチェックを開始");
 
 	const creatorsSnapshot = await firestore.collection("creators").get();
@@ -166,7 +184,7 @@ async function checkOrphanedCreators(result: IntegrityCheckResult): Promise<void
 				result.checks.orphanedCreators.cleaned++;
 				batchCount++;
 
-				if (batchCount >= FIRESTORE_BATCH_LIMIT) {
+				if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
 					await batch.commit();
 					batchCount = 0;
 				}
@@ -182,19 +200,19 @@ async function checkOrphanedCreators(result: IntegrityCheckResult): Promise<void
 			result.checks.orphanedCreators.cleaned++;
 			batchCount++;
 
-			if (batchCount >= FIRESTORE_BATCH_LIMIT) {
+			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
 				await batch.commit();
 				batchCount = 0;
 			}
 		}
 	}
 
-	if (batchCount > 0) {
+	if (!dryRun && batchCount > 0) {
 		await batch.commit();
 	}
 
 	logger.info(
-		`孤立Creatorチェック完了: ${result.checks.orphanedCreators.checked}件チェック、${result.checks.orphanedCreators.cleaned}件クリーンアップ`,
+		`孤立Creatorチェック完了: ${result.checks.orphanedCreators.checked}件チェック、${result.checks.orphanedCreators.cleaned}件${dryRun ? "要クリーンアップ" : "クリーンアップ"}`,
 	);
 }
 
@@ -278,13 +296,17 @@ async function restoreCreatorWorkMapping(
 }
 
 /**
- * バッチが満杯の場合はコミット
+ * バッチが満杯の場合はコミット（dryRun の場合は書き込まない）
  */
 async function commitBatchIfNeeded(
 	batch: WriteBatch,
 	stats: RestoreStats,
 	force = false,
+	dryRun = false,
 ): Promise<void> {
+	if (dryRun) {
+		return;
+	}
 	if (stats.batchCount >= FIRESTORE_BATCH_LIMIT || (force && stats.batchCount > 0)) {
 		await batch.commit();
 		stats.batchCount = 0;
@@ -294,7 +316,10 @@ async function commitBatchIfNeeded(
 /**
  * 削除されたCreator-Work関連を復元
  */
-async function restoreCreatorWorkRelations(result: IntegrityCheckResult): Promise<void> {
+async function restoreCreatorWorkRelations(
+	result: IntegrityCheckResult,
+	dryRun: boolean,
+): Promise<void> {
 	logger.info("Creator-Work関連の復元を開始");
 
 	const worksSnapshot = await firestore.collection("works").get();
@@ -339,19 +364,19 @@ async function restoreCreatorWorkRelations(result: IntegrityCheckResult): Promis
 				);
 
 				// バッチサイズチェック
-				await commitBatchIfNeeded(batch, stats);
+				await commitBatchIfNeeded(batch, stats, false, dryRun);
 
 				// Creator-Workマッピングの復元
 				await restoreCreatorWorkMapping(creatorRef, workDoc, workData, creator, type, batch, stats);
 
 				// バッチサイズチェック
-				await commitBatchIfNeeded(batch, stats);
+				await commitBatchIfNeeded(batch, stats, false, dryRun);
 			}
 		}
 	}
 
 	// 残りのバッチをコミット
-	await commitBatchIfNeeded(batch, stats, true);
+	await commitBatchIfNeeded(batch, stats, true, dryRun);
 
 	// 結果に追加
 	result.checks.creatorWorkRestore = {
@@ -361,14 +386,17 @@ async function restoreCreatorWorkRelations(result: IntegrityCheckResult): Promis
 	};
 
 	logger.info(
-		`Creator-Work関連復元完了: ${worksSnapshot.size}件チェック、${stats.restoredCount}件マッピング復元、${stats.creatorsCreated}件Creator作成`,
+		`Creator-Work関連復元完了: ${worksSnapshot.size}件チェック、${stats.restoredCount}件マッピング${dryRun ? "要復元" : "復元"}、${stats.creatorsCreated}件Creator${dryRun ? "要作成" : "作成"}`,
 	);
 }
 
 /**
  * Work-Circle相互参照の整合性をチェック
  */
-async function checkWorkCircleConsistency(result: IntegrityCheckResult): Promise<void> {
+async function checkWorkCircleConsistency(
+	result: IntegrityCheckResult,
+	dryRun: boolean,
+): Promise<void> {
 	logger.info("Work-Circle相互参照の整合性チェックを開始");
 
 	const worksSnapshot = await firestore.collection("works").get();
@@ -414,19 +442,19 @@ async function checkWorkCircleConsistency(result: IntegrityCheckResult): Promise
 			result.checks.workCircleConsistency.fixed++;
 			batchCount++;
 
-			if (batchCount >= FIRESTORE_BATCH_LIMIT) {
+			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
 				await batch.commit();
 				batchCount = 0;
 			}
 		}
 	}
 
-	if (batchCount > 0) {
+	if (!dryRun && batchCount > 0) {
 		await batch.commit();
 	}
 
 	logger.info(
-		`Work-Circle整合性チェック完了: ${result.checks.workCircleConsistency.checked}件チェック、${result.checks.workCircleConsistency.fixed}件修正`,
+		`Work-Circle整合性チェック完了: ${result.checks.workCircleConsistency.checked}件チェック、${result.checks.workCircleConsistency.fixed}件${dryRun ? "要修正" : "修正"}`,
 	);
 }
 
@@ -467,15 +495,26 @@ async function saveIntegrityCheckResult(result: IntegrityCheckResult): Promise<v
 }
 
 /**
- * Cloud Functions エントリーポイント
+ * 整合性チェックの本体ロジック
+ *
+ * 4種の検査（Circle workIds / 孤立Creator / Work-Circle / Creator-Work復元）を実行し、
+ * 結果を返す。dryRun=false（既定）の場合のみ Firestore へ修正と結果を書き込む。
+ *
+ * Cloud Functions ハンドラ（{@link checkDataIntegrity}）からも、
+ * ローカル手動実行・インテグレーションテストからも共通で呼ばれる正本。
+ *
+ * @param options.dryRun true で書き込みを一切行わない観測専用モード
+ * @returns 検査結果（dryRun でも「要修正件数」を含む）
  */
-export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<void> {
+export async function runIntegrityCheck(
+	options: IntegrityCheckOptions = {},
+): Promise<IntegrityCheckResult> {
+	const dryRun = options.dryRun ?? false;
 	const startTime = Date.now();
-
-	logger.info("データ整合性チェックを開始", { eventType: event.type });
 
 	const result: IntegrityCheckResult = {
 		timestamp: new Date().toISOString(),
+		dryRun,
 		checks: {
 			circleWorkCounts: { checked: 0, mismatches: 0, fixed: 0 },
 			orphanedCreators: { checked: 0, found: 0, cleaned: 0 },
@@ -486,36 +525,56 @@ export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<vo
 		executionTimeMs: 0,
 	};
 
-	try {
-		// 1. CircleのworkIds配列の整合性チェック
-		await checkCircleWorkCounts(result);
+	// 1. CircleのworkIds配列の整合性チェック
+	await checkCircleWorkCounts(result, dryRun);
 
-		// 2. 孤立したCreatorマッピングのクリーンアップ
-		await checkOrphanedCreators(result);
+	// 2. 孤立したCreatorマッピングのクリーンアップ
+	await checkOrphanedCreators(result, dryRun);
 
-		// 3. Work-Circle相互参照の整合性
-		await checkWorkCircleConsistency(result);
+	// 3. Work-Circle相互参照の整合性
+	await checkWorkCircleConsistency(result, dryRun);
 
-		// 4. Creator-Work関連の復元（削除されたデータの回復）
-		await restoreCreatorWorkRelations(result);
+	// 4. Creator-Work関連の復元（削除されたデータの回復）
+	await restoreCreatorWorkRelations(result, dryRun);
 
-		// 総計を計算
-		result.totalIssues =
-			result.checks.circleWorkCounts.mismatches +
-			result.checks.orphanedCreators.found +
-			result.checks.workCircleConsistency.mismatches;
+	// 総計を計算
+	result.totalIssues =
+		result.checks.circleWorkCounts.mismatches +
+		result.checks.orphanedCreators.found +
+		result.checks.workCircleConsistency.mismatches;
 
-		result.totalFixed =
-			result.checks.circleWorkCounts.fixed +
-			result.checks.orphanedCreators.cleaned +
-			result.checks.workCircleConsistency.fixed +
-			(result.checks.creatorWorkRestore?.restored || 0) +
-			(result.checks.creatorWorkRestore?.creatorsCreated || 0);
+	result.totalFixed =
+		result.checks.circleWorkCounts.fixed +
+		result.checks.orphanedCreators.cleaned +
+		result.checks.workCircleConsistency.fixed +
+		(result.checks.creatorWorkRestore?.restored || 0) +
+		(result.checks.creatorWorkRestore?.creatorsCreated || 0);
 
-		result.executionTimeMs = Date.now() - startTime;
+	result.executionTimeMs = Date.now() - startTime;
 
-		// 結果を保存
+	// 結果を保存（dryRun では書き込まない）
+	if (dryRun) {
+		logger.info("dry-run: 書き込みをスキップしました（検出のみ）", {
+			totalIssues: result.totalIssues,
+			wouldFix: result.totalFixed,
+		});
+	} else {
 		await saveIntegrityCheckResult(result);
+	}
+
+	return result;
+}
+
+/**
+ * Cloud Functions エントリーポイント
+ *
+ * 本番スケジュール実行用。常に dryRun=false（修正を書き込む）。
+ */
+export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<void> {
+	logger.info("データ整合性チェックを開始", { eventType: event.type });
+
+	try {
+		const result = await runIntegrityCheck();
 
 		logger.info("データ整合性チェック完了", {
 			totalChecked:

--- a/apps/functions/src/tools/core/run-data-integrity-check.ts
+++ b/apps/functions/src/tools/core/run-data-integrity-check.ts
@@ -3,52 +3,67 @@
  * データ整合性チェック手動実行スクリプト
  *
  * 使用方法:
- * pnpm check:integrity
+ *   pnpm check:integrity              # 通常実行（Firestore へ修正を書き込む）
+ *   pnpm check:integrity -- --dry-run # 観測専用（検出のみ・書き込まない）
  *
- * このスクリプトは本番環境のCloud Functionsで実行される
- * データ整合性チェック機能を手動でローカル実行するためのものです。
+ * 本番環境の Cloud Functions で実行されるデータ整合性チェック機能を
+ * 手動でローカル実行するためのもの。dry-run なら「何を直すか」を
+ * 本番データを汚さずに確認できる。
+ *
+ * 接続先は環境変数で決まる:
+ *   - FIRESTORE_EMULATOR_HOST 設定時 → Emulator
+ *   - 未設定 → ADC で本番 Firestore（dry-run 推奨）
  */
 
-import type { CloudEvent } from "@google-cloud/functions-framework";
-import { checkDataIntegrity } from "../../endpoints/data-integrity-check";
+import { type IntegrityCheckResult, runIntegrityCheck } from "../../endpoints/data-integrity-check";
 import * as logger from "../../shared/logger";
+
+function printReport(result: IntegrityCheckResult): void {
+	const c = result.checks;
+	logger.info("=====================================");
+	logger.info(`📊 整合性チェック結果 (${result.dryRun ? "DRY-RUN / 書き込みなし" : "適用済み"})`);
+	logger.info(
+		`- Circle workIds : ${c.circleWorkCounts.checked}件中 ${c.circleWorkCounts.mismatches}件不整合 / ${c.circleWorkCounts.fixed}件${result.dryRun ? "要修正" : "修正"}`,
+	);
+	logger.info(
+		`- 孤立Creator    : ${c.orphanedCreators.checked}件中 ${c.orphanedCreators.found}件検出 / ${c.orphanedCreators.cleaned}件${result.dryRun ? "要削除" : "削除"}`,
+	);
+	logger.info(
+		`- Work-Circle    : ${c.workCircleConsistency.checked}件中 ${c.workCircleConsistency.mismatches}件不整合 / ${c.workCircleConsistency.fixed}件${result.dryRun ? "要修正" : "修正"}`,
+	);
+	if (c.creatorWorkRestore) {
+		logger.info(
+			`- Creator-Work復元: ${c.creatorWorkRestore.checked}件中 ${c.creatorWorkRestore.restored}件マッピング / ${c.creatorWorkRestore.creatorsCreated}件Creator${result.dryRun ? "要復元/作成" : "復元/作成"}`,
+		);
+	}
+	logger.info(
+		`- 合計           : ${result.totalIssues}件の問題 / ${result.totalFixed}件${result.dryRun ? "要対応" : "対応済み"}`,
+	);
+	logger.info("=====================================");
+}
 
 /**
  * メイン実行関数
  */
 async function main(): Promise<void> {
+	const dryRun = process.argv.includes("--dry-run");
+
 	try {
-		logger.info("🔍 データ整合性チェック - 手動実行開始");
+		logger.info(`🔍 データ整合性チェック - 手動実行開始${dryRun ? "（DRY-RUN）" : ""}`);
 		logger.info("=====================================");
 
-		// Cloud Functionsイベントを模擬
-		const mockEvent: CloudEvent<unknown> = {
-			specversion: "1.0",
-			type: "manual.execution",
-			source: "local-script",
-			subject: "data-integrity-check",
-			id: `manual-${Date.now()}`,
-			time: new Date().toISOString(),
-			datacontenttype: "application/json",
-			data: {
-				type: "data_integrity_check",
-				description: "手動実行によるデータ整合性チェック",
-			},
-		};
-
-		// データ整合性チェックを実行
 		const startTime = Date.now();
-		await checkDataIntegrity(mockEvent);
+		const result = await runIntegrityCheck({ dryRun });
 		const executionTime = Date.now() - startTime;
 
-		logger.info("=====================================");
-		logger.info(`✅ データ整合性チェック完了 (実行時間: ${(executionTime / 1000).toFixed(1)}秒)`);
+		printReport(result);
+		logger.info(`✅ 完了 (実行時間: ${(executionTime / 1000).toFixed(1)}秒)`);
 
-		// 結果の確認方法を案内
-		logger.info("\n📊 結果の確認:");
-		logger.info("Firestoreコンソールで以下のパスを確認してください:");
-		logger.info("- dlsiteMetadata/dataIntegrityCheck");
-		logger.info("- dlsiteMetadata/dataIntegrityCheck/history");
+		if (!dryRun) {
+			logger.info("\n📊 結果の確認: Firestore の以下を参照してください:");
+			logger.info("- dlsiteMetadata/dataIntegrityCheck");
+			logger.info("- dlsiteMetadata/dataIntegrityCheck/history");
+		}
 	} catch (error) {
 		logger.error("❌ データ整合性チェックエラー", { error });
 		process.exit(1);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"typecheck": "pnpm -r typecheck",
 		"typecheck:fast": "pnpm -r typecheck:fast",
 		"test": "pnpm -r test",
+		"test:integration": "bash scripts/test-functions-integration.sh",
 		"verify": "pnpm lint && pnpm typecheck && pnpm test",
 		"test:coverage": "pnpm -r test:coverage",
 		"knip": "knip",

--- a/scripts/test-functions-integration.sh
+++ b/scripts/test-functions-integration.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOST_PORT="${FIRESTORE_EMULATOR_HOST:-127.0.0.1:8765}"
+EMU_PORT="${HOST_PORT##*:}"
 export FIRESTORE_EMULATOR_HOST="${HOST_PORT}"
 export GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-suzumina-click}"
 
@@ -20,7 +21,9 @@ cleanup() {
   if [[ "${STARTED_EMULATOR}" == "1" ]]; then
     echo "[itest] Emulator を停止します"
     [[ -n "${EMULATOR_PID}" ]] && kill "${EMULATOR_PID}" 2>/dev/null || true
-    pkill -f "cloud-firestore-emulator" 2>/dev/null || true
+    # gcloud 配下の Java 子プロセスが残ることがあるためフォールバックで掃除するが、
+    # dev:local(8080) など別ポートのエミュレータを巻き込まないよう、起動したポートに限定する。
+    pkill -f "cloud_firestore_emulator.*${EMU_PORT}" 2>/dev/null || true
   fi
 }
 trap cleanup EXIT INT TERM

--- a/scripts/test-functions-integration.sh
+++ b/scripts/test-functions-integration.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Cloud Run Functions のインテグレーションテストを Firestore Emulator 実機で回す。
+#   - dev:local(8080) とは別ポート(8765)で使い捨て Emulator を起動
+#   - RUN_INTEGRATION_TESTS=true を立てて該当テストのみ実行
+#   - 各テストは Emulator のデータを全消去するため、本ポートに本物データを置かないこと
+#
+# firebase コマンドは使わない（CLAUDE.md 方針）。gcloud 版 Emulator を利用。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST_PORT="${FIRESTORE_EMULATOR_HOST:-127.0.0.1:8765}"
+export FIRESTORE_EMULATOR_HOST="${HOST_PORT}"
+export GOOGLE_CLOUD_PROJECT="${GOOGLE_CLOUD_PROJECT:-suzumina-click}"
+
+STARTED_EMULATOR=0
+EMULATOR_PID=""
+
+cleanup() {
+  if [[ "${STARTED_EMULATOR}" == "1" ]]; then
+    echo "[itest] Emulator を停止します"
+    [[ -n "${EMULATOR_PID}" ]] && kill "${EMULATOR_PID}" 2>/dev/null || true
+    pkill -f "cloud-firestore-emulator" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+emulator_up() {
+  curl -s -o /dev/null "http://${HOST_PORT}/" 2>/dev/null
+}
+
+if emulator_up; then
+  echo "[itest] 既存の Emulator (${HOST_PORT}) を利用します"
+else
+  echo "[itest] Emulator を ${HOST_PORT} で起動します..."
+  bash "${ROOT}/scripts/firestore-emulator.sh" &
+  EMULATOR_PID=$!
+  STARTED_EMULATOR=1
+  for _ in $(seq 1 60); do
+    if emulator_up; then break; fi
+    sleep 1
+  done
+  if ! emulator_up; then
+    echo "[itest] Emulator の起動を確認できませんでした (${HOST_PORT})" >&2
+    exit 1
+  fi
+fi
+
+echo "[itest] インテグレーションテストを実行します"
+RUN_INTEGRATION_TESTS=true pnpm --filter @suzumina.click/functions test:integration


### PR DESCRIPTION
## 概要
[SPR-138](https://linear.app/nothink/issue/SPR-138)（SPR-136 調査からの派生A・動機④: 整合性関数が正しく集計し直しているか確証が欲しい）。

`checkDataIntegrity` の集計修復ロジックを、決定論的・安全に検証できるようにする。

## 変更点
- **dry-run（report-only）モード**: `data-integrity-check.ts` を `runIntegrityCheck({ dryRun })` に再構成。`dryRun=true` で検出・集計はするが Firestore 書き込み（`batch.commit` / 結果保存）を一切スキップ。本番ハンドラ `checkDataIntegrity` は**挙動不変**（dryRun=false 固定）。結果型に `dryRun` フラグ追加。
- **手動ツール**: `pnpm check:integrity -- --dry-run` で観測専用実行＋結果レポート出力。
- **エミュレータ注入インテグレーションテスト**: 既知の壊れデータを Firestore Emulator に注入 → 実行 → 4種の修復（Circle workIds 重複/存在しない作品除去・孤立Creator/空Creator削除・Work-Circle 補完・Creator-Work 復元）＋ dry-run 非書き込みを、**検出件数と Firestore 実体**の両面で assert。
- **安全装置**: `RUN_INTEGRATION_TESTS` + `FIRESTORE_EMULATOR_HOST` 不在時は describe ごとスキップ → 通常の `pnpm test` / CI では走らない。専用ポート 8765 の使い捨て Emulator を起動する `scripts/test-functions-integration.sh`（dev:local の 8080 と分離）。dryRun 分岐はユニットテストでもカバー。

## 実行方法
- `pnpm test:integration`（ルート）: 8765 で Emulator 起動 → 該当テスト → 自動停止。
- `pnpm check:integrity -- --dry-run`: ローカルから観測専用で「何を直すか」確認。

## 検証
- ✅ `pnpm verify` 全パス（lint + typecheck + 全テスト、functions 352 passed / 統合5件はゲートでスキップ）
- ✅ `pnpm test:integration` を実 Firestore Emulator で実行 → **5/5 passed**

## 留意
- Emulator は複合インデックスを強制しないため、本番 `FAILED_PRECONDITION` はこのテストでは検出不可。
- 整合性関数の潜在バグ（commit 済み WriteBatch の同一変数再利用＝1カテゴリ >400 件修正時に throw）を別途発見。範囲外のため別タスクに切り出し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)