### PR TITLE
test: web の works/lib util を網羅し branches を引き上げ (SPR-152 第8弾)

### DIFF
--- a/apps/web/src/app/works/lib/__tests__/work-filtering.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-filtering.test.ts
@@ -77,10 +77,12 @@ describe("filterWorksByUnifiedData", () => {
 	it("ageRating（特定指定）", () => {
 		expect(run({ ageRating: ["18禁"] })).toEqual(["w2"]);
 	});
-	it("language 指定でも配列を返す（shared-types フィルタ経由）", () => {
+	// language / showR18 の実フィルタロジックは shared-types 側（filterWorksByLanguage /
+	// filterR18Content）の責務。ここでは当該分岐が実行され例外なく配列を返すことだけを担保する。
+	it("language 指定で当該分岐を通り配列を返す（実フィルタは shared-types の責務）", () => {
 		expect(Array.isArray(filterWorksByUnifiedData(works, { language: "ja" }))).toBe(true);
 	});
-	it("showR18:false でも配列を返す（R18 除外フィルタ経由）", () => {
+	it("showR18:false で R18 除外分岐を通り配列を返す（実フィルタは shared-types の責務）", () => {
 		expect(Array.isArray(filterWorksByUnifiedData(works, { showR18: false }))).toBe(true);
 	});
 });

--- a/apps/web/src/app/works/lib/__tests__/work-filtering.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-filtering.test.ts
@@ -1,0 +1,98 @@
+import type { WorkDocument } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import {
+	type EnhancedSearchParams,
+	filterWorksBySearchText,
+	filterWorksByUnifiedData,
+	needsComplexFiltering,
+} from "../work-filtering";
+
+const work = (over: Partial<WorkDocument>): WorkDocument => over as WorkDocument;
+
+const works: WorkDocument[] = [
+	work({
+		productId: "w1",
+		title: "癒しのASMR",
+		circle: "C1",
+		category: "SOU",
+		creators: { voice_by: [{ name: "声優A" }] } as never,
+		genres: ["癒し"],
+		price: { current: 500 } as never,
+		rating: { stars: 4 } as never,
+		ageRating: "全年齢",
+		highResImageUrl: "http://img/h.jpg",
+	}),
+	work({
+		productId: "w2",
+		title: "ゲーム実況",
+		circle: "C2",
+		category: "GAM",
+		creators: { voice_by: [{ name: "声優B" }] } as never,
+		genres: ["ゲーム"],
+		price: { current: 2000 } as never,
+		rating: { stars: 2 } as never,
+		ageRating: "18禁",
+		highResImageUrl: "",
+	}),
+];
+
+const ids = (ws: WorkDocument[]) => ws.map((w) => w.productId);
+
+describe("filterWorksBySearchText", () => {
+	it("タイトル/サークル/クリエイター名を横断検索（大小無視）", () => {
+		expect(ids(filterWorksBySearchText(works, "asmr"))).toEqual(["w1"]);
+		expect(ids(filterWorksBySearchText(works, "声優B"))).toEqual(["w2"]);
+		expect(ids(filterWorksBySearchText(works, "C1"))).toEqual(["w1"]);
+	});
+});
+
+describe("filterWorksByUnifiedData", () => {
+	const run = (params: EnhancedSearchParams) => ids(filterWorksByUnifiedData(works, params));
+
+	it("category（all はスキップ）", () => {
+		expect(run({ category: "SOU" })).toEqual(["w1"]);
+		expect(run({ category: "all" })).toEqual(["w1", "w2"]);
+	});
+	it("search", () => {
+		expect(run({ search: "ゲーム" })).toEqual(["w2"]);
+	});
+	it("voiceActors（部分一致）", () => {
+		expect(run({ voiceActors: ["声優A"] })).toEqual(["w1"]);
+	});
+	it("genres（AND）", () => {
+		expect(run({ genres: ["癒し"] })).toEqual(["w1"]);
+		expect(run({ genres: ["癒し", "ゲーム"] })).toEqual([]);
+	});
+	it("priceRange", () => {
+		expect(run({ priceRange: { max: 1000 } })).toEqual(["w1"]);
+		expect(run({ priceRange: { min: 1000 } })).toEqual(["w2"]);
+	});
+	it("ratingRange", () => {
+		expect(run({ ratingRange: { min: 3 } })).toEqual(["w1"]);
+	});
+	it("hasHighResImage", () => {
+		expect(run({ hasHighResImage: true })).toEqual(["w1"]);
+		expect(run({ hasHighResImage: false })).toEqual(["w2"]);
+	});
+	it("ageRating（特定指定）", () => {
+		expect(run({ ageRating: ["18禁"] })).toEqual(["w2"]);
+	});
+	it("language 指定でも配列を返す（shared-types フィルタ経由）", () => {
+		expect(Array.isArray(filterWorksByUnifiedData(works, { language: "ja" }))).toBe(true);
+	});
+	it("showR18:false でも配列を返す（R18 除外フィルタ経由）", () => {
+		expect(Array.isArray(filterWorksByUnifiedData(works, { showR18: false }))).toBe(true);
+	});
+});
+
+describe("needsComplexFiltering", () => {
+	it("検索条件があれば true", () => {
+		expect(needsComplexFiltering({ search: "x" })).toBe(true);
+		expect(needsComplexFiltering({ voiceActors: ["a"] })).toBe(true);
+		expect(needsComplexFiltering({ showR18: false })).toBe(true);
+	});
+	it("条件が無ければ false", () => {
+		expect(needsComplexFiltering({})).toBe(false);
+		expect(needsComplexFiltering({ category: "SOU" })).toBe(false); // category は対象外
+	});
+});

--- a/apps/web/src/app/works/lib/__tests__/work-similarity.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-similarity.test.ts
@@ -1,0 +1,53 @@
+import type { WorkDocument } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { calculateSimilarityScore } from "../work-similarity";
+
+const work = (over: Partial<WorkDocument>): WorkDocument => over as WorkDocument;
+
+const base = work({
+	circle: "C1",
+	category: "SOU",
+	creators: { voice_by: [{ name: "声優A" }, { name: "声優B" }] } as never,
+	genres: ["癒し", "ASMR"],
+	price: { current: 1000 } as never,
+});
+
+describe("calculateSimilarityScore", () => {
+	it("サークル一致で +10（byCircle 有効時のみ）", () => {
+		expect(calculateSimilarityScore(work({ circle: "C1" }), base, true, false, false)).toBe(10);
+		expect(calculateSimilarityScore(work({ circle: "C1" }), base, false, false, false)).toBe(0);
+	});
+
+	it("声優の共通数 × 3（部分一致含む）", () => {
+		const w = work({ creators: { voice_by: [{ name: "声優A" }] } as never });
+		expect(calculateSimilarityScore(w, base, false, true, false)).toBe(3);
+	});
+
+	it("ジャンルの共通数 × 2", () => {
+		const w = work({ genres: ["癒し"] });
+		expect(calculateSimilarityScore(w, base, false, false, true)).toBe(2);
+	});
+
+	it("カテゴリ一致で +1", () => {
+		expect(calculateSimilarityScore(work({ category: "SOU" }), base, false, false, false)).toBe(1);
+	});
+
+	it("価格差 500 未満で +1", () => {
+		const near = work({ price: { current: 1200 } as never });
+		const far = work({ price: { current: 5000 } as never });
+		expect(calculateSimilarityScore(near, base, false, false, false)).toBe(1);
+		expect(calculateSimilarityScore(far, base, false, false, false)).toBe(0);
+	});
+
+	it("複合条件のスコアを合算する", () => {
+		const w = work({
+			circle: "C1",
+			category: "SOU",
+			creators: { voice_by: [{ name: "声優A" }, { name: "声優B" }] } as never,
+			genres: ["癒し", "ASMR"],
+			price: { current: 1000 } as never,
+		});
+		// circle10 + voice(2*3=6) + genre(2*2=4) + category1 + price1 = 22
+		expect(calculateSimilarityScore(w, base, true, true, true)).toBe(22);
+	});
+});

--- a/apps/web/src/app/works/lib/__tests__/work-similarity.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-similarity.test.ts
@@ -18,9 +18,20 @@ describe("calculateSimilarityScore", () => {
 		expect(calculateSimilarityScore(work({ circle: "C1" }), base, false, false, false)).toBe(0);
 	});
 
-	it("声優の共通数 × 3（部分一致含む）", () => {
+	it("声優の共通数 × 3（完全一致）", () => {
 		const w = work({ creators: { voice_by: [{ name: "声優A" }] } as never });
 		expect(calculateSimilarityScore(w, base, false, true, false)).toBe(3);
+	});
+
+	it("声優は部分一致（includes）でも加点される", () => {
+		// base「フルネーム太郎」、work「太郎」→ includes でマッチ（1名 × 3）。
+		// category を base 側のみ設定し、未指定同士の category 一致(+1)を避ける。
+		const singleBase = work({
+			category: "SOU",
+			creators: { voice_by: [{ name: "フルネーム太郎" }] } as never,
+		});
+		const w = work({ category: "GAM", creators: { voice_by: [{ name: "太郎" }] } as never });
+		expect(calculateSimilarityScore(w, singleBase, false, true, false)).toBe(3);
 	});
 
 	it("ジャンルの共通数 × 2", () => {

--- a/apps/web/src/app/works/lib/__tests__/work-sorting.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-sorting.test.ts
@@ -1,0 +1,39 @@
+import type { WorkDocument } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { sortWorks } from "../work-sorting";
+
+const work = (over: Partial<WorkDocument>): WorkDocument => over as WorkDocument;
+
+const a = work({ productId: "a", releaseDateISO: "2024-01-01", price: { current: 300 } as never, rating: { stars: 4, count: 10 } as never });
+const b = work({ productId: "b", releaseDateISO: "2024-06-01", price: { current: 100 } as never, rating: { stars: 5, count: 2 } as never });
+const c = work({ productId: "c", releaseDateISO: "2023-01-01", price: { current: 200 } as never, rating: { stars: 3, count: 50 } as never });
+
+const ids = (works: WorkDocument[]) => works.map((w) => w.productId);
+
+describe("sortWorks", () => {
+	const items = [a, b, c];
+
+	it("newest（既定）は新しい順", () => {
+		expect(ids(sortWorks(items, "newest"))).toEqual(["b", "a", "c"]);
+		expect(ids(sortWorks(items, "unknown"))).toEqual(["b", "a", "c"]); // default
+	});
+	it("oldest は古い順", () => {
+		expect(ids(sortWorks(items, "oldest"))).toEqual(["c", "a", "b"]);
+	});
+	it("price_low / price_high", () => {
+		expect(ids(sortWorks(items, "price_low"))).toEqual(["b", "c", "a"]);
+		expect(ids(sortWorks(items, "price_high"))).toEqual(["a", "c", "b"]);
+	});
+	it("rating（星）/ popular（評価数）", () => {
+		expect(ids(sortWorks(items, "rating"))).toEqual(["b", "a", "c"]);
+		expect(ids(sortWorks(items, "popular"))).toEqual(["c", "a", "b"]);
+	});
+	it("元配列を破壊しない", () => {
+		sortWorks(items, "oldest");
+		expect(ids(items)).toEqual(["a", "b", "c"]);
+	});
+	it("欠落フィールドは既定値で扱う", () => {
+		const r = sortWorks([work({ productId: "x" }), b], "price_low");
+		expect(r[0]?.productId).toBe("x"); // price 無し → 0 で最安
+	});
+});

--- a/apps/web/src/app/works/lib/__tests__/work-statistics.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-statistics.test.ts
@@ -1,0 +1,74 @@
+import type { WorkDocument } from "@suzumina.click/shared-types";
+import { describe, expect, it, vi } from "vitest";
+import { generateDataQualityReport, generateWorksStats } from "../work-statistics";
+
+vi.mock("@/lib/logger", () => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+	debug: vi.fn(),
+}));
+
+const work = (over: Partial<WorkDocument>): WorkDocument => over as WorkDocument;
+
+const works: WorkDocument[] = [
+	work({
+		category: "SOU",
+		price: { current: 1000 } as never,
+		rating: { stars: 4 } as never,
+		genres: ["癒し", "ASMR"],
+		creators: { voice_by: [{ name: "声優A" }] } as never,
+		highResImageUrl: "http://img/h.jpg",
+		dataSources: { searchResult: {}, infoAPI: {} } as never,
+	}),
+	work({
+		category: "SOU",
+		price: { current: 2000 } as never,
+		rating: { stars: 2 } as never,
+		genres: ["癒し"],
+		creators: {
+			voice_by: [{ name: "声優A" }, { name: "声優B" }],
+			scenario_by: [{ name: "脚本" }],
+		} as never,
+	}),
+	work({ category: "GAM", price: { current: 3000 } as never, genres: ["ゲーム"] }),
+];
+
+describe("generateWorksStats", () => {
+	it("overview を集計する（平均価格は四捨五入）", async () => {
+		const stats = await generateWorksStats(works);
+		expect(stats.overview.totalWorks).toBe(3);
+		expect(stats.overview.totalValue).toBe(6000);
+		expect(stats.overview.averagePrice).toBe(2000);
+	});
+
+	it("カテゴリ別に集計し平均を算出する", async () => {
+		const stats = await generateWorksStats(works);
+		expect(stats.byCategory.SOU?.count).toBe(2);
+		expect(stats.byCategory.SOU?.averagePrice).toBe(1500);
+		expect(stats.byCategory.SOU?.averageRating).toBe(3); // (4+2)/2
+		expect(stats.byCategory.GAM?.count).toBe(1);
+	});
+
+	it("人気タグ・人気声優を出現数の降順で返す", async () => {
+		const stats = await generateWorksStats(works);
+		expect(stats.trends.popularTags[0]).toEqual({ tag: "癒し", count: 2 });
+		expect(stats.trends.popularVoiceActors[0]).toEqual({ voiceActor: "声優A", count: 2 });
+	});
+});
+
+describe("generateDataQualityReport", () => {
+	it("各品質指標とパーセンテージを集計する", () => {
+		const report = generateDataQualityReport(works);
+		expect(report.total).toBe(3);
+		expect(report.hasHighResImage).toBe(1);
+		expect(report.hasVoiceActors).toBe(2);
+		expect(report.hasDetailedCreators).toBe(1); // scenario_by を持つ 1 件
+		expect(report.hasRating).toBe(2);
+		expect(report.hasGenres).toBe(3);
+		expect(report.hasDataSources).toBe(1);
+		expect(report.dataSourceCoverage.allThree).toBe(1); // searchResult & infoAPI
+		expect(report.percentages.hasGenres).toBe(100);
+		expect(report.percentages.hasHighResImage).toBe(33); // round(1/3*100)
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,13 +35,14 @@ export default defineConfig({
 				"**/e2e/**",
 				"src/**/layout.tsx", // App Router boilerplate
 			],
-			// 現状の実測値を下限とするラチェット閾値（回帰ガード）。
-			// 目標値への引き上げは SPR-152 で段階的に行う。
+			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
+			// works/lib の純粋 util（sorting/similarity/filtering/statistics）を
+			// 網羅し branches 59% まで改善。残り（component/Server Actions）は後続増分。
 			thresholds: {
-				statements: 62,
-				branches: 52,
-				functions: 60,
-				lines: 63,
+				statements: 66,
+				branches: 57,
+				functions: 66,
+				lines: 66,
 			},
 		},
 		exclude: [

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,8 +35,7 @@ export default defineConfig({
 				"**/e2e/**",
 				"src/**/layout.tsx", // App Router boilerplate
 			],
-			// 実測フロアに合わせたラチェット閾値（回帰ガード）。
-			// 純粋 util を優先網羅。残り（component/Server Actions）は後続増分で引き上げる。
+			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
 				statements: 66,
 				branches: 57,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,9 +35,8 @@ export default defineConfig({
 				"**/e2e/**",
 				"src/**/layout.tsx", // App Router boilerplate
 			],
-			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
-			// works/lib の純粋 util（sorting/similarity/filtering/statistics）を
-			// 網羅し branches 59% まで改善。残り（component/Server Actions）は後続増分。
+			// 実測フロアに合わせたラチェット閾値（回帰ガード）。
+			// 純粋 util を優先網羅。残り（component/Server Actions）は後続増分で引き上げる。
 			thresholds: {
 				statements: 66,
 				branches: 57,


### PR DESCRIPTION
## 概要

SPR-152 第8増分。**web** に着手。テストが無かった `app/works/lib` の純粋ユーティリティを網羅し branches を 54.5→59.5 に改善。

## 追加テスト（純粋関数・テスト新規）

- `work-sorting`: 全ソート種別（newest/oldest/price_low/price_high/rating/popular）・元配列非破壊・既定値
- `work-similarity`: サークル/声優（部分一致 ×3）/ジャンル（×2）/カテゴリ/価格帯の加点と合算
- `work-filtering`: `filterWorksBySearchText`・`filterWorksByUnifiedData`（category/search/voiceActors/genres(AND)/priceRange/ratingRange/hasHighResImage/ageRating/language/showR18 の各分岐）・`needsComplexFiltering`
- `work-statistics`: `generateWorksStats`（overview・カテゴリ別集計・人気タグ/声優の降順）・`generateDataQualityReport`（品質指標・パーセンテージ）

## カバレッジ（web 実測）

| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 64.3 | **68.2** | 66 |
| branches | 54.5 | **59.5** | 57 |
| functions | 62.6 | **69.0** | 66 |
| lines | 65.2 | **68.7** | 66 |

## 確認

- `pnpm verify` EXIT 0（671 tests pass、lint/typecheck 含め全 green）

## SPR-152 進捗

- ✅ shared-types（全80）・✅ functions（branches 75）・🔄 ui（branches 64）・🔄 web（branches 59、+5pp）
- 残り: ui/web の component・hook・Server Actions（描画/モック系）

🤖 Generated with [Claude Code](https://claude.com/claude-code)