### PR TITLE
feat(infra): DLsite スキーマdrift の log-based アラートを追加（SPR-144）

### DIFF
--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -189,3 +189,78 @@ resource "google_monitoring_alert_policy" "dlsite_function_failure" {
 
   depends_on = [google_monitoring_notification_channel.email]
 }
+# ログベースメトリクス - スキーマドリフト（SPR-140 / SPR-144）
+# 本番フェッチ経路で、既知フィールド集合に無い新フィールドが出現すると
+# logger.warn が jsonPayload.alert="dlsite_schema_drift" 付きで出力される。
+resource "google_logging_metric" "dlsite_schema_drift" {
+  name    = "dlsite_schema_drift"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_function"
+    resource.labels.function_name="fetchDLsiteUnifiedData"
+    jsonPayload.alert="dlsite_schema_drift"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "DLsite Schema Drift Detected"
+  }
+}
+
+# DLsite スキーマドリフトアラート（新フィールド出現）
+resource "google_monitoring_alert_policy" "dlsite_schema_drift" {
+  display_name = "DLsite Schema Drift Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "既知集合に無い新フィールドを検出"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_schema_drift.id}\" resource.type=\"cloud_function\""
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # DLsite API スキーマドリフト検出（新フィールド）
+
+    DLsite Individual Info API のレスポンスに、既知フィールド集合（ベースライン）に
+    無いトップレベルフィールドが出現しました（取得可能データの増加など）。
+
+    ## 対応方法
+    1. Cloud Logging で jsonPayload.alert="dlsite_schema_drift" の WARN を確認し、
+       jsonPayload.newFields で新フィールド名を把握する。
+    2. 必要なら shared-types の DLsiteApiResponse スキーマにフィールドを追加する。
+    3. ベースラインを再生成して更新する:
+       pnpm --filter @suzumina.click/functions tools:capture -- --limit 150
+       → apps/functions/src/services/dlsite/dlsite-known-api-fields.ts を更新（SPR-140）。
+
+    ## ログ確認コマンド
+    ```bash
+    gcloud logging read 'resource.type="cloud_function" AND resource.labels.function_name="fetchDLsiteUnifiedData" AND jsonPayload.alert="dlsite_schema_drift"' --limit=20 --format=json
+    ```
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.dlsite_schema_drift
+  ]
+}


### PR DESCRIPTION
## 概要
[SPR-144](https://linear.app/nothink/issue/SPR-144)（SPR-140 のフォロー）。SPR-140 で本番 `fetchDLsiteUnifiedData` が出す `jsonPayload.alert="dlsite_schema_drift"` の WARN を、**能動通知に変えるアラートポリシー**を Terraform で追加。これで SPR-140 の完了条件「閾値超でアラートが飛ぶ」を満たす。

## 変更
`terraform/monitoring_dlsite.tf` に2リソース追加（既存 `dlsite_no_data` の log-based-metric + alert-policy パターンを踏襲、`email` 通知チャンネルを利用）:
- `google_logging_metric.dlsite_schema_drift` — `resource.labels.function_name="fetchDLsiteUnifiedData"` かつ `jsonPayload.alert="dlsite_schema_drift"` を計数。
- `google_monitoring_alert_policy.dlsite_schema_drift` — count > 0 で通知。documentation に対応手順（新フィールド確認 → スキーマ/ベースライン更新 `tools:capture --limit 150`）を記載。

## 検証
- ✅ `terraform validate` 成功（offline / `init -backend=false`）。
- ✅ `terraform fmt` 済み。既存リソースは無変更（追記のみ）。
- ⚠️ **apply は未実施**。production workspace で実施が必要（MEMORY: default で plan すると全リソース to create / full apply は live を巻き戻すため、本2リソースに `-target` 推奨）。マージ後に terraform-plan/apply 経路で適用してください。

## 補足（SPR-140 レビュー指摘#2・スコープ外）
消失フィールド検出・存在率ヒストグラムは未実装（`tools:capture` が補完）。ローカル前回比 drift は SPR-143。

🤖 Generated with [Claude Code](https://claude.com/claude-code)