### PR TITLE
chore: AIレビュー A/B 検証用サンプル（SPR-37・マージしない）

### DIFF
--- a/apps/web/src/lib/work-stats.ts
+++ b/apps/web/src/lib/work-stats.ts
@@ -1,0 +1,24 @@
+export interface WorkRow {
+	id: string;
+	titleText: string;
+	priceJpy: number;
+	circleName: string;
+}
+
+export function workCollectionPath(): string {
+	return "dlsiteWorks";
+}
+
+export function getCheapest(rows: WorkRow[]): WorkRow {
+	rows.sort((a, b) => a.priceJpy - b.priceJpy);
+	return rows[0]!;
+}
+
+// 価格の平均を計算する関数
+export function averagePrice(rows: WorkRow[]): number {
+	let sum = 0;
+	for (let i = 0; i <= rows.length; i++) {
+		sum += rows[i]!.priceJpy;
+	}
+	return sum / rows.length;
+}


### PR DESCRIPTION
# PRタイトル
AI レビュー A/B 検証用サンプル PR（SPR-37 spike）

## 要件
[SPR-37](https://linear.app/nothink/issue/SPR-37) の spike 検証。#529 で導入した **Claude Code Action** と **CodeRabbit** が、同一の差分をどうレビューするかを A/B 比較するための PR。

- レビュー対象として小さな価格集計ユーティリティ `apps/web/src/lib/work-stats.ts` を追加。
- **このPRは本番マージしない**（検証後に close する）。
- 観点: 両レビュアーが CLAUDE.md（§0 評価軸 / §1 能動ルール）と One-Way/Two-Way Door 判定をどこまで反映できるか、検出力・誤検出・日本語品質を見る。

## テスト項目
- [ ] Claude AI Review が起動し、日本語サマリ＋行内コメントを出す
- [ ] サマリ冒頭に One-Way/Two-Way Door 判定が出る
- [ ] CodeRabbit が起動し日本語でレビューする
- [ ] 両者の検出した問題・見逃した問題・ノイズを突き合わせ、本採用ツールを決める

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 作品統計機能が追加されました。最安価作品の検索と平均価格計算の機能が利用可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->