### PR TITLE
test: server-action-wrapper / firestore-helpers を網羅 (SPR-153 ②)

### DIFF
--- a/apps/web/src/lib/__tests__/firestore-helpers.test.ts
+++ b/apps/web/src/lib/__tests__/firestore-helpers.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateCounter } from "../firestore-helpers";
+
+const getFirestore = vi.fn();
+vi.mock("@/lib/firestore", () => ({ getFirestore: () => getFirestore() }));
+vi.mock("@/lib/logger", () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }));
+
+// runTransaction(cb) が transaction を渡す Firestore モック
+const setup = (doc: { exists: boolean; data?: () => unknown }) => {
+	const update = vi.fn();
+	const transaction = { get: vi.fn().mockResolvedValue(doc), update };
+	getFirestore.mockReturnValue({
+		collection: () => ({ doc: () => ({ __ref: true }) }),
+		runTransaction: (cb: (t: typeof transaction) => unknown) => Promise.resolve(cb(transaction)),
+	});
+	return { update };
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("updateCounter", () => {
+	it("加算して newValue を返す", async () => {
+		const { update } = setup({ exists: true, data: () => ({ stats: { likeCount: 5 } }) });
+		const r = await updateCounter("audioButtons", "ab1", "stats.likeCount", 1);
+		expect(r).toEqual({ success: true, newValue: 6 });
+		expect(update).toHaveBeenCalled();
+	});
+
+	it("min で下限クランプ（0 未満にならない）", async () => {
+		setup({ exists: true, data: () => ({ stats: { likeCount: 0 } }) });
+		const r = await updateCounter("audioButtons", "ab1", "stats.likeCount", -1, { min: 0 });
+		expect(r.newValue).toBe(0);
+	});
+
+	it("max で上限クランプ", async () => {
+		setup({ exists: true, data: () => ({ stock: 99 }) });
+		const r = await updateCounter("products", "p1", "stock", 5, { max: 100 });
+		expect(r.newValue).toBe(100);
+	});
+
+	it("現在値が数値でなければ 0 起点", async () => {
+		setup({ exists: true, data: () => ({}) });
+		const r = await updateCounter("c", "d", "missing.field", 1);
+		expect(r.newValue).toBe(1);
+	});
+
+	it("updateTimestamp=false ではタイムスタンプを書かない", async () => {
+		const { update } = setup({ exists: true, data: () => ({ n: 1 }) });
+		await updateCounter("c", "d", "n", 1, { updateTimestamp: false });
+		const updates = update.mock.calls[0]?.[1] as Record<string, unknown>;
+		expect(updates).toEqual({ n: 2 });
+		expect(updates.updatedAt).toBeUndefined();
+	});
+
+	it("ドキュメント不在は失敗", async () => {
+		setup({ exists: false });
+		expect((await updateCounter("c", "d", "n", 1)).success).toBe(false);
+	});
+
+	it("データ無効は失敗", async () => {
+		setup({ exists: true, data: () => null });
+		expect((await updateCounter("c", "d", "n", 1)).success).toBe(false);
+	});
+
+	it("トランザクション例外は失敗", async () => {
+		getFirestore.mockReturnValue({
+			collection: () => ({ doc: () => ({}) }),
+			runTransaction: () => Promise.reject(new Error("tx fail")),
+		});
+		expect(await updateCounter("c", "d", "n", 1)).toEqual({
+			success: false,
+			error: "カウンターの更新に失敗しました",
+		});
+	});
+});

--- a/apps/web/src/lib/__tests__/server-action-wrapper.test.ts
+++ b/apps/web/src/lib/__tests__/server-action-wrapper.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	withAuthenticatedAction,
+	withErrorHandling,
+	withValidation,
+} from "../server-action-wrapper";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }));
+
+const auth = vi.mocked(await import("@/auth")).auth;
+const opts = { action: "testAction", errorMessage: "失敗しました" };
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("withErrorHandling", () => {
+	it("成功時は { success:true, data }", async () => {
+		const r = await withErrorHandling(async () => 42, opts);
+		expect(r).toEqual({ success: true, data: 42 });
+	});
+
+	it("Error throw 時はそのメッセージを返す", async () => {
+		const r = await withErrorHandling(async () => {
+			throw new Error("具体的エラー");
+		}, opts);
+		expect(r).toEqual({ success: false, error: "具体的エラー" });
+	});
+
+	it("非 Error throw 時は既定メッセージ", async () => {
+		const r = await withErrorHandling(async () => {
+			throw "文字列エラー";
+		}, opts);
+		expect(r).toEqual({ success: false, error: "失敗しました" });
+	});
+});
+
+describe("withAuthenticatedAction", () => {
+	it("未認証は authErrorMessage（既定文言）", async () => {
+		auth.mockResolvedValue(null as never);
+		const r = await withAuthenticatedAction(async () => "x", opts);
+		expect(r).toEqual({ success: false, error: "ログインが必要です" });
+	});
+
+	it("authErrorMessage 指定時はそれを使う", async () => {
+		auth.mockResolvedValue(null as never);
+		const r = await withAuthenticatedAction(async () => "x", {
+			...opts,
+			authErrorMessage: "要ログイン",
+		});
+		expect(r.success).toBe(false);
+		if (!r.success) expect(r.error).toBe("要ログイン");
+	});
+
+	it("認証済みは user を渡して実行", async () => {
+		auth.mockResolvedValue({ user: { discordId: "u1" } } as never);
+		const r = await withAuthenticatedAction(async (user) => `hi ${user.discordId}`, opts);
+		expect(r).toEqual({ success: true, data: "hi u1" });
+	});
+
+	it("本処理の例外は catch する", async () => {
+		auth.mockResolvedValue({ user: { discordId: "u1" } } as never);
+		const r = await withAuthenticatedAction(async () => {
+			throw new Error("boom");
+		}, opts);
+		expect(r).toEqual({ success: false, error: "boom" });
+	});
+});
+
+describe("withValidation", () => {
+	it("バリデーション失敗時はそのエラーを返し fn を呼ばない", async () => {
+		const fn = vi.fn();
+		const r = await withValidation("bad", () => "入力エラー", fn, opts);
+		expect(r).toEqual({ success: false, error: "入力エラー" });
+		expect(fn).not.toHaveBeenCalled();
+	});
+
+	it("バリデーション成功時は fn を実行（withErrorHandling 経由）", async () => {
+		const r = await withValidation(
+			"ok",
+			() => null,
+			async (input) => `processed:${input}`,
+			opts,
+		);
+		expect(r).toEqual({ success: true, data: "processed:ok" });
+	});
+
+	it("成功後の fn 例外は withErrorHandling が捕捉", async () => {
+		const r = await withValidation(
+			"ok",
+			() => null,
+			async () => {
+				throw new Error("fn fail");
+			},
+			opts,
+		);
+		expect(r).toEqual({ success: false, error: "fn fail" });
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,8 +37,8 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 76,
-				branches: 65,
+				statements: 77,
+				branches: 66,
 				functions: 79,
 				lines: 77,
 			},


### PR DESCRIPTION
## 概要

SPR-153 ②（util/lib）。全 Server Action が依存する基盤ユーティリティを網羅。

## 追加テスト（純粋・モックで完結）
- `lib/server-action-wrapper`（50%→）: `withErrorHandling`（成功 / Error / 非Error）・`withAuthenticatedAction`（未認証 / authErrorMessage / 認証済み実行 / 本処理例外）・`withValidation`（検証失敗で fn 未実行 / 成功 / fn 例外を withErrorHandling が捕捉）
- `lib/firestore-helpers` `updateCounter`（0%→）: 加算・min/max クランプ・非数値起点・`updateTimestamp=false`・ドキュメント不在・データ無効・トランザクション例外

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 76.6 | **77.5** | 77 |
| branches | 65.2 | **66.2** | 66 |
| functions | 79.0 | **79.5** | 79 |
| lines | 77.0 | **78.0** | 77 |

## 確認
- `pnpm verify` EXIT 0（web 780 tests pass、全 green）

## SPR-153 進捗
- ① 大型 Server Actions: 完了 / ② util・lib: 着手（本PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)