### PR TITLE
refactor(web): dataSourceCoverage の allThree を実態に合わせて改名

### DIFF
--- a/apps/web/src/app/works/lib/__tests__/work-statistics.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-statistics.test.ts
@@ -67,7 +67,7 @@ describe("generateDataQualityReport", () => {
 		expect(report.hasRating).toBe(2);
 		expect(report.hasGenres).toBe(3);
 		expect(report.hasDataSources).toBe(1);
-		expect(report.dataSourceCoverage.allThree).toBe(1); // searchResult & infoAPI
+		expect(report.dataSourceCoverage.searchResultAndInfoAPI).toBe(1); // searchResult & infoAPI
 		expect(report.percentages.hasGenres).toBe(100);
 		expect(report.percentages.hasHighResImage).toBe(33); // round(1/3*100)
 	});

--- a/apps/web/src/app/works/lib/work-statistics.ts
+++ b/apps/web/src/app/works/lib/work-statistics.ts
@@ -15,8 +15,8 @@ interface QualityStats {
 	dataSourceCoverage: {
 		searchResult: number;
 		infoAPI: number;
-		detailPage: number;
-		allThree: number;
+		/** searchResult と infoAPI の両方を持つ件数（dataSources は detailPage を持たない） */
+		searchResultAndInfoAPI: number;
 	};
 }
 
@@ -55,7 +55,7 @@ function updateDataSourceStats(work: WorkDocument, stats: QualityStats) {
 		if (sources.infoAPI) stats.dataSourceCoverage.infoAPI++;
 
 		if (sources.searchResult && sources.infoAPI) {
-			stats.dataSourceCoverage.allThree++;
+			stats.dataSourceCoverage.searchResultAndInfoAPI++;
 		}
 	}
 }
@@ -71,7 +71,7 @@ function calculateQualityPercentages(stats: QualityStats) {
 		hasDetailedCreators: Math.round((stats.hasDetailedCreators / total) * 100),
 		hasRating: Math.round((stats.hasRating / total) * 100),
 		hasGenres: Math.round((stats.hasGenres / total) * 100),
-		dataSourceCoverage: Math.round((stats.dataSourceCoverage.allThree / total) * 100),
+		dataSourceCoverage: Math.round((stats.dataSourceCoverage.searchResultAndInfoAPI / total) * 100),
 	};
 }
 
@@ -215,8 +215,7 @@ export function generateDataQualityReport(allWorks: WorkDocument[]) {
 		dataSourceCoverage: {
 			searchResult: 0,
 			infoAPI: 0,
-			detailPage: 0,
-			allThree: 0,
+			searchResultAndInfoAPI: 0,
 		},
 	};
 


### PR DESCRIPTION
## 概要

`generateDataQualityReport` 内の `dataSourceCoverage.allThree` は名前が「3ソース全部」を示唆するが、実装は `searchResult && infoAPI` の **2条件のみ**で `detailPage` を含まない（軸3: 名前と実態のズレ）。

## 判断の根拠

`dataSources` の実データ構造（[`DataSourceTrackingSchema`](packages/shared-types/src/entities/work/work-schemas.ts)）は `searchResult` と `infoAPI` の **2フィールドのみ**で、`detailPage` は存在しない。コードベース全体で `dataSourceCoverage.detailPage` に値が入る箇所もゼロ。

したがって:
- 選択肢1（detailPage を条件に追加）は **不可能**（データに detailPage が無い）
- `detailPage: number` カウンタ自体も **常に 0 の死んだ misleading フィールド**

→ **選択肢2: 実態に合わせたリネーム**を採用。

## 変更内容

- `allThree` → `searchResultAndInfoAPI` に改名（型・初期化・集計 `updateDataSourceStats`・パーセンテージ計算 `calculateQualityPercentages` の全参照を更新）
- 常に 0 で実態のない `detailPage` カウンタを型・初期化から削除
- 「dataSources は detailPage を持たない」旨を近接コメントで明示（軸2の予測可能性）
- テスト `work-statistics.test.ts` の参照を更新

## 影響範囲

`getDataQualityReport`（`apps/web/src/app/works/actions.ts`）は定義のみで、`dataSourceCoverage`/`allThree` を描画する UI 消費者は無いため安全。Two-Way Door。

## 確認

- `pnpm verify` green（lint + typecheck + test）

Claude AI Review（#544）で pre-existing として指摘された件への対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)