### PR TITLE
test: use-play-count フックを網羅 (SPR-153 ②)

### DIFF
--- a/apps/web/src/hooks/__tests__/use-play-count.test.ts
+++ b/apps/web/src/hooks/__tests__/use-play-count.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePlayCount } from "../use-play-count";
+
+const incrementPlayCount = vi.fn().mockResolvedValue({ success: true });
+vi.mock("@/app/buttons/actions", () => ({
+	incrementPlayCount: (...a: unknown[]) => incrementPlayCount(...a),
+}));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("usePlayCount", () => {
+	it("初回再生はバッチ(1s)後に incrementPlayCount を呼ぶ", () => {
+		const { result } = renderHook(() => usePlayCount());
+		act(() => result.current.handlePlay("a"));
+		// バッチ待ち前は未呼び出し
+		expect(incrementPlayCount).not.toHaveBeenCalled();
+		// バッチ 1s → 各増分 setTimeout(index*100)
+		act(() => vi.advanceTimersByTime(1000));
+		act(() => vi.advanceTimersByTime(100));
+		expect(incrementPlayCount).toHaveBeenCalledWith("a");
+		expect(incrementPlayCount).toHaveBeenCalledTimes(1);
+	});
+
+	it("同一セッションで再度再生してもデバウンスされ重複増分しない", () => {
+		const { result } = renderHook(() => usePlayCount());
+		act(() => result.current.handlePlay("a"));
+		act(() => vi.advanceTimersByTime(1100));
+		expect(incrementPlayCount).toHaveBeenCalledTimes(1);
+		// 30秒以内の再生は無視（playedInSession に既存）
+		act(() => result.current.handlePlay("a"));
+		act(() => vi.advanceTimersByTime(1100));
+		expect(incrementPlayCount).toHaveBeenCalledTimes(1);
+	});
+
+	it("複数ボタンはまとめて処理される", () => {
+		const { result } = renderHook(() => usePlayCount());
+		act(() => {
+			result.current.handlePlay("a");
+			result.current.handlePlay("b");
+		});
+		act(() => vi.advanceTimersByTime(1000));
+		act(() => vi.advanceTimersByTime(200)); // index 0,1 → 0ms,100ms
+		expect(incrementPlayCount).toHaveBeenCalledWith("a");
+		expect(incrementPlayCount).toHaveBeenCalledWith("b");
+	});
+
+	it("cleanup はタイマーをクリアし以降増分しない", () => {
+		const { result } = renderHook(() => usePlayCount());
+		act(() => result.current.handlePlay("a"));
+		act(() => result.current.cleanup());
+		act(() => vi.advanceTimersByTime(2000));
+		expect(incrementPlayCount).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,9 +37,9 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
 			thresholds: {
-				statements: 78,
-				branches: 67,
-				functions: 80,
+				statements: 79,
+				branches: 68,
+				functions: 81,
 				lines: 79,
 			},
 		},


### PR DESCRIPTION
## 概要

SPR-153 ②（util/lib）の仕上げ。テスト無しだった `hooks/use-play-count.ts`（br 10%）を fake timers で網羅。

## 追加テスト（`@testing-library/react` renderHook + `vi.useFakeTimers`）
- 初回再生はバッチ（1s）後に `incrementPlayCount` を呼ぶ
- 同一セッションの再再生はデバウンスで重複増分しない
- 複数ボタンの一括処理
- `cleanup` でタイマー解除し以降増分しない

## カバレッジ（web 実測）
| | before | after | 閾値(新) |
|---|---|---|---|
| statements | 78.9 | **79.5** | 79 |
| branches | 68.3 | **68.6** | 68 |
| functions | 81.0 | **81.7** | 81 |
| lines | 79.5 | **80.1** | 79 |

## 備考
- `sitemap.ts` は既存テストが充実（7ケース・91% stmt）。残る branches は `||` フォールバック中心で低 ROI のため本 Issue では対象外とする。

## 確認
- `pnpm verify` EXIT 0（web 809 tests pass、全 green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)