### PR TITLE
refactor(shared-types): CreatorUtils.fromApiCreaters のタイポを fromApiCreators へ修正

### DIFF
--- a/packages/shared-types/src/value-objects/__tests__/creator-type.test.ts
+++ b/packages/shared-types/src/value-objects/__tests__/creator-type.test.ts
@@ -247,7 +247,7 @@ describe("creator-type", () => {
 			});
 		});
 
-		describe("fromApiCreaters", () => {
+		describe("fromApiCreators", () => {
 			it("should convert API format to CreatorsInfo", () => {
 				const apiData = [
 					{ type: "voice", name: "涼花みなせ" },
@@ -256,19 +256,19 @@ describe("creator-type", () => {
 					{ type: "unknown", name: "Unknown Creator" }, // Should go to other
 				];
 
-				const creators = CreatorUtils.fromApiCreaters(apiData);
+				const creators = CreatorUtils.fromApiCreators(apiData);
 				expect(creators.voice).toEqual(["涼花みなせ", "Voice Actor 2"]);
 				expect(creators.scenario).toEqual(["Writer 1"]);
 				expect(creators.other).toEqual(["Unknown Creator"]);
 			});
 
 			it("should handle empty input", () => {
-				const creators = CreatorUtils.fromApiCreaters([]);
+				const creators = CreatorUtils.fromApiCreators([]);
 				expect(creators.hasCreators()).toBe(false);
 			});
 
 			it("should handle undefined input", () => {
-				const creators = CreatorUtils.fromApiCreaters(undefined);
+				const creators = CreatorUtils.fromApiCreators(undefined);
 				expect(creators.hasCreators()).toBe(false);
 			});
 
@@ -278,7 +278,7 @@ describe("creator-type", () => {
 					{ type: "voice", name: "涼花みなせ" }, // Duplicate
 				];
 
-				const creators = CreatorUtils.fromApiCreaters(apiData);
+				const creators = CreatorUtils.fromApiCreators(apiData);
 				expect(creators.voice).toEqual(["涼花みなせ"]);
 			});
 		});

--- a/packages/shared-types/src/value-objects/work/__tests__/creator-type.test.ts
+++ b/packages/shared-types/src/value-objects/work/__tests__/creator-type.test.ts
@@ -132,12 +132,12 @@ describe("CreatorUtils", () => {
 		expect(CreatorUtils.mergeCreators(["a", "b"], ["b", "c"])).toEqual(["a", "b", "c"]);
 	});
 
-	it("fromApiCreaters は undefined で空 VO を返す", () => {
-		expect(CreatorUtils.fromApiCreaters().totalCount()).toBe(0);
+	it("fromApiCreators は undefined で空 VO を返す", () => {
+		expect(CreatorUtils.fromApiCreators().totalCount()).toBe(0);
 	});
 
-	it("fromApiCreaters は既知タイプへ振り分け、未知は other へ", () => {
-		const vo = CreatorUtils.fromApiCreaters([
+	it("fromApiCreators は既知タイプへ振り分け、未知は other へ", () => {
+		const vo = CreatorUtils.fromApiCreators([
 			{ type: "voice", name: "声優A" },
 			{ type: "Voice", name: "声優A" }, // 大文字小文字を吸収 + 重複除去
 			{ type: "unknown", name: "謎" },

--- a/packages/shared-types/src/value-objects/work/creator-type.ts
+++ b/packages/shared-types/src/value-objects/work/creator-type.ts
@@ -307,9 +307,9 @@ export const CreatorUtils = {
 	},
 
 	/**
-	 * APIのcreater情報からCreatorsオブジェクトを構築
+	 * APIのcreator情報からCreatorsオブジェクトを構築
 	 */
-	fromApiCreaters: (creaters?: Array<{ type: string; name: string }>): CreatorsInfoValueObject => {
+	fromApiCreators: (creators?: Array<{ type: string; name: string }>): CreatorsInfoValueObject => {
 		const result: Record<string, string[]> = {
 			voice: [],
 			scenario: [],
@@ -318,7 +318,7 @@ export const CreatorUtils = {
 			other: [],
 		};
 
-		if (!creaters) {
+		if (!creators) {
 			const createResult = CreatorsInfoValueObject.create(result);
 			if (!createResult.isOk()) {
 				throw new Error(createResult.error.message);
@@ -326,7 +326,7 @@ export const CreatorUtils = {
 			return createResult.value;
 		}
 
-		creaters.forEach(({ type, name }) => {
+		creators.forEach(({ type, name }) => {
 			const normalizedType = type.toLowerCase();
 			if (normalizedType in result && result[normalizedType]) {
 				result[normalizedType]?.push(name);


### PR DESCRIPTION
## 概要

`CreatorUtils.fromApiCreaters` のタイポ（`creators` の `o` 抜け）を `fromApiCreators` へリネーム。名前が意図を正確に表すようにする（軸3）。

## 変更内容

- `packages/shared-types/src/value-objects/work/creator-type.ts`
  - メソッド名 `fromApiCreaters` → `fromApiCreators`
  - 引数名 `creaters` → `creators`（`.forEach` 参照含む）
  - JSDoc コメント `APIのcreater情報` → `APIのcreator情報`
- `packages/shared-types/src/value-objects/__tests__/creator-type.test.ts`
  - `describe` 名・呼び出し4箇所を更新
- 全リポジトリ grep（`rg "fromApiCreaters"`）で本体・テスト以外の呼び出しなしを確認

## 確認

- `pnpm verify` green（lint + typecheck + test、カバレッジ閾値含む）
- リネーム後 `fromApiCreaters` の残存ゼロ

## 背景

Claude AI Review（#535）で軸3（名前が意図を正確に表す）の観点で指摘された改善。Two-Way Door。

🤖 Generated with [Claude Code](https://claude.com/claude-code)