### PR TITLE
ci(functions): エミュレータ統合テストを pr-check に追加（SPR-141）

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,6 +31,7 @@ jobs:
       workflows: ${{ steps.changes.outputs.workflows }}
       dependencies: ${{ steps.changes.outputs.dependencies }}
       docker: ${{ steps.changes.outputs.docker }}
+      integration: ${{ steps.changes.outputs.integration }}
 
     steps:
       - name: Checkout code
@@ -53,6 +54,14 @@ jobs:
               - 'packages/typescript-config/**'
             workflows:
               - '.github/workflows/**'
+            # functions のエミュレータ統合テストを走らせる対象。functions 本体に加え、
+            # テスト基盤スクリプトと本ワークフロー自身（ジョブ定義の自己検証）を含める。
+            integration:
+              - 'apps/functions/**'
+              - 'packages/shared-types/**'
+              - 'scripts/test-functions-integration.sh'
+              - 'scripts/firestore-emulator.sh'
+              - '.github/workflows/pr-check.yml'
             dependencies:
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -194,9 +203,10 @@ jobs:
     name: Functions Integration (Emulator)
     runs-on: ubuntu-latest
     needs: changes
-    # functions 本体の変更時に走らせるのが主目的。あわせてワークフロー自身の変更時にも
-    # 走らせ、本ジョブ（やテスト基盤）の改修をその PR 上で自己検証できるようにする。
-    if: needs.changes.outputs.functions == 'true' || needs.changes.outputs.workflows == 'true'
+    # functions 本体・依存(shared-types)・テスト基盤スクリプト・本ワークフロー自身の
+    # いずれかが変わったら実行（integration フィルタ）。pr-check.yml を含むので
+    # 本ジョブの改修は当該 PR 上で自己検証される。
+    if: needs.changes.outputs.integration == 'true'
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -186,6 +186,59 @@ jobs:
           fi
           echo "🎉 All checks completed successfully"
 
+  # functions のエミュレータ統合テスト（SPR-141）。
+  # 決定論的・外部API非依存・GCP課金なし（Emulator は runner 上で完結）。
+  # 高速な parallel-check とは分離した専用ジョブにし、functions 変更時のみ実行する。
+  # 実外部API系（SPR-139 の地域制限/スキーマ捕捉）は runner が海外IP・非決定論のため CI に載せない。
+  functions-integration:
+    name: Functions Integration (Emulator)
+    runs-on: ubuntu-latest
+    needs: changes
+    # functions 本体の変更時に走らせるのが主目的。あわせてワークフロー自身の変更時にも
+    # 走らせ、本ジョブ（やテスト基盤）の改修をその PR 上で自己検証できるようにする。
+    if: needs.changes.outputs.functions == 'true' || needs.changes.outputs.workflows == 'true'
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.16.0'
+          cache: 'pnpm'
+
+      # gcloud 版 Firestore Emulator は JVM 上で動くため Java が必要（firebase CLI は使わない）
+      - name: Setup Java (Firestore Emulator 用)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # 認証不要（Emulator はローカル完結）。install_components で
+      # component-manager 有効な gcloud を action 側に用意させ、apt 管理 gcloud の
+      # 「component manager 無効」問題を回避する。
+      - name: Setup gcloud + Firestore emulator
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          install_components: 'cloud-firestore-emulator'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # scripts/test-functions-integration.sh が専用ポート(8765)で Emulator を起動し、
+      # RUN_INTEGRATION_TESTS=true を立てて統合テストのみ実行・終了後に停止する。
+      - name: Run integration tests (Firestore Emulator)
+        env:
+          CLOUDSDK_CORE_PROJECT: suzumina-click
+        run: pnpm test:integration
+
   build-check:
     name: Build Verification
     runs-on: ubuntu-latest
@@ -313,7 +366,8 @@ jobs:
   pr-summary:
     name: PR Summary
     runs-on: ubuntu-latest
-    needs: [changes, parallel-check, build-check, docker-build-check, security-check, secret-scan]
+    needs:
+      [changes, parallel-check, functions-integration, build-check, docker-build-check, security-check, secret-scan]
     if: always()
     
     steps:
@@ -331,6 +385,7 @@ jobs:
           
           echo "### 🧪 Quality Checks" >> $GITHUB_STEP_SUMMARY
           echo "- Parallel Check: ${{ needs.parallel-check.result == 'success' && '✅ Passed' || needs.parallel-check.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Functions Integration (Emulator): ${{ needs.functions-integration.result == 'success' && '✅ Passed' || needs.functions-integration.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Build Verification: ${{ needs.build-check.result == 'success' && '✅ Passed' || needs.build-check.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Docker Build (web): ${{ needs.docker-build-check.result == 'success' && '✅ Passed' || needs.docker-build-check.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY
           echo "- Security Check: ${{ needs.security-check.result == 'success' && '✅ Passed' || needs.security-check.result == 'skipped' && '⏭️ Skipped' || '❌ Failed' }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 概要
[SPR-141](https://linear.app/nothink/issue/SPR-141)。SPR-138/#522 で追加した Firestore Emulator ベースの統合テスト（`pnpm test:integration` / `RUN_INTEGRATION_TESTS` ゲート）を CI に組み込む。

## 変更
`.github/workflows/pr-check.yml` に独立ジョブ `functions-integration` を追加。
- **ゲート**: `functions` または `workflows` の変更時のみ実行（後者で本ジョブ自身を当該 PR 上で自己検証）。
- **gcloud**: `setup-gcloud@v3` の `install_components: cloud-firestore-emulator` で導入（apt 管理 gcloud の component-manager 無効問題を回避）。firebase CLI は使わない（CLAUDE.md 方針）。
- 既存の高速 `parallel-check` とは分離。`pr-summary` に結果行を追加。

## なぜ CI に入れるか
統合テストは自動スキップ設計のため、CI 不在だと `pnpm verify` 緑でも回帰を検知できず腐る（軸1）。決定論的・外部API非依存・GCP課金なし（Emulator は runner 上で完結）で CI に向く。

## 恒久 CI ポリシー
- **エミュレータ系の統合テスト → CI 可**（本 PR）。
- **実外部API系（SPR-139 の地域制限/スキーマ捕捉）→ CI 不可**（runner は海外IP・レート制限・クォータ課金・非決定論）。ローカル/手動のみ。

## 検証
- 本 PR は `workflows` 変更を含むため、この PR 自身で `functions-integration` ジョブが実行され green になることを確認する（CI 結果を参照）。
- 当面 ruleset の必須チェック昇格はしない（安定確認後に検討）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)