### PR TITLE
test: shared-types の branches を引き上げ (SPR-152 第2弾)

### DIFF
--- a/packages/shared-types/src/entities/work/__tests__/work-utils.test.ts
+++ b/packages/shared-types/src/entities/work/__tests__/work-utils.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+	getAgeCategoryDisplayName,
+	getAgeCategoryStringDisplayName,
+	getWorkCategoryDisplayName,
+	getWorkCategoryDisplayNameSafe,
+	getWorkCategoryDisplayText,
+	getWorkLanguageDisplayName,
+	getWorkLanguageDisplayNameSafe,
+	normalizeLanguageCode,
+	optimizeDateFormats,
+	parseSizeToBytes,
+} from "../work-utils";
+
+describe("optimizeDateFormats", () => {
+	it("日本語日付を ISO に変換する", () => {
+		expect(optimizeDateFormats("2023年03月05日")).toEqual({
+			original: "2023年03月05日",
+			iso: "2023-03-05",
+			display: "2023年03月05日",
+		});
+	});
+
+	it("ISO 日付を日本語表示に変換する", () => {
+		expect(optimizeDateFormats("2023-03-05")).toEqual({
+			original: "2023-03-05",
+			iso: "2023-03-05",
+			display: "2023年03月05日",
+		});
+	});
+
+	it("どちらにも一致しない場合は original/display のみ返す", () => {
+		expect(optimizeDateFormats("不明")).toEqual({
+			original: "不明",
+			display: "不明",
+		});
+	});
+});
+
+describe("parseSizeToBytes", () => {
+	it("未指定は undefined", () => {
+		expect(parseSizeToBytes(undefined)).toBeUndefined();
+		expect(parseSizeToBytes("")).toBeUndefined();
+	});
+
+	it("単位ごとにバイト換算する", () => {
+		expect(parseSizeToBytes("1KB")).toBe(1024);
+		expect(parseSizeToBytes("2 MB")).toBe(2 * 1024 * 1024);
+		expect(parseSizeToBytes("1.5GB")).toBe(Math.round(1.5 * 1024 ** 3));
+	});
+
+	it("単位の大文字小文字を問わない", () => {
+		expect(parseSizeToBytes("10mb")).toBe(10 * 1024 * 1024);
+	});
+
+	it("マッチしない文字列は undefined", () => {
+		expect(parseSizeToBytes("わからない")).toBeUndefined();
+	});
+});
+
+describe("category 表示名", () => {
+	it("既知カテゴリは日本語名", () => {
+		expect(getWorkCategoryDisplayName("SOU")).toBe("ボイス・ASMR");
+	});
+
+	it("Safe 版は未知カテゴリをそのまま返す", () => {
+		expect(getWorkCategoryDisplayNameSafe("SOU")).toBe("ボイス・ASMR");
+		expect(getWorkCategoryDisplayNameSafe("UNKNOWN")).toBe("UNKNOWN");
+	});
+
+	it("originalCategoryText を優先し、無ければマッピング", () => {
+		expect(getWorkCategoryDisplayText({ category: "SOU", originalCategoryText: "音声作品" })).toBe(
+			"音声作品",
+		);
+		expect(getWorkCategoryDisplayText({ category: "SOU", originalCategoryText: "  " })).toBe(
+			"ボイス・ASMR",
+		);
+		expect(getWorkCategoryDisplayText({ category: "RPG" })).toBe("ロールプレイング");
+	});
+});
+
+describe("language 表示名", () => {
+	it("既知言語は日本語名", () => {
+		expect(getWorkLanguageDisplayName("ja")).toBe("日本語");
+		expect(getWorkLanguageDisplayName("en")).toBe("英語");
+	});
+
+	it("Safe 版は未知言語をそのまま返す", () => {
+		expect(getWorkLanguageDisplayNameSafe("ja")).toBe("日本語");
+		expect(getWorkLanguageDisplayNameSafe("xx")).toBe("xx");
+	});
+});
+
+describe("年齢カテゴリ表示名", () => {
+	it("数値カテゴリ", () => {
+		expect(getAgeCategoryDisplayName(1)).toBe("全年齢");
+		expect(getAgeCategoryDisplayName(3)).toBe("18禁");
+		expect(getAgeCategoryDisplayName(99)).toBe("不明");
+	});
+
+	it("文字列カテゴリ", () => {
+		expect(getAgeCategoryStringDisplayName("general")).toBe("全年齢");
+		expect(getAgeCategoryStringDisplayName("adult")).toBe("18禁");
+		expect(getAgeCategoryStringDisplayName("unknown")).toBe("不明");
+	});
+});
+
+describe("normalizeLanguageCode", () => {
+	it("別名・大文字を正規化する", () => {
+		expect(normalizeLanguageCode("japanese")).toBe("ja");
+		expect(normalizeLanguageCode("EN-US")).toBe("en");
+		expect(normalizeLanguageCode("chinese_simplified")).toBe("zh-cn");
+	});
+
+	it("未知コードは other", () => {
+		expect(normalizeLanguageCode("klingon")).toBe("other");
+	});
+});

--- a/packages/shared-types/src/value-objects/work/__tests__/creator-type.test.ts
+++ b/packages/shared-types/src/value-objects/work/__tests__/creator-type.test.ts
@@ -58,7 +58,6 @@ describe("アクセサ / ビジネスロジック", () => {
 	it("getAll は優先順位順に全クリエイターを返す", () => {
 		const all = sample().getAll();
 		expect(all[0]).toEqual({ type: "voice", name: "佐倉" });
-		// voice(1) → scenario(2) → illustration(3) の順
 		expect(all.map((c) => c.type)).toEqual(["voice", "voice", "scenario", "illustration"]);
 	});
 

--- a/packages/shared-types/src/value-objects/work/__tests__/creator-type.test.ts
+++ b/packages/shared-types/src/value-objects/work/__tests__/creator-type.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { CREATOR_ROLE_LABELS, CreatorsInfoValueObject, CreatorUtils } from "../creator-type";
+
+const create = (data: Parameters<typeof CreatorsInfoValueObject.create>[0]) =>
+	CreatorsInfoValueObject.create(data)._unsafeUnwrap();
+
+const sample = () =>
+	create({
+		voice: ["佐倉", "鈴鹿"],
+		scenario: ["脚本家"],
+		illustration: ["絵師"],
+	});
+
+describe("CreatorsInfoValueObject.create / validate", () => {
+	it("正常データで生成できる", () => {
+		const result = CreatorsInfoValueObject.create({ voice: ["a"] });
+		expect(result.isOk()).toBe(true);
+		expect(create({ voice: ["a"] }).voice).toEqual(["a"]);
+	});
+
+	it("欠落フィールドは空配列で補完される", () => {
+		const vo = create({});
+		expect(vo.voice).toEqual([]);
+		expect(vo.other).toEqual([]);
+	});
+
+	it("配列でない値はバリデーションエラー", () => {
+		const result = CreatorsInfoValueObject.create({ voice: "x" as never });
+		expect(result.isOk()).toBe(false);
+	});
+});
+
+describe("fromPlainObject", () => {
+	it("オブジェクト以外はエラー", () => {
+		expect(CreatorsInfoValueObject.fromPlainObject(null).isOk()).toBe(false);
+		expect(CreatorsInfoValueObject.fromPlainObject("x").isOk()).toBe(false);
+	});
+
+	it("文字列配列でないフィールドはエラー", () => {
+		expect(CreatorsInfoValueObject.fromPlainObject({ voice: [1, 2] }).isOk()).toBe(false);
+	});
+
+	it("有効なオブジェクトから復元できる", () => {
+		const result = CreatorsInfoValueObject.fromPlainObject({ voice: ["a"], music: ["m"] });
+		expect(result.isOk()).toBe(true);
+		expect(result._unsafeUnwrap().music).toEqual(["m"]);
+	});
+});
+
+describe("アクセサ / ビジネスロジック", () => {
+	it("アクセサは内部配列のコピーを返す（不変性）", () => {
+		const vo = sample();
+		const voices = vo.voice;
+		voices.push("改ざん");
+		expect(vo.voice).toEqual(["佐倉", "鈴鹿"]);
+	});
+
+	it("getAll は優先順位順に全クリエイターを返す", () => {
+		const all = sample().getAll();
+		expect(all[0]).toEqual({ type: "voice", name: "佐倉" });
+		// voice(1) → scenario(2) → illustration(3) の順
+		expect(all.map((c) => c.type)).toEqual(["voice", "voice", "scenario", "illustration"]);
+	});
+
+	it("hasCreators / countByType / totalCount", () => {
+		const vo = sample();
+		expect(vo.hasCreators()).toBe(true);
+		expect(vo.countByType("voice")).toBe(2);
+		expect(vo.countByType("music")).toBe(0);
+		expect(vo.totalCount()).toBe(4);
+		expect(create({}).hasCreators()).toBe(false);
+	});
+
+	it("getPrimary は各タイプ先頭1名を返す", () => {
+		expect(sample().getPrimary()).toEqual({
+			voice: "佐倉",
+			scenario: "脚本家",
+			illustration: "絵師",
+		});
+	});
+
+	it("isValid / getValidationErrors", () => {
+		const vo = sample();
+		expect(vo.isValid()).toBe(true);
+		expect(vo.getValidationErrors()).toEqual([]);
+	});
+});
+
+describe("equals / clone / toPlainObject", () => {
+	it("順序が違っても内容が同じなら equals は true", () => {
+		const a = create({ voice: ["x", "y"] });
+		const b = create({ voice: ["y", "x"] });
+		expect(a.equals(b)).toBe(true);
+	});
+
+	it("内容が違えば false / インスタンスでなければ false", () => {
+		const a = sample();
+		const b = create({ voice: ["z"] });
+		expect(a.equals(b)).toBe(false);
+		expect(a.equals(null as never)).toBe(false);
+	});
+
+	it("clone は等価な別インスタンス", () => {
+		const a = sample();
+		const c = a.clone();
+		expect(c).not.toBe(a);
+		expect(a.equals(c)).toBe(true);
+	});
+
+	it("toPlainObject は全ロールを含む", () => {
+		expect(sample().toPlainObject()).toEqual({
+			voice: ["佐倉", "鈴鹿"],
+			scenario: ["脚本家"],
+			illustration: ["絵師"],
+			music: [],
+			other: [],
+		});
+	});
+});
+
+describe("CreatorUtils", () => {
+	it("getTypeLabel", () => {
+		expect(CreatorUtils.getTypeLabel("voice")).toBe(CREATOR_ROLE_LABELS.voice);
+	});
+
+	it("getTypeLabels は件数で表記を変える", () => {
+		expect(CreatorUtils.getTypeLabels([])).toBe("");
+		expect(CreatorUtils.getTypeLabels(["voice"])).toBe("声優");
+		expect(CreatorUtils.getTypeLabels(["voice", "music"])).toBe("声優 / 音楽");
+	});
+
+	it("mergeCreators は重複除去する", () => {
+		expect(CreatorUtils.mergeCreators(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"]);
+	});
+
+	it("fromApiCreaters は undefined で空 VO を返す", () => {
+		expect(CreatorUtils.fromApiCreaters().totalCount()).toBe(0);
+	});
+
+	it("fromApiCreaters は既知タイプへ振り分け、未知は other へ", () => {
+		const vo = CreatorUtils.fromApiCreaters([
+			{ type: "voice", name: "声優A" },
+			{ type: "Voice", name: "声優A" }, // 大文字小文字を吸収 + 重複除去
+			{ type: "unknown", name: "謎" },
+		]);
+		expect(vo.voice).toEqual(["声優A"]);
+		expect(vo.other).toEqual(["謎"]);
+	});
+});

--- a/packages/shared-types/vitest.config.ts
+++ b/packages/shared-types/vitest.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
 			// statements / lines / functions は目標 80 を超過。
-			// branches は 73.2% まで改善（残りは後続増分で 80 を目指す）。
+			// branches は後続増分で 80 を目指す。
 			thresholds: {
 				statements: 82,
 				branches: 72,

--- a/packages/shared-types/vitest.config.ts
+++ b/packages/shared-types/vitest.config.ts
@@ -20,13 +20,13 @@ export default defineConfig({
 				"**/plain-objects/**", // plain object types only
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
-			// statements / lines / functions は目標 80 に到達済み。
-			// branches は 71.3% まで改善（残りは後続増分で 80 を目指す）。
+			// statements / lines / functions は目標 80 を超過。
+			// branches は 73.2% まで改善（残りは後続増分で 80 を目指す）。
 			thresholds: {
-				statements: 80,
-				branches: 70,
-				functions: 83,
-				lines: 80,
+				statements: 82,
+				branches: 72,
+				functions: 85,
+				lines: 82,
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

SPR-152 の第2増分。shared-types の branches を目標 80 へ近づける。value-object / utility の未テスト分岐を実テストで補強（除外でのメトリクス稼ぎはしない / 軸3）。

## 追加テスト

- `entities/work/work-utils`（純粋関数・専用テストなし→新規）: 日付最適化・サイズ→バイト変換・カテゴリ/言語表示名（safe 版含む）・年齢カテゴリ・言語コード正規化
- `value-objects/work/creator-type`（専用テストなし→新規）: `CreatorsInfoValueObject` の create/validate・fromPlainObject・アクセサ不変性・getAll 優先順位・hasCreators/countByType/totalCount/getPrimary・equals/clone/toPlainObject・`CreatorUtils`

## カバレッジ（shared-types 実測）

| | before(#534後) | after | 閾値(新) |
|---|---|---|---|
| statements | 81.6 | **83.6** | 82 |
| branches | 71.3 | **73.2** | 72 |
| functions | 84.9 | **86.2** | 85 |
| lines | 82.2 | **84.3** | 82 |

`creator-type.ts` は branches 62.3→85.5 と大きく改善。

## 確認

- `pnpm verify` EXIT 0（995 tests pass、lint/typecheck 含め全 green）

## フォローアップ（SPR-152 継続）

- shared-types branches 80 への残りは大物（`transformers/audio-button`・`*-firestore`・`firestore-final`）が必要 → 別増分
- functions branches（60→75）、ui / web の引き上げ

🤖 Generated with [Claude Code](https://claude.com/claude-code)