### PR TITLE
test: videos/actions.ts の getVideoById/getTotalVideoCount を網羅 (SPR-153)

### DIFF
--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getPopularVideoTags, getVideosList, getVideoTitles } from "../actions";
+import {
+	getPopularVideoTags,
+	getTotalVideoCount,
+	getVideoById,
+	getVideosList,
+	getVideoTitles,
+} from "../actions";
 
 // Mock Firestore
 const mockGet = vi.fn();
@@ -527,6 +533,76 @@ describe("Video Server Actions", () => {
 			const result = await getPopularVideoTags();
 
 			expect(result).toEqual([]);
+		});
+	});
+
+	// --- SPR-153: 未カバーだった getVideoById / getTotalVideoCount ---
+
+	const videoData = (over: Record<string, unknown> = {}) => ({
+		id: "video-1",
+		videoId: "video-1",
+		title: "動画1",
+		channelId: "channel-1",
+		channelTitle: "チャンネル1",
+		publishedAt: new Date("2024-01-01").toISOString(),
+		duration: "PT5M",
+		thumbnailUrl: "https://example.com/t.jpg",
+		thumbnails: { high: { url: "https://example.com/t.jpg" } },
+		status: { privacyStatus: "public", uploadStatus: "processed" },
+		...over,
+	});
+
+	describe("getVideoById", () => {
+		it("存在しなければ null", async () => {
+			mockDoc.mockReturnValue({ get: vi.fn().mockResolvedValue({ exists: false }) });
+			expect(await getVideoById("video-404")).toBeNull();
+		});
+
+		it("存在すれば PlainObject を返す", async () => {
+			mockDoc.mockReturnValue({
+				get: vi.fn().mockResolvedValue({ id: "video-1", exists: true, data: () => videoData() }),
+			});
+			const r = await getVideoById("video-1");
+			expect(r?.videoId).toBe("video-1");
+		});
+
+		it("例外時は null", async () => {
+			mockDoc.mockReturnValue({ get: vi.fn().mockRejectedValue(new Error("fs")) });
+			expect(await getVideoById("video-1")).toBeNull();
+		});
+	});
+
+	describe("getTotalVideoCount", () => {
+		it("フィルタ無しは count() 集計の値を返す（fast path）", async () => {
+			mockCount.mockReturnValue({
+				get: vi.fn().mockResolvedValue({ data: () => ({ count: 42 }) }),
+			});
+			expect(await getTotalVideoCount()).toBe(42);
+		});
+
+		it("フィルタ有りは全件取得しメモリ上でフィルタした件数を返す", async () => {
+			mockGet.mockResolvedValue({
+				docs: [
+					{ id: "video-1", data: () => videoData() },
+					// 非公開は除外される
+					{
+						id: "video-2",
+						data: () =>
+							videoData({
+								id: "video-2",
+								videoId: "video-2",
+								status: { privacyStatus: "private" },
+							}),
+					},
+				],
+			});
+			const n = await getTotalVideoCount({ year: "2024" });
+			expect(n).toBe(1);
+		});
+
+		it("例外時は 0", async () => {
+			mockCount.mockReturnValue({ get: vi.fn().mockRejectedValue(new Error("fs")) });
+			expect(await getTotalVideoCount()).toBe(0);
 		});
 	});
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 73,
-				branches: 62,
-				functions: 75,
-				lines: 74,
+				statements: 74,
+				branches: 63,
+				functions: 77,
+				lines: 75,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-153 第2弾。`app/videos/actions.ts`（530L）の未カバー関数を網羅。既存テスト（getVideoTitles/getVideosList/getPopularVideoTags）を拡張。

## 追加テスト
- `getVideoById`: 不在→null / 取得→PlainObject / 例外→null
- `getTotalVideoCount`: フィルタ無し→`count()` 集計（fast path）/ フィルタ有り→全件取得+メモリフィルタの件数 / 例外→0

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 74.7 | **75.1** | 74 |
| branches | 63.6 | **64.0** | 63 |
| functions | 76.6 | **77.1** | 77 |
| lines | 75.1 | **75.6** | 75 |

## 確認
- `pnpm verify` EXIT 0（web 747 tests pass、全 green）

## SPR-153 進捗（①大型 Server Actions）
- [x] works/actions.ts / [x] videos/actions.ts（本PR）
- [ ] buttons/actions.ts（564L）/ creators/[creatorId]/actions.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)