### PR TITLE
test: ui の utils を網羅し branches を引き上げ (SPR-152 第7弾)

### DIFF
--- a/packages/ui/src/components/custom/configurable-list/utils/__tests__/classHelpers.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/utils/__tests__/classHelpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { generateGridClasses } from "../classHelpers";
+
+describe("generateGridClasses", () => {
+	it("gridColumns 未指定は基本クラスのみ", () => {
+		expect(generateGridClasses(undefined)).toBe("grid gap-6");
+	});
+
+	it("各ブレークポイントのカラム数をクラス化する", () => {
+		const r = generateGridClasses({ default: 1, sm: 2, lg: 4 });
+		expect(r).toContain("grid-cols-1");
+		expect(r).toContain("sm:grid-cols-2");
+		expect(r).toContain("lg:grid-cols-4");
+	});
+
+	it("範囲外(1未満/12超)のカラム数は無視する", () => {
+		const r = generateGridClasses({ default: 0, sm: 13, md: 6 });
+		expect(r).not.toContain("grid-cols-0");
+		expect(r).not.toContain("sm:grid-cols-13");
+		expect(r).toContain("md:grid-cols-6");
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/utils/__tests__/dataAdapter.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/utils/__tests__/dataAdapter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { StandardListParams } from "../../types";
+import { calculatePagination, createDataAdapter, wrapLegacyFetchData } from "../dataAdapter";
+
+const listParams = (over: Partial<StandardListParams> = {}): StandardListParams =>
+	({ page: 1, itemsPerPage: 10, filters: {}, ...over }) as StandardListParams;
+
+describe("createDataAdapter.toParams", () => {
+	it("既定マッピング（page/limit）でパラメータを生成する", () => {
+		const adapter = createDataAdapter({
+			resultMapping: { items: "items", total: "total" },
+		});
+		const params = adapter.toParams(listParams({ page: 2, itemsPerPage: 20 })) as Record<
+			string,
+			unknown
+		>;
+		expect(params).toEqual({ page: 2, limit: 20 });
+	});
+
+	it("paramMapping 指定時はキー名を差し替える", () => {
+		const adapter = createDataAdapter({
+			paramMapping: { page: "p", itemsPerPage: "size", sort: "order", search: "q" },
+			resultMapping: { items: "items", total: "total" },
+		});
+		const params = adapter.toParams(
+			listParams({ page: 3, itemsPerPage: 5, sort: "date", search: "kw" }),
+		) as Record<string, unknown>;
+		expect(params).toMatchObject({ p: 3, size: 5, order: "date", q: "kw" });
+	});
+
+	it("sort/search 既定キー & フィルター変換（undefined は除外）", () => {
+		const adapter = createDataAdapter({
+			filterTransforms: { genre: (v) => `g:${v}`, drop: () => undefined },
+			resultMapping: { items: "items", total: "total" },
+		});
+		const params = adapter.toParams(
+			listParams({
+				sort: "name",
+				search: "s",
+				filters: { genre: "rpg", drop: "x", skip: undefined },
+			}),
+		) as Record<string, unknown>;
+		expect(params.sort).toBe("name");
+		expect(params.search).toBe("s");
+		expect(params.genre).toBe("g:rpg");
+		expect(params).not.toHaveProperty("drop"); // 変換で undefined
+		expect(params).not.toHaveProperty("skip"); // 元値 undefined
+	});
+});
+
+describe("createDataAdapter.fromResult", () => {
+	it("文字列キーで items/total を取り出す", () => {
+		const adapter = createDataAdapter({
+			resultMapping: { items: "rows", total: "count" },
+		});
+		expect(adapter.fromResult({ rows: [1, 2], count: 2 })).toEqual({ items: [1, 2], total: 2 });
+	});
+
+	it("関数で items/total を導出する", () => {
+		const adapter = createDataAdapter<number, { data: number[] }>({
+			resultMapping: { items: (r) => r.data, total: (r) => r.data.length },
+		});
+		expect(adapter.fromResult({ data: [1, 2, 3] })).toEqual({ items: [1, 2, 3], total: 3 });
+	});
+});
+
+describe("wrapLegacyFetchData", () => {
+	it("adapter で変換しつつ legacy fetch をラップする", async () => {
+		const fetchData = vi.fn().mockResolvedValue({ items: ["a"], totalCount: 1, filteredCount: 1 });
+		const adapter = createDataAdapter<string>({
+			resultMapping: { items: "items", total: "totalCount" },
+		});
+		const wrapped = wrapLegacyFetchData(fetchData, adapter);
+		const result = await wrapped(listParams());
+		expect(fetchData).toHaveBeenCalledWith({ page: 1, limit: 10 });
+		expect(result).toEqual({ items: ["a"], total: 1 });
+	});
+});
+
+describe("calculatePagination", () => {
+	it("総ページ数・前後フラグ・インデックスを算出する", () => {
+		expect(calculatePagination(25, 10, 1)).toEqual({
+			totalPages: 3,
+			hasNext: true,
+			hasPrev: false,
+			startIndex: 0,
+			endIndex: 10,
+		});
+		expect(calculatePagination(25, 10, 3)).toEqual({
+			totalPages: 3,
+			hasNext: false,
+			hasPrev: true,
+			startIndex: 20,
+			endIndex: 25,
+		});
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/utils/__tests__/filterHelpers.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/utils/__tests__/filterHelpers.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import type { FilterConfig } from "../../types";
+import {
+	generateOptions,
+	generateYearOptions,
+	getDefaultFilterValues,
+	hasActiveFilters,
+	isFilterEnabled,
+	normalizeOptions,
+	transformFilterValue,
+	validateFilterValue,
+} from "../filterHelpers";
+
+const cfg = (over: Partial<FilterConfig> & { type: FilterConfig["type"] }): FilterConfig =>
+	over as FilterConfig;
+
+describe("transformFilterValue", () => {
+	it("showAll かつ 'all' は emptyValue（既定 undefined）に変換", () => {
+		expect(transformFilterValue("all", cfg({ type: "select", showAll: true }))).toBeUndefined();
+		expect(
+			transformFilterValue("all", cfg({ type: "select", showAll: true, emptyValue: "" })),
+		).toBe("");
+	});
+
+	it("tags/multiselect の空配列は undefined", () => {
+		expect(transformFilterValue([], cfg({ type: "tags" }))).toBeUndefined();
+		expect(transformFilterValue([], cfg({ type: "multiselect" }))).toBeUndefined();
+	});
+
+	it("その他はそのまま返す", () => {
+		expect(transformFilterValue("x", cfg({ type: "select" }))).toBe("x");
+		expect(transformFilterValue(["a"], cfg({ type: "tags" }))).toEqual(["a"]);
+	});
+});
+
+describe("normalizeOptions", () => {
+	it("空配列はそのまま", () => {
+		expect(normalizeOptions([])).toEqual([]);
+	});
+	it("文字列配列はオブジェクト化", () => {
+		expect(normalizeOptions(["a", "b"])).toEqual([
+			{ value: "a", label: "a" },
+			{ value: "b", label: "b" },
+		]);
+	});
+	it("オブジェクト配列はそのまま", () => {
+		const opts = [{ value: "v", label: "L" }];
+		expect(normalizeOptions(opts)).toBe(opts);
+	});
+});
+
+describe("generateOptions", () => {
+	it("select/multiselect/tags 以外は空配列", () => {
+		expect(generateOptions(cfg({ type: "range" }))).toEqual([]);
+	});
+	it("select + showAll は 'すべて' を先頭に付与", () => {
+		const r = generateOptions(cfg({ type: "select", showAll: true, options: ["a"] }));
+		expect(r[0]).toEqual({ value: "all", label: "すべて" });
+		expect(r[1]).toEqual({ value: "a", label: "a" });
+	});
+	it("showAll なしは baseOptions のみ", () => {
+		expect(generateOptions(cfg({ type: "multiselect", options: ["a"] }))).toEqual([
+			{ value: "a", label: "a" },
+		]);
+	});
+});
+
+describe("isFilterEnabled / validateFilterValue", () => {
+	it("enabled 未指定は true、関数は評価結果", () => {
+		expect(isFilterEnabled("k", cfg({ type: "select" }), {})).toBe(true);
+		expect(
+			isFilterEnabled("k", cfg({ type: "select", enabled: (f) => f.other === 1 }), { other: 1 }),
+		).toBe(true);
+		expect(
+			isFilterEnabled("k", cfg({ type: "select", enabled: (f) => f.other === 1 }), { other: 2 }),
+		).toBe(false);
+	});
+
+	it("validate 未指定は true、関数は評価結果", () => {
+		expect(validateFilterValue("x", cfg({ type: "select" }))).toBe(true);
+		expect(validateFilterValue(5, cfg({ type: "range", validate: (v) => (v as number) > 3 }))).toBe(
+			true,
+		);
+		expect(validateFilterValue(1, cfg({ type: "range", validate: (v) => (v as number) > 3 }))).toBe(
+			false,
+		);
+	});
+});
+
+describe("getDefaultFilterValues", () => {
+	it("型ごとの既定値・defaultValue 優先", () => {
+		const defaults = getDefaultFilterValues({
+			s: cfg({ type: "select", showAll: true }),
+			s2: cfg({ type: "select" }),
+			b: cfg({ type: "boolean" }),
+			t: cfg({ type: "tags" }),
+			r: cfg({ type: "range" }),
+			d: cfg({ type: "date" }),
+			dr: cfg({ type: "dateRange" }),
+			ov: cfg({ type: "select", defaultValue: "x" }),
+		});
+		expect(defaults.s).toBe("all");
+		expect(defaults.s2).toBe("");
+		expect(defaults.b).toBe(false);
+		expect(defaults.t).toEqual([]);
+		expect(defaults.r).toEqual({ min: undefined, max: undefined });
+		expect(defaults.d).toBeUndefined();
+		expect(defaults.dr).toEqual({ start: undefined, end: undefined });
+		expect(defaults.ov).toBe("x");
+	});
+});
+
+describe("hasActiveFilters", () => {
+	const configs = {
+		sel: cfg({ type: "select", showAll: true }),
+		tags: cfg({ type: "tags" }),
+		rng: cfg({ type: "range" }),
+	};
+
+	it("'all'・空配列・デフォルトは非アクティブ", () => {
+		expect(hasActiveFilters({ sel: "all", tags: [] }, configs)).toBe(false);
+	});
+
+	it("値が入っていればアクティブ", () => {
+		expect(hasActiveFilters({ tags: ["a"] }, configs)).toBe(true);
+	});
+
+	it("range は min/max いずれか指定でアクティブ", () => {
+		expect(hasActiveFilters({ rng: { min: undefined, max: undefined } }, configs)).toBe(false);
+		expect(hasActiveFilters({ rng: { min: 1 } }, configs)).toBe(true);
+	});
+
+	it("未知キーは無視", () => {
+		expect(hasActiveFilters({ unknown: "x" }, configs)).toBe(false);
+	});
+});
+
+describe("generateYearOptions", () => {
+	it("endYear から startYear まで降順", () => {
+		expect(generateYearOptions(2020, 2022)).toEqual([
+			{ value: "2022", label: "2022年" },
+			{ value: "2021", label: "2021年" },
+			{ value: "2020", label: "2020年" },
+		]);
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/utils/__tests__/filtering.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/utils/__tests__/filtering.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { FilterConfig } from "../../types";
+import { applyCustomFilters, applySearchFilter } from "../filtering";
+
+const cfg = (over: Partial<FilterConfig> & { type: FilterConfig["type"] }): FilterConfig =>
+	over as FilterConfig;
+
+describe("applySearchFilter", () => {
+	const items = [{ title: "Apple pie" }, { title: "Banana" }];
+
+	it("search/searchable が無効ならそのまま返す", () => {
+		expect(applySearchFilter(items, undefined, true)).toBe(items);
+		expect(applySearchFilter(items, "a", false)).toBe(items);
+	});
+
+	it("大文字小文字を無視して部分一致で絞り込む", () => {
+		expect(applySearchFilter(items, "apple", true)).toEqual([{ title: "Apple pie" }]);
+	});
+
+	it("検索対象テキストが無い項目は除外", () => {
+		expect(applySearchFilter([{ foo: 1 }] as never, "a", true)).toEqual([]);
+	});
+});
+
+describe("applyCustomFilters", () => {
+	it("未設定キー・空文字・変換結果 undefined はスキップ", () => {
+		const items = [{ kind: "a" }, { kind: "b" }];
+		const r = applyCustomFilters(
+			items,
+			{ kind: "", unknown: "x", tags: [] },
+			{ kind: cfg({ type: "select" }), tags: cfg({ type: "tags" }) },
+		);
+		expect(r).toEqual(items); // すべてスキップされ全件
+	});
+
+	it("multiselect/tags: 配列の交差で絞り込む", () => {
+		const items = [{ tags: ["x", "y"] }, { tags: ["z"] }];
+		const r = applyCustomFilters(items, { tags: ["x"] }, { tags: cfg({ type: "tags" }) });
+		expect(r).toEqual([{ tags: ["x", "y"] }]);
+	});
+
+	it("range: min/max で絞り込む", () => {
+		const items = [{ score: 5 }, { score: 15 }];
+		const r = applyCustomFilters(items, { score: { min: 10 } }, { score: cfg({ type: "range" }) });
+		expect(r).toEqual([{ score: 15 }]);
+	});
+
+	it("boolean: 真偽一致で絞り込む", () => {
+		const items = [{ active: true }, { active: false }];
+		const r = applyCustomFilters(items, { active: true }, { active: cfg({ type: "boolean" }) });
+		expect(r).toEqual([{ active: true }]);
+	});
+
+	it("select(default): 等値一致で絞り込む", () => {
+		const items = [{ kind: "a" }, { kind: "b" }];
+		const r = applyCustomFilters(items, { kind: "a" }, { kind: cfg({ type: "select" }) });
+		expect(r).toEqual([{ kind: "a" }]);
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/utils/__tests__/typeSafeAccess.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/utils/__tests__/typeSafeAccess.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+	getDateProperty,
+	getFilterableValue,
+	getNumericProperty,
+	getSearchableText,
+	getStringProperty,
+} from "../typeSafeAccess";
+
+describe("getSearchableText", () => {
+	it("オブジェクト以外は null", () => {
+		expect(getSearchableText(null)).toBeNull();
+		expect(getSearchableText("x")).toBeNull();
+	});
+	it("一般的なプロパティを優先順で返す", () => {
+		expect(getSearchableText({ title: "T" })).toBe("T");
+		expect(getSearchableText({ description: "D" })).toBe("D");
+	});
+	it("ネストした data も探索する", () => {
+		expect(getSearchableText({ data: { name: "N" } })).toBe("N");
+	});
+	it("該当なしは null", () => {
+		expect(getSearchableText({ foo: 1 })).toBeNull();
+	});
+});
+
+describe("getDateProperty", () => {
+	it("Date / 文字列 / Firestore Timestamp をパースする", () => {
+		const d = new Date("2024-01-01T00:00:00.000Z");
+		expect(getDateProperty({ createdAt: d })).toEqual(d);
+		expect(getDateProperty({ updatedAt: "2024-02-02T00:00:00.000Z" })?.toISOString()).toBe(
+			"2024-02-02T00:00:00.000Z",
+		);
+		expect(getDateProperty({ date: { toDate: () => d } })).toEqual(d);
+	});
+	it("無効文字列・該当なし・非オブジェクトは null", () => {
+		expect(getDateProperty({ createdAt: "not-a-date" })).toBeNull();
+		expect(getDateProperty({ foo: 1 })).toBeNull();
+		expect(getDateProperty(42)).toBeNull();
+	});
+	it("ネストした data も探索する", () => {
+		expect(getDateProperty({ data: { date: "2024-03-03T00:00:00.000Z" } })).not.toBeNull();
+	});
+});
+
+describe("getNumericProperty", () => {
+	it("数値・数値文字列をパース、パスを辿る", () => {
+		expect(getNumericProperty({ a: 5 }, "a")).toBe(5);
+		expect(getNumericProperty({ a: "5.5" }, "a")).toBe(5.5);
+		expect(getNumericProperty({ a: { b: 3 } }, "a.b")).toBe(3);
+	});
+	it("欠落・非数値・非オブジェクトは null", () => {
+		expect(getNumericProperty({ a: { b: 1 } }, "a.c")).toBeNull();
+		expect(getNumericProperty({ a: "x" }, "a")).toBeNull();
+		expect(getNumericProperty(null, "a")).toBeNull();
+	});
+});
+
+describe("getStringProperty", () => {
+	it("文字列・toString 可能な値を返す", () => {
+		expect(getStringProperty({ a: "s" }, "a")).toBe("s");
+		expect(getStringProperty({ a: 42 }, "a")).toBe("42");
+	});
+	it("欠落・非オブジェクトは null", () => {
+		expect(getStringProperty({ a: {} }, "a.b")).toBeNull();
+		expect(getStringProperty(null, "a")).toBeNull();
+	});
+});
+
+describe("getFilterableValue", () => {
+	it("プロパティパスを辿って値を返す", () => {
+		expect(getFilterableValue({ a: { b: "v" } }, "a.b")).toBe("v");
+	});
+	it("非オブジェクト・途中 null は undefined", () => {
+		expect(getFilterableValue(null, "a")).toBeUndefined();
+		expect(getFilterableValue({ a: null }, "a.b")).toBeUndefined();
+	});
+});

--- a/packages/ui/src/lib/__tests__/youtube-category-utils.test.ts
+++ b/packages/ui/src/lib/__tests__/youtube-category-utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+	getSupportedCategoryIds,
+	getYouTubeCategoryName,
+	isValidCategoryId,
+} from "../youtube-category-utils";
+
+describe("getYouTubeCategoryName", () => {
+	it("未指定は null", () => {
+		expect(getYouTubeCategoryName(undefined)).toBeNull();
+		expect(getYouTubeCategoryName("")).toBeNull();
+	});
+	it("既知カテゴリは日本語名", () => {
+		expect(getYouTubeCategoryName("10")).toBe("音楽");
+		expect(getYouTubeCategoryName("20")).toBe("ゲーム");
+	});
+	it("未知カテゴリは『カテゴリ{id}』", () => {
+		expect(getYouTubeCategoryName("999")).toBe("カテゴリ999");
+	});
+});
+
+describe("getSupportedCategoryIds", () => {
+	it("既知カテゴリ ID 一覧を返す", () => {
+		const ids = getSupportedCategoryIds();
+		expect(ids).toContain("10");
+		expect(ids.length).toBeGreaterThan(10);
+	});
+});
+
+describe("isValidCategoryId", () => {
+	it("既知は true、未知は false", () => {
+		expect(isValidCategoryId("10")).toBe(true);
+		expect(isValidCategoryId("999")).toBe(false);
+	});
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -51,13 +51,14 @@ export default defineConfig({
 			],
 			// カバレッジレポート形式
 			reporter: ["text", "html", "lcov"],
-			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
-			// 目標値への引き上げは SPR-152 で段階的に行う。
+			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
+			// configurable-list utils / category-utils を網羅し branches 64% まで改善。
+			// 残り（component/hook 描画系）は後続増分で。
 			thresholds: {
-				statements: 57,
-				branches: 51,
-				functions: 57,
-				lines: 59,
+				statements: 67,
+				branches: 62,
+				functions: 61,
+				lines: 67,
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

SPR-152 第7増分。**ui** に着手。テストが無かった純粋ユーティリティを網羅し branches を 52.8→64.2（+11.4pp）に改善。

## 追加テスト（すべて純粋関数・テスト新規）

- `configurable-list/utils/filterHelpers`（8関数）: transformFilterValue / normalizeOptions / generateOptions / isFilterEnabled / validateFilterValue / getDefaultFilterValues（型別既定値）/ hasActiveFilters / generateYearOptions
- `configurable-list/utils/typeSafeAccess`（5関数）: getSearchableText / getDateProperty（Date/文字列/Timestamp）/ getNumericProperty / getStringProperty / getFilterableValue（パス探索）
- `configurable-list/utils/filtering`: applySearchFilter / applyCustomFilters（multiselect・tags・range・boolean・select 各分岐）
- `configurable-list/utils/classHelpers`: generateGridClasses（範囲外カラム無視）
- `configurable-list/utils/dataAdapter`: createDataAdapter（paramMapping/filterTransforms/resultMapping）/ wrapLegacyFetchData / calculatePagination
- `lib/youtube-category-utils`: カテゴリ名変換・一覧・妥当性

## カバレッジ（ui 実測）

| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 58.8 | **69.4** | 67 |
| branches | 52.8 | **64.2** | 62 |
| functions | 58.4 | **63.9** | 61 |
| lines | 59.9 | **69.6** | 67 |

## 確認

- `pnpm verify` EXIT 0（357 tests pass、lint/typecheck 含め全 green）

## SPR-152 進捗

- ✅ shared-types（全80）・✅ functions（branches 75）・🔄 ui（branches 64、+11pp）
- 残り: ui の component/hook 描画系、web

🤖 Generated with [Claude Code](https://claude.com/claude-code)