### PR TITLE
test: logger / converters を網羅 (SPR-153 ②)

### DIFF
--- a/apps/web/src/app/buttons/utils/__tests__/audio-button-converters.test.ts
+++ b/apps/web/src/app/buttons/utils/__tests__/audio-button-converters.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { convertFirestoreToAudioButton, fetchAndConvertButtons } from "../audio-button-converters";
+
+vi.mock("@/lib/logger", () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }));
+
+const fsButton = (over: Record<string, unknown> = {}) =>
+	({
+		id: "ab1",
+		buttonText: "ボタン",
+		videoId: "vid1",
+		videoTitle: "動画",
+		startTime: 0,
+		endTime: 5,
+		createdBy: "u1",
+		createdByName: "作者",
+		createdAt: "2024-01-01T00:00:00.000Z",
+		...over,
+		// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小データ
+	}) as any;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("convertFirestoreToAudioButton", () => {
+	it("有効データは AudioButton に変換", () => {
+		const r = convertFirestoreToAudioButton(fsButton());
+		expect(r?.id).toBe("ab1");
+		expect(r?.buttonText).toBe("ボタン");
+	});
+
+	it("必須欠落（buttonText/videoId なし）は null", () => {
+		expect(convertFirestoreToAudioButton(fsButton({ buttonText: "", videoId: "" }))).toBeNull();
+	});
+});
+
+describe("fetchAndConvertButtons", () => {
+	it("クエリ結果を変換し null を除外する", async () => {
+		const query = {
+			get: vi.fn().mockResolvedValue({
+				docs: [
+					{ id: "ab1", data: () => fsButton({ id: undefined }) },
+					{ id: "ab2", data: () => fsButton({ id: undefined, buttonText: "", videoId: "" }) }, // → null
+				],
+			}),
+		};
+		const r = await fetchAndConvertButtons(query as never);
+		expect(r).toHaveLength(1);
+		expect(r[0]?.id).toBe("ab1");
+	});
+});

--- a/apps/web/src/app/buttons/utils/__tests__/audio-button-converters.test.ts
+++ b/apps/web/src/app/buttons/utils/__tests__/audio-button-converters.test.ts
@@ -29,7 +29,7 @@ describe("convertFirestoreToAudioButton", () => {
 		expect(r?.buttonText).toBe("ボタン");
 	});
 
-	it("必須欠落（buttonText/videoId なし）は null", () => {
+	it("必須フィールドが空文字なら null", () => {
 		expect(convertFirestoreToAudioButton(fsButton({ buttonText: "", videoId: "" }))).toBeNull();
 	});
 });

--- a/apps/web/src/app/works/utils/__tests__/work-converters.test.ts
+++ b/apps/web/src/app/works/utils/__tests__/work-converters.test.ts
@@ -1,0 +1,60 @@
+import type { WorkDocument } from "@suzumina.click/shared-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { convertDocsToWorks, convertWorksToPlainObjects } from "../work-converters";
+
+vi.mock("@/lib/logger", () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }));
+
+const workData = (over: Record<string, unknown> = {}): WorkDocument =>
+	({
+		productId: "RJ001",
+		title: "作品1",
+		circle: "サークル1",
+		category: "SOU",
+		price: { current: 1000, currency: "JPY" },
+		rating: { stars: 4.5, count: 10 },
+		releaseDateISO: "2024-01-01",
+		language: "ja",
+		...over,
+		// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 WorkDocument
+	}) as any;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("convertDocsToWorks", () => {
+	it("doc を変換し、id 欠落は productId で補完する", async () => {
+		const docs = [
+			{ id: "RJ001", data: () => workData({ productId: "RJ001" }) },
+			{ id: "doc2", data: () => workData({ productId: "RJ002", id: undefined }) },
+		];
+		const r = await convertDocsToWorks(docs as never);
+		expect(r).toHaveLength(2);
+		expect(r.map((w) => w.productId)).toEqual(["RJ001", "RJ002"]);
+	});
+
+	it("変換に失敗した doc はスキップして処理を継続する", async () => {
+		const docs = [
+			{ id: "RJ001", data: () => workData() },
+			{ id: "bad", data: () => ({}) }, // 不正データ → 変換失敗 → スキップ
+		];
+		const r = await convertDocsToWorks(docs as never);
+		expect(r.length).toBeGreaterThanOrEqual(1);
+		expect(r.some((w) => w.productId === "RJ001")).toBe(true);
+	});
+});
+
+describe("convertWorksToPlainObjects", () => {
+	it("WorkDocument 配列を変換し id 欠落は productId 補完", () => {
+		const r = convertWorksToPlainObjects([
+			workData(),
+			workData({ productId: "RJ002", id: undefined }),
+		]);
+		expect(r).toHaveLength(2);
+	});
+
+	it("不正データはスキップ", () => {
+		const r = convertWorksToPlainObjects([workData(), {} as never]);
+		expect(r.length).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/apps/web/src/lib/__tests__/logger.test.ts
+++ b/apps/web/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { debug, error, info, LogLevel, warn } from "../logger";
+
+const origEnv = process.env.NODE_ENV;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+	logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+	errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	(process.env as { NODE_ENV?: string }).NODE_ENV = origEnv;
+});
+
+const setEnv = (v: string) => {
+	(process.env as { NODE_ENV?: string }).NODE_ENV = v;
+};
+
+describe("logger（開発環境: severity 別 console）", () => {
+	beforeEach(() => setEnv("development"));
+
+	it("info/debug は console.log", () => {
+		info("情報");
+		debug("デバッグ");
+		expect(logSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("warn は console.warn、error は console.error", () => {
+		warn("警告");
+		error("エラー");
+		expect(warnSpy).toHaveBeenCalledWith("[WARNING] 警告", expect.any(Object));
+		expect(errorSpy).toHaveBeenCalledWith("[ERROR] エラー", expect.any(Object));
+	});
+
+	it("プレーンなメタデータはマージされる", () => {
+		info("msg", { userId: "u1" });
+		const [, rest] = logSpy.mock.calls[0] as [string, Record<string, unknown>];
+		expect(rest.userId).toBe("u1");
+	});
+});
+
+describe("logger（本番環境: JSON 構造化ログ）", () => {
+	beforeEach(() => setEnv("production"));
+
+	it("severity 付き JSON を console.log に出力", () => {
+		error("本番エラー");
+		const json = JSON.parse(logSpy.mock.calls[0]?.[0] as string);
+		expect(json.severity).toBe(LogLevel.ERROR);
+		expect(json.message).toBe("本番エラー");
+		expect(json.timestamp).toBeDefined();
+	});
+});
+
+describe("エラーのシリアライズ", () => {
+	beforeEach(() => setEnv("development"));
+
+	it("Error を直接渡すと message/name/stack を抽出", () => {
+		error("失敗", new Error("boom"));
+		const [, rest] = errorSpy.mock.calls[0] as [string, Record<string, unknown>];
+		expect(rest.error).toMatchObject({ message: "boom", name: "Error" });
+	});
+
+	it("{ error: Error } は serializeError 経由", () => {
+		error("失敗", { error: new Error("inner") });
+		const [, rest] = errorSpy.mock.calls[0] as [string, Record<string, unknown>];
+		expect((rest.error as { message: string }).message).toBe("inner");
+	});
+
+	it("{ error: 独自オブジェクト } は message/code/details を抽出", () => {
+		error("失敗", { error: { message: "独自", code: "E_X", details: { a: 1 } } });
+		const [, rest] = errorSpy.mock.calls[0] as [string, Record<string, unknown>];
+		expect(rest.error).toMatchObject({ message: "独自", code: "E_X", details: { a: 1 } });
+	});
+
+	it("{ error: message なしオブジェクト } は既定値", () => {
+		error("失敗", { error: { foo: "bar" } });
+		const [, rest] = errorSpy.mock.calls[0] as [string, Record<string, unknown>];
+		expect(rest.error).toMatchObject({ message: "Unknown error", code: "UNKNOWN" });
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -39,8 +39,8 @@ export default defineConfig({
 			thresholds: {
 				statements: 77,
 				branches: 66,
-				functions: 79,
-				lines: 77,
+				functions: 80,
+				lines: 78,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-153 ②（util/lib 隙間埋め）。

## 追加テスト
- `lib/logger`（45%→）: 開発環境の severity 別 console（info/debug→log, warn→warn, error→error）・本番環境の JSON 構造化ログ・Error/独自エラーオブジェクト/プレーンメタデータのシリアライズ分岐
- `buttons/utils/audio-button-converters`（0%→）: Firestore→AudioButton 変換・必須欠落で null・クエリ結果の null 除外
- `works/utils/work-converters`（20%→）: doc 変換・id 欠落の productId 補完・変換失敗のスキップ継続

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 77.5 | **77.9** | 77 |
| branches | 66.2 | **67.0** | 66 |
| functions | 79.5 | **80.2** | 80 |
| lines | 78.0 | **78.5** | 78 |

## 確認
- `pnpm verify` EXIT 0（web 795 tests pass、全 green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)