### PR TITLE
test: ui の configurable-list hooks を網羅 (SPR-152 第9弾)

### DIFF
--- a/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useListHandlers.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useListHandlers.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { FilterConfig, StandardListParams } from "../../types";
+import { useListHandlers } from "../useListHandlers";
+
+const makeUrlHook = () => ({
+	setSearch: vi.fn(),
+	setSort: vi.fn(),
+	setFilter: vi.fn(),
+	setPage: vi.fn(),
+	resetFilters: vi.fn(),
+	setItemsPerPage: vi.fn(),
+});
+
+const filters: Record<string, FilterConfig> = {
+	cat: { type: "select" } as FilterConfig,
+};
+
+const setup = (urlSync: boolean) => {
+	const urlHook = makeUrlHook();
+	const setLocalParams = vi.fn();
+	const { result } = renderHook(() =>
+		useListHandlers({ urlSync, urlHook, setLocalParams, filters }),
+	);
+	return { result, urlHook, setLocalParams };
+};
+
+// setLocalParams に渡された updater を prev に適用して結果を得る
+const applyUpdater = (
+	setLocalParams: ReturnType<typeof vi.fn>,
+	prev: Partial<StandardListParams>,
+) => {
+	const updater = setLocalParams.mock.calls.at(-1)?.[0] as (
+		p: StandardListParams,
+	) => StandardListParams;
+	return updater(prev as StandardListParams);
+};
+
+describe("useListHandlers (urlSync=true)", () => {
+	it("各操作は urlHook に委譲する", () => {
+		const { result, urlHook, setLocalParams } = setup(true);
+		act(() => result.current.handleSearch("q"));
+		act(() => result.current.handleSortChange("newest"));
+		act(() => result.current.handleFilterChange("cat", "SOU"));
+		act(() => result.current.handlePageChange(3));
+		act(() => result.current.handleResetFilters());
+		act(() => result.current.handleItemsPerPageChange("24"));
+
+		expect(urlHook.setSearch).toHaveBeenCalledWith("q");
+		expect(urlHook.setSort).toHaveBeenCalledWith("newest");
+		expect(urlHook.setFilter).toHaveBeenCalledWith("cat", "SOU");
+		expect(urlHook.setPage).toHaveBeenCalledWith(3);
+		expect(urlHook.resetFilters).toHaveBeenCalled();
+		expect(urlHook.setItemsPerPage).toHaveBeenCalledWith(24);
+		expect(setLocalParams).not.toHaveBeenCalled();
+	});
+});
+
+describe("useListHandlers (urlSync=false)", () => {
+	it("handleSearch / handleSortChange はローカル state を更新", () => {
+		const { result, urlHook, setLocalParams } = setup(false);
+		act(() => result.current.handleSearch("q"));
+		expect(applyUpdater(setLocalParams, { search: "" })).toMatchObject({ search: "q" });
+		act(() => result.current.handleSortChange("rating"));
+		expect(applyUpdater(setLocalParams, {})).toMatchObject({ sort: "rating" });
+		expect(urlHook.setSearch).not.toHaveBeenCalled();
+	});
+
+	it("handleFilterChange は filters をマージ", () => {
+		const { result, setLocalParams } = setup(false);
+		act(() => result.current.handleFilterChange("cat", "SOU"));
+		expect(applyUpdater(setLocalParams, { filters: { other: 1 } as never })).toMatchObject({
+			filters: { other: 1, cat: "SOU" },
+		});
+	});
+
+	it("handlePageChange / handleItemsPerPageChange（ページは 1 にリセット）", () => {
+		const { result, setLocalParams } = setup(false);
+		act(() => result.current.handlePageChange(5));
+		expect(applyUpdater(setLocalParams, {})).toMatchObject({ page: 5 });
+		act(() => result.current.handleItemsPerPageChange("48"));
+		expect(applyUpdater(setLocalParams, {})).toMatchObject({ itemsPerPage: 48, page: 1 });
+	});
+
+	it("handleResetFilters は既定フィルタと空検索に戻す", () => {
+		const { result, setLocalParams } = setup(false);
+		act(() => result.current.handleResetFilters());
+		const next = applyUpdater(setLocalParams, { search: "x", filters: { cat: "SOU" } as never });
+		expect(next.search).toBe("");
+		expect(next.filters).toEqual({ cat: "" }); // select 既定値
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useListUrl.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useListUrl.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FilterConfig } from "../../types";
+import { useListUrl } from "../useListUrl";
+
+// useSearchParams を可変ホルダー経由でモック
+const h = vi.hoisted(() => ({ sp: new URLSearchParams() }));
+vi.mock("next/navigation", () => ({
+	useSearchParams: () => h.sp,
+}));
+
+const setSP = (qs: string) => {
+	h.sp = new URLSearchParams(qs);
+};
+
+// 最後に pushState されたURLのクエリを返す
+const lastPushedParams = (spy: ReturnType<typeof vi.spyOn>) => {
+	const url = spy.mock.calls.at(-1)?.[2] as string;
+	const qs = url.includes("?") ? url.split("?")[1] : "";
+	return new URLSearchParams(qs);
+};
+
+const filters: Record<string, FilterConfig> = {
+	genre: { type: "select", showAll: true } as FilterConfig,
+	tags: { type: "tags" } as FilterConfig,
+	flag: { type: "boolean" } as FilterConfig,
+	price: { type: "range" } as FilterConfig,
+	period: { type: "dateRange" } as FilterConfig,
+};
+
+let pushSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	setSP("");
+	pushSpy = vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+	vi.spyOn(window, "dispatchEvent").mockImplementation(() => true);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("useListUrl: URL 解析", () => {
+	it("既定値（page=1/limit=defaultPageSize/sort=defaultSort）", () => {
+		const { result } = renderHook(() => useListUrl({ defaultPageSize: 24, defaultSort: "newest" }));
+		expect(result.current.params.page).toBe(1);
+		expect(result.current.params.itemsPerPage).toBe(24);
+		expect(result.current.params.sort).toBe("newest");
+		expect(result.current.params.search).toBe("");
+	});
+
+	it("基本パラメータを解析する", () => {
+		setSP("page=3&limit=50&sort=rating&q=word");
+		const { result } = renderHook(() => useListUrl());
+		expect(result.current.params).toMatchObject({
+			page: 3,
+			itemsPerPage: 50,
+			sort: "rating",
+			search: "word",
+		});
+	});
+
+	it("フィルターを型ごとに解析する", () => {
+		setSP("tags=a|b&flag=true&price=10-20&period=2024-01-01~2024-02-01&genre=SOU");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		const f = result.current.params.filters;
+		expect(f.tags).toEqual(["a", "b"]);
+		expect(f.flag).toBe(true);
+		expect(f.price).toEqual({ min: 10, max: 20 });
+		expect(f.period).toEqual({ start: "2024-01-01", end: "2024-02-01" });
+		expect(f.genre).toBe("SOU");
+	});
+
+	it("tags の旧カンマ形式も解析する", () => {
+		setSP("tags=x,y");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		expect(result.current.params.filters.tags).toEqual(["x", "y"]);
+	});
+});
+
+describe("useListUrl: setter（pushState）", () => {
+	it("setPage は page を設定、1 は既定で削除", () => {
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.setPage(4));
+		expect(lastPushedParams(pushSpy).get("page")).toBe("4");
+		act(() => result.current.setPage(1));
+		expect(lastPushedParams(pushSpy).get("page")).toBeNull();
+	});
+
+	it("setSearch は q を設定しページを 1 に戻す（page は URL から消える）", () => {
+		setSP("page=5");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.setSearch("kw"));
+		const p = lastPushedParams(pushSpy);
+		expect(p.get("q")).toBe("kw");
+		expect(p.get("page")).toBeNull();
+	});
+
+	it("setSort は sort を設定", () => {
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.setSort("rating"));
+		expect(lastPushedParams(pushSpy).get("sort")).toBe("rating");
+	});
+
+	it("setFilter: 配列はパイプ結合、boolean/range もシリアライズ", () => {
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.setFilter("tags", ["a", "b"]));
+		expect(lastPushedParams(pushSpy).get("tags")).toBe("a|b");
+		act(() => result.current.setFilter("price", { min: 5, max: 9 }));
+		expect(lastPushedParams(pushSpy).get("price")).toBe("5-9");
+	});
+
+	it("setFilter: 'all'（showAll）はURLから除外", () => {
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.setFilter("genre", "all"));
+		expect(lastPushedParams(pushSpy).get("genre")).toBeNull();
+	});
+
+	it("resetFilters は既存フィルターを削除する", () => {
+		setSP("tags=a|b&flag=true");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.resetFilters());
+		const p = lastPushedParams(pushSpy);
+		expect(p.get("tags")).toBeNull();
+		expect(p.get("flag")).toBeNull();
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useListUrl.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useListUrl.test.ts
@@ -96,18 +96,23 @@ describe("useListUrl: setter（pushState）", () => {
 		expect(p.get("page")).toBeNull();
 	});
 
-	it("setSort は sort を設定", () => {
+	it("setSort は sort を設定しページを 1 に戻す（page は URL から消える）", () => {
+		setSP("page=3");
 		const { result } = renderHook(() => useListUrl({ filters }));
 		act(() => result.current.setSort("rating"));
-		expect(lastPushedParams(pushSpy).get("sort")).toBe("rating");
+		const p = lastPushedParams(pushSpy);
+		expect(p.get("sort")).toBe("rating");
+		expect(p.get("page")).toBeNull();
 	});
 
-	it("setFilter: 配列はパイプ結合、boolean/range もシリアライズ", () => {
+	it("setFilter: 配列はパイプ結合、range はハイフン結合、boolean は文字列化", () => {
 		const { result } = renderHook(() => useListUrl({ filters }));
 		act(() => result.current.setFilter("tags", ["a", "b"]));
 		expect(lastPushedParams(pushSpy).get("tags")).toBe("a|b");
 		act(() => result.current.setFilter("price", { min: 5, max: 9 }));
 		expect(lastPushedParams(pushSpy).get("price")).toBe("5-9");
+		act(() => result.current.setFilter("flag", true));
+		expect(lastPushedParams(pushSpy).get("flag")).toBe("true");
 	});
 
 	it("setFilter: 'all'（showAll）はURLから除外", () => {

--- a/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useSearchInput.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/hooks/__tests__/useSearchInput.test.ts
@@ -1,0 +1,57 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSearchInput } from "../useSearchInput";
+
+const keyEvent = (key: string) => ({ key }) as React.KeyboardEvent<HTMLInputElement>;
+
+describe("useSearchInput", () => {
+	it("初期値を保持し、変更で localSearchValue が更新される", () => {
+		const onSearch = vi.fn();
+		const { result } = renderHook(() => useSearchInput({ initialValue: "init", onSearch }));
+		expect(result.current.localSearchValue).toBe("init");
+
+		act(() => result.current.handleSearchChange("typed"));
+		expect(result.current.localSearchValue).toBe("typed");
+		// 変更だけでは onSearch を呼ばない
+		expect(onSearch).not.toHaveBeenCalled();
+	});
+
+	it("Enter で onSearch を現在値で呼ぶ", () => {
+		const onSearch = vi.fn();
+		const { result } = renderHook(() => useSearchInput({ initialValue: "", onSearch }));
+		act(() => result.current.handleSearchChange("hello"));
+		act(() => result.current.handleSearchKeyDown(keyEvent("Enter")));
+		expect(onSearch).toHaveBeenCalledWith("hello");
+	});
+
+	it("IME変換中(composition)の Enter では onSearch を呼ばない", () => {
+		const onSearch = vi.fn();
+		const { result } = renderHook(() => useSearchInput({ initialValue: "", onSearch }));
+		act(() => result.current.handleSearchChange("かな"));
+		act(() => result.current.handleCompositionStart());
+		act(() => result.current.handleSearchKeyDown(keyEvent("Enter")));
+		expect(onSearch).not.toHaveBeenCalled();
+
+		// 変換確定後の Enter は呼ぶ
+		act(() => result.current.handleCompositionEnd());
+		act(() => result.current.handleSearchKeyDown(keyEvent("Enter")));
+		expect(onSearch).toHaveBeenCalledWith("かな");
+	});
+
+	it("Enter 以外のキーでは呼ばない", () => {
+		const onSearch = vi.fn();
+		const { result } = renderHook(() => useSearchInput({ initialValue: "", onSearch }));
+		act(() => result.current.handleSearchKeyDown(keyEvent("a")));
+		expect(onSearch).not.toHaveBeenCalled();
+	});
+
+	it("外部 initialValue の変更に同期する", () => {
+		const onSearch = vi.fn();
+		const { result, rerender } = renderHook(
+			({ initialValue }) => useSearchInput({ initialValue, onSearch }),
+			{ initialProps: { initialValue: "a" } },
+		);
+		rerender({ initialValue: "b" });
+		expect(result.current.localSearchValue).toBe("b");
+	});
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -51,14 +51,12 @@ export default defineConfig({
 			],
 			// カバレッジレポート形式
 			reporter: ["text", "html", "lcov"],
-			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）。
-			// configurable-list utils / category-utils を網羅し branches 64% まで改善。
-			// 残り（component/hook 描画系）は後続増分で。
+			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 67,
-				branches: 62,
-				functions: 61,
-				lines: 67,
+				statements: 72,
+				branches: 67,
+				functions: 66,
+				lines: 72,
 			},
 		},
 	},


### PR DESCRIPTION
## 概要

SPR-152 第9増分。ui の**描画系（hooks）**に着手。`renderHook` で検証し branches を 64.2→69.6（目標 65 超え）。

## 追加テスト

- `useListUrl`（25%→76% branches）: `useSearchParams` をモックし、URL 解析（page/limit/sort/q・フィルター型別 parse: multiselect の pipe/comma・boolean・range・dateRange）と setter（pushState 経由の serialize・既定値/`all` の URL 除外・page リセット・resetFilters）を網羅
- `useListHandlers`: `urlSync` 真偽の両分岐（urlHook 委譲 / ローカル state updater）
- `useSearchInput`: IME composition 中の Enter 抑止・確定後の onSearch・初期値同期

## カバレッジ（ui 実測）

| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 69.4 | **74.2** | 72 |
| branches | 64.2 | **69.6** | 67 |
| functions | 63.9 | **68.8** | 66 |
| lines | 69.6 | **74.4** | 72 |

## 確認

- `pnpm verify` EXIT 0（377 tests pass、lint/typecheck 含め全 green）

## SPR-152 進捗

- ✅ shared-types（80）・✅ functions（75）・✅ ui（branches 69.6）・🔄 web（59.5）
- 残り: web の hooks/contexts/Server Actions、両者の component（描画）

🤖 Generated with [Claude Code](https://claude.com/claude-code)