### PR TITLE
test: web の Server Actions を網羅 (SPR-152 第11弾)

### DIFF
--- a/apps/web/src/actions/__tests__/autocomplete.test.ts
+++ b/apps/web/src/actions/__tests__/autocomplete.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getAutocompleteSuggestions } from "../autocomplete";
+
+vi.mock("@/lib/firestore", () => ({ getFirestore: vi.fn() }));
+const { getFirestore } = vi.mocked(await import("@/lib/firestore"));
+
+// コレクション名ごとに docs を返すチェーン可能な Firestore モック
+const makeFirestore = (docsByCollection: Record<string, Array<{ id: string; data: unknown }>>) => {
+	const makeQuery = (name: string) => {
+		const q: Record<string, unknown> = {};
+		q.where = vi.fn(() => q);
+		q.orderBy = vi.fn(() => q);
+		q.limit = vi.fn(() => q);
+		q.get = vi.fn().mockResolvedValue({
+			docs: (docsByCollection[name] || []).map((d) => ({ id: d.id, data: () => d.data })),
+		});
+		return q;
+	};
+	return { collection: vi.fn((name: string) => makeQuery(name)) };
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("getAutocompleteSuggestions", () => {
+	it("空クエリはスキーマ検証エラー", async () => {
+		const r = await getAutocompleteSuggestions("");
+		expect(r.success).toBe(false);
+	});
+
+	it("2文字未満は空候補で即返す（Firestore を引かない）", async () => {
+		getFirestore.mockReturnValue(makeFirestore({}) as never);
+		const r = await getAutocompleteSuggestions("a");
+		expect(r).toMatchObject({
+			success: true,
+			data: { suggestions: [], meta: { total: 0 } },
+		});
+		expect(getFirestore).not.toHaveBeenCalled();
+	});
+
+	it("人気タグ・動的タグ・タイトルを集約し人気タグを優先する", async () => {
+		getFirestore.mockReturnValue(
+			makeFirestore({
+				audioButtons: [
+					{
+						id: "b1",
+						data: { isPublic: true, tags: ["ゲーム", "実況"], title: "ゲーム配信", playCount: 50 },
+					},
+				],
+				videos: [{ id: "v1", data: { title: "ゲーム実況動画" } }],
+			}) as never,
+		);
+		const r = await getAutocompleteSuggestions("ゲーム");
+		expect(r.success).toBe(true);
+		if (r.success) {
+			// 人気タグ「ゲーム」(count 999) が先頭
+			expect(r.data.suggestions[0]).toMatchObject({ text: "ゲーム", type: "tag", count: 999 });
+			expect(r.data.meta.sources.tags).toBeGreaterThan(0);
+			expect(r.data.meta.sources.titles).toBeGreaterThan(0);
+			// タイトル候補が含まれる
+			expect(r.data.suggestions.some((s) => s.type === "title")).toBe(true);
+		}
+	});
+
+	it("マッチしないクエリでも success（候補は少数）", async () => {
+		getFirestore.mockReturnValue(makeFirestore({ audioButtons: [], videos: [] }) as never);
+		const r = await getAutocompleteSuggestions("該当しない語");
+		expect(r.success).toBe(true);
+	});
+
+	it("getFirestore が例外を投げると失敗を返す", async () => {
+		getFirestore.mockImplementation(() => {
+			throw new Error("fs down");
+		});
+		const r = await getAutocompleteSuggestions("ゲーム");
+		expect(r).toEqual({ success: false, error: "オートコンプリート候補の取得に失敗しました。" });
+	});
+});

--- a/apps/web/src/actions/__tests__/favorites.test.ts
+++ b/apps/web/src/actions/__tests__/favorites.test.ts
@@ -29,7 +29,7 @@ beforeEach(() => {
 describe("addFavoriteAction", () => {
 	it("未ログインはエラー", async () => {
 		logout();
-		expect(await addFavoriteAction({ audioButtonId: "a" } as never)).toEqual({
+		expect(await addFavoriteAction({ audioButtonId: "a" })).toEqual({
 			success: false,
 			error: "ログインが必要です",
 		});
@@ -39,7 +39,7 @@ describe("addFavoriteAction", () => {
 	it("ログイン時は addFavorite に委譲", async () => {
 		login();
 		fs.addFavorite.mockResolvedValue({ success: true } as never);
-		const r = await addFavoriteAction({ audioButtonId: "a" } as never);
+		const r = await addFavoriteAction({ audioButtonId: "a" });
 		expect(r).toEqual({ success: true });
 		expect(fs.addFavorite).toHaveBeenCalledWith("u1", { audioButtonId: "a" });
 	});
@@ -47,7 +47,7 @@ describe("addFavoriteAction", () => {
 	it("例外は catch してエラーメッセージを返す", async () => {
 		login();
 		fs.addFavorite.mockRejectedValue(new Error("boom"));
-		expect(await addFavoriteAction({ audioButtonId: "a" } as never)).toEqual({
+		expect(await addFavoriteAction({ audioButtonId: "a" })).toEqual({
 			success: false,
 			error: "boom",
 		});
@@ -55,12 +55,24 @@ describe("addFavoriteAction", () => {
 });
 
 describe("removeFavoriteAction", () => {
-	it("未ログインはエラー / ログイン時委譲", async () => {
+	it("未ログインはエラー", async () => {
 		logout();
-		expect((await removeFavoriteAction({ audioButtonId: "a" } as never)).success).toBe(false);
+		expect((await removeFavoriteAction({ audioButtonId: "a" })).success).toBe(false);
+	});
+
+	it("ログイン時は removeFavorite に委譲", async () => {
 		login();
 		fs.removeFavorite.mockResolvedValue({ success: true } as never);
-		expect(await removeFavoriteAction({ audioButtonId: "a" } as never)).toEqual({ success: true });
+		expect(await removeFavoriteAction({ audioButtonId: "a" })).toEqual({ success: true });
+	});
+
+	it("例外は catch してエラーメッセージを返す", async () => {
+		login();
+		fs.removeFavorite.mockRejectedValue(new Error("boom"));
+		expect(await removeFavoriteAction({ audioButtonId: "a" })).toEqual({
+			success: false,
+			error: "boom",
+		});
 	});
 });
 
@@ -71,9 +83,12 @@ describe("toggleFavoriteAction", () => {
 		expect(await toggleFavoriteAction("a")).toEqual({ success: true, isFavorited: true });
 	});
 
-	it("未ログインはエラー / 例外は catch", async () => {
+	it("未ログインはエラー", async () => {
 		logout();
 		expect((await toggleFavoriteAction("a")).success).toBe(false);
+	});
+
+	it("例外は catch する", async () => {
 		login();
 		fs.toggleFavorite.mockRejectedValue(new Error("x"));
 		expect((await toggleFavoriteAction("a")).success).toBe(false);

--- a/apps/web/src/actions/__tests__/favorites.test.ts
+++ b/apps/web/src/actions/__tests__/favorites.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	addFavoriteAction,
+	getFavoriteStatusAction,
+	getFavoritesStatusAction,
+	removeFavoriteAction,
+	toggleFavoriteAction,
+} from "../favorites";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/favorites-firestore", () => ({
+	addFavorite: vi.fn(),
+	removeFavorite: vi.fn(),
+	toggleFavorite: vi.fn(),
+	getFavoriteStatus: vi.fn(),
+	getFavoritesStatus: vi.fn(),
+}));
+
+const auth = vi.mocked(await import("@/auth")).auth;
+const fs = vi.mocked(await import("@/lib/favorites-firestore"));
+
+const login = () => auth.mockResolvedValue({ user: { discordId: "u1" } } as never);
+const logout = () => auth.mockResolvedValue(null as never);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("addFavoriteAction", () => {
+	it("未ログインはエラー", async () => {
+		logout();
+		expect(await addFavoriteAction({ audioButtonId: "a" } as never)).toEqual({
+			success: false,
+			error: "ログインが必要です",
+		});
+		expect(fs.addFavorite).not.toHaveBeenCalled();
+	});
+
+	it("ログイン時は addFavorite に委譲", async () => {
+		login();
+		fs.addFavorite.mockResolvedValue({ success: true } as never);
+		const r = await addFavoriteAction({ audioButtonId: "a" } as never);
+		expect(r).toEqual({ success: true });
+		expect(fs.addFavorite).toHaveBeenCalledWith("u1", { audioButtonId: "a" });
+	});
+
+	it("例外は catch してエラーメッセージを返す", async () => {
+		login();
+		fs.addFavorite.mockRejectedValue(new Error("boom"));
+		expect(await addFavoriteAction({ audioButtonId: "a" } as never)).toEqual({
+			success: false,
+			error: "boom",
+		});
+	});
+});
+
+describe("removeFavoriteAction", () => {
+	it("未ログインはエラー / ログイン時委譲", async () => {
+		logout();
+		expect((await removeFavoriteAction({ audioButtonId: "a" } as never)).success).toBe(false);
+		login();
+		fs.removeFavorite.mockResolvedValue({ success: true } as never);
+		expect(await removeFavoriteAction({ audioButtonId: "a" } as never)).toEqual({ success: true });
+	});
+});
+
+describe("toggleFavoriteAction", () => {
+	it("ログイン時は isFavorited を返す", async () => {
+		login();
+		fs.toggleFavorite.mockResolvedValue({ isFavorited: true } as never);
+		expect(await toggleFavoriteAction("a")).toEqual({ success: true, isFavorited: true });
+	});
+
+	it("未ログインはエラー / 例外は catch", async () => {
+		logout();
+		expect((await toggleFavoriteAction("a")).success).toBe(false);
+		login();
+		fs.toggleFavorite.mockRejectedValue(new Error("x"));
+		expect((await toggleFavoriteAction("a")).success).toBe(false);
+	});
+});
+
+describe("getFavoriteStatusAction", () => {
+	it("未ログイン/例外時は isFavorited:false", async () => {
+		logout();
+		expect(await getFavoriteStatusAction("a")).toEqual({ isFavorited: false });
+		login();
+		fs.getFavoriteStatus.mockRejectedValue(new Error("x"));
+		expect(await getFavoriteStatusAction("a")).toEqual({ isFavorited: false });
+	});
+
+	it("ログイン時は取得結果を返す", async () => {
+		login();
+		fs.getFavoriteStatus.mockResolvedValue({ isFavorited: true } as never);
+		expect(await getFavoriteStatusAction("a")).toEqual({ isFavorited: true });
+	});
+});
+
+describe("getFavoritesStatusAction", () => {
+	it("未ログイン時は全て false の Map", async () => {
+		logout();
+		const map = await getFavoritesStatusAction(["a", "b"]);
+		expect(map.get("a")).toBe(false);
+		expect(map.get("b")).toBe(false);
+	});
+
+	it("ログイン時は委譲結果を返す", async () => {
+		login();
+		const expected = new Map([["a", true]]);
+		fs.getFavoritesStatus.mockResolvedValue(expected as never);
+		expect(await getFavoritesStatusAction(["a"])).toBe(expected);
+	});
+
+	it("例外時は全て false の Map", async () => {
+		login();
+		fs.getFavoritesStatus.mockRejectedValue(new Error("x"));
+		const map = await getFavoritesStatusAction(["a", "b"]);
+		expect([...map.values()]).toEqual([false, false]);
+	});
+});

--- a/apps/web/src/actions/__tests__/user-tags.test.ts
+++ b/apps/web/src/actions/__tests__/user-tags.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateUserTagsAction } from "../user-tags";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/video-firestore", () => ({ updateVideoUserTags: vi.fn() }));
+
+const auth = vi.mocked(await import("@/auth")).auth;
+const { updateVideoUserTags } = vi.mocked(await import("@/lib/video-firestore"));
+
+const login = () => auth.mockResolvedValue({ user: { discordId: "u1" } } as never);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	login();
+});
+
+describe("updateUserTagsAction: 検証分岐", () => {
+	it("未ログインはエラー", async () => {
+		auth.mockResolvedValue(null as never);
+		expect(await updateUserTagsAction({ videoId: "v", userTags: [] })).toEqual({
+			success: false,
+			error: "ログインが必要です",
+		});
+	});
+
+	it("videoId 必須", async () => {
+		expect((await updateUserTagsAction({ videoId: "", userTags: [] })).error).toBe(
+			"動画IDが必要です",
+		);
+	});
+
+	it("タグは最大10個", async () => {
+		const tags = Array.from({ length: 11 }, (_, i) => `t${i}`);
+		expect((await updateUserTagsAction({ videoId: "v", userTags: tags })).error).toContain(
+			"最大10個",
+		);
+	});
+
+	it("空タグは不可", async () => {
+		expect((await updateUserTagsAction({ videoId: "v", userTags: [""] })).error).toContain(
+			"空のタグ",
+		);
+	});
+
+	it("30文字超は不可", async () => {
+		expect(
+			(await updateUserTagsAction({ videoId: "v", userTags: ["a".repeat(31)] })).error,
+		).toContain("30文字以内");
+	});
+
+	it("重複タグは不可", async () => {
+		expect((await updateUserTagsAction({ videoId: "v", userTags: ["x", "x"] })).error).toContain(
+			"重複",
+		);
+	});
+});
+
+describe("updateUserTagsAction: Firestore 連携", () => {
+	it("成功時は userTags を返す", async () => {
+		updateVideoUserTags.mockResolvedValue({ success: true, userTags: ["a"] } as never);
+		expect(await updateUserTagsAction({ videoId: "v", userTags: ["a"] })).toEqual({
+			success: true,
+			userTags: ["a"],
+		});
+		expect(updateVideoUserTags).toHaveBeenCalledWith("v", ["a"]);
+	});
+
+	it("失敗時は error（既定文言フォールバック）", async () => {
+		updateVideoUserTags.mockResolvedValue({ success: false } as never);
+		expect((await updateUserTagsAction({ videoId: "v", userTags: ["a"] })).error).toBe(
+			"ユーザータグの更新に失敗しました",
+		);
+	});
+
+	it("失敗時は result.error を優先", async () => {
+		updateVideoUserTags.mockResolvedValue({ success: false, error: "固有エラー" } as never);
+		expect((await updateUserTagsAction({ videoId: "v", userTags: ["a"] })).error).toBe(
+			"固有エラー",
+		);
+	});
+
+	it("例外は catch する", async () => {
+		updateVideoUserTags.mockRejectedValue(new Error("boom"));
+		expect((await updateUserTagsAction({ videoId: "v", userTags: ["a"] })).error).toBe("boom");
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 67,
-				branches: 58,
-				functions: 67,
-				lines: 67,
+				statements: 70,
+				branches: 60,
+				functions: 70,
+				lines: 70,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-152 第11増分。web の **Server Actions** に着手。`auth` / Firestore / 委譲先をモックして網羅。

## 追加テスト（テスト新規）

- `actions/favorites`: add/remove/toggle/get/getBulk の各 action — 未ログイン・委譲・例外の各分岐
- `actions/user-tags`: 認証 / videoId 必須 / タグ最大10 / 空タグ / 30文字超 / 重複 の検証分岐 + Firestore 成否（error フォールバック）・例外
- `actions/autocomplete`: スキーマ検証エラー・2文字未満の早期 return・人気タグ/動的タグ/タイトルの集約と優先ソート・Firestore 例外（チェーン可能モック）

## カバレッジ（web 実測・通算）

| | 開始時 | after | 閾値(新) |
|---|---|---|---|
| statements | 64.3 | **71.9** | 70 |
| branches | 54.5 | **62.2** | 60 |
| functions | 62.6 | **72.3** | 70 |
| lines | 65.2 | **72.4** | 70 |

（本 PR で branches 60.3→62.2）

## 確認

- `pnpm verify` EXIT 0（715 tests pass、lint/typecheck 含め全 green）

## SPR-152 進捗

- ✅ shared-types（80）・✅ functions（75）・✅ ui（69.6）・🔄 web（62.2、+7.7pp 通算）
- 残り: web の他 Server Actions（works/videos/buttons 等の大型 actions.ts）・component 描画系

🤖 Generated with [Claude Code](https://claude.com/claude-code)