### PR TITLE
fix(functions): 整合性チェックの commit 済み WriteBatch 再利用バグを修正（SPR-142）

### DIFF
--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
@@ -26,6 +26,7 @@ const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || "suzumina-click";
 let getFirestore: () => Firestore;
 let resetFirestoreInstance: () => void;
 let runIntegrityCheck: typeof RunIntegrityCheck;
+let batchLimit: number;
 
 // 変更前の env を退避し、afterAll で復元する（プロセスグローバルの汚染防止）
 let prevAllowTestFirestore: string | undefined;
@@ -59,7 +60,9 @@ describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", (
 		const firestoreModule = await import("../../infrastructure/database/firestore");
 		getFirestore = firestoreModule.getFirestore;
 		resetFirestoreInstance = firestoreModule.resetFirestoreInstance;
-		({ runIntegrityCheck } = await import("../data-integrity-check"));
+		const dicModule = await import("../data-integrity-check");
+		runIntegrityCheck = dicModule.runIntegrityCheck;
+		batchLimit = dicModule.FIRESTORE_BATCH_LIMIT;
 	});
 
 	beforeEach(async () => {
@@ -200,30 +203,67 @@ describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", (
 		);
 	});
 
-	it("400件超の修正でもバッチ分割で例外なく完了する（WriteBatch 再利用回帰 / SPR-142）", async () => {
+	it("400件超の Circle 修正でもバッチ分割で例外なく完了する（commitAndRenew 回帰 / SPR-142）", async () => {
 		const db = getFirestore();
 		// 存在する作品を1件用意（存在チェックを通し、circle あたりの batch 操作を1回に保つ）
 		await db.collection("works").doc("RJ001").set({ title: "w1", circleId: "RG0" });
 
-		// FIRESTORE_BATCH_LIMIT(400) を超える 401 サークルに重複 workIds を仕込む
-		const COUNT = 401;
-		const seed = db.batch(); // Firestore のバッチ上限は500なので 401 は1バッチで投入可
+		// 分割コミット境界（FIRESTORE_BATCH_LIMIT）を1件超えるサークルに重複 workIds を仕込む
+		const COUNT = batchLimit + 1;
+		// Firestore のバッチ上限は500。境界(400)+1 は1バッチで投入できる前提
+		const seed = db.batch();
 		for (let i = 0; i < COUNT; i++) {
 			seed.set(db.collection("circles").doc(`RG${i}`), { workIds: ["RJ001", "RJ001"] });
 		}
 		await seed.commit();
 
-		// 修正前は 401 件目の update が commit 済み batch への書き込みで例外になる。
-		// 修正後は 400 件ごとに新バッチへ差し替わり、例外なく完走する。
+		// 修正前は境界超過の update が commit 済み batch への書き込みで例外になる。
+		// 修正後は境界ごとに新バッチへ差し替わり、例外なく完走する。
 		const result = await runIntegrityCheck();
 
 		expect(result.checks.circleWorkCounts.checked).toBe(COUNT);
 		expect(result.checks.circleWorkCounts.fixed).toBeGreaterThanOrEqual(COUNT);
 
 		// 重複が全サークルで解消されている（境界の先頭・末尾を抜き取り確認）
-		for (const id of ["RG0", "RG400"]) {
+		for (const id of ["RG0", `RG${COUNT - 1}`]) {
 			const circle = await db.collection("circles").doc(id).get();
 			expect(circle.data()?.workIds as string[]).toEqual(["RJ001"]);
+		}
+	});
+
+	it("400件超の Creator-Work 復元でもバッチ分割で例外なく完了する（commitBatchIfNeeded 回帰 / SPR-142）", async () => {
+		const db = getFirestore();
+		// 1作品に境界超のクリエイターを詰め、復元側（commitBatchIfNeeded）の分割を強制する。
+		// クリエイター毎に ensure(set) + mapping(set) の2書き込みが出るため、COUNT 件で境界を複数回跨ぐ。
+		const COUNT = batchLimit + 1;
+		const voiceBy = Array.from({ length: COUNT }, (_, i) => ({ id: `C${i}`, name: `creator${i}` }));
+		await db
+			.collection("circles")
+			.doc("RG0")
+			.set({ workIds: ["RJ001"] });
+		await db
+			.collection("works")
+			.doc("RJ001")
+			.set({
+				title: "w1",
+				circleId: "RG0",
+				circle: "サークル名",
+				creators: { voice_by: voiceBy },
+			});
+
+		// 修正前は commit 済み batch への set で例外。修正後は分割コミットで完走する。
+		const result = await runIntegrityCheck();
+
+		expect(result.checks.creatorWorkRestore?.checked).toBe(1);
+		expect(result.checks.creatorWorkRestore?.restored).toBe(COUNT);
+		expect(result.checks.creatorWorkRestore?.creatorsCreated).toBe(COUNT);
+
+		// 境界の先頭・末尾のクリエイターとマッピングが実際に作成されている
+		for (const id of ["C0", `C${COUNT - 1}`]) {
+			expect((await db.collection("creators").doc(id).get()).exists).toBe(true);
+			expect(
+				(await db.collection("creators").doc(id).collection("works").doc("RJ001").get()).exists,
+			).toBe(true);
 		}
 	});
 });

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
@@ -199,4 +199,31 @@ describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", (
 			false,
 		);
 	});
+
+	it("400件超の修正でもバッチ分割で例外なく完了する（WriteBatch 再利用回帰 / SPR-142）", async () => {
+		const db = getFirestore();
+		// 存在する作品を1件用意（存在チェックを通し、circle あたりの batch 操作を1回に保つ）
+		await db.collection("works").doc("RJ001").set({ title: "w1", circleId: "RG0" });
+
+		// FIRESTORE_BATCH_LIMIT(400) を超える 401 サークルに重複 workIds を仕込む
+		const COUNT = 401;
+		const seed = db.batch(); // Firestore のバッチ上限は500なので 401 は1バッチで投入可
+		for (let i = 0; i < COUNT; i++) {
+			seed.set(db.collection("circles").doc(`RG${i}`), { workIds: ["RJ001", "RJ001"] });
+		}
+		await seed.commit();
+
+		// 修正前は 401 件目の update が commit 済み batch への書き込みで例外になる。
+		// 修正後は 400 件ごとに新バッチへ差し替わり、例外なく完走する。
+		const result = await runIntegrityCheck();
+
+		expect(result.checks.circleWorkCounts.checked).toBe(COUNT);
+		expect(result.checks.circleWorkCounts.fixed).toBeGreaterThanOrEqual(COUNT);
+
+		// 重複が全サークルで解消されている（境界の先頭・末尾を抜き取り確認）
+		for (const id of ["RG0", "RG400"]) {
+			const circle = await db.collection("circles").doc(id).get();
+			expect(circle.data()?.workIds as string[]).toEqual(["RJ001"]);
+		}
+	});
 });

--- a/apps/functions/src/endpoints/data-integrity-check.ts
+++ b/apps/functions/src/endpoints/data-integrity-check.ts
@@ -27,7 +27,8 @@ const INTEGRITY_CHECK_COLLECTION = "dlsiteMetadata";
 const INTEGRITY_CHECK_DOC_ID = "dataIntegrityCheck";
 
 // Firestoreバッチ操作の制限値（500より少し余裕を持たせた値）
-const FIRESTORE_BATCH_LIMIT = 400;
+// 分割コミットの境界。テストはこの値+1で分割パスを確実に踏むため export する。
+export const FIRESTORE_BATCH_LIMIT = 400;
 
 /**
  * バッチをコミットして新しい空バッチを返す。

--- a/apps/functions/src/endpoints/data-integrity-check.ts
+++ b/apps/functions/src/endpoints/data-integrity-check.ts
@@ -30,6 +30,18 @@ const INTEGRITY_CHECK_DOC_ID = "dataIntegrityCheck";
 const FIRESTORE_BATCH_LIMIT = 400;
 
 /**
+ * バッチをコミットして新しい空バッチを返す。
+ *
+ * @google-cloud/firestore では commit 済みの WriteBatch に再度書き込む／コミットすると
+ * 例外（Cannot modify a WriteBatch that has been committed）になる。
+ * 400件ごとの分割コミットのたびに、このヘルパで必ず新しいバッチへ差し替えること。
+ */
+async function commitAndRenew(batch: WriteBatch): Promise<WriteBatch> {
+	await batch.commit();
+	return firestore.batch();
+}
+
+/**
  * 整合性チェックの実行オプション
  */
 export interface IntegrityCheckOptions {
@@ -81,7 +93,7 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult, dryRun: boole
 	logger.info("CircleのworkIds配列の整合性チェックを開始");
 
 	const circlesSnapshot = await firestore.collection("circles").get();
-	const batch = firestore.batch();
+	let batch = firestore.batch();
 	let batchCount = 0;
 
 	for (const circleDoc of circlesSnapshot.docs) {
@@ -110,7 +122,7 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult, dryRun: boole
 
 			// バッチサイズ制限
 			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
-				await batch.commit();
+				batch = await commitAndRenew(batch);
 				batchCount = 0;
 			}
 		}
@@ -140,7 +152,7 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult, dryRun: boole
 			batchCount++;
 
 			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
-				await batch.commit();
+				batch = await commitAndRenew(batch);
 				batchCount = 0;
 			}
 		}
@@ -162,7 +174,7 @@ async function checkOrphanedCreators(result: IntegrityCheckResult, dryRun: boole
 	logger.info("孤立したCreatorマッピングのチェックを開始");
 
 	const creatorsSnapshot = await firestore.collection("creators").get();
-	const batch = firestore.batch();
+	let batch = firestore.batch();
 	let batchCount = 0;
 
 	for (const creatorDoc of creatorsSnapshot.docs) {
@@ -185,7 +197,7 @@ async function checkOrphanedCreators(result: IntegrityCheckResult, dryRun: boole
 				batchCount++;
 
 				if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
-					await batch.commit();
+					batch = await commitAndRenew(batch);
 					batchCount = 0;
 				}
 			} else {
@@ -201,7 +213,7 @@ async function checkOrphanedCreators(result: IntegrityCheckResult, dryRun: boole
 			batchCount++;
 
 			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
-				await batch.commit();
+				batch = await commitAndRenew(batch);
 				batchCount = 0;
 			}
 		}
@@ -296,21 +308,26 @@ async function restoreCreatorWorkMapping(
 }
 
 /**
- * バッチが満杯の場合はコミット（dryRun の場合は書き込まない）
+ * バッチが満杯の場合はコミットし、新しい空バッチを返す（dryRun の場合は書き込まない）。
+ *
+ * commit 済みの WriteBatch は再利用できないため、呼び出し側は必ず戻り値で
+ * バッチを差し替えること（`batch = await commitBatchIfNeeded(batch, ...)`）。
  */
 async function commitBatchIfNeeded(
 	batch: WriteBatch,
 	stats: RestoreStats,
 	force = false,
 	dryRun = false,
-): Promise<void> {
+): Promise<WriteBatch> {
 	if (dryRun) {
-		return;
+		return batch;
 	}
 	if (stats.batchCount >= FIRESTORE_BATCH_LIMIT || (force && stats.batchCount > 0)) {
 		await batch.commit();
 		stats.batchCount = 0;
+		return firestore.batch();
 	}
+	return batch;
 }
 
 /**
@@ -323,7 +340,7 @@ async function restoreCreatorWorkRelations(
 	logger.info("Creator-Work関連の復元を開始");
 
 	const worksSnapshot = await firestore.collection("works").get();
-	const batch = firestore.batch();
+	let batch = firestore.batch();
 	const processedCreators = new Set<string>();
 
 	const stats: RestoreStats = {
@@ -364,19 +381,19 @@ async function restoreCreatorWorkRelations(
 				);
 
 				// バッチサイズチェック
-				await commitBatchIfNeeded(batch, stats, false, dryRun);
+				batch = await commitBatchIfNeeded(batch, stats, false, dryRun);
 
 				// Creator-Workマッピングの復元
 				await restoreCreatorWorkMapping(creatorRef, workDoc, workData, creator, type, batch, stats);
 
 				// バッチサイズチェック
-				await commitBatchIfNeeded(batch, stats, false, dryRun);
+				batch = await commitBatchIfNeeded(batch, stats, false, dryRun);
 			}
 		}
 	}
 
 	// 残りのバッチをコミット
-	await commitBatchIfNeeded(batch, stats, true, dryRun);
+	batch = await commitBatchIfNeeded(batch, stats, true, dryRun);
 
 	// 結果に追加
 	result.checks.creatorWorkRestore = {
@@ -400,7 +417,7 @@ async function checkWorkCircleConsistency(
 	logger.info("Work-Circle相互参照の整合性チェックを開始");
 
 	const worksSnapshot = await firestore.collection("works").get();
-	const batch = firestore.batch();
+	let batch = firestore.batch();
 	let batchCount = 0;
 
 	for (const workDoc of worksSnapshot.docs) {
@@ -443,7 +460,7 @@ async function checkWorkCircleConsistency(
 			batchCount++;
 
 			if (!dryRun && batchCount >= FIRESTORE_BATCH_LIMIT) {
-				await batch.commit();
+				batch = await commitAndRenew(batch);
 				batchCount = 0;
 			}
 		}


### PR DESCRIPTION
## 概要
[SPR-142](https://linear.app/nothink/issue/SPR-142)（PR #522 レビュー指摘#2の派生）。整合性チェックの潜在バグを修正。

## バグ
`data-integrity-check.ts` の各検査関数（checkCircleWorkCounts / checkOrphanedCreators / checkWorkCircleConsistency / restoreCreatorWorkRelations）は冒頭で `const batch = firestore.batch()` を一度生成し、`batchCount >= FIRESTORE_BATCH_LIMIT(400)` ごとに `await batch.commit()` した後も**同じ WriteBatch を使い回していた**。`@google-cloud/firestore` では commit 済みの WriteBatch に再書き込み/再 commit すると `Cannot modify a WriteBatch that has been committed` 例外になるため、1カテゴリで 400 件超の修正が出ると実行時に落ちる（本番で大量不整合が出たときのみ顕在化）。

## 修正
- `commitAndRenew(batch)` ヘルパを導入し、分割コミットのたびに新しい空バッチへ差し替え。
- `commitBatchIfNeeded` は新バッチを返すよう変更し、呼び出し側で `batch = await commitBatchIfNeeded(...)` と再代入。
- dryRun モードの挙動は不変。

## テスト
- 401 サークルに重複 workIds を注入し、分割コミット境界（400件）を跨ぐ回帰テストを統合テストに追加。
- **バグ版（main 相当）で赤 → 修正版で緑**を実機で確認済み（commit 済み batch への `batch.update` で例外が出ることを確認）。

## 検証
- ✅ `pnpm verify` 全パス
- ✅ `pnpm test:integration` 実 Emulator で **6/6 passed**（新 >400 回帰含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)