### PR TITLE
ci: AI レビュー A/B 構成（Claude Code Action + CodeRabbit）（SPR-37）

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,56 @@
+# CodeRabbit 設定 — AI レビュー spike（SPR-37）。
+# public リポジトリのため無料枠で動作する。Claude Code Action（.github/workflows/claude-review.yml）と A/B 比較する。
+# 前提: coderabbit.ai で GitHub App をこのリポジトリに連携すること（設定ファイルだけでは起動しない）。
+# 方針: 採否の最終判断は人=唯一のレビュアー。CodeRabbit はノイズ込みでも検出力を広く見るため profile を assertive にする。
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: ja-JP
+
+tone_instructions: "簡潔で実用的に。確信の持てない指摘は要確認と明示し断定しない。重大度を付ける。"
+
+reviews:
+  profile: assertive
+  # CodeRabbit に承認/変更要求の workflow までは任せない（最終判断は人）。
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    base_branches:
+      - main
+    drafts: false
+
+  path_instructions:
+    # === One-Way Door（やり直しが効かない＝人間レビュー必須。AI のみの自己マージは非推奨と明示せよ）===
+    - path: "apps/functions/**"
+      instructions: |
+        Cloud Functions / Firestore のデータ操作。One-Way Door として扱う。
+        非正規化の新規追加は整合性 cron（checkDataIntegrity）の保守負債を増やすため警告する。
+        Firestore コレクション名の正本は `works`。旧称/別名の参照を指摘する。
+        merge:true + undefined skip による「sticky フィールド」（旧値残存）のリスクを指摘する。
+    - path: "**/*.tf"
+      instructions: "Terraform/GCP インフラ。One-Way Door。本番は production workspace 前提。drift/巻き戻しリスクを指摘する。"
+    - path: ".github/workflows/**"
+      instructions: "CI/CD。One-Way Door として扱い、人間レビュー必須である旨を明示する。"
+    - path: "packages/shared-types/**"
+      instructions: "全体波及する基盤型。One-Way Door。破壊的変更は影響範囲を必ず指摘する。型は必ずここを正本とする。"
+    - path: "apps/web/src/**/auth/**"
+      instructions: "NextAuth/Discord 認証・認可。One-Way Door。権限・セッション境界の誤りを最優先で指摘する。"
+
+    # === Two-Way Door / 共通の品質観点 ===
+    - path: "apps/web/**"
+      instructions: |
+        基本は Two-Way Door（戻せる UI/表示）。データ操作は Server Actions、表示は Server Components 優先。
+        命名と挙動の予測可能性（軸2）と、名前・型と振る舞いのズレ（軸3）を最優先で見る。
+    - path: "**/*.{ts,tsx}"
+      instructions: |
+        TypeScript strict / Biome 準拠。型は @suzumina.click/shared-types を使う。
+        get/find 系の隠れた副作用、責務の広狭を指摘。不要コメントや自動生成ドキュメントを足していないか確認。
+    - path: "**/__tests__/**"
+      instructions: "テストは __tests__ に置く規約。ソース同居を指摘する。"
+
+# 既存の能動ルール（CLAUDE.md）をレビュー知識として読み込ませる。
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/CLAUDE.md"
+      - "docs/reference/*.md"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  id-token: write # claude-code-action の OIDC ブートストラップに必須
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,73 @@
+name: Claude AI Review
+
+# AI レビュー spike（SPR-37）: Claude Code Action による PR 自動レビュー。
+# 認証は Max サブスクリプション枠（OAuth トークン）。API 従量課金は使わない。
+#   前提: ローカルで `claude setup-token` を実行し、出力を Secret `CLAUDE_CODE_OAUTH_TOKEN` に登録すること。
+# 方針: 非ブロッキング（PR を fail させない・必須チェックにしない）。所見は PR コメント/行内コメントで可視化するだけ。
+#   採否の最終判断は人=唯一のレビュアーが行う前提（ソロ開発のセルフマージ・ポリシー）。
+# 並走中の CodeRabbit（.coderabbit.yaml）と A/B 比較し、検出力・ノイズ・日本語品質を見極める。
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  claude-review:
+    name: Claude review
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # fork からの PR では OAuth Secret を渡さない（漏洩防止）。draft は対象外。
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          use_sticky_comment: true
+          prompt: |
+            あなたはこのリポジトリの PR レビュアーです。リポジトリ直下の CLAUDE.md が「能動ルールの単一ソース」です。
+            必ず CLAUDE.md を読み、その §0 の評価軸と §1 の能動ルールに沿ってレビューしてください。
+
+            # 出力言語
+            すべて日本語で書く（技術用語は原語のまま）。
+
+            # 最優先で見る観点（CLAUDE.md §0 の評価軸）
+            - 軸3（最優先）: 名前・型の約束と実際の振る舞いのズレ。get/find 系の隠れた副作用、責務の広狭、
+              Firestore コレクション名の混同（正本は `works`）、正本が曖昧な箇所。
+            - 軸2: 命名と挙動の予測可能性。新しい変換層・抽象の追加は原則指摘（Entity/PlainObject 変換層は尊重）。
+            - 軸1: 系の劣化。非正規化の追加（整合性 cron `checkDataIntegrity` の保守負債を増やす）、版ズレ。
+            - §1 の能動ルール違反: pnpm 以外/npm 混入、テスト配置（__tests__ 外）、shared-types を使わない型定義、
+              不要コメント、自動生成ドキュメント、Entity 化ゲート未通過の新規 Entity。
+
+            # セルフマージ・ポリシー判定（このリポジトリ用）
+            レビュー冒頭に必ず「Door 判定」を 1 行で出す。基準は「容易にやり直せるか」。
+            - **One-Way Door（人間レビュー必須・自己マージ非推奨）**: Firestore スキーマ/非正規化, 整合性 cron,
+              NextAuth/Discord 認証・認可, Terraform/GCP インフラ, .github/workflows（CI/CD）, packages/shared-types
+              の破壊的変更, 新規 Entity 追加。これらを含むなら「⚠️ One-Way Door: 人間レビュー必須」と明示。
+            - **Two-Way Door（AI レビューのみで自己マージ可の候補）**: 上記に該当せず、戻せる UI/表示/軽微なロジック変更。
+              「✅ Two-Way Door: 重大所見が無ければ自己マージ可」と明示。
+
+            # 所見の出し方
+            - 具体的な行に対しては GitHub の **行内レビューコメント**で指摘する。
+            - 全体所見はサマリコメントにまとめ、重大度（blocker / major / minor / nit）を付ける。
+            - 確信が持てない指摘は「要確認」と明示し、断定しない（ノイズを最小化）。
+            - 問題が無ければ「重大所見なし」とはっきり書く。
+          # モデルは固定しない（版ズレ回避: CLAUDE.md 軸1）。action 既定の最新モデルに任せる。
+          claude_args: |
+            --max-turns 20


### PR DESCRIPTION
# PRタイトル
AI レビュー A/B 構成の追加（SPR-37 spike）

## 要件
[SPR-37](https://linear.app/nothink/issue/SPR-37) の spike。LLM 自動レビューでレビューコストを下げる仕組みを模索する。
本 PR 自体が **A/B のスモークテスト**を兼ねる（このPRに対し両レビュアーが起動するか・日本語所見が出るかを観測）。

- `.github/workflows/claude-review.yml` — Claude Code Action による PR 自動レビュー。認証は **Max サブスク OAuth 枠**（`CLAUDE_CODE_OAUTH_TOKEN`）。API 従量課金なし。
- `.coderabbit.yaml` — CodeRabbit（public 無料枠）の設定。
- 両者に **CLAUDE.md を能動ルールの単一ソース**として読ませ、**One-Way/Two-Way Door** のセルフマージ判定を出力させる。
- 非ブロッキング（必須チェックにしない／採否の最終判断は人=唯一のレビュアー）。

## 動かすための手元作業（2つ）
1. `claude setup-token` を実行 → 出力を Secret `CLAUDE_CODE_OAUTH_TOKEN` に登録（Claude 起動の前提）
2. https://coderabbit.ai で GitHub App をこのリポジトリに連携（CodeRabbit 起動の前提）

## テスト項目
- [ ] Claude AI Review workflow が起動し、日本語のサマリ＋行内コメントを出す
- [ ] サマリ冒頭に One-Way/Two-Way Door 判定が出る
- [ ] CodeRabbit が起動し、日本語でレビューする
- [ ] 両者の検出力・ノイズ・日本語品質を比較し、本採用するツールを決める

🤖 Generated with [Claude Code](https://claude.com/claude-code)