### PR TITLE
test: shared-types のカバレッジを目標値へ引き上げ (SPR-152 第1弾)

### DIFF
--- a/packages/shared-types/src/__tests__/video-operations.test.ts
+++ b/packages/shared-types/src/__tests__/video-operations.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+	canCreateButton,
+	formatDuration,
+	getAgeInDays,
+	getAllTags,
+	getAudioButtonCount,
+	getAudioButtonCreationErrorMessage,
+	getDisplayTitle,
+	getFormattedViewCount,
+	getThumbnailUrl,
+	getYouTubeUrl,
+	hasAudioButtons,
+	isArchived,
+	isLive,
+	isOlderThan,
+	isPossiblyLive,
+	isPremiere,
+	isUpcoming,
+} from "../operations/video";
+import type { VideoPlainObject } from "../plain-objects/video-plain";
+
+const video = (over: Partial<VideoPlainObject> = {}): VideoPlainObject =>
+	({
+		videoId: "vid123",
+		title: "テスト動画",
+		publishedAt: "2024-01-01T00:00:00.000Z",
+		duration: "PT1M30S",
+		...over,
+	}) as VideoPlainObject;
+
+describe("状態判定", () => {
+	it("isArchived は _computed を優先し、無ければ videoType を見る", () => {
+		expect(isArchived(video({ _computed: { isArchived: true } } as never))).toBe(true);
+		expect(isArchived(video({ videoType: "archived" } as never))).toBe(true);
+		expect(isArchived(video({ videoType: "normal" } as never))).toBe(false);
+	});
+
+	it("isPremiere は _computed を優先し、無ければ videoType を見る", () => {
+		expect(isPremiere(video({ _computed: { isPremiere: true } } as never))).toBe(true);
+		expect(isPremiere(video({ videoType: "premiere" } as never))).toBe(true);
+		expect(isPremiere(video())).toBe(false);
+	});
+
+	it("isLive / isUpcoming は liveBroadcastContent を見る", () => {
+		expect(isLive(video({ liveBroadcastContent: "live" } as never))).toBe(true);
+		expect(isLive(video({ liveBroadcastContent: "none" } as never))).toBe(false);
+		expect(isUpcoming(video({ liveBroadcastContent: "upcoming" } as never))).toBe(true);
+		expect(isUpcoming(video())).toBe(false);
+	});
+
+	it("isPossiblyLive は常に false", () => {
+		expect(isPossiblyLive(video())).toBe(false);
+	});
+});
+
+describe("canCreateButton / エラーメッセージ", () => {
+	it("_computed.canCreateButton を優先する", () => {
+		expect(canCreateButton(video({ _computed: { canCreateButton: true } } as never))).toBe(true);
+		expect(canCreateButton(video({ _computed: { canCreateButton: false } } as never))).toBe(false);
+	});
+
+	it("_computed が無ければ archived のみ作成可", () => {
+		expect(canCreateButton(video({ videoType: "archived" } as never))).toBe(true);
+		expect(canCreateButton(video({ videoType: "normal" } as never))).toBe(false);
+	});
+
+	it("ライブ中・配信予定・長さ不明はエラーメッセージを返す", () => {
+		expect(
+			getAudioButtonCreationErrorMessage(video({ liveBroadcastContent: "live" } as never)),
+		).toBe("ライブ配信中は音声ボタンを作成できません");
+		expect(
+			getAudioButtonCreationErrorMessage(video({ liveBroadcastContent: "upcoming" } as never)),
+		).toBe("配信予定の動画には音声ボタンを作成できません");
+		expect(getAudioButtonCreationErrorMessage(video({ duration: "PT0S" }))).toBe(
+			"動画の長さが不明なため音声ボタンを作成できません",
+		);
+		expect(getAudioButtonCreationErrorMessage(video({ duration: undefined } as never))).toBe(
+			"動画の長さが不明なため音声ボタンを作成できません",
+		);
+	});
+
+	it("条件を満たせば null（作成可）", () => {
+		expect(getAudioButtonCreationErrorMessage(video())).toBeNull();
+	});
+});
+
+describe("表示系", () => {
+	it("getDisplayTitle / getYouTubeUrl", () => {
+		expect(getDisplayTitle(video({ title: "タイトル" }))).toBe("タイトル");
+		expect(getYouTubeUrl(video({ videoId: "abc" }))).toBe("https://www.youtube.com/watch?v=abc");
+	});
+
+	it("getThumbnailUrl は指定品質→フォールバック→構築 URL の順", () => {
+		const withThumb = video({
+			thumbnails: { high: { url: "http://h.jpg" } },
+		} as never);
+		expect(getThumbnailUrl(withThumb, "high")).toBe("http://h.jpg");
+		// medium 指定だが medium が無いので fallback で high
+		expect(getThumbnailUrl(withThumb, "medium")).toBe("http://h.jpg");
+		// thumbnails 無し → 構築 URL
+		expect(getThumbnailUrl(video({ videoId: "zzz" }))).toBe(
+			"https://i.ytimg.com/vi/zzz/mqdefault.jpg",
+		);
+	});
+
+	it("getFormattedViewCount は1万以上で『万』表記", () => {
+		expect(getFormattedViewCount(video({ statistics: { viewCount: 12345 } } as never))).toBe(
+			"1.2万",
+		);
+		expect(getFormattedViewCount(video({ statistics: { viewCount: 999 } } as never))).toBe("999");
+		expect(getFormattedViewCount(video())).toBe("0");
+	});
+});
+
+describe("formatDuration", () => {
+	it("時・分・秒を整形する", () => {
+		expect(formatDuration("PT1H2M3S")).toBe("1:02:03");
+		expect(formatDuration("PT5M9S")).toBe("5:09");
+		expect(formatDuration("PT0S")).toBe("0:00");
+	});
+
+	it("不正な形式は 0:00", () => {
+		expect(formatDuration("invalid")).toBe("0:00");
+	});
+});
+
+describe("tags / audio buttons", () => {
+	it("getAllTags は全ソースを重複排除して結合する", () => {
+		const v = video({
+			tags: {
+				playlistTags: ["a", "b"],
+				userTags: ["b", "c"],
+				contentTags: ["c", "d"],
+			},
+		} as never);
+		expect(getAllTags(v).sort()).toEqual(["a", "b", "c", "d"]);
+	});
+
+	it("タグが無ければ空配列", () => {
+		expect(getAllTags(video())).toEqual([]);
+	});
+
+	it("hasAudioButtons / getAudioButtonCount", () => {
+		expect(
+			hasAudioButtons(video({ audioButtonInfo: { hasButtons: true, count: 3 } } as never)),
+		).toBe(true);
+		expect(hasAudioButtons(video())).toBe(false);
+		expect(getAudioButtonCount(video({ audioButtonInfo: { count: 3 } } as never))).toBe(3);
+		expect(getAudioButtonCount(video())).toBe(0);
+	});
+});
+
+describe("日付系", () => {
+	it("isOlderThan は指定日数より古いか判定する", () => {
+		expect(isOlderThan(video({ publishedAt: "2000-01-01T00:00:00.000Z" }), 30)).toBe(true);
+		const recent = new Date().toISOString();
+		expect(isOlderThan(video({ publishedAt: recent }), 30)).toBe(false);
+	});
+
+	it("getAgeInDays は公開からの経過日数を返す", () => {
+		const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+		expect(getAgeInDays(video({ publishedAt: tenDaysAgo }))).toBe(10);
+	});
+});

--- a/packages/shared-types/src/__tests__/video-operations.test.ts
+++ b/packages/shared-types/src/__tests__/video-operations.test.ts
@@ -160,6 +160,9 @@ describe("日付系", () => {
 
 	it("getAgeInDays は公開からの経過日数を返す", () => {
 		const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
-		expect(getAgeInDays(video({ publishedAt: tenDaysAgo }))).toBe(10);
+		// 実装は Math.ceil のため、生成〜計測の僅差で 11 になり得る（境界フレーキー回避）
+		const age = getAgeInDays(video({ publishedAt: tenDaysAgo }));
+		expect(age).toBeGreaterThanOrEqual(10);
+		expect(age).toBeLessThanOrEqual(11);
 	});
 });

--- a/packages/shared-types/src/utilities/__tests__/aggregator.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/aggregator.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { UserWorkEvaluation } from "../../entities/user-evaluation";
+import { calculateCharacteristicAverage, calculateEvaluationStats } from "../evaluation/aggregator";
+
+const evaluation = (over: Partial<UserWorkEvaluation> = {}): UserWorkEvaluation => ({
+	workId: "RJ1",
+	userId: "u1",
+	overallRating: 4,
+	recommendedTags: [],
+	isPublic: true,
+	createdAt: "2024-01-01T00:00:00.000Z",
+	updatedAt: "2024-01-01T00:00:00.000Z",
+	...over,
+});
+
+describe("calculateCharacteristicAverage", () => {
+	it("該当する値が無ければ undefined", () => {
+		expect(calculateCharacteristicAverage([evaluation()], "pitch", "voiceQuality")).toBeUndefined();
+	});
+
+	it("指定カテゴリ・特性の平均値・評価者数を返す", () => {
+		const evals = [
+			evaluation({ voiceQuality: { pitch: { value: 4, evaluatorCount: 1 } } }),
+			evaluation({ voiceQuality: { pitch: { value: 2, evaluatorCount: 1 } } }),
+		];
+		const result = calculateCharacteristicAverage(evals, "pitch", "voiceQuality");
+		expect(result).toEqual({ value: 3, confidence: 0.2, evaluatorCount: 2 });
+	});
+
+	it("confidence は最大 1 にクランプされる", () => {
+		const evals = Array.from({ length: 15 }, () =>
+			evaluation({ personality: { maturity: { value: 5, evaluatorCount: 1 } } }),
+		);
+		const result = calculateCharacteristicAverage(evals, "maturity", "personality");
+		expect(result?.confidence).toBe(1);
+		expect(result?.value).toBe(5);
+	});
+
+	it("平均値は小数第2位に丸める", () => {
+		const evals = [
+			evaluation({ behaviorExpression: { energy: { value: 1, evaluatorCount: 1 } } }),
+			evaluation({ behaviorExpression: { energy: { value: 2, evaluatorCount: 1 } } }),
+			evaluation({ behaviorExpression: { energy: { value: 2, evaluatorCount: 1 } } }),
+		];
+		const result = calculateCharacteristicAverage(evals, "energy", "behaviorExpression");
+		expect(result?.value).toBe(1.67);
+	});
+
+	it("attributeCharm カテゴリも集計できる", () => {
+		const evals = [evaluation({ attributeCharm: { appeal: { value: 3, evaluatorCount: 1 } } })];
+		const result = calculateCharacteristicAverage(evals, "appeal", "attributeCharm");
+		expect(result?.value).toBe(3);
+	});
+});
+
+describe("calculateEvaluationStats", () => {
+	it("空配列なら平均 0・件数 0", () => {
+		const stats = calculateEvaluationStats([]);
+		expect(stats.totalEvaluations).toBe(0);
+		expect(stats.averageRating).toBe(0);
+		expect(stats.recentEvaluations).toEqual([]);
+	});
+
+	it("星別分布・平均・総数を集計する", () => {
+		const stats = calculateEvaluationStats([
+			evaluation({ overallRating: 5 }),
+			evaluation({ overallRating: 5 }),
+			evaluation({ overallRating: 3 }),
+		]);
+		expect(stats.ratingDistribution["5"]).toBe(2);
+		expect(stats.ratingDistribution["3"]).toBe(1);
+		expect(stats.totalEvaluations).toBe(3);
+		expect(stats.averageRating).toBe(4.33);
+	});
+
+	it("recentEvaluations は公開のみを新しい順で最大10件返す", () => {
+		const evals = [
+			evaluation({ isPublic: false, createdAt: "2024-03-01T00:00:00.000Z" }),
+			evaluation({ isPublic: true, createdAt: "2024-01-01T00:00:00.000Z" }),
+			evaluation({ isPublic: true, createdAt: "2024-02-01T00:00:00.000Z" }),
+		];
+		const stats = calculateEvaluationStats(evals);
+		expect(stats.recentEvaluations).toHaveLength(2);
+		// 新しい順（2月 → 1月）
+		expect(stats.recentEvaluations[0]?.createdAt).toBe("2024-02-01T00:00:00.000Z");
+	});
+});

--- a/packages/shared-types/src/utilities/__tests__/avatar.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/avatar.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { createDiscordAvatarUrl } from "../discord/avatar";
+
+describe("createDiscordAvatarUrl", () => {
+	it("userId が空ならデフォルトアバター(0)を返す", () => {
+		expect(createDiscordAvatarUrl("", "hash")).toBe(
+			"https://cdn.discordapp.com/embed/avatars/0.png",
+		);
+	});
+
+	it("avatarHash が無い場合は userId に基づくデフォルトアバターを返す", () => {
+		// 12 % 5 = 2
+		expect(createDiscordAvatarUrl("12", null)).toBe(
+			"https://cdn.discordapp.com/embed/avatars/2.png",
+		);
+		expect(createDiscordAvatarUrl("10", undefined)).toBe(
+			"https://cdn.discordapp.com/embed/avatars/0.png",
+		);
+	});
+
+	it("通常の avatarHash は png として size 付き URL を返す", () => {
+		expect(createDiscordAvatarUrl("user1", "abcdef")).toBe(
+			"https://cdn.discordapp.com/avatars/user1/abcdef.png?size=128",
+		);
+	});
+
+	it("a_ で始まる avatarHash はアニメーション gif として扱う", () => {
+		expect(createDiscordAvatarUrl("user1", "a_animated", 256)).toBe(
+			"https://cdn.discordapp.com/avatars/user1/a_animated.gif?size=256",
+		);
+	});
+
+	it("size 引数を URL に反映する", () => {
+		expect(createDiscordAvatarUrl("user1", "abc", 512)).toContain("?size=512");
+	});
+});

--- a/packages/shared-types/src/utilities/__tests__/circle-conversions.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/circle-conversions.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { CircleDocument } from "../../types/firestore/circle";
+import {
+	convertToCirclePlainObject,
+	convertToCirclePlainObjects,
+	isCirclePlainObject,
+} from "../circle-conversions";
+
+const baseDoc = (over: Partial<CircleDocument> = {}): CircleDocument =>
+	({
+		circleId: "RG12345",
+		name: "テストサークル",
+		nameEn: "Test Circle",
+		workIds: ["RJ1", "RJ2"],
+		createdAt: "2024-01-01T00:00:00.000Z",
+		updatedAt: "2024-02-01T00:00:00.000Z",
+		...over,
+	}) as CircleDocument;
+
+describe("convertToCirclePlainObject", () => {
+	it("null / undefined は null を返す", () => {
+		expect(convertToCirclePlainObject(null)).toBeNull();
+		expect(convertToCirclePlainObject(undefined)).toBeNull();
+	});
+
+	it("workIds の件数を workCount に反映する", () => {
+		const result = convertToCirclePlainObject(baseDoc());
+		expect(result?.workCount).toBe(2);
+	});
+
+	it("workIds が無い場合 workCount は 0", () => {
+		const result = convertToCirclePlainObject(baseDoc({ workIds: undefined }));
+		expect(result?.workCount).toBe(0);
+	});
+
+	it("文字列の日時はそのまま保持する", () => {
+		const result = convertToCirclePlainObject(baseDoc());
+		expect(result?.createdAt).toBe("2024-01-01T00:00:00.000Z");
+	});
+
+	it("Firestore Timestamp(toDate) は ISO 文字列に変換する", () => {
+		const ts = { toDate: () => new Date("2024-03-03T00:00:00.000Z") };
+		const result = convertToCirclePlainObject(baseDoc({ createdAt: ts as never }));
+		expect(result?.createdAt).toBe("2024-03-03T00:00:00.000Z");
+	});
+
+	it("Date 型は ISO 文字列に変換する", () => {
+		const result = convertToCirclePlainObject(
+			baseDoc({ updatedAt: new Date("2024-04-04T00:00:00.000Z") as never }),
+		);
+		expect(result?.updatedAt).toBe("2024-04-04T00:00:00.000Z");
+	});
+
+	it("変換不能な日時は null になる", () => {
+		const result = convertToCirclePlainObject(baseDoc({ createdAt: 12345 as never }));
+		expect(result?.createdAt).toBeNull();
+	});
+});
+
+describe("convertToCirclePlainObjects", () => {
+	it("配列を変換し null を除外する", () => {
+		const results = convertToCirclePlainObjects([baseDoc(), baseDoc({ circleId: "RG2" })]);
+		expect(results).toHaveLength(2);
+		expect(results.map((c) => c.circleId)).toEqual(["RG12345", "RG2"]);
+	});
+});
+
+describe("isCirclePlainObject", () => {
+	it("必須フィールドを満たすオブジェクトは true", () => {
+		expect(isCirclePlainObject({ circleId: "RG1", name: "n", workCount: 3 })).toBe(true);
+	});
+
+	it("型が異なる/欠落するものは false", () => {
+		expect(isCirclePlainObject(null)).toBe(false);
+		expect(isCirclePlainObject({ circleId: "RG1", name: "n" })).toBe(false);
+		expect(isCirclePlainObject({ circleId: 1, name: "n", workCount: 3 })).toBe(false);
+	});
+});

--- a/packages/shared-types/src/utilities/__tests__/firestore-utils.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/firestore-utils.test.ts
@@ -37,9 +37,9 @@ describe("toServerModel", () => {
 			{ videoId: "v1", title: "t", publishedAt: "not-a-date" },
 			fakeFirestore,
 		);
-		// new Date("not-a-date") は Invalid Date → fromDate に渡るが iso が例外、
-		// 実装は try/catch ではなく fromDate に委譲するため kind は fromDate になる
-		expect(result.publishedAt).toHaveProperty("kind");
+		// "not-a-date" → new Date() で Invalid Date → fromDate 内の toISOString() が
+		// RangeError → toServerModel の try/catch で捕捉され now() を返す
+		expect(result.publishedAt).toEqual({ kind: "now" });
 	});
 });
 

--- a/packages/shared-types/src/utilities/__tests__/firestore-utils.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/firestore-utils.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { FirestoreServerVideoData } from "../../types/firestore/video";
+import { fromServerModel, toServerModel } from "../firestore-utils";
+
+// Admin SDK Timestamp のスタブ
+const fakeFirestore = {
+	Timestamp: {
+		now: () => ({ kind: "now" }),
+		fromDate: (date: Date) => ({ kind: "fromDate", iso: date.toISOString() }),
+	},
+};
+
+describe("toServerModel", () => {
+	it("videoId が無ければ id を流用する", () => {
+		const result = toServerModel({ id: "abc", title: "t" }, fakeFirestore);
+		expect(result.videoId).toBe("abc");
+		expect(result.id).toBe("abc");
+	});
+
+	it("description が無ければ空文字にする", () => {
+		const result = toServerModel({ videoId: "v1", title: "t" }, fakeFirestore);
+		expect(result.description).toBe("");
+	});
+
+	it("日時があれば fromDate、無ければ now を使う", () => {
+		const result = toServerModel(
+			{ videoId: "v1", title: "t", publishedAt: "2024-01-01T00:00:00.000Z" },
+			fakeFirestore,
+		);
+		expect(result.publishedAt).toEqual({ kind: "fromDate", iso: "2024-01-01T00:00:00.000Z" });
+		// lastFetchedAt は未指定なので now
+		expect(result.lastFetchedAt).toEqual({ kind: "now" });
+	});
+
+	it("不正な日時文字列は now にフォールバックする", () => {
+		const result = toServerModel(
+			{ videoId: "v1", title: "t", publishedAt: "not-a-date" },
+			fakeFirestore,
+		);
+		// new Date("not-a-date") は Invalid Date → fromDate に渡るが iso が例外、
+		// 実装は try/catch ではなく fromDate に委譲するため kind は fromDate になる
+		expect(result.publishedAt).toHaveProperty("kind");
+	});
+});
+
+describe("fromServerModel", () => {
+	const base = (over: Partial<FirestoreServerVideoData> = {}): FirestoreServerVideoData =>
+		({
+			id: "abc",
+			videoId: "abc",
+			title: "t",
+			channelId: "c1",
+			channelTitle: "ch",
+			thumbnailUrl: "http://example.com/t.jpg",
+			...over,
+		}) as FirestoreServerVideoData;
+
+	it("Firestore Timestamp(toDate) を ISO 文字列に変換する", () => {
+		const ts = { toDate: () => new Date("2024-05-05T00:00:00.000Z") };
+		const result = fromServerModel(base({ publishedAt: ts as never }));
+		expect(result.publishedAt).toBe("2024-05-05T00:00:00.000Z");
+	});
+
+	it("文字列日時もそのまま ISO 化する", () => {
+		const result = fromServerModel(base({ publishedAt: "2024-06-06T00:00:00.000Z" as never }));
+		expect(result.publishedAt).toBe("2024-06-06T00:00:00.000Z");
+	});
+
+	it("liveBroadcastContent 未指定は 'none' を補完する", () => {
+		const result = fromServerModel(base());
+		expect(result.liveBroadcastContent).toBe("none");
+	});
+
+	it("id が無ければ videoId を使う", () => {
+		const result = fromServerModel(base({ id: undefined }));
+		expect(result.id).toBe("abc");
+	});
+});

--- a/packages/shared-types/src/utilities/__tests__/guild-membership.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/guild-membership.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import type { GuildMembership } from "../../entities/user";
+import { isValidGuildMember, SUZUMINA_GUILD_ID } from "../discord/guild-membership";
+
+const membership = (over: Partial<GuildMembership>): GuildMembership => ({
+	guildId: SUZUMINA_GUILD_ID,
+	userId: "user-1",
+	isMember: true,
+	...over,
+});
+
+describe("isValidGuildMember", () => {
+	it("対象ギルドのメンバーなら true", () => {
+		expect(isValidGuildMember(membership({}))).toBe(true);
+	});
+
+	it("対象ギルドでも isMember が false なら false", () => {
+		expect(isValidGuildMember(membership({ isMember: false }))).toBe(false);
+	});
+
+	it("別ギルドなら false", () => {
+		expect(isValidGuildMember(membership({ guildId: "999" }))).toBe(false);
+	});
+});

--- a/packages/shared-types/src/utilities/__tests__/relative-time.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/relative-time.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { formatMemberSince, formatRelativeTime } from "../formatters/relative-time";
+
+const ago = (ms: number): string => new Date(Date.now() - ms).toISOString();
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe("formatRelativeTime", () => {
+	it("1分以内は『たった今』", () => {
+		expect(formatRelativeTime(ago(30 * 1000))).toBe("たった今");
+		expect(formatRelativeTime(ago(MIN))).toBe("たった今");
+	});
+
+	it("数分前は『N分前』", () => {
+		expect(formatRelativeTime(ago(5 * MIN))).toBe("5分前");
+	});
+
+	it("数時間前は『N時間前』", () => {
+		expect(formatRelativeTime(ago(3 * HOUR))).toBe("3時間前");
+	});
+
+	it("1日前は『昨日』", () => {
+		expect(formatRelativeTime(ago(DAY + HOUR))).toBe("昨日");
+	});
+
+	it("1週間未満は『N日前』", () => {
+		expect(formatRelativeTime(ago(3 * DAY))).toBe("3日前");
+	});
+
+	it("1ヶ月未満は『N週間前』", () => {
+		expect(formatRelativeTime(ago(10 * DAY))).toBe("1週間前");
+	});
+
+	it("1年未満は『Nヶ月前』", () => {
+		expect(formatRelativeTime(ago(60 * DAY))).toBe("2ヶ月前");
+	});
+
+	it("1年以上は『N年前』", () => {
+		expect(formatRelativeTime(ago(400 * DAY))).toBe("1年前");
+	});
+});
+
+describe("formatMemberSince", () => {
+	it("年月を日本語表記で返す", () => {
+		expect(formatMemberSince("2020-03-15T00:00:00.000Z")).toBe("2020年3月から");
+	});
+
+	it("月は 1 始まりで返す", () => {
+		expect(formatMemberSince("2023-12-01T12:00:00.000Z")).toBe("2023年12月から");
+	});
+});

--- a/packages/shared-types/src/utilities/__tests__/user-labels.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/user-labels.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveDisplayName } from "../user/display-name";
+import { getUserRoleLabel } from "../user/role-label";
+
+describe("getUserRoleLabel", () => {
+	it("各ロールを日本語ラベルに変換する", () => {
+		expect(getUserRoleLabel("member")).toBe("メンバー");
+		expect(getUserRoleLabel("moderator")).toBe("モデレーター");
+		expect(getUserRoleLabel("admin")).toBe("管理者");
+	});
+});
+
+describe("resolveDisplayName", () => {
+	it("displayName があれば最優先で返す", () => {
+		expect(resolveDisplayName("表示名", "global", "user")).toBe("表示名");
+	});
+
+	it("displayName が無ければ globalName を返す", () => {
+		expect(resolveDisplayName(undefined, "global", "user")).toBe("global");
+	});
+
+	it("displayName も globalName も無ければ username を返す", () => {
+		expect(resolveDisplayName(undefined, undefined, "user")).toBe("user");
+	});
+
+	it("空文字は falsy として扱い次の候補にフォールバックする", () => {
+		expect(resolveDisplayName("", "", "user")).toBe("user");
+	});
+});

--- a/packages/shared-types/vitest.config.ts
+++ b/packages/shared-types/vitest.config.ts
@@ -19,13 +19,14 @@ export default defineConfig({
 				"**/types/firestore/**", // firestore type definitions only
 				"**/plain-objects/**", // plain object types only
 			],
-			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
-			// 目標値（80）への引き上げは SPR-152 で段階的に行う。
+			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
+			// statements / lines / functions は目標 80 に到達済み。
+			// branches は 71.3% まで改善（残りは後続増分で 80 を目指す）。
 			thresholds: {
-				statements: 72,
-				branches: 63,
-				functions: 77,
-				lines: 72,
+				statements: 80,
+				branches: 70,
+				functions: 83,
+				lines: 80,
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

SPR-152（カバレッジ閾値を段階的に目標値へ引き上げる）の第1増分。最優先の `packages/shared-types`（型の正本・目標80）から着手。

未テストだった**純粋関数群**にテストを追加し、閾値をラチェットで引き上げる。除外でメトリクスを稼ぐのではなく実テストで担保している（軸3）。

## 追加テスト（すべて純粋関数）

- `utilities/`: `avatar` / `relative-time` / `user-labels`(role-label, display-name) / `aggregator` / `guild-membership` / `circle-conversions` / `firestore-utils`
- `operations/video`: 状態判定（archived/premiere/live/upcoming）・音声ボタン作成可否・表示系（thumbnail/viewCount）・`formatDuration`・タグ集約・日付系

## カバレッジ（shared-types 実測）

| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 73.7 | **81.6** | 80 |
| branches | 64.5 | **71.3** | 70 |
| functions | 78.9 | **84.9** | 83 |
| lines | 74.0 | **82.2** | 80 |

statements / lines / functions が目標 **80 到達**。branches（71.3）は次の増分で 80 を目指す。

## 確認

- `pnpm verify` EXIT 0（lint + typecheck + test 全 green、959 tests pass）
- 閾値は実測の 1〜2pp 下に設定（変動吸収のマージン）

## フォローアップ（SPR-152 継続）

- shared-types branches を 80 へ（`work-creators` / `work-price` / `creator-type` 等の分岐補強）
- functions branches、ui / web の引き上げ

🤖 Generated with [Claude Code](https://claude.com/claude-code)