### PR TITLE
refactor(web): buildWorksQuery の未使用 showR18 パラメータを削除

### DIFF
--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -21,10 +21,10 @@ async function getWorksWithSimpleQuery(
 	firestore: FirebaseFirestore.Firestore,
 	params: EnhancedSearchParams,
 ): Promise<WorkListResultPlain> {
-	const { page = 1, limit = 12, sort = "newest", category, showR18, ageRating } = params;
+	const { page = 1, limit = 12, sort = "newest", category, ageRating } = params;
 
 	// クエリ構築
-	let query = buildWorksQuery(firestore, { category, showR18, ageRating, sort });
+	let query = buildWorksQuery(firestore, { category, ageRating, sort });
 	query = query.limit(limit);
 
 	// オフセット処理
@@ -91,7 +91,7 @@ async function getWorksWithComplexFiltering(
 	} = params;
 
 	// クエリ構築
-	let query = buildWorksQuery(firestore, { category, showR18, ageRating, sort });
+	let query = buildWorksQuery(firestore, { category, ageRating, sort });
 
 	// ページネーション用のオフセット
 	const startOffset = (page - 1) * limit;

--- a/apps/web/src/app/works/lib/work-query-builder.ts
+++ b/apps/web/src/app/works/lib/work-query-builder.ts
@@ -5,7 +5,6 @@ export function buildWorksQuery(
 	firestore: FirebaseFirestore.Firestore,
 	params: {
 		category?: string;
-		showR18?: boolean;
 		ageRating?: string[];
 		sort?: string;
 	},


### PR DESCRIPTION
## 概要

`buildWorksQuery` の params 型に宣言されていた未使用パラメータ `showR18?: boolean` を削除しました。R18 フィルタはメモリ側の `filterWorksByUnifiedData`（`work-filtering.ts`）が正本で、Firestore クエリ段では一切使われていませんでした。型の約束と実装のズレ（軸3）を解消します。

Claude AI Review（[#546](https://github.com/nothink-jp/suzumina.click/pull/546)）の nit 指摘への対応。

## 確認

- `showR18` を Firestore クエリ段で効かせるべきではない: R18 は検索・言語・声優等の他フィルタと合流してメモリ側で処理するのが正本。クエリ段の where 化は複合インデックス／ページネーションと衝突するため不適。
- 影響範囲:
  - `work-query-builder.ts`: params 型から `showR18` を削除
  - `actions.ts`（getWorksWithSimpleQuery）: destructure と呼び出しから除去
  - `actions.ts`（getWorksWithComplexFiltering）: `buildWorksQuery` 呼び出しから除去（`requiresFullDataFetch` 判定と `filterWorksByUnifiedData` では引き続き使うため destructure は残置）
- `pnpm verify` green（lint + typecheck + test）

## レビュー区分

Two-Way Door（戻せる軽微リファクタ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)