### PR TITLE
test: カバレッジ閾値を verify/CI で常時強制する (SPR-151)

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -14,7 +14,7 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
-		"test:integration": "vitest run src/endpoints/__tests__/data-integrity-check.integration.test.ts",
+		"test:integration": "vitest run --coverage.enabled=false src/endpoints/__tests__/data-integrity-check.integration.test.ts",
 		"seed:dump": "dotenv -e .env -- tsx src/tools/firestore-local/dump.ts",
 		"seed:load": "tsx src/tools/firestore-local/seed.ts",
 		"collect:work-ids": "dotenv -e .env -- tsx src/tools/core/collect-work-ids.ts",

--- a/apps/functions/vitest.config.ts
+++ b/apps/functions/vitest.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
 			},
 		},
 		coverage: {
+			// `vitest run`（= pnpm test / verify / CI）で常に閾値を強制する（SPR-151）
+			enabled: true,
 			provider: "v8",
 			reporter: ["text", "json", "lcov", "clover"],
 			reportsDirectory: "./coverage",
@@ -32,11 +34,13 @@ export default defineConfig({
 				"src/tools/firestore-local/**", // ローカル Emulator のシード/ダンプ用 dev ツール
 				"scripts/**", // Build scripts
 			],
+			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
+			// 目標値への引き上げは SPR-152 で段階的に行う。
 			thresholds: {
-				statements: 50,
-				branches: 75,
-				functions: 70,
-				lines: 50,
+				statements: 72,
+				branches: 60,
+				functions: 80,
+				lines: 72,
 			},
 		},
 	},

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -19,6 +19,31 @@ export default defineConfig({
 				external: ["next/server"],
 			},
 		},
+		coverage: {
+			// `vitest run`（= pnpm test / verify / CI）で常に閾値を強制する（SPR-151）
+			enabled: true,
+			provider: "v8",
+			reporter: ["text", "json", "lcov"],
+			exclude: [
+				"node_modules/**",
+				"**/dist/**",
+				"**/.next/**",
+				"**/*.d.ts",
+				"**/*.config.{js,ts,mjs,cjs,mts,cts}",
+				"**/*.stories.{ts,tsx}",
+				"**/__tests__/**",
+				"**/e2e/**",
+				"src/**/layout.tsx", // App Router boilerplate
+			],
+			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
+			// 目標値への引き上げは SPR-152 で段階的に行う。
+			thresholds: {
+				statements: 62,
+				branches: 52,
+				functions: 60,
+				lines: 63,
+			},
+		},
 		exclude: [
 			"**/node_modules/**",
 			"**/dist/**",

--- a/packages/shared-types/vitest.config.ts
+++ b/packages/shared-types/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		coverage: {
+			// `vitest run`（= pnpm test / verify / CI）で常に閾値を強制する（SPR-151）
+			enabled: true,
 			provider: "v8",
 			reporter: ["text", "json", "lcov"],
 			exclude: [
@@ -17,11 +19,13 @@ export default defineConfig({
 				"**/types/firestore/**", // firestore type definitions only
 				"**/plain-objects/**", // plain object types only
 			],
+			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
+			// 目標値（80）への引き上げは SPR-152 で段階的に行う。
 			thresholds: {
-				statements: 80,
-				branches: 80,
-				functions: 80,
-				lines: 80,
+				statements: 72,
+				branches: 63,
+				functions: 77,
+				lines: 72,
 			},
 		},
 	},

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -13,6 +13,8 @@ export default defineConfig({
 		environment: "happy-dom",
 		setupFiles: ["./vitest.setup.ts"],
 		coverage: {
+			// `vitest run`（= pnpm test / verify / CI）で常に閾値を強制する（SPR-151）
+			enabled: true,
 			// カバレッジ対象ファイルを明示的に指定
 			include: [
 				"src/components/custom/**/*.{ts,tsx}", // カスタムコンポーネントのみ
@@ -49,8 +51,6 @@ export default defineConfig({
 			],
 			// カバレッジレポート形式
 			reporter: ["text", "html", "lcov"],
-			// `vitest run`（= pnpm test / verify / CI）で常に閾値を強制する（SPR-151）
-			enabled: true,
 			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
 			// 目標値への引き上げは SPR-152 で段階的に行う。
 			thresholds: {

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -5,10 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	resolve: {
 		alias: {
-			"@suzumina.click/shared-types": resolve(
-				__dirname,
-				"../shared-types/src/index.ts",
-			),
+			"@suzumina.click/shared-types": resolve(__dirname, "../shared-types/src/index.ts"),
 		},
 	},
 	test: {
@@ -52,12 +49,15 @@ export default defineConfig({
 			],
 			// カバレッジレポート形式
 			reporter: ["text", "html", "lcov"],
-			// カバレッジ閾値（品質を担保しつつ実用的な範囲で設定）
+			// `vitest run`（= pnpm test / verify / CI）で常に閾値を強制する（SPR-151）
+			enabled: true,
+			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
+			// 目標値への引き上げは SPR-152 で段階的に行う。
 			thresholds: {
-				statements: 70, // 新しいコンポーネント追加を考慮
-				branches: 65, // 複雑な条件分岐の多いコンポーネント対応
-				functions: 40, // AudioButton削除後の現実的な閾値
-				lines: 70, // 実装済み機能の主要パスをカバー
+				statements: 57,
+				branches: 51,
+				functions: 57,
+				lines: 59,
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

カバレッジ閾値が `pnpm verify` / CI で**一度も評価されていなかった**問題を修正する（SPR-151）。

これまで:
- `verify` → `pnpm -r test` → 各パッケージ `vitest run`（**`--coverage` なし**）
- どの `vitest.config.ts` にも `coverage.enabled` が無く、`vitest run` 単体では計測が走らない
- CI（`pr-check.yml`）も各パッケージの `test` を呼ぶだけで `test:coverage` を呼ぶ workflow は皆無

→ `vitest.config.ts` の閾値は手動 `pnpm test:coverage` 時のみ効く死んだ設定だった。

## 変更内容

1. **常時強制**: 各 `vitest.config.ts` の `coverage` に `enabled: true` を追加。`vitest run`（= `pnpm test` / `verify` / CI）で常に閾値が評価される。
2. **閾値をラチェット化**: 旧閾値はどれも未達だったため、実測フロア（1〜2pp下）に再設定（回帰ガード）。
3. **apps/web に coverage 設定を新規追加**（従来ゼロ）。
4. **統合テストの誤発火回避**: `functions` の `test:integration` に `--coverage.enabled=false`（単一ファイル実行で閾値が誤発火するため）。

| パッケージ | 旧 (st/br/fn/ln) | 新 | 実測 |
|---|---|---|---|
| shared-types | 80/80/80/80 | 72/63/77/72 | 73.7/64.5/78.9/74.0 |
| ui | 70/65/40/70 | 57/51/57/59 | 58.8/52.8/58.4/59.9 |
| functions | 50/75/70/50 | 72/60/80/72 | 73.5/61.7/81.5/73.4 |
| apps/web | なし | 62/52/60/63 | 64.3/54.5/62.6/65.2 |

## 確認

- `pnpm verify` EXIT 0（lint + typecheck + test 全 green、閾値違反ゼロ）
- CLAUDE.md §1 の「verify でカバレッジ閾値も強制される」記述が初めて実装と一致（doc 修正不要）

## フォローアップ

目標水準（shared-types 80 等）への段階的引き上げは SPR-152 で対応。

Closes SPR-151

🤖 Generated with [Claude Code](https://claude.com/claude-code)