### PR TITLE
test: buttons/actions.ts の未カバー関数を網羅 (SPR-153)

### DIFF
--- a/apps/web/src/app/buttons/__tests__/actions.test.ts
+++ b/apps/web/src/app/buttons/__tests__/actions.test.ts
@@ -757,8 +757,6 @@ describe("Audio Button Server Actions", () => {
 		});
 	});
 
-	// --- SPR-153: 未カバーだった関数 ---
-
 	describe("カウンタ操作（updateCounter 委譲）", () => {
 		it("各 increment/decrement は updateCounter に正しい引数で委譲する", async () => {
 			mockUpdateCounter.mockResolvedValue({ success: true });

--- a/apps/web/src/app/buttons/__tests__/actions.test.ts
+++ b/apps/web/src/app/buttons/__tests__/actions.test.ts
@@ -2,9 +2,17 @@ import type { CreateAudioButtonInput } from "@suzumina.click/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createAudioButton,
+	decrementDislikeCount,
+	decrementLikeCount,
 	deleteAudioButton,
 	getAudioButtonById,
 	getAudioButtonsList,
+	getRecentAudioButtons,
+	incrementDislikeCount,
+	incrementLikeCount,
+	incrementPlayCount,
+	updateAudioButton,
+	updateAudioButtonTags,
 } from "../actions";
 
 // Mock Firestore
@@ -36,6 +44,12 @@ vi.mock("@google-cloud/firestore", () => ({
 	FieldValue: {
 		increment: vi.fn(),
 	},
+}));
+
+// increment/decrement 系は updateCounter への委譲のため、ヘルパーをモックして委譲を検証
+const mockUpdateCounter = vi.fn();
+vi.mock("@/lib/firestore-helpers", () => ({
+	updateCounter: (...args: unknown[]) => mockUpdateCounter(...args),
 }));
 
 // Mock logger
@@ -740,6 +754,90 @@ describe("Audio Button Server Actions", () => {
 			const count = await getAudioButtonCount("test-video-id");
 
 			expect(count).toBe(0);
+		});
+	});
+
+	// --- SPR-153: 未カバーだった関数 ---
+
+	describe("カウンタ操作（updateCounter 委譲）", () => {
+		it("各 increment/decrement は updateCounter に正しい引数で委譲する", async () => {
+			mockUpdateCounter.mockResolvedValue({ success: true });
+			await incrementLikeCount("ab1");
+			expect(mockUpdateCounter).toHaveBeenCalledWith("audioButtons", "ab1", "stats.likeCount", 1, {
+				min: 0,
+			});
+			await decrementLikeCount("ab1");
+			expect(mockUpdateCounter).toHaveBeenCalledWith("audioButtons", "ab1", "stats.likeCount", -1, {
+				min: 0,
+			});
+			await incrementDislikeCount("ab1");
+			expect(mockUpdateCounter).toHaveBeenCalledWith(
+				"audioButtons",
+				"ab1",
+				"stats.dislikeCount",
+				1,
+				{ min: 0 },
+			);
+			await decrementDislikeCount("ab1");
+			expect(mockUpdateCounter).toHaveBeenCalledWith(
+				"audioButtons",
+				"ab1",
+				"stats.dislikeCount",
+				-1,
+				{ min: 0 },
+			);
+			await incrementPlayCount("ab1");
+			expect(mockUpdateCounter).toHaveBeenCalledWith("audioButtons", "ab1", "stats.playCount", 1, {
+				min: 0,
+			});
+		});
+
+		it("updateCounter の結果をそのまま返す", async () => {
+			mockUpdateCounter.mockResolvedValue({ success: false, error: "x" });
+			expect(await incrementLikeCount("ab1")).toEqual({ success: false, error: "x" });
+		});
+	});
+
+	describe("updateAudioButton", () => {
+		it("存在しなければ失敗", async () => {
+			mockGet.mockResolvedValue({ exists: false });
+			const r = await updateAudioButton("ab1", { buttonText: "新" });
+			expect(r.success).toBe(false);
+		});
+
+		it("作成者以外は権限エラー", async () => {
+			mockGet.mockResolvedValue({ exists: true, data: () => ({ creatorId: "other-user" }) });
+			const r = await updateAudioButton("ab1", { buttonText: "新" });
+			expect(r.success).toBe(false);
+			expect(r.error).toBeDefined();
+		});
+
+		it("作成者本人は更新成功", async () => {
+			mockGet.mockResolvedValue({
+				exists: true,
+				data: () => ({ creatorId: "123456789012345678" }),
+			});
+			const r = await updateAudioButton("ab1", { buttonText: "新", isPublic: false });
+			expect(r.success).toBe(true);
+		});
+	});
+
+	describe("updateAudioButtonTags", () => {
+		it("存在しなければ失敗", async () => {
+			mockGet.mockResolvedValue({ exists: false });
+			expect((await updateAudioButtonTags("ab1", ["t"])).success).toBe(false);
+		});
+
+		it("ログインユーザーはタグ更新成功（作成者でなくても可）", async () => {
+			mockGet.mockResolvedValue({ exists: true, data: () => ({ creatorId: "other-user" }) });
+			expect((await updateAudioButtonTags("ab1", ["t1", "t2"])).success).toBe(true);
+		});
+	});
+
+	describe("getRecentAudioButtons", () => {
+		it("一覧取得失敗時は空配列を返す", async () => {
+			mockGet.mockRejectedValue(new Error("fs"));
+			expect(await getRecentAudioButtons(5)).toEqual([]);
 		});
 	});
 });

--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -536,8 +536,6 @@ describe("Video Server Actions", () => {
 		});
 	});
 
-	// --- SPR-153: 未カバーだった getVideoById / getTotalVideoCount ---
-
 	const videoData = (over: Record<string, unknown> = {}) => ({
 		id: "video-1",
 		videoId: "video-1",

--- a/apps/web/src/app/works/__tests__/actions.test.ts
+++ b/apps/web/src/app/works/__tests__/actions.test.ts
@@ -238,8 +238,6 @@ describe("Works Server Actions", () => {
 		});
 	});
 
-	// --- 以下 SPR-153: 未カバーだった Server Actions ---
-
 	const workData = (over: Record<string, unknown> = {}) => ({
 		productId: "RJ001",
 		title: "作品1",

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 74,
-				branches: 63,
-				functions: 77,
-				lines: 75,
+				statements: 75,
+				branches: 64,
+				functions: 78,
+				lines: 76,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-153 第3弾。最も branch が低かった `app/buttons/actions.ts`（564L, br 37.5%）の未カバー関数を網羅。既存テスト（create/list/getById/delete/getCount）を拡張。

## 追加テスト
- **increment/decrement Like/Dislike・incrementPlayCount**: `updateCounter`（`@/lib/firestore-helpers`）への委譲を検証（引数・戻り値パススルー）。ヘルパーをモック
- **updateAudioButton**: 不在 / 権限なし（作成者以外）/ 作成者本人の更新成功
- **updateAudioButtonTags**: 不在 / ログインユーザーは更新成功（作成者不問）
- **getRecentAudioButtons**: 一覧取得失敗時の空配列フォールバック

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 75.1 | **76.2** | 75 |
| branches | 64.0 | **64.6** | 64 |
| functions | 77.1 | **78.7** | 78 |
| lines | 75.6 | **76.7** | 76 |

## 確認
- `pnpm verify` EXIT 0（web 755 tests pass、全 green）

## SPR-153 進捗（①大型 Server Actions）
- [x] works / [x] videos / [x] buttons（本PR）
- [ ] creators/[creatorId]/actions.ts（279L, テスト無し）

🤖 Generated with [Claude Code](https://claude.com/claude-code)