### PR TITLE
test: web の settings/auth/contact Server Actions を網羅 (SPR-152 第12弾)

### DIFF
--- a/apps/web/src/app/auth/__tests__/actions.test.ts
+++ b/apps/web/src/app/auth/__tests__/actions.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { signInAction, signOutAction } from "../actions";
+
+vi.mock("@/auth", () => ({ signIn: vi.fn(), signOut: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }));
+
+const { signIn, signOut } = vi.mocked(await import("@/auth"));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("signInAction", () => {
+	it("Discord で signIn を呼ぶ", async () => {
+		signIn.mockResolvedValue(undefined as never);
+		await signInAction();
+		expect(signIn).toHaveBeenCalledWith("discord", { redirectTo: "/" });
+	});
+
+	it("エラーは再 throw する", async () => {
+		signIn.mockRejectedValue(new Error("auth fail"));
+		await expect(signInAction()).rejects.toThrow("auth fail");
+	});
+});
+
+describe("signOutAction", () => {
+	it("signOut を呼ぶ", async () => {
+		signOut.mockResolvedValue(undefined as never);
+		await signOutAction();
+		expect(signOut).toHaveBeenCalledWith({ redirectTo: "/" });
+	});
+
+	it("エラーは再 throw する", async () => {
+		signOut.mockRejectedValue(new Error("signout fail"));
+		await expect(signOutAction()).rejects.toThrow("signout fail");
+	});
+});

--- a/apps/web/src/app/contact/__tests__/actions.test.ts
+++ b/apps/web/src/app/contact/__tests__/actions.test.ts
@@ -1,0 +1,68 @@
+import type { ContactFormData } from "@suzumina.click/shared-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { submitContactForm } from "../actions";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/headers", () => ({ headers: vi.fn() }));
+vi.mock("@/lib/email", () => ({ sendContactNotification: vi.fn() }));
+vi.mock("@/lib/firestore", () => ({ getFirestore: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ error: vi.fn() }));
+
+const { headers } = vi.mocked(await import("next/headers"));
+const { sendContactNotification } = vi.mocked(await import("@/lib/email"));
+const { getFirestore } = vi.mocked(await import("@/lib/firestore"));
+
+const validData: ContactFormData = {
+	category: "bug",
+	subject: "件名です",
+	content: "これは十分な長さの本文です。",
+};
+
+const setupFirestore = () => {
+	const add = vi.fn().mockResolvedValue({ id: "doc1" });
+	getFirestore.mockReturnValue({ collection: vi.fn(() => ({ add })) } as never);
+	return { add };
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	headers.mockResolvedValue({
+		get: (k: string) => (k === "x-forwarded-for" ? "1.2.3.4, 5.6.7.8" : "UA/1.0"),
+	} as never);
+	sendContactNotification.mockResolvedValue(undefined as never);
+});
+
+describe("submitContactForm", () => {
+	it("正常送信で Firestore 保存・メール通知・id 返却", async () => {
+		const { add } = setupFirestore();
+		const r = await submitContactForm(validData);
+		expect(r).toEqual({ success: true, message: "お問い合わせを受け付けました", id: "doc1" });
+		// IP は x-forwarded-for の先頭
+		expect(add).toHaveBeenCalledWith(
+			expect.objectContaining({ ipAddress: "1.2.3.4", status: "new" }),
+		);
+		expect(sendContactNotification).toHaveBeenCalled();
+	});
+
+	it("バリデーション失敗（短い content）は errors を返す", async () => {
+		const r = await submitContactForm({ ...validData, content: "短い" });
+		expect(r.success).toBe(false);
+		expect(r.message).toBe("入力内容に不備があります");
+		expect(r.errors?.length).toBeGreaterThan(0);
+	});
+
+	it("メール通知失敗でもメイン処理は成功する", async () => {
+		setupFirestore();
+		sendContactNotification.mockRejectedValue(new Error("smtp down"));
+		const r = await submitContactForm(validData);
+		expect(r.success).toBe(true);
+	});
+
+	it("Firestore 例外は失敗を返す", async () => {
+		getFirestore.mockReturnValue({
+			collection: vi.fn(() => ({ add: vi.fn().mockRejectedValue(new Error("fs down")) })),
+		} as never);
+		const r = await submitContactForm(validData);
+		expect(r).toEqual({ success: false, message: "お問い合わせの送信に失敗しました" });
+	});
+});

--- a/apps/web/src/app/contact/__tests__/actions.test.ts
+++ b/apps/web/src/app/contact/__tests__/actions.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/logger", () => ({ error: vi.fn() }));
 const { headers } = vi.mocked(await import("next/headers"));
 const { sendContactNotification } = vi.mocked(await import("@/lib/email"));
 const { getFirestore } = vi.mocked(await import("@/lib/firestore"));
+const { revalidatePath } = vi.mocked(await import("next/cache"));
 
 const validData: ContactFormData = {
 	category: "bug",
@@ -42,6 +43,8 @@ describe("submitContactForm", () => {
 			expect.objectContaining({ ipAddress: "1.2.3.4", status: "new" }),
 		);
 		expect(sendContactNotification).toHaveBeenCalled();
+		// キャッシュ無効化の契約も担保
+		expect(revalidatePath).toHaveBeenCalledWith("/contact");
 	});
 
 	it("バリデーション失敗（短い content）は errors を返す", async () => {

--- a/apps/web/src/app/settings/__tests__/actions.test.ts
+++ b/apps/web/src/app/settings/__tests__/actions.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateUserProfile } from "../actions";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/user-firestore", () => ({ updateUser: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+const auth = vi.mocked(await import("@/auth")).auth;
+const { updateUser } = vi.mocked(await import("@/lib/user-firestore"));
+const { revalidatePath } = vi.mocked(await import("next/cache"));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("updateUserProfile", () => {
+	it("未認証はエラー", async () => {
+		auth.mockResolvedValue(null as never);
+		expect(await updateUserProfile({ isPublicProfile: true })).toEqual({
+			success: false,
+			error: "認証が必要です",
+		});
+		expect(updateUser).not.toHaveBeenCalled();
+	});
+
+	it("認証済みは updateUser を呼びキャッシュを再検証する", async () => {
+		auth.mockResolvedValue({ user: { discordId: "u1" } } as never);
+		updateUser.mockResolvedValue(undefined as never);
+		expect(await updateUserProfile({ isPublicProfile: false })).toEqual({ success: true });
+		expect(updateUser).toHaveBeenCalledWith({ discordId: "u1", isPublicProfile: false });
+		expect(revalidatePath).toHaveBeenCalledWith("/users/u1");
+		expect(revalidatePath).toHaveBeenCalledWith("/settings");
+	});
+
+	it("例外時はエラーを返す", async () => {
+		auth.mockResolvedValue({ user: { discordId: "u1" } } as never);
+		updateUser.mockRejectedValue(new Error("db down"));
+		expect(await updateUserProfile({ isPublicProfile: true })).toEqual({
+			success: false,
+			error: "プロフィールの更新に失敗しました",
+		});
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 70,
-				branches: 60,
-				functions: 70,
-				lines: 70,
+				statements: 71,
+				branches: 61,
+				functions: 71,
+				lines: 72,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-152 第12増分。未テストだった小型 Server Action 3ファイルを網羅（認証フロー含む）。各ファイルは個別に 0%→高カバレッジ。

## 追加テスト（テスト新規）

- `settings/updateUserProfile`: 未認証 / 成功（updateUser + revalidatePath）/ 例外
- `auth/signInAction`・`signOutAction`: signIn/signOut（discord, redirectTo）呼び出し・エラー再 throw
- `contact/submitContactForm`: 正常（Firestore add + メール通知 + id 返却・IP は x-forwarded-for 先頭）/ バリデーション失敗（ZodError → errors）/ メール送信失敗でもメイン処理継続 / Firestore 例外

## カバレッジ（web 実測）

| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 71.9 | **72.3** | 71 |
| branches | 62.2 | **62.3** | 61 |
| functions | 72.3 | **72.5** | 71 |
| lines | 72.4 | **72.8** | 72 |

※ web は規模が大きく集約 % の動きは小さいが、対象3ファイルは個別に大幅改善（認証フローの回帰ガード）。

## 確認

- `pnpm verify` EXIT 0（729 tests pass、lint/typecheck 含め全 green）

## SPR-152 進捗

- ✅ shared-types / functions / ui（目標達成）・🔄 web（branches 62.3）
- 残り: web の大型 actions.ts（works/videos/buttons）・component 描画系

🤖 Generated with [Claude Code](https://claude.com/claude-code)