### PR TITLE
fix(shared-types): durationText の生成経路による表記不整合を解消

### DIFF
--- a/packages/shared-types/src/transformers/__tests__/audio-button.test.ts
+++ b/packages/shared-types/src/transformers/__tests__/audio-button.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { audioButtonTransformers } from "../audio-button";
+
+const { fromFirestore, createAudioButton } = audioButtonTransformers;
+
+describe("audioButtonTransformers", () => {
+	describe("durationText の表記統一", () => {
+		// 0秒→"再生" / <60秒→"N秒" / 60秒以上→"m:ss" を正本とし、
+		// fromFirestore / createAudioButton のどちらの経路でも同一になることを保証する。
+		it.each([
+			{ duration: 0, expected: "再生" },
+			{ duration: 5, expected: "5秒" },
+			{ duration: 59, expected: "59秒" },
+			{ duration: 60, expected: "1:00" },
+			{ duration: 65, expected: "1:05" },
+			{ duration: 125, expected: "2:05" },
+		])("duration=$duration の durationText は $expected", ({ duration, expected }) => {
+			const fromFs = fromFirestore({
+				id: "test",
+				buttonText: "テスト",
+				videoId: "video-1",
+				startTime: 0,
+				endTime: duration,
+				duration,
+			});
+			expect(fromFs?._computed.durationText).toBe(expected);
+
+			const created = createAudioButton({
+				buttonText: "テスト",
+				videoId: "video-1",
+				videoTitle: "タイトル",
+				startTime: 0,
+				endTime: duration,
+				creatorId: "creator-1",
+				creatorName: "クリエイター",
+			});
+			expect(created._computed.durationText).toBe(expected);
+		});
+
+		it("同一 duration で両経路の durationText が一致する", () => {
+			const duration = 5;
+			const fromFs = fromFirestore({
+				buttonText: "テスト",
+				videoId: "video-1",
+				startTime: 10,
+				endTime: 15,
+			});
+			const created = createAudioButton({
+				buttonText: "テスト",
+				videoId: "video-1",
+				videoTitle: "タイトル",
+				startTime: 10,
+				endTime: 15,
+				creatorId: "creator-1",
+				creatorName: "クリエイター",
+			});
+			expect(fromFs?._computed.durationText).toBe(created._computed.durationText);
+			expect(fromFs?._computed.durationText).toBe("5秒");
+			expect(duration).toBe(5);
+		});
+	});
+
+	describe("fromFirestore", () => {
+		it("レガシーなフィールド名（sourceVideoId / title / createdBy）を吸収する", () => {
+			const result = fromFirestore({
+				id: "legacy",
+				title: "レガシータイトル",
+				sourceVideoId: "legacy-video",
+				sourceVideoTitle: "動画タイトル",
+				startTime: 0,
+				endTime: 30,
+				createdBy: "user-1",
+				createdByName: "ユーザー",
+			});
+			expect(result).not.toBeNull();
+			expect(result?.buttonText).toBe("レガシータイトル");
+			expect(result?.videoId).toBe("legacy-video");
+			expect(result?.creatorId).toBe("user-1");
+			expect(result?._computed.durationText).toBe("30秒");
+		});
+
+		it("buttonText か videoId が欠落していたら null を返す", () => {
+			expect(fromFirestore({ videoId: "v" })).toBeNull();
+			expect(fromFirestore({ buttonText: "t" })).toBeNull();
+		});
+
+		it("stats を優先しつつ engagementRate を補完する", () => {
+			const result = fromFirestore({
+				buttonText: "テスト",
+				videoId: "video-1",
+				startTime: 0,
+				endTime: 10,
+				stats: { playCount: 10, likeCount: 2, dislikeCount: 0 },
+			});
+			expect(result?.stats.engagementRate).toBeCloseTo(0.2);
+			expect(result?._computed.isPopular).toBe(false);
+		});
+	});
+
+	describe("createAudioButton", () => {
+		it("duration を startTime/endTime から算出する", () => {
+			const created = createAudioButton({
+				buttonText: "テスト",
+				videoId: "video-1",
+				videoTitle: "タイトル",
+				startTime: 100,
+				endTime: 130,
+				creatorId: "creator-1",
+				creatorName: "クリエイター",
+			});
+			expect(created.duration).toBe(30);
+			expect(created._computed.durationText).toBe("30秒");
+		});
+	});
+});

--- a/packages/shared-types/src/transformers/audio-button.ts
+++ b/packages/shared-types/src/transformers/audio-button.ts
@@ -126,9 +126,9 @@ function buildComputedProperties(
 	const isPopular = playCount >= 100;
 	const popularityScore = playCount + likeCount * 2 - dislikeCount;
 
-	const minutes = Math.floor(duration / 60);
-	const seconds = Math.floor(duration % 60);
-	const durationText = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+	// createAudioButton と同一の表記（0秒→"再生" / <60秒→"N秒" / それ以上→"m:ss"）に統一する。
+	// 生成経路（fromFirestore / createAudioButton）で durationText がズレないように formatDuration を正本とする。
+	const durationText = formatDuration(duration);
 
 	const searchableText = [
 		buttonText.toLowerCase(),


### PR DESCRIPTION
## 概要

`packages/shared-types/src/transformers/audio-button.ts` で、同じ `duration` でも生成経路によって `_computed.durationText` が異なる値になる不整合を修正します（PR #537 Claude AI Review [major] 指摘）。

- `fromFirestore`（`buildComputedProperties`）: 常に `"m:ss"`（例 5秒→`"0:05"`、0秒→`"0:00"`）
- `createAudioButton`（`formatDuration`）: `0秒→"再生"` / `<60秒→"N秒"` / `60秒以上→"m:ss"`

## 正本の決定

UI 表示の実態から **`formatDuration` の「再生 / N秒 / m:ss」表記を正本**と判断しました。

- `createAudioButton` がこの表記を使用
- 本番 web の表示パス `convertToAudioButtonPlainObject`（`apps/web/src/lib/audio-buttons-firestore.ts`）も独自の同一ロジックを使用

`fromFirestore` は `audio-button-actions.ts` / `favorites/actions.ts` / `audio-button-converters.ts` で実利用される本番経路のため、実害のある欠陥でした。

## 変更内容

1. `buildComputedProperties` のインライン `m:ss` 算出を削除し、`formatDuration(duration)` に集約（単一の正本を共有）
2. 統一後の挙動を固定する新規テストを追加 — 指摘にあった `__tests__/audio-button.test.ts` は未実在だったため新規作成。両経路で同一 `duration` が同一 `durationText` になることを保証
3. `apps/web` 側への影響を確認 — `fromFirestore` を使う web テストに `durationText` アサーションは無く破壊なし。本番表示パスは元々正しい表記のため影響なし
4. `pnpm verify` green（shared-types カバレッジ閾値も超過）

## レビュー区分

Two-Way Door（表示ロジック）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)