### PR TITLE
fix(functions): 音声ボタン作成可否の判定を archived のみに統一

### DIFF
--- a/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
@@ -58,9 +58,8 @@ describe("mapYouTubeToVideoPlainObject", () => {
 			contentTags: ["t1", "t2"],
 		});
 		expect(v?.videoType).toBe("normal");
-		// 注: normal は hasAudioButtons=true だが _computed.canCreateButton=false（archived のみ true）。
-		// ソース側の非一貫性だが現挙動として固定する（統一は別タスク）。
-		expect(v?.hasAudioButtons).toBe(true);
+		// 許諾上ボタン作成可は archived のみ。normal は hasAudioButtons / canCreateButton とも false で整合する。
+		expect(v?.hasAudioButtons).toBe(false);
 		expect(v?._computed?.canCreateButton).toBe(false);
 	});
 

--- a/apps/functions/src/services/mappers/video-mapper.ts
+++ b/apps/functions/src/services/mappers/video-mapper.ts
@@ -61,7 +61,9 @@ function calculateAudioButtonInfo(videoType: string): {
 	count: number;
 	hasButtons: boolean;
 } {
-	const canCreate = videoType === "normal" || videoType === "archived";
+	// 許諾により音声ボタンを作成できるのは配信アーカイブ(archived)のみ。
+	// _computed.canCreateButton / shared-types の canCreateButton と判定を一致させる。
+	const canCreate = videoType === "archived";
 	return {
 		count: 0,
 		hasButtons: canCreate,


### PR DESCRIPTION
## 概要
`apps/functions/src/services/mappers/video-mapper.ts` に存在した音声ボタン作成可否の判定二系統の不整合を解消する。

`calculateAudioButtonInfo` が `normal || archived` を許可していたため、`videoType="normal"` の動画で以下の食い違いが生じていた:
- `hasAudioButtons = true`（`calculateAudioButtonInfo` 経由）
- `_computed.canCreateButton = false`（`videoType === "archived"` のみ）

軸3（名前/意図と振る舞いのズレ）に該当。Claude AI Review（[#540](https://github.com/nothink-jp/suzumina.click/pull/540)）で指摘。

## 正本の確認
音声ボタンを作成できるのは **配信アーカイブ(archived)のみ** が正本:
- shared-types `canCreateButton` … `_computed.canCreateButton` 優先、fallback も `isArchived` のみ
- UI 実挙動（`VideoDetail.tsx`）… 不可理由「許諾により音声ボタンを作成できるのは配信アーカイブのみです」

## 変更
- `calculateAudioButtonInfo` の `canCreate` から `videoType === "normal"` を除去し archived のみに統一。意図を近接コメントで明示。

## 影響確認
- `apps/web` の `hasAudioButtons` 設定は `count > 0` から独立算出のため影響なし。
- functions 内で `hasAudioButtons` を書くのはこの mapper のみ。
- `video-mapper.test.ts` は全体が `describe.skip`（Entity→PlainObject 移行待ち）で、`hasAudioButtons` の能動アサーションは存在しないため更新対象テストなし。

## 検証
- `pnpm verify` green（lint + typecheck + test、カバレッジ閾値含む）

Two-Way Door（表示/判定ロジック）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)