### PR TITLE
test: functions branches を目標 75 まで引き上げ (SPR-152 第6弾)

### DIFF
--- a/apps/functions/src/infrastructure/management/__tests__/config-manager-methods.test.ts
+++ b/apps/functions/src/infrastructure/management/__tests__/config-manager-methods.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../shared/logger", () => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+}));
+
+import { ConfigManager, getConfig, isFeatureEnabled } from "../config-manager";
+
+const mgr = ConfigManager.getInstance();
+
+describe("ConfigManager: アクセサ", () => {
+	it("各セクションはコピーを返す", () => {
+		expect(typeof mgr.getFirestoreConfig().batchSize).toBe("number");
+		expect(typeof mgr.getErrorHandlingConfig().debugMode).toBe("boolean");
+		expect(typeof mgr.getPerformanceConfig().concurrency).toBe("number");
+	});
+
+	it("isFeatureEnabled は boolean を返す", () => {
+		const key = Object.keys(mgr.getConfig().features)[0] as keyof ReturnType<
+			typeof mgr.getConfig
+		>["features"];
+		expect(typeof mgr.isFeatureEnabled(key)).toBe("boolean");
+	});
+
+	it("ヘルパー関数 getConfig / isFeatureEnabled", () => {
+		expect(getConfig().environment).toBeDefined();
+		const key = Object.keys(getConfig().features)[0] as Parameters<typeof isFeatureEnabled>[0];
+		expect(typeof isFeatureEnabled(key)).toBe("boolean");
+	});
+});
+
+describe("ConfigManager: validateConfig", () => {
+	it("既定設定は妥当", () => {
+		expect(mgr.validateConfig().isValid).toBe(true);
+	});
+
+	it("不正値はすべてのエラーを列挙する", () => {
+		mgr.updateSectionConfig("dlsite", { maxPagesPerExecution: 0, requestDelay: -1 });
+		mgr.updateSectionConfig("youtube", { maxBatchSize: 99, dailyQuotaLimit: 1 });
+		mgr.updateSectionConfig("firestore", { batchSize: 999 });
+		mgr.updateSectionConfig("performance", { concurrency: 99 });
+
+		const result = mgr.validateConfig();
+		expect(result.isValid).toBe(false);
+		expect(result.errors).toEqual(
+			expect.arrayContaining([
+				"DLsite maxPagesPerExecution must be at least 1",
+				"DLsite requestDelay must be non-negative",
+				"YouTube maxBatchSize cannot exceed 50 (API limit)",
+				"YouTube dailyQuotaLimit seems too low",
+				"Firestore batchSize cannot exceed 500",
+				"Performance concurrency seems too high",
+			]),
+		);
+	});
+});
+
+describe("ConfigManager: 更新", () => {
+	it("updateSectionConfig はセクションをマージ更新する", () => {
+		mgr.updateSectionConfig("dlsite", { maxPagesPerExecution: 7 });
+		expect(mgr.getDLsiteConfig().maxPagesPerExecution).toBe(7);
+		// 他フィールドは保持
+		expect(typeof mgr.getDLsiteConfig().itemsPerPage).toBe("number");
+	});
+
+	it("updateConfig はネストを深くマージし lastUpdated を更新する", () => {
+		mgr.updateConfig({ youtube: { maxPagesPerExecution: 3 } } as never);
+		expect(mgr.getYouTubeConfig().maxPagesPerExecution).toBe(3);
+		// 深いマージで他の youtube フィールドが消えない
+		expect(typeof mgr.getYouTubeConfig().dailyQuotaLimit).toBe("number");
+		expect(mgr.getConfig().lastUpdated).toBeDefined();
+	});
+
+	it("updateConfig: トップレベル primitive を更新し、undefined 値は既存を保持する", () => {
+		const before = mgr.getYouTubeConfig().maxPagesPerExecution;
+		mgr.updateConfig({
+			version: "v-test", // トップレベル primitive
+			youtube: { maxPagesPerExecution: undefined }, // undefined はスキップ（既存保持）
+			// 既存に無いネストキー → deepMerge の `result[key] || {}` 分岐を通す
+			extraSection: { nested: 1 },
+		} as never);
+		expect(mgr.getConfig().version).toBe("v-test");
+		expect(mgr.getYouTubeConfig().maxPagesPerExecution).toBe(before);
+		expect((mgr.getConfig() as Record<string, unknown>).extraSection).toEqual({ nested: 1 });
+	});
+});
+
+describe("ConfigManager: getDebugInfo", () => {
+	it("fullConfig・validation・environmentOverrides を含む", () => {
+		const info = mgr.getDebugInfo();
+		expect(info.fullConfig).toBeDefined();
+		expect(info.validation).toHaveProperty("isValid");
+		expect(info).toHaveProperty("environmentOverrides");
+	});
+});

--- a/apps/functions/src/infrastructure/management/__tests__/config-manager-methods.test.ts
+++ b/apps/functions/src/infrastructure/management/__tests__/config-manager-methods.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../shared/logger", () => ({
 	info: vi.fn(),
@@ -9,7 +9,12 @@ vi.mock("../../../shared/logger", () => ({
 
 import { ConfigManager, getConfig, isFeatureEnabled } from "../config-manager";
 
-const mgr = ConfigManager.getInstance();
+// 各テストでシングルトン状態をリセットし、テスト順序に依存させない
+let mgr: ConfigManager;
+beforeEach(() => {
+	(ConfigManager as unknown as { instance: ConfigManager | undefined }).instance = undefined;
+	mgr = ConfigManager.getInstance();
+});
 
 describe("ConfigManager: アクセサ", () => {
 	it("各セクションはコピーを返す", () => {

--- a/apps/functions/src/services/dlsite/__tests__/work-id-validator.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/work-id-validator.test.ts
@@ -53,6 +53,15 @@ describe("Work ID Validator", () => {
 			expect(result).toHaveProperty("regionWarning");
 			expect(result).toHaveProperty("details");
 		});
+
+		it("logDetails 有効時は欠落/余剰の詳細ログ分岐を通る", () => {
+			// 期待: RJ123456/RJ789012/RJ111111/RJ222222（モック）
+			// 取得: 一部一致 + 期待外 → missing>0 かつ extra>0 の両分岐を通す
+			const result = validateWorkIds(["RJ123456", "RJ_EXTRA"], { logDetails: true });
+			expect(result.totalFound).toBe(2);
+			expect(result.details.expectedButNotFound.length).toBeGreaterThan(0);
+			expect(result.details.foundButNotExpected.length).toBeGreaterThan(0);
+		});
 	});
 
 	describe("handleNoWorkIdsError", () => {

--- a/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// quota monitor をモックして quota 充足/不足の両分岐を検証する
+const canExecuteOperation = vi.fn(() => true);
+const recordQuotaUsage = vi.fn();
+const logQuotaUsage = vi.fn();
+const suggestOptimalOperations = vi.fn(() => ({ feasible: true, alternatives: [] as string[] }));
+vi.mock("../../../infrastructure/monitoring/youtube-quota-monitor", () => ({
+	canExecuteOperation: (...a: unknown[]) => canExecuteOperation(...a),
+	recordQuotaUsage: (...a: unknown[]) => recordQuotaUsage(...a),
+	getYouTubeQuotaMonitor: () => ({ logQuotaUsage, suggestOptimalOperations }),
+}));
+
+vi.mock("../../../shared/logger", () => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+}));
+
+import {
+	fetchChannelPlaylists,
+	fetchPlaylistItems,
+	fetchVideoDetails,
+	searchVideos,
+} from "../youtube-api";
+
+const makeClient = () => ({
+	search: { list: vi.fn() },
+	videos: { list: vi.fn() },
+	playlists: { list: vi.fn() },
+	playlistItems: { list: vi.fn() },
+});
+// biome-ignore lint/suspicious/noExplicitAny: フェイククライアントを型に流し込む
+const asYoutube = (c: ReturnType<typeof makeClient>) => c as any;
+
+beforeEach(() => {
+	canExecuteOperation.mockReturnValue(true);
+	suggestOptimalOperations.mockReturnValue({ feasible: true, alternatives: [] });
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("searchVideos: クォータ不足", () => {
+	it("クォータ不足は例外", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		await expect(searchVideos(asYoutube(makeClient()))).rejects.toThrow("クォータ");
+	});
+});
+
+describe("fetchVideoDetails: クォータ分岐", () => {
+	it("不足かつ代替不能なら例外（alternatives を含む）", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		suggestOptimalOperations.mockReturnValue({ feasible: false, alternatives: ["後で再試行"] });
+		await expect(fetchVideoDetails(asYoutube(makeClient()), ["v1"])).rejects.toThrow("後で再試行");
+	});
+
+	it("不足でも代替可能なら処理を継続する", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		suggestOptimalOperations.mockReturnValue({ feasible: true, alternatives: [] });
+		const c = makeClient();
+		c.videos.list.mockResolvedValue({ data: { items: [{ id: "v1" }] } });
+		const r = await fetchVideoDetails(asYoutube(c), ["v1"]);
+		expect(r).toHaveLength(1);
+	});
+});
+
+describe("fetchChannelPlaylists", () => {
+	it("クォータ不足は例外", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		await expect(fetchChannelPlaylists(asYoutube(makeClient()), "ch")).rejects.toThrow("クォータ");
+	});
+
+	it("プレイリストを既定値付きで写像する", async () => {
+		const c = makeClient();
+		c.playlists.list.mockResolvedValue({
+			data: {
+				items: [
+					{
+						id: "p1",
+						snippet: { title: "PL1", description: "d", publishedAt: "2024" },
+						contentDetails: { itemCount: 3 },
+					},
+					{}, // 欠落フィールド → 既定値
+				],
+			},
+		});
+		const r = await fetchChannelPlaylists(asYoutube(c), "ch");
+		expect(r[0]).toEqual({
+			id: "p1",
+			title: "PL1",
+			videoCount: 3,
+			description: "d",
+			publishedAt: "2024",
+		});
+		expect(r[1]).toEqual({ id: "", title: "", videoCount: 0, description: "", publishedAt: "" });
+		expect(recordQuotaUsage).toHaveBeenCalledWith("playlists");
+	});
+
+	it("items 無しは空配列", async () => {
+		const c = makeClient();
+		c.playlists.list.mockResolvedValue({ data: {} });
+		expect(await fetchChannelPlaylists(asYoutube(c), "ch")).toEqual([]);
+	});
+
+	it("API エラーは再 throw", async () => {
+		const c = makeClient();
+		c.playlists.list.mockRejectedValue(new Error("pl fail"));
+		await expect(fetchChannelPlaylists(asYoutube(c), "ch")).rejects.toThrow("pl fail");
+	});
+});
+
+describe("fetchPlaylistItems", () => {
+	it("クォータ不足は空配列（即 break）", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		expect(await fetchPlaylistItems(asYoutube(makeClient()), "pl")).toEqual([]);
+	});
+
+	it("ページネーションして videoId を集約する（空 videoId は除外）", async () => {
+		const c = makeClient();
+		c.playlistItems.list
+			.mockResolvedValueOnce({
+				data: { items: [{ contentDetails: { videoId: "a" } }], nextPageToken: "n1" },
+			})
+			.mockResolvedValueOnce({
+				data: { items: [{ contentDetails: { videoId: "b" } }, { contentDetails: {} }] },
+			});
+		const r = await fetchPlaylistItems(asYoutube(c), "pl");
+		expect(r).toEqual(["a", "b"]);
+		expect(c.playlistItems.list).toHaveBeenCalledTimes(2);
+	});
+
+	it("API エラーは break して取得済みを返す", async () => {
+		const c = makeClient();
+		c.playlistItems.list.mockRejectedValue(new Error("items fail"));
+		expect(await fetchPlaylistItems(asYoutube(c), "pl")).toEqual([]);
+	});
+});

--- a/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
@@ -1,31 +1,18 @@
 /**
- * YouTube Firestore  Service Tests
+ * YouTube Firestore Service Tests
  */
 
-import type { Video } from "@suzumina.click/shared-types";
 import type { youtube_v3 } from "googleapis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { saveVideosToFirestore, updateVideoWith } from "../youtube-firestore";
+import { SUZUKA_MINASE_CHANNEL_ID } from "../../../shared/common";
 
-// Mocks
+const mockBatchSet = vi.fn();
+const mockBatchCommit = vi.fn().mockResolvedValue(undefined);
+const mockDoc = vi.fn((id: string) => ({ id }));
 vi.mock("../../../infrastructure/database/firestore", () => ({
 	default: {
-		collection: vi.fn(() => ({
-			doc: vi.fn(() => ({
-				set: vi.fn(),
-			})),
-		})),
-		batch: vi.fn(() => ({
-			set: vi.fn(),
-			commit: vi.fn().mockResolvedValue(undefined),
-		})),
-	},
-	Timestamp: {
-		now: vi.fn(() => ({
-			toDate: () => new Date("2025-01-25T00:00:00Z"),
-			seconds: 1737763200,
-			nanoseconds: 0,
-		})),
+		collection: vi.fn(() => ({ doc: mockDoc })),
+		batch: vi.fn(() => ({ set: mockBatchSet, commit: mockBatchCommit })),
 	},
 }));
 
@@ -36,236 +23,96 @@ vi.mock("../../../shared/logger", () => ({
 	debug: vi.fn(),
 }));
 
+const fromYouTubeAPI = vi.fn();
+const fromYouTubeAPIWithTags = vi.fn();
 vi.mock("../../mappers/video-mapper", () => ({
 	VideoMapper: {
-		fromYouTubeAPI: vi.fn(),
-		fromYouTubeAPIWithTags: vi.fn(),
+		fromYouTubeAPI: (...a: unknown[]) => fromYouTubeAPI(...a),
+		fromYouTubeAPIWithTags: (...a: unknown[]) => fromYouTubeAPIWithTags(...a),
 	},
 }));
 
-import firestore from "../../../infrastructure/database/firestore";
-import * as logger from "../../../shared/logger";
-import { VideoMapper } from "../../mappers/video-mapper";
+import { saveVideosToFirestore, updateVideoWith } from "../youtube-firestore";
 
-// biome-ignore lint/suspicious/noSkippedTests: Entity tests need migration to PlainObject
-describe.skip("YouTube Firestore  Service (Entity tests - needs migration to PlainObject)", () => {
-	let mockBatches: any[];
-	let mockCollection: any;
-	let mockDoc: any;
+// videoToFirestore（実物）が受け付ける最小の VideoPlainObject
+const plainObject = (id = "v1") =>
+	({
+		id,
+		videoId: id,
+		title: "t",
+		publishedAt: "2024-01-01T00:00:00.000Z",
+		lastFetchedAt: "2024-01-01T00:00:00.000Z",
+		_computed: { videoType: "normal" },
+		// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 plain object
+	}) as any;
 
-	beforeEach(() => {
-		mockBatches = [];
-		mockDoc = {
-			set: vi.fn(),
-		};
-		mockCollection = {
-			doc: vi.fn(() => mockDoc),
-		};
+const ytVideo = (over: Partial<youtube_v3.Schema$Video> = {}): youtube_v3.Schema$Video => ({
+	id: "v1",
+	snippet: { channelId: SUZUKA_MINASE_CHANNEL_ID, title: "動画", ...over.snippet },
+	...over,
+});
 
-		vi.mocked(firestore.batch).mockImplementation(() => {
-			const batch = {
-				set: vi.fn(),
-				commit: vi.fn().mockResolvedValue(undefined),
-			};
-			mockBatches.push(batch);
-			return batch;
-		});
-		vi.mocked(firestore.collection).mockReturnValue(mockCollection as any);
+beforeEach(() => {
+	fromYouTubeAPI.mockReturnValue(plainObject());
+	fromYouTubeAPIWithTags.mockReturnValue(plainObject());
+	mockBatchCommit.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("updateVideoWith", () => {
+	it("マッピング失敗時は null", () => {
+		fromYouTubeAPI.mockReturnValue(null);
+		expect(updateVideoWith({} as never, ytVideo())).toBeNull();
 	});
 
-	afterEach(() => {
-		vi.clearAllMocks();
-		vi.resetAllMocks();
+	it("成功時は FirestoreServerVideoData を返す", () => {
+		const r = updateVideoWith({} as never, ytVideo());
+		expect(r).not.toBeNull();
+		expect(r?.videoId).toBe("v1");
 	});
 
-	describe("saveVideosToFirestore", () => {
-		const createMockYouTubeVideo = (id: string, channelId: string): youtube_v3.Schema$Video => ({
-			id,
-			snippet: {
-				channelId,
-				title: `Video ${id}`,
-				description: "Test video",
-				publishedAt: "2025-01-25T00:00:00Z",
-			},
-			contentDetails: {
-				duration: "PT5M",
-			},
-			statistics: {
-				viewCount: "1000",
-				likeCount: "100",
-			},
+	it("マッパーが例外を投げたら null", () => {
+		fromYouTubeAPI.mockImplementation(() => {
+			throw new Error("boom");
 		});
+		expect(updateVideoWith({} as never, ytVideo())).toBeNull();
+	});
+});
 
-		const createMockVideoEntity = (id: string): Video => {
-			const mockEntity = {
-				content: {
-					videoId: { value: id },
-				},
-				toFirestore: vi.fn(() => ({
-					videoId: id,
-					title: `Video ${id}`,
-					description: "Test video",
-					channelId: "test-channel",
-					channelTitle: "Test Channel",
-					publishedAt: new Date("2025-01-25T00:00:00Z"),
-					thumbnailUrl: `https://img.youtube.com/vi/${id}/hqdefault.jpg`,
-					lastFetchedAt: new Date("2025-01-25T00:00:00Z"),
-				})),
-			} as any;
-			return mockEntity;
-		};
-
-		it("空の配列を渡した場合は0を返す", async () => {
-			const result = await saveVideosToFirestore([]);
-			expect(result).toBe(0);
-			expect(mockBatches).toHaveLength(0);
-		});
-
-		it("Entity 形式で動画を保存する", async () => {
-			const mockVideos = [
-				createMockYouTubeVideo("video1", "channel1"),
-				createMockYouTubeVideo("video2", "channel1"),
-			];
-
-			vi.mocked(VideoMapper.fromYouTubeAPIWithTags)
-				.mockReturnValueOnce(createMockVideoEntity("video1"))
-				.mockReturnValueOnce(createMockVideoEntity("video2"));
-
-			const result = await saveVideosToFirestore(mockVideos);
-
-			expect(result).toBe(2);
-			expect(mockBatches).toHaveLength(1);
-			expect(mockBatches[0].set).toHaveBeenCalledTimes(2);
-			expect(mockBatches[0].commit).toHaveBeenCalledTimes(1);
-
-			// データが正しく保存されていることを確認
-			const firstCall = mockBatches[0].set.mock.calls[0];
-			expect(firstCall[1].videoId).toBe("video1");
-
-			// 成功時は警告ログが出力されないことを確認
-			expect(logger.warn).not.toHaveBeenCalled();
-		});
-
-		it("チャンネルIDがない動画はスキップする", async () => {
-			const mockVideos = [
-				createMockYouTubeVideo("video1", "channel1"),
-				{ id: "video2", snippet: { title: "No channel" } },
-			];
-
-			vi.mocked(VideoMapper.fromYouTubeAPIWithTags).mockReturnValue(
-				createMockVideoEntity("video1"),
-			);
-
-			const result = await saveVideosToFirestore(mockVideos);
-
-			expect(result).toBe(1);
-			expect(logger.warn).toHaveBeenCalledWith("動画にチャンネルIDがありません", {
-				videoId: "video2",
-			});
-		});
-
-		it("Entity 変換に失敗した場合はスキップする", async () => {
-			const mockVideos = [createMockYouTubeVideo("video1", "channel1")];
-
-			vi.mocked(VideoMapper.fromYouTubeAPIWithTags).mockReturnValue(null);
-
-			const result = await saveVideosToFirestore(mockVideos);
-
-			expect(result).toBe(0);
-			expect(logger.warn).toHaveBeenCalledWith("一部の動画保存に失敗", {
-				total: 1,
-				saved: 0,
-				failed: 1,
-			});
-		});
-
-		it("バッチサイズを超える場合は複数バッチに分割する", async () => {
-			// 501個の動画を作成
-			const mockVideos = Array.from({ length: 501 }, (_, i) =>
-				createMockYouTubeVideo(`video${i}`, "channel1"),
-			);
-
-			vi.mocked(VideoMapper.fromYouTubeAPIWithTags).mockImplementation((video) =>
-				createMockVideoEntity(video.id!),
-			);
-
-			const result = await saveVideosToFirestore(mockVideos);
-
-			expect(result).toBe(501);
-			expect(mockBatches).toHaveLength(2); // 500 + 1
-			expect(mockBatches[0].commit).toHaveBeenCalledTimes(1);
-			expect(mockBatches[1].commit).toHaveBeenCalledTimes(1);
-
-			// 成功時は警告ログが出力されないことを確認
-			expect(logger.warn).not.toHaveBeenCalled();
-		});
+describe("saveVideosToFirestore", () => {
+	it("空配列は 0 を返しコミットしない", async () => {
+		expect(await saveVideosToFirestore([])).toBe(0);
+		expect(mockBatchCommit).not.toHaveBeenCalled();
 	});
 
-	describe("updateVideoWith", () => {
-		const mockExistingData = {
-			videoId: "video1",
-			title: "Old Title",
-			channelId: "channel1",
-			channelTitle: "Test Channel",
-			publishedAt: new Date("2025-01-01T00:00:00Z"),
-			updatedAt: new Date("2025-01-01T00:00:00Z"),
-		};
+	it("channelId 欠落・不許可チャンネルはスキップされる", async () => {
+		const result = await saveVideosToFirestore([
+			ytVideo({ id: "no-channel", snippet: { title: "x" } }), // channelId 欠落
+			ytVideo({ id: "other", snippet: { channelId: "OTHER", title: "x" } }), // 不許可
+		]);
+		expect(result).toBe(0);
+		expect(mockBatchCommit).not.toHaveBeenCalled();
+	});
 
-		const mockNewVideo: youtube_v3.Schema$Video = {
-			id: "video1",
-			snippet: {
-				title: "New Title",
-				channelId: "channel1",
-				publishedAt: "2025-01-25T00:00:00Z",
-			},
-		};
+	it("許可チャンネルの動画を保存しコミットする", async () => {
+		const result = await saveVideosToFirestore([ytVideo({ id: "v1" }), ytVideo({ id: "v2" })]);
+		expect(result).toBe(2);
+		expect(mockBatchSet).toHaveBeenCalledTimes(2);
+		expect(mockBatchCommit).toHaveBeenCalledTimes(1);
+	});
 
-		it("既存データをEntity 形式で更新する", () => {
-			const mockVideoEntity = {
-				toFirestore: vi.fn(() => ({
-					videoId: "video1",
-					title: "New Title",
-					channelId: "channel1",
-					channelTitle: "Test Channel",
-					publishedAt: new Date("2025-01-25T00:00:00Z"),
-					thumbnailUrl: "https://img.youtube.com/vi/video1/hqdefault.jpg",
-					lastFetchedAt: new Date("2025-01-25T00:00:00Z"),
-				})),
-			} as any;
+	it("マッピング失敗の動画はバッチに含めない", async () => {
+		fromYouTubeAPIWithTags.mockReturnValueOnce(null).mockReturnValueOnce(plainObject("v2"));
+		const result = await saveVideosToFirestore([ytVideo({ id: "v1" }), ytVideo({ id: "v2" })]);
+		expect(result).toBe(1);
+	});
 
-			vi.mocked(VideoMapper.fromYouTubeAPI).mockReturnValue(mockVideoEntity);
-
-			const result = updateVideoWith(mockExistingData as any, mockNewVideo);
-
-			expect(result).not.toBeNull();
-			expect(result!.title).toBe("New Title");
-			// 形式で更新されていることを確認
-			expect(result!.videoId).toBe("video1");
-		});
-
-		it("Entity 変換に失敗した場合はnullを返す", () => {
-			vi.mocked(VideoMapper.fromYouTubeAPI).mockReturnValue(null);
-
-			const result = updateVideoWith(mockExistingData as any, mockNewVideo);
-
-			expect(result).toBeNull();
-		});
-
-		it("エラーが発生した場合はnullを返す", () => {
-			vi.mocked(VideoMapper.fromYouTubeAPI).mockImplementation(() => {
-				throw new Error("Test error");
-			});
-
-			const result = updateVideoWith(mockExistingData as any, mockNewVideo);
-
-			expect(result).toBeNull();
-			expect(logger.error).toHaveBeenCalledWith(
-				"Entity 更新エラー",
-				expect.objectContaining({
-					videoId: "video1",
-					error: "Test error",
-				}),
-			);
-		});
+	it("コミット失敗時は 0 を返す", async () => {
+		mockBatchCommit.mockRejectedValue(new Error("commit fail"));
+		const result = await saveVideosToFirestore([ytVideo({ id: "v1" })]);
+		expect(result).toBe(0);
 	});
 });

--- a/apps/functions/vitest.config.ts
+++ b/apps/functions/vitest.config.ts
@@ -35,12 +35,13 @@ export default defineConfig({
 				"scripts/**", // Build scripts
 			],
 			// 現状の実測値を下限とするラチェット閾値（回帰ガード / SPR-152）。
-			// branches は video-mapper 網羅で 69% まで改善。目標 75 へは後続増分で。
+			// branches は video-mapper / youtube-api / youtube-firestore / config-manager
+			// 網羅で目標 75 を達成（実測 st83/br75/fn89/ln83）。
 			thresholds: {
-				statements: 75,
-				branches: 67,
-				functions: 82,
-				lines: 75,
+				statements: 82,
+				branches: 73,
+				functions: 88,
+				lines: 82,
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

SPR-152 第6増分。**functions の branches が目標 75 に到達**（61.7→75.1）。YouTube/設定まわりの未カバー分岐を網羅。

## 追加・置換テスト

- **youtube-api**（31%→89.6% branches）: 既存テスト未カバーの `fetchChannelPlaylists` / `fetchPlaylistItems`（プレイリスト系）と quota 不足分岐を追加（quota-monitor をモック）
- **youtube-firestore**（0%→網羅）: 旧 `describe.skip`（Entity 時代の死んだテスト）を全面置換。`saveVideosToFirestore`（チャンネルフィルタ・バッチ・コミット失敗・マッピング失敗）と `updateVideoWith` を実関数で検証（firestore/VideoMapper をモック）
- **config-manager**: `validateConfig` 全エラー分岐・`updateConfig`/`updateSectionConfig`・`deepMerge`（深いマージ/undefined スキップ/新規キー）・`getDebugInfo` を網羅
- **work-id-validator**: `logDetails` 詳細ログ分岐を網羅

## カバレッジ（functions 実測）

| | before(#540後) | after | 閾値(新) |
|---|---|---|---|
| statements | 73.5 | **83.6** | 82 |
| branches | 61.7 | **75.1** ✅ | 73 |
| functions | 81.5 | **89.5** | 88 |
| lines | 73.4 | **83.3** | 82 |

## 確認

- `pnpm verify` EXIT 0（426 tests pass、lint/typecheck 含め全 green）
- youtube-firestore の skip 解消で functions の skip 済みテストは 15→7 に減少（残りは別途棚卸し候補）

## SPR-152 進捗

- ✅ shared-types: 全4指標 80 達成
- ✅ functions: branches 75 達成（他指標も 83〜89）
- ⬜ 残: ui / web の引き上げ

🤖 Generated with [Claude Code](https://claude.com/claude-code)