### PR TITLE
test: creators/[creatorId]/actions.ts のソート分岐を網羅 (SPR-153)

### DIFF
--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -811,16 +811,12 @@ describe("Creator page server actions", () => {
 			["price_high", "RJ222222"],
 			["oldest", "RJ222222"],
 			["newest", "RJ111111"],
+			["popular", "RJ222222"], // 評価が高い方が先頭（compareByRating）
+			["unknown-sort", "RJ111111"], // default ブランチ = newest と同挙動
 		])("sort=%s で先頭が %s になる", async (sort, expectedFirst) => {
 			setupSortWorks();
 			const result = await getCreatorWorksList({ creatorId: "VA12345", sort });
 			expect(result.works[0]?.productId).toBe(expectedFirst);
-		});
-
-		it("sort=popular（評価順）でも 2 件返す", async () => {
-			setupSortWorks();
-			const result = await getCreatorWorksList({ creatorId: "VA12345", sort: "popular" });
-			expect(result.works).toHaveLength(2);
 		});
 
 		it("works サブコレクションが空なら空結果", async () => {

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -769,6 +769,67 @@ describe("Creator page server actions", () => {
 
 			expect(result).toEqual({ works: [], totalCount: 0 });
 		});
+
+		// --- ソート分岐（compareWorks）の網羅 ---
+		const sortWorks = [
+			{
+				id: "RJ111111",
+				productId: "RJ111111",
+				title: "A",
+				releaseDateISO: "2025-01-15",
+				price: { current: 1100, currency: "JPY" },
+				rating: { stars: 3, count: 10 },
+				creators: {},
+			},
+			{
+				id: "RJ222222",
+				productId: "RJ222222",
+				title: "B",
+				releaseDateISO: "2025-01-10",
+				price: { current: 2200, currency: "JPY" },
+				rating: { stars: 5, count: 50 },
+				creators: {},
+			},
+		];
+		const setupSortWorks = () => {
+			setupCreatorMocks(
+				{ name: "C" },
+				{ empty: false, docs: sortWorks.map((w) => ({ id: w.id, data: () => ({}) })) },
+			);
+			mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
+				Promise.resolve(
+					refs.map((ref) => {
+						const w = sortWorks.find((x) => x.id === ref.id);
+						return { exists: !!w, id: ref.id, data: () => w };
+					}),
+				),
+			);
+		};
+
+		it.each([
+			["price_low", "RJ111111"],
+			["price_high", "RJ222222"],
+			["oldest", "RJ222222"],
+			["newest", "RJ111111"],
+		])("sort=%s で先頭が %s になる", async (sort, expectedFirst) => {
+			setupSortWorks();
+			const result = await getCreatorWorksList({ creatorId: "VA12345", sort });
+			expect(result.works[0]?.productId).toBe(expectedFirst);
+		});
+
+		it("sort=popular（評価順）でも 2 件返す", async () => {
+			setupSortWorks();
+			const result = await getCreatorWorksList({ creatorId: "VA12345", sort: "popular" });
+			expect(result.works).toHaveLength(2);
+		});
+
+		it("works サブコレクションが空なら空結果", async () => {
+			setupCreatorMocks({ name: "C" }, { empty: true, docs: [] });
+			expect(await getCreatorWorksList({ creatorId: "VA12345" })).toEqual({
+				works: [],
+				totalCount: 0,
+			});
+		});
 	});
 
 	afterEach(() => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 75,
-				branches: 64,
-				functions: 78,
-				lines: 76,
+				statements: 76,
+				branches: 65,
+				functions: 79,
+				lines: 77,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-153 第4弾（① 大型 Server Actions の最後）。`creators/[creatorId]/actions.ts`（既存テスト有・branches 53%）を拡張し、`compareWorks` の全ソート分岐を網羅。

※ Issue では「テスト無し」としていたが既存テスト有りだった。実際の課題は branches 53% の低さ → ソート分岐の未カバーが主因。

## 追加テスト
- `getCreatorWorksList`: `sort` = price_low / price_high / oldest / newest / popular の先頭順序（`compareWorks` → compareByPrice/Date/Rating 分岐）
- works サブコレクションが空のケース

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 75.1 | **76.6** | 76 |
| branches | 64.6 | **65.2** | 65 |
| functions | 78.7 | **79.0** | 79 |
| lines | 76.7 | **77.0** | 77 |

`creators/[creatorId]/actions.ts` 単体: branches 53→**70%**。**web 全体が目標下限 65% に到達。**

## 確認
- `pnpm verify` EXIT 0（web 761 tests pass、全 green）

## SPR-153 ① 完了
- [x] works / [x] videos / [x] buttons / [x] creators

🤖 Generated with [Claude Code](https://claude.com/claude-code)