### PR TITLE
test: web コンポーネント描画テストでカバレッジ上積み (SPR-155)

### DIFF
--- a/apps/web/src/app/__tests__/sitemap.test.ts
+++ b/apps/web/src/app/__tests__/sitemap.test.ts
@@ -202,6 +202,127 @@ describe("sitemap", () => {
 		expect(urls.every((url) => !url.match(/\/videos\/[^/]+$/))).toBe(true);
 	});
 
+	it("videos の可視性: status.privacyStatus が public 以外の動画は除外し、public は含める", async () => {
+		const firestoreMock = buildCollectionResolvers({
+			videos: async () =>
+				buildSnapshot([
+					{
+						id: "video-public",
+						data: () => ({
+							status: { privacyStatus: "public" },
+							updatedAt: "2024-01-01T00:00:00Z",
+						}),
+					},
+					{
+						id: "video-private",
+						data: () => ({
+							status: { privacyStatus: "private" },
+							updatedAt: "2024-01-01T00:00:00Z",
+						}),
+					},
+				]),
+			works: async () => buildSnapshot([]),
+			audioButtons: async () => buildSnapshot([]),
+		});
+
+		(getFirestore as any).mockReturnValue(firestoreMock);
+
+		const result = await sitemap();
+		const urls = result.map((entry) => entry.url);
+
+		expect(urls).toContain("https://suzumina.click/videos/video-public");
+		expect(urls).not.toContain("https://suzumina.click/videos/video-private");
+	});
+
+	it("lastModified の date フォールバック: updatedAt / createdAt が無くても Date.now() で URL は生成される", async () => {
+		const firestoreMock = buildCollectionResolvers({
+			// createdAt のみ（updatedAt 無し） / 日付なし（Date.now() フォールバック）
+			videos: async () =>
+				buildSnapshot([
+					{ id: "video-c", data: () => ({ createdAt: "2024-01-01T00:00:00Z" }) },
+					{ id: "video-nodate", data: () => ({}) },
+				]),
+			// updatedAt / createdAt いずれも無し → Date.now() にフォールバック
+			works: async () => buildSnapshot([{ id: "RJ-nodate", data: () => ({}) }]),
+			audioButtons: async () => buildSnapshot([{ id: "audio-nodate", data: () => ({}) }]),
+		});
+
+		(getFirestore as any).mockReturnValue(firestoreMock);
+
+		const result = await sitemap();
+		const byUrl = new Map(result.map((entry) => [entry.url, entry]));
+
+		expect(byUrl.has("https://suzumina.click/videos/video-c")).toBe(true);
+		expect(byUrl.has("https://suzumina.click/works/RJ-nodate")).toBe(true);
+		expect(byUrl.has("https://suzumina.click/buttons/audio-nodate")).toBe(true);
+		// 日付欠落でも lastModified は有効な Date になる
+		expect(byUrl.get("https://suzumina.click/works/RJ-nodate")?.lastModified).toBeInstanceOf(Date);
+	});
+
+	it("個別コレクション失敗時の fallback: works が throw しても videos/audioButtons は含まれ warn される", async () => {
+		const firestoreMock = buildCollectionResolvers({
+			videos: async () =>
+				buildSnapshot([{ id: "video-ok", data: () => ({ updatedAt: "2024-01-01T00:00:00Z" }) }]),
+			works: async () => {
+				throw new Error("works query failed");
+			},
+			audioButtons: async () =>
+				buildSnapshot([{ id: "audio-ok", data: () => ({ updatedAt: "2024-01-01T00:00:00Z" }) }]),
+		});
+
+		(getFirestore as any).mockReturnValue(firestoreMock);
+
+		const result = await sitemap();
+		const urls = result.map((entry) => entry.url);
+
+		expect(urls).toContain("https://suzumina.click/videos/video-ok");
+		expect(urls).toContain("https://suzumina.click/buttons/audio-ok");
+		expect(urls.every((url) => !url.match(/\/works\/[^/]+$/))).toBe(true);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Failed to fetch works for sitemap:",
+			expect.objectContaining({ error: expect.any(Error) }),
+		);
+	});
+
+	it("個別コレクション失敗時の fallback: audioButtons が throw しても videos/works は含まれ warn される", async () => {
+		const firestoreMock = buildCollectionResolvers({
+			videos: async () =>
+				buildSnapshot([{ id: "video-ok", data: () => ({ updatedAt: "2024-01-01T00:00:00Z" }) }]),
+			works: async () =>
+				buildSnapshot([{ id: "RJ-ok", data: () => ({ updatedAt: "2024-01-01T00:00:00Z" }) }]),
+			audioButtons: async () => {
+				throw new Error("audioButtons query failed");
+			},
+		});
+
+		(getFirestore as any).mockReturnValue(firestoreMock);
+
+		const result = await sitemap();
+		const urls = result.map((entry) => entry.url);
+
+		expect(urls).toContain("https://suzumina.click/videos/video-ok");
+		expect(urls).toContain("https://suzumina.click/works/RJ-ok");
+		expect(urls.every((url) => !url.match(/\/buttons\/[^/]+$/))).toBe(true);
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Failed to fetch audio buttons for sitemap:",
+			expect.objectContaining({ error: expect.any(Error) }),
+		);
+	});
+
+	it("baseUrl フォールバック: NEXT_PUBLIC_APP_URL 未設定時は本番 URL を使う", async () => {
+		delete process.env.NEXT_PUBLIC_APP_URL;
+		const firestoreMock = buildCollectionResolvers({
+			videos: async () => buildSnapshot([]),
+			works: async () => buildSnapshot([]),
+			audioButtons: async () => buildSnapshot([]),
+		});
+
+		(getFirestore as any).mockReturnValue(firestoreMock);
+
+		const result = await sitemap();
+		expect(result.map((entry) => entry.url)).toContain("https://suzumina.click");
+	});
+
 	it("staticPages の保証: 公開ページ一覧が必ず含まれる", async () => {
 		const firestoreMock = buildCollectionResolvers({
 			videos: async () => buildSnapshot([]),

--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useSession } from "next-auth/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { updateUserTagsAction } from "@/actions/user-tags";
+import { buildTagSearchHref } from "@/lib/tag-search";
 import { VideoUserTagEditor } from "../video-user-tag-editor";
 
 vi.mock("next-auth/react", () => ({
@@ -11,6 +12,16 @@ vi.mock("next-auth/react", () => ({
 
 vi.mock("@/actions/user-tags", () => ({
 	updateUserTagsAction: vi.fn(),
+}));
+
+// router.push / router.refresh の副作用を検証するため next/navigation をローカルでモックして捕捉する
+// （vitest.setup.ts のグローバルモックは毎回新しい vi.fn を返し捕捉できないため）。
+const { mockPush, mockRefresh } = vi.hoisted(() => ({
+	mockPush: vi.fn(),
+	mockRefresh: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }));
 
 // 子コンポーネントは本体ロジックの検証外なのでスタブ化する。
@@ -115,6 +126,8 @@ describe("VideoUserTagEditor", () => {
 			videoId: "abc123",
 			userTags: ["new-tag"],
 		});
+		// 成功時は最新データ取得のためページをリフレッシュする
+		expect(mockRefresh).toHaveBeenCalledTimes(1);
 	});
 
 	it("保存失敗（error あり）はそのエラーメッセージを返す", async () => {
@@ -189,11 +202,13 @@ describe("VideoUserTagEditor", () => {
 		expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
 	});
 
-	it("タグクリックで一覧へ遷移する（onTagClick 経由でクラッシュしない）", () => {
+	it("タグクリックで buildTagSearchHref の URL に router.push する", () => {
 		(useSession as any).mockReturnValue(loggedIn);
 		render(<VideoUserTagEditor video={createVideo()} />);
 
-		// ThreeLayerTagDisplay スタブのタグをクリックしても例外が出ない
-		expect(() => fireEvent.click(screen.getByText("tag-display"))).not.toThrow();
+		// ThreeLayerTagDisplay スタブが onTagClick("ASMR", "user") を発火する
+		fireEvent.click(screen.getByText("tag-display"));
+
+		expect(mockPush).toHaveBeenCalledWith(buildTagSearchHref("ASMR", "user"));
 	});
 });

--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
@@ -1,0 +1,199 @@
+import type { VideoPlainObject } from "@suzumina.click/shared-types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useSession } from "next-auth/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { updateUserTagsAction } from "@/actions/user-tags";
+import { VideoUserTagEditor } from "../video-user-tag-editor";
+
+vi.mock("next-auth/react", () => ({
+	useSession: vi.fn(),
+}));
+
+vi.mock("@/actions/user-tags", () => ({
+	updateUserTagsAction: vi.fn(),
+}));
+
+// 子コンポーネントは本体ロジックの検証外なのでスタブ化する。
+// onTagClick / onUpdateTags のコールバックを発火できるようにしておく。
+vi.mock("@suzumina.click/ui/components/custom/three-layer-tag-display", () => ({
+	ThreeLayerTagDisplay: ({
+		onTagClick,
+	}: {
+		onTagClick: (tag: string, layer: "playlist" | "user" | "category") => void;
+	}) => (
+		<button type="button" onClick={() => onTagClick("ASMR", "user")}>
+			tag-display
+		</button>
+	),
+}));
+
+// onUpdateTags の戻り値を捕捉する（handleUpdateTags の分岐検証用）
+const { updateResult } = vi.hoisted(() => ({
+	updateResult: { value: null as unknown },
+}));
+
+vi.mock("@/components/video/video-tag-editor", () => ({
+	VideoTagEditor: ({
+		videoId,
+		onUpdateTags,
+	}: {
+		videoId: string;
+		onUpdateTags: (videoId: string, tags: string[]) => Promise<unknown>;
+	}) => (
+		<button
+			type="button"
+			onClick={async () => {
+				updateResult.value = await onUpdateTags(videoId, ["new-tag"]);
+			}}
+		>
+			保存
+		</button>
+	),
+}));
+
+const loggedIn = { data: { user: { discordId: "123" } } };
+const loggedOut = { data: null };
+
+const createVideo = (): VideoPlainObject =>
+	({
+		videoId: "abc123",
+		categoryId: "10",
+		tags: {
+			playlistTags: ["プレイリスト"],
+			userTags: ["みんな"],
+		},
+	}) as unknown as VideoPlainObject;
+
+// tags / categoryId 未設定（`?.` と `|| []` / `categoryName || undefined` のフォールバック検証用）
+const createVideoWithoutTags = (): VideoPlainObject =>
+	({
+		videoId: "abc123",
+	}) as unknown as VideoPlainObject;
+
+describe("VideoUserTagEditor", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		updateResult.value = null;
+	});
+
+	it("未ログイン時は編集セクションを出さずログイン誘導を表示する", () => {
+		(useSession as any).mockReturnValue(loggedOut);
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		expect(screen.getByText(/ログインしてください/)).toBeInTheDocument();
+		expect(screen.queryByText("みんなのタグ編集")).not.toBeInTheDocument();
+	});
+
+	it("ログイン時は編集セクションと編集ボタンを表示する", () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		expect(screen.getByText("みんなのタグ編集")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /編集/ })).toBeInTheDocument();
+		// ログイン時は誘導文を出さない
+		expect(screen.queryByText(/ログインしてください/)).not.toBeInTheDocument();
+	});
+
+	it("編集ボタンでエディタを開き、保存成功でエディタを閉じる", async () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		(updateUserTagsAction as any).mockResolvedValue({ success: true });
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+		// エディタ（スタブの保存ボタン）が出る
+		const saveButton = screen.getByRole("button", { name: "保存" });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(updateResult.value).toEqual({ success: true });
+		});
+		// 成功時はエディタが閉じ、再び編集ボタンが見える
+		await waitFor(() => {
+			expect(screen.queryByRole("button", { name: "保存" })).not.toBeInTheDocument();
+		});
+		expect(updateUserTagsAction).toHaveBeenCalledWith({
+			videoId: "abc123",
+			userTags: ["new-tag"],
+		});
+	});
+
+	it("保存失敗（error あり）はそのエラーメッセージを返す", async () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		(updateUserTagsAction as any).mockResolvedValue({ success: false, error: "権限がありません" });
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+		fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+		await waitFor(() => {
+			expect(updateResult.value).toEqual({ success: false, error: "権限がありません" });
+		});
+	});
+
+	it("保存失敗（error なし）は既定メッセージを返す", async () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		(updateUserTagsAction as any).mockResolvedValue({ success: false });
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+		fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+		await waitFor(() => {
+			expect(updateResult.value).toEqual({
+				success: false,
+				error: "タグの更新に失敗しました",
+			});
+		});
+	});
+
+	it("アクションが Error を throw した場合はその message を返す", async () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		(updateUserTagsAction as any).mockRejectedValue(new Error("ネットワークエラー"));
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+		fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+		await waitFor(() => {
+			expect(updateResult.value).toEqual({ success: false, error: "ネットワークエラー" });
+		});
+	});
+
+	it("アクションが Error 以外を throw した場合は既定メッセージを返す", async () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		(updateUserTagsAction as any).mockRejectedValue("文字列エラー");
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+		fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+		await waitFor(() => {
+			expect(updateResult.value).toEqual({
+				success: false,
+				error: "タグの更新に失敗しました",
+			});
+		});
+	});
+
+	it("tags / categoryId が無くてもフォールバックして描画できる", () => {
+		(useSession as any).mockReturnValue(loggedOut);
+		expect(() => render(<VideoUserTagEditor video={createVideoWithoutTags()} />)).not.toThrow();
+		expect(screen.getByText("tag-display")).toBeInTheDocument();
+	});
+
+	it("tags が無い状態でも編集エディタを開ける（プロップのフォールバック）", () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		render(<VideoUserTagEditor video={createVideoWithoutTags()} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+		expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
+	});
+
+	it("タグクリックで一覧へ遷移する（onTagClick 経由でクラッシュしない）", () => {
+		(useSession as any).mockReturnValue(loggedIn);
+		render(<VideoUserTagEditor video={createVideo()} />);
+
+		// ThreeLayerTagDisplay スタブのタグをクリックしても例外が出ない
+		expect(() => fireEvent.click(screen.getByText("tag-display"))).not.toThrow();
+	});
+});

--- a/apps/web/src/app/works/components/__tests__/work-card.test.tsx
+++ b/apps/web/src/app/works/components/__tests__/work-card.test.tsx
@@ -1,0 +1,240 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import WorkCard, { formatDate } from "../work-card";
+
+// next/link は素の <a> に置換（href 検証を容易にする）
+vi.mock("next/link", () => ({
+	default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+// WorkCard が参照するフィールドのみを満たす最小 fixture（不要フィールドは cast で省略）
+const createWork = (overrides: Partial<WorkPlainObject> = {}): WorkPlainObject =>
+	({
+		id: "RJ123456",
+		title: "テスト作品",
+		circle: "テストサークル",
+		circleId: "RG12345",
+		workUrl: "https://www.dlsite.com/work/RJ123456",
+		thumbnailUrl: "thumb.jpg",
+		highResImageUrl: "high.jpg",
+		releaseDate: "2023年5月6日",
+		genres: ["ボイス・ASMR", "癒し"],
+		price: {
+			current: 1100,
+			original: 2200,
+			currency: "JPY",
+			discount: 50,
+			isFree: false,
+			isDiscounted: true,
+			formattedPrice: "¥1,100",
+		},
+		creators: {
+			voiceActors: [{ id: "CR001", name: "声優A" }],
+			scenario: [],
+			illustration: [],
+			music: [],
+			others: [],
+			voiceActorNames: ["声優A"],
+			scenarioNames: [],
+			illustrationNames: [],
+			musicNames: [],
+			otherNames: [],
+		},
+		...overrides,
+	}) as WorkPlainObject;
+
+describe("formatDate", () => {
+	it('"YYYY年M月D日" を 0 埋め付き "YYYY/MM/DD" に整形する', () => {
+		expect(formatDate("2023年5月6日")).toBe("2023/05/06");
+	});
+
+	it('"YYYY/M/D" を 0 埋め付き "YYYY/MM/DD" に整形する', () => {
+		expect(formatDate("2023/5/6")).toBe("2023/05/06");
+		// 後続文字列があっても日付部分のみ取り出す
+		expect(formatDate("2023/12/25 ほか")).toBe("2023/12/25");
+	});
+
+	it("ISO/日時文字列は JST 暦日に整形する（TZ 非依存）", () => {
+		// UTC 16:00 は JST では翌日 01:00 → 同日扱いにならず JST の暦日になる
+		expect(formatDate("2023-05-06T00:00:00Z")).toBe("2023/05/06");
+	});
+
+	it("パースできない文字列はそのまま返す", () => {
+		expect(formatDate("不明な日付")).toBe("不明な日付");
+	});
+});
+
+describe("WorkCard", () => {
+	it("基本情報（タイトル・サークル・発売日）を表示する", () => {
+		render(<WorkCard work={createWork()} />);
+		expect(screen.getByText("テスト作品")).toBeInTheDocument();
+		expect(screen.getByText("テストサークル")).toBeInTheDocument();
+		// 発売日は formatDate 経由で整形される
+		expect(screen.getByText("2023/05/06")).toBeInTheDocument();
+	});
+
+	it("セール中は割引価格・元価格・OFF バッジ・セール中バッジを表示する", () => {
+		render(<WorkCard work={createWork()} />);
+		expect(screen.getByText("¥1,100")).toBeInTheDocument();
+		expect(screen.getByText("¥2,200")).toBeInTheDocument();
+		expect(screen.getByText("50% OFF")).toBeInTheDocument();
+		expect(screen.getByText("セール中")).toBeInTheDocument();
+	});
+
+	it("非セール時は単一価格を表示し、セール中バッジ・OFF を出さない", () => {
+		const work = createWork({
+			price: {
+				current: 2200,
+				original: 2200,
+				currency: "JPY",
+				isFree: false,
+				isDiscounted: false,
+				formattedPrice: "¥2,200",
+			},
+		});
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("¥2,200")).toBeInTheDocument();
+		expect(screen.queryByText("セール中")).not.toBeInTheDocument();
+		expect(screen.queryByText(/% OFF/)).not.toBeInTheDocument();
+	});
+
+	it("compact variant では価格ブロックを表示せず、詳細ボタンが「詳細を見る」表記になる", () => {
+		render(<WorkCard work={createWork()} variant="compact" />);
+		// 価格は非表示
+		expect(screen.queryByText("¥1,100")).not.toBeInTheDocument();
+		// compact では詳細ボタンが「詳細を見る」（default は「詳細」）
+		expect(screen.getByRole("link", { name: "詳細を見る" })).toBeInTheDocument();
+	});
+
+	it("default variant では詳細ボタンが「詳細」表記になる", () => {
+		render(<WorkCard work={createWork()} />);
+		expect(screen.getByRole("link", { name: "詳細" })).toBeInTheDocument();
+	});
+
+	it("circleId があるとサークルリンクを張る", () => {
+		render(<WorkCard work={createWork()} />);
+		const circleLink = screen.getByText("テストサークル").closest("a");
+		expect(circleLink).toHaveAttribute("href", "/circles/RG12345");
+	});
+
+	it("circleId が無いとサークル名はリンクにせず段落表示する", () => {
+		render(<WorkCard work={createWork({ circleId: undefined })} />);
+		const circle = screen.getByText("テストサークル");
+		expect(circle.closest("a")).toBeNull();
+		expect(circle.tagName).toBe("P");
+	});
+
+	it("ジャンルを最大 3 件まで表示する", () => {
+		const work = createWork({ genres: ["g1", "g2", "g3", "g4"] });
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("g1")).toBeInTheDocument();
+		expect(screen.getByText("g3")).toBeInTheDocument();
+		expect(screen.queryByText("g4")).not.toBeInTheDocument();
+	});
+
+	it("genres が配列でない場合はジャンルを表示しない", () => {
+		const work = createWork({ genres: undefined as unknown as string[] });
+		render(<WorkCard work={work} />);
+		// クラッシュせず描画でき、タイトルは出る
+		expect(screen.getByText("テスト作品")).toBeInTheDocument();
+	});
+
+	it("releaseDate が無いと発売日は「不明」と表示する", () => {
+		render(<WorkCard work={createWork({ releaseDate: undefined })} />);
+		expect(screen.getByText("不明")).toBeInTheDocument();
+	});
+
+	it("声優を最大 2 名表示し、3 名以上で「他」を付ける", () => {
+		const work = createWork({
+			creators: {
+				...createWork().creators,
+				voiceActors: [
+					{ id: "a", name: "声優A" },
+					{ id: "b", name: "声優B" },
+					{ id: "c", name: "声優C" },
+				],
+			},
+		});
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("声優A")).toBeInTheDocument();
+		expect(screen.getByText("声優B")).toBeInTheDocument();
+		expect(screen.queryByText("声優C")).not.toBeInTheDocument();
+		expect(screen.getByText(/他/)).toBeInTheDocument();
+		// id があれば creators リンクは id を使う
+		expect(screen.getByText("声優A").closest("a")).toHaveAttribute("href", "/creators/a");
+	});
+
+	it("声優が空配列なら CV 表示を出さない", () => {
+		const work = createWork({
+			creators: { ...createWork().creators, voiceActors: [] },
+		});
+		render(<WorkCard work={work} />);
+		expect(screen.queryByText("CV:")).not.toBeInTheDocument();
+	});
+
+	it("声優に id が無い場合は name を creators リンクに使う", () => {
+		const work = createWork({
+			creators: {
+				...createWork().creators,
+				voiceActors: [{ name: "名前のみ声優" }],
+			},
+		});
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("名前のみ声優").closest("a")).toHaveAttribute(
+			"href",
+			"/creators/%E5%90%8D%E5%89%8D%E3%81%AE%E3%81%BF%E5%A3%B0%E5%84%AA",
+		);
+	});
+
+	it("priority=true でサムネイルが eager 読み込みになる", () => {
+		render(<WorkCard work={createWork()} priority />);
+		const img = screen.getByAltText("テスト作品のサムネイル画像");
+		expect(img).toHaveAttribute("loading", "eager");
+	});
+
+	it("priority 未指定（default false）でサムネイルが lazy 読み込みになる", () => {
+		render(<WorkCard work={createWork()} />);
+		const img = screen.getByAltText("テスト作品のサムネイル画像");
+		expect(img).toHaveAttribute("loading", "lazy");
+	});
+
+	it("price が無い場合は ¥0 表示にフォールバックしセール表示を出さない", () => {
+		const work = createWork({ price: undefined as unknown as WorkPlainObject["price"] });
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("¥0")).toBeInTheDocument();
+		expect(screen.queryByText("セール中")).not.toBeInTheDocument();
+	});
+
+	it("highResImageUrl が無いと thumbnailUrl をサムネイルに使う", () => {
+		render(<WorkCard work={createWork({ highResImageUrl: undefined })} />);
+		const img = screen.getByAltText("テスト作品のサムネイル画像");
+		expect(img).toHaveAttribute("src", "thumb.jpg");
+	});
+
+	it("highResImageUrl も thumbnailUrl も無いと placeholder にフォールバックする", () => {
+		render(<WorkCard work={createWork({ highResImageUrl: undefined, thumbnailUrl: undefined })} />);
+		const img = screen.getByAltText("テスト作品のサムネイル画像");
+		expect(img).toHaveAttribute("src", "/placeholder.svg");
+	});
+
+	it("creators が無くてもクラッシュせず CV 表示を出さない", () => {
+		const work = createWork({
+			creators: undefined as unknown as WorkPlainObject["creators"],
+		});
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("テスト作品")).toBeInTheDocument();
+		expect(screen.queryByText("CV:")).not.toBeInTheDocument();
+	});
+
+	it("DLsite 購入リンクを workUrl で別タブに張る", () => {
+		render(<WorkCard work={createWork()} />);
+		const buyLink = screen.getByLabelText("テスト作品をDLsiteで購入");
+		expect(buyLink).toHaveAttribute("href", "https://www.dlsite.com/work/RJ123456");
+		expect(buyLink).toHaveAttribute("target", "_blank");
+	});
+});

--- a/apps/web/src/app/works/components/__tests__/work-card.test.tsx
+++ b/apps/web/src/app/works/components/__tests__/work-card.test.tsx
@@ -1,6 +1,6 @@
 import type { WorkPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import WorkCard, { formatDate } from "../work-card";
 
 // next/link は素の <a> に置換（href 検証を容易にする）

--- a/apps/web/src/components/system/__tests__/protected-route.test.tsx
+++ b/apps/web/src/components/system/__tests__/protected-route.test.tsx
@@ -1,0 +1,133 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { auth } from "@/auth";
+import ProtectedRoute, { requireAuth } from "../protected-route";
+
+vi.mock("@/auth", () => ({
+	auth: vi.fn(),
+}));
+
+// next/headers の headers() を制御する
+const { headersStore } = vi.hoisted(() => ({
+	headersStore: { xUrl: null as string | null },
+}));
+vi.mock("next/headers", () => ({
+	headers: vi.fn(async () => ({
+		get: (key: string) => (key === "x-url" ? headersStore.xUrl : null),
+	})),
+}));
+
+// Next の redirect は実装上 throw して以降の処理を止める。テストでも同じ挙動にする。
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn((url: string) => {
+		throw new Error(`REDIRECT:${url}`);
+	}),
+}));
+
+import { redirect } from "next/navigation";
+
+const makeUser = (overrides: Record<string, unknown> = {}) => ({
+	discordId: "user-1",
+	isActive: true,
+	role: "member" as const,
+	...overrides,
+});
+
+describe("ProtectedRoute", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		headersStore.xUrl = null;
+	});
+
+	it("認証済み・アクティブ・権限十分なら children を描画する", async () => {
+		(auth as any).mockResolvedValue({ user: makeUser() });
+
+		const element = await ProtectedRoute({ children: <div>secret</div> });
+		const { getByText } = render(element);
+
+		expect(getByText("secret")).toBeInTheDocument();
+		expect(redirect).not.toHaveBeenCalled();
+	});
+
+	it("未認証なら fallback へ x-url を callbackUrl 付きでリダイレクトする", async () => {
+		(auth as any).mockResolvedValue(null);
+		headersStore.xUrl = "/works/RJ123456";
+
+		await expect(ProtectedRoute({ children: <div>secret</div> })).rejects.toThrow("REDIRECT:");
+		expect(redirect).toHaveBeenCalledWith("/auth/signin?callbackUrl=%2Fworks%2FRJ123456");
+	});
+
+	it("未認証かつ x-url ヘッダが無い場合は /buttons/create を callbackUrl に使う", async () => {
+		(auth as any).mockResolvedValue(null);
+		headersStore.xUrl = null;
+
+		await expect(ProtectedRoute({ children: <div>x</div> })).rejects.toThrow("REDIRECT:");
+		expect(redirect).toHaveBeenCalledWith("/auth/signin?callbackUrl=%2Fbuttons%2Fcreate");
+	});
+
+	it("fallbackUrl を指定するとその URL にリダイレクトする", async () => {
+		(auth as any).mockResolvedValue(null);
+
+		await expect(ProtectedRoute({ children: <div>x</div>, fallbackUrl: "/login" })).rejects.toThrow(
+			"REDIRECT:",
+		);
+		expect(redirect).toHaveBeenCalledWith("/login?callbackUrl=%2Fbuttons%2Fcreate");
+	});
+
+	it("非アクティブユーザーは AccessDenied にリダイレクトする", async () => {
+		(auth as any).mockResolvedValue({ user: makeUser({ isActive: false }) });
+
+		await expect(ProtectedRoute({ children: <div>x</div> })).rejects.toThrow("REDIRECT:");
+		expect(redirect).toHaveBeenCalledWith("/auth/error?error=AccessDenied");
+	});
+
+	it("権限不足（member が admin ページ）は AccessDenied にリダイレクトする", async () => {
+		(auth as any).mockResolvedValue({ user: makeUser({ role: "member" }) });
+
+		await expect(ProtectedRoute({ children: <div>x</div>, requireRole: "admin" })).rejects.toThrow(
+			"REDIRECT:",
+		);
+		expect(redirect).toHaveBeenCalledWith("/auth/error?error=AccessDenied");
+	});
+
+	it("上位権限（admin が moderator ページ）は許可され children を描画する", async () => {
+		(auth as any).mockResolvedValue({ user: makeUser({ role: "admin" }) });
+
+		const element = await ProtectedRoute({
+			children: <div>mod-area</div>,
+			requireRole: "moderator",
+		});
+		const { getByText } = render(element);
+
+		expect(getByText("mod-area")).toBeInTheDocument();
+		expect(redirect).not.toHaveBeenCalled();
+	});
+});
+
+describe("requireAuth", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("アクティブユーザーなら user を返す", async () => {
+		const user = makeUser();
+		(auth as any).mockResolvedValue({ user });
+
+		await expect(requireAuth()).resolves.toEqual(user);
+		expect(redirect).not.toHaveBeenCalled();
+	});
+
+	it("セッションが無ければ signin にリダイレクトする", async () => {
+		(auth as any).mockResolvedValue(null);
+
+		await expect(requireAuth()).rejects.toThrow("REDIRECT:/auth/signin");
+		expect(redirect).toHaveBeenCalledWith("/auth/signin");
+	});
+
+	it("非アクティブユーザーは signin にリダイレクトする", async () => {
+		(auth as any).mockResolvedValue({ user: makeUser({ isActive: false }) });
+
+		await expect(requireAuth()).rejects.toThrow("REDIRECT:/auth/signin");
+		expect(redirect).toHaveBeenCalledWith("/auth/signin");
+	});
+});

--- a/apps/web/src/contexts/__tests__/age-verification-context.test.tsx
+++ b/apps/web/src/contexts/__tests__/age-verification-context.test.tsx
@@ -1,0 +1,112 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { AgeVerificationProvider, useAgeVerification } from "../age-verification-context";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+	<AgeVerificationProvider>{children}</AgeVerificationProvider>
+);
+
+const renderAgeVerification = () => renderHook(() => useAgeVerification(), { wrapper });
+
+// 30日判定用のヘルパ（ISO 文字列）
+const daysAgoIso = (days: number) => {
+	const d = new Date();
+	d.setDate(d.getDate() - days);
+	return d.toISOString();
+};
+
+describe("useAgeVerification", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it("Provider 外で使うと例外を投げる", () => {
+		expect(() => renderHook(() => useAgeVerification())).toThrow(
+			"useAgeVerification must be used within an AgeVerificationProvider",
+		);
+	});
+
+	it("初期状態（localStorage 空）は未確認・非アダルト・読込完了", () => {
+		const { result } = renderAgeVerification();
+		expect(result.current.isAgeVerified).toBe(false);
+		expect(result.current.isAdult).toBe(false);
+		expect(result.current.showR18Content).toBe(false);
+		expect(result.current.isLoading).toBe(false);
+	});
+
+	it("updateAgeVerification(true) で確認済み・アダルト・R18 表示可になり localStorage に保存する", () => {
+		const { result } = renderAgeVerification();
+
+		act(() => {
+			result.current.updateAgeVerification(true);
+		});
+
+		expect(result.current.isAgeVerified).toBe(true);
+		expect(result.current.isAdult).toBe(true);
+		expect(result.current.showR18Content).toBe(true);
+		expect(localStorage.getItem("age-verified")).toBe("true");
+		expect(localStorage.getItem("age-verification-adult")).toBe("true");
+		expect(localStorage.getItem("age-verification-date")).not.toBeNull();
+	});
+
+	it("updateAgeVerification(false) は確認済みだが非アダルト・R18 非表示", () => {
+		const { result } = renderAgeVerification();
+
+		act(() => {
+			result.current.updateAgeVerification(false);
+		});
+
+		expect(result.current.isAgeVerified).toBe(true);
+		expect(result.current.isAdult).toBe(false);
+		expect(result.current.showR18Content).toBe(false);
+		expect(localStorage.getItem("age-verification-adult")).toBe("false");
+	});
+
+	it("30日以内の有効な確認（adult=true）はマウント時に復元される", () => {
+		localStorage.setItem("age-verified", "true");
+		localStorage.setItem("age-verification-date", daysAgoIso(10));
+		localStorage.setItem("age-verification-adult", "true");
+
+		const { result } = renderAgeVerification();
+
+		expect(result.current.isAgeVerified).toBe(true);
+		expect(result.current.isAdult).toBe(true);
+		expect(result.current.showR18Content).toBe(true);
+	});
+
+	it("30日以内の確認でも adult=false なら復元時に R18 は非表示", () => {
+		localStorage.setItem("age-verified", "true");
+		localStorage.setItem("age-verification-date", daysAgoIso(10));
+		localStorage.setItem("age-verification-adult", "false");
+
+		const { result } = renderAgeVerification();
+
+		expect(result.current.isAgeVerified).toBe(true);
+		expect(result.current.isAdult).toBe(false);
+		expect(result.current.showR18Content).toBe(false);
+	});
+
+	it("30日を超えた確認は期限切れとしてクリアされ未確認に戻る", () => {
+		localStorage.setItem("age-verified", "true");
+		localStorage.setItem("age-verification-date", daysAgoIso(40));
+		localStorage.setItem("age-verification-adult", "true");
+
+		const { result } = renderAgeVerification();
+
+		expect(result.current.isAgeVerified).toBe(false);
+		expect(result.current.isAdult).toBe(false);
+		// 期限切れの値は削除される
+		expect(localStorage.getItem("age-verified")).toBeNull();
+		expect(localStorage.getItem("age-verification-date")).toBeNull();
+		expect(localStorage.getItem("age-verification-adult")).toBeNull();
+	});
+
+	it("age-verified が true でも日付が無ければ復元しない", () => {
+		localStorage.setItem("age-verified", "true");
+		// age-verification-date 無し
+
+		const { result } = renderAgeVerification();
+
+		expect(result.current.isAgeVerified).toBe(false);
+	});
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -37,10 +37,10 @@ export default defineConfig({
 			],
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152, SPR-155）
 			thresholds: {
-				statements: 80,
-				branches: 70,
-				functions: 82,
-				lines: 80,
+				statements: 81,
+				branches: 71,
+				functions: 83,
+				lines: 81,
 			},
 		},
 		exclude: [

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -38,9 +38,9 @@ export default defineConfig({
 			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152, SPR-155）
 			thresholds: {
 				statements: 81,
-				branches: 71,
+				branches: 72,
 				functions: 83,
-				lines: 81,
+				lines: 82,
 			},
 		},
 		exclude: [

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,12 +35,12 @@ export default defineConfig({
 				"**/e2e/**",
 				"src/**/layout.tsx", // App Router boilerplate
 			],
-			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152）
+			// 実測フロアに合わせたラチェット閾値（回帰ガード / SPR-152, SPR-155）
 			thresholds: {
-				statements: 79,
-				branches: 68,
-				functions: 81,
-				lines: 79,
+				statements: 80,
+				branches: 70,
+				functions: 82,
+				lines: 80,
 			},
 		},
 		exclude: [


### PR DESCRIPTION
## 概要

[SPR-155](https://linear.app/nothink/issue/SPR-155)（任意・低優先）の実装。分岐が濃い未テスト component に `@testing-library/react` の描画テストを追加し、ラチェット運用で apps/web のカバレッジ閾値を引き上げる。すべて**テスト追加のみ**で本番挙動の変更はなし（変更は `vitest.config.ts` の閾値のみ）。

## 内容（3コミット）

| コミット | 対象 | branches |
|---|---|---|
| PR1 | `work-card.tsx` / `sitemap.ts` | 12%→96% / 47%→100% |
| PR2 | `age-verification-context.tsx` / `video-user-tag-editor.tsx` | 30%→100% / →100% |
| PR3 | `protected-route.tsx` | 8%→100% |

## カバレッジ推移（apps/web 全体）

| | 開始 | 完了 |
|---|---|---|
| statements | 79.5% | 81.51% |
| branches | 68.6% | 72.26% |
| functions | 81.7% | 83.42% |
| lines | 80.1% | 82.06% |

閾値を実測フロアにラチェット引き上げ（statements 79→81 / branches 68→72 / functions 81→83 / lines 79→82）。テスト総数 838→874、`pnpm verify` green。

## レビュー観点（One-Way Door）

- `protected-route.test.tsx` は **NextAuth/認可分岐**に触れるテスト。CLAUDE.md のセルフマージ・ポリシー上 One-Way Door 寄りのため、`redirect` を Next 同様 throw させて以降の処理を止める前提のモック設計が妥当か要確認。
- `video-user-tag-editor.test.tsx` は子コンポーネント（VideoTagEditor / ThreeLayerTagDisplay）とサーバーアクションをスタブ化し、本体の `handleUpdateTags` 分岐に絞っている。

## スコープ外

- `video-detail.tsx`（br 53%）の top-up は計画通り任意・未着手（895 行で ROI 低）。
- `app/**/page.tsx`（Server Component 中心）は別 Issue 候補。

🤖 Generated with [Claude Code](https://claude.com/claude-code)