### PR TITLE
fix(ci): Claude レビューがコメント投稿できるよう修正（SPR-37）

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,12 +6,17 @@ name: Claude AI Review
 # 方針: 非ブロッキング（PR を fail させない・必須チェックにしない）。所見は PR コメント/行内コメントで可視化するだけ。
 #   採否の最終判断は人=唯一のレビュアーが行う前提（ソロ開発のセルフマージ・ポリシー）。
 # 並走中の CodeRabbit（.coderabbit.yaml）と A/B 比較し、検出力・ノイズ・日本語品質を見極める。
+#
+# 重要: コメント投稿には公式 pr-review-comprehensive.yml 同様に track_progress: true と、
+#   claude_args の --allowedTools での明示許可が必須（agent モード既定ではコメント用 MCP が起動せず投稿できない）。
+#   また claude-code-action は workflow が main と同一になるまで実レビューをスキップする仕様のため、
+#   この workflow の変更は main にマージするまで効かない。
 
 on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -40,8 +45,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          use_sticky_comment: true
+          # 進捗トラッキングコメントを作成し、コメント投稿用ツールを有効化する（タグモード）。
+          track_progress: true
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             あなたはこのリポジトリの PR レビュアーです。リポジトリ直下の CLAUDE.md が「能動ルールの単一ソース」です。
             必ず CLAUDE.md を読み、その §0 の評価軸と §1 の能動ルールに沿ってレビューしてください。
 
@@ -65,10 +74,12 @@ jobs:
               「✅ Two-Way Door: 重大所見が無ければ自己マージ可」と明示。
 
             # 所見の出し方
-            - 具体的な行に対しては GitHub の **行内レビューコメント**で指摘する。
-            - 全体所見はサマリコメントにまとめ、重大度（blocker / major / minor / nit）を付ける。
+            - 具体的な行に対しては inline review comment（mcp__github_inline_comment__create_inline_comment）で指摘する。
+            - 全体所見はトップレベルコメントにまとめ、重大度（blocker / major / minor / nit）を付ける。
             - 確信が持てない指摘は「要確認」と明示し、断定しない（ノイズを最小化）。
             - 問題が無ければ「重大所見なし」とはっきり書く。
           # モデルは固定しない（版ズレ回避: CLAUDE.md 軸1）。action 既定の最新モデルに任せる。
+          # 行内コメント投稿ツールと gh コマンドを明示許可（これが無いと投稿できない）。
           claude_args: |
             --max-turns 20
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
# PRタイトル
Claude AI Review のコメント投稿不能を修正（SPR-37）

## 要件
#530 で Claude review が実行されたものの、**所見を1件も投稿できなかった**。原因は agent モードの仕様で、`--allowedTools` にコメント系ツールを明示しない限りコメント用 MCP サーバが起動しないため（ログに `permission_denials_count: 2` / `No buffered inline comments`）。

公式 [`pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) に倣い修正：
- `track_progress: true`（タグモード＝トラッキングコメント作成＋コメント投稿を有効化）
- `claude_args` の `--allowedTools` に `mcp__github_inline_comment__create_inline_comment` と `Bash(gh pr comment/diff/view:*)` を追加

## 注意（仕様）
claude-code-action は **workflow が main と同一になるまで実レビューをスキップ**するため、本修正は **main にマージして初めて有効化**される。マージ後に #530 を再トリガー（push か reopen）して動作確認する。

## テスト項目
- [ ] マージ後、#530 で Claude が日本語サマリ＋行内コメントを投稿する
- [ ] サマリ冒頭に One-Way/Two-Way Door 判定が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * コードレビューが「レビュー準備完了」状態のプルリクエストでも実行されるようになりました
  * コードレビューのトラッキング機能が強化され、インラインコメント機能が改善されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->