### PR TITLE
test: google-consent-mode を網羅 (SPR-153 ②)

### DIFF
--- a/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
+++ b/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getCurrentConsentState,
+	resetAllConsent,
+	sendGoogleAnalyticsEvent,
+	sendGoogleAnalyticsPageView,
+	updateConsent,
+	updateGoogleConsent,
+} from "../google-consent-mode";
+
+const gtag = vi.fn();
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	(window as unknown as { gtag: typeof gtag }).gtag = gtag;
+	localStorage.clear();
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+const grantAnalytics = {
+	analytics: true,
+	advertising: false,
+	functional: true,
+	personalization: false,
+};
+
+describe("getCurrentConsentState", () => {
+	it("保存が無ければ null", () => {
+		expect(getCurrentConsentState()).toBeNull();
+	});
+
+	it("保存値を ConsentState に正規化する（functional は既定 true）", () => {
+		localStorage.setItem("consent-state", JSON.stringify({ analytics: true }));
+		expect(getCurrentConsentState()).toEqual({
+			analytics: true,
+			advertising: false,
+			functional: true,
+			personalization: false,
+		});
+	});
+
+	it("不正 JSON は null（catch）", () => {
+		localStorage.setItem("consent-state", "{壊れた");
+		expect(getCurrentConsentState()).toBeNull();
+	});
+});
+
+describe("updateGoogleConsent", () => {
+	it("gtag が無ければ何もしない", () => {
+		(window as unknown as { gtag: unknown }).gtag = undefined;
+		updateGoogleConsent(grantAnalytics);
+		expect(gtag).not.toHaveBeenCalled();
+	});
+
+	it("gtag があれば consent update と event を送る", () => {
+		updateGoogleConsent(grantAnalytics);
+		expect(gtag).toHaveBeenCalledWith("consent", "update", expect.objectContaining({
+			analytics_storage: "granted",
+			ad_storage: "denied",
+		}));
+		expect(gtag).toHaveBeenCalledWith("event", "consent_update", expect.any(Object));
+	});
+});
+
+describe("updateConsent", () => {
+	it("gtag 更新 + localStorage 保存を行う", () => {
+		updateConsent(grantAnalytics);
+		expect(gtag).toHaveBeenCalledWith("consent", "update", expect.any(Object));
+		expect(JSON.parse(localStorage.getItem("consent-state") || "{}")).toEqual(grantAnalytics);
+		expect(localStorage.getItem("consent-state-date")).toBeTruthy();
+	});
+});
+
+describe("resetAllConsent", () => {
+	it("既定状態に更新し localStorage を削除する", () => {
+		localStorage.setItem("consent-state", JSON.stringify(grantAnalytics));
+		localStorage.setItem("age-verification", "1");
+		resetAllConsent();
+		// 既定（functional のみ true）で update
+		expect(gtag).toHaveBeenCalledWith(
+			"consent",
+			"update",
+			expect.objectContaining({ analytics_storage: "denied", functionality_storage: "granted" }),
+		);
+		expect(localStorage.getItem("consent-state")).toBeNull();
+		expect(localStorage.getItem("age-verification")).toBeNull();
+	});
+});
+
+describe("sendGoogleAnalyticsPageView / Event", () => {
+	it("analytics 同意が無ければ gtag を呼ばない", () => {
+		localStorage.setItem("consent-state", JSON.stringify({ analytics: false }));
+		sendGoogleAnalyticsPageView("/x");
+		sendGoogleAnalyticsEvent("evt");
+		expect(gtag).not.toHaveBeenCalled();
+	});
+
+	it("analytics 同意 + measurementId があれば送信する", () => {
+		process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = "G-TEST";
+		localStorage.setItem("consent-state", JSON.stringify({ analytics: true }));
+		sendGoogleAnalyticsPageView("/page");
+		expect(gtag).toHaveBeenCalledWith("config", "G-TEST", expect.objectContaining({ page_path: "/page" }));
+		sendGoogleAnalyticsEvent("my_event", { foo: 1 });
+		expect(gtag).toHaveBeenCalledWith("event", "my_event", { foo: 1 });
+		process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = undefined;
+	});
+
+	it("gtag 未定義なら何もしない", () => {
+		(window as unknown as { gtag: unknown }).gtag = undefined;
+		sendGoogleAnalyticsEvent("evt");
+		expect(gtag).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
+++ b/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
@@ -18,6 +18,8 @@ beforeEach(() => {
 
 afterEach(() => {
 	localStorage.clear();
+	// 文字列 "undefined" が残らないよう削除（テスト間の漏れ防止）
+	delete process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
 });
 
 const grantAnalytics = {
@@ -105,7 +107,6 @@ describe("sendGoogleAnalyticsPageView / Event", () => {
 		expect(gtag).toHaveBeenCalledWith("config", "G-TEST", expect.objectContaining({ page_path: "/page" }));
 		sendGoogleAnalyticsEvent("my_event", { foo: 1 });
 		expect(gtag).toHaveBeenCalledWith("event", "my_event", { foo: 1 });
-		process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID = undefined;
 	});
 
 	it("gtag 未定義なら何もしない", () => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 77,
-				branches: 66,
+				statements: 78,
+				branches: 67,
 				functions: 80,
-				lines: 78,
+				lines: 79,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

SPR-153 ②。`lib/consent/google-consent-mode.ts`（285L, 0%）を happy-dom + `window.gtag` モックで網羅。

## 追加テスト
- `getCurrentConsentState`: 未保存→null / 保存値の正規化（functional 既定 true）/ 不正 JSON→null（catch）
- `updateGoogleConsent`: gtag 無し→早期 return / consent update + event 送信
- `updateConsent`: gtag 更新 + localStorage 保存
- `resetAllConsent`: 既定状態更新 + localStorage 削除
- `sendGoogleAnalyticsPageView` / `sendGoogleAnalyticsEvent`: 同意なし/gtag 無しで送信せず・同意+measurementId で送信

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 77.9 | **78.9** | 78 |
| branches | 67.0 | **68.3** | 67 |
| functions | 80.2 | **81.0** | 80 |
| lines | 78.5 | **79.5** | 79 |

## 確認
- `pnpm verify` EXIT 0（web 805 tests pass、全 green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)