### PR TITLE
fix(web): ホーム / の dev hydration / dynamic 警告を解消 (SPR-162)

### DIFF
--- a/apps/web/src/components/analytics/google-analytics-script.tsx
+++ b/apps/web/src/components/analytics/google-analytics-script.tsx
@@ -1,5 +1,4 @@
 import Script from "next/script";
-import { info as logInfo, warn as logWarn } from "@/lib/logger";
 
 /**
  * Google Analytics 4 Script Component
@@ -10,14 +9,7 @@ export function GoogleAnalyticsScript() {
 
 	// Don't render if measurement ID is not configured
 	if (!measurementId) {
-		if (process.env.NODE_ENV === "development") {
-			logWarn("Google Analytics Measurement ID not configured");
-		}
 		return null;
-	}
-
-	if (process.env.NODE_ENV === "development") {
-		logInfo("Google Analytics Script loading with ID:", { measurementId });
 	}
 
 	return (

--- a/apps/web/src/components/sections/works-section.tsx
+++ b/apps/web/src/components/sections/works-section.tsx
@@ -4,6 +4,7 @@ import type { WorkPlainObject } from "@suzumina.click/shared-types";
 import { LoadingSkeleton } from "@suzumina.click/ui/components/custom/loading-skeleton";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { LazyFeaturedWorksCarousel } from "@/components/optimization/lazy-components";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 
@@ -21,6 +22,15 @@ export function WorksSection({
 	error = null,
 }: WorksSectionProps) {
 	const { showR18Content } = useAgeVerification();
+
+	// 年齢確認状態はクライアントの localStorage から決まる。SSR（およびストリーミングされた
+	// 動的セクションのサーバ HTML）は常に未確認＝全年齢ビューを描画するため、マウント完了まで
+	// 同じ値に揃えてハイドレーション不一致を防ぐ（確定後に再描画される）。
+	const [mounted, setMounted] = useState(false);
+	useEffect(() => {
+		setMounted(true);
+	}, []);
+	const effectiveShowR18 = mounted && showR18Content;
 
 	if (loading) {
 		return (
@@ -60,7 +70,7 @@ export function WorksSection({
 		);
 	}
 
-	const worksToShow = showR18Content ? works : allAgesWorks;
+	const worksToShow = effectiveShowR18 ? works : allAgesWorks;
 
 	return (
 		<section className="py-8 sm:py-12 bg-background">
@@ -69,14 +79,14 @@ export function WorksSection({
 					<div>
 						<h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-foreground mb-2 flex items-center gap-2">
 							🎭 新着作品
-							{!showR18Content && (
+							{!effectiveShowR18 && (
 								<span className="ml-2 text-sm text-blue-600 bg-blue-50 px-2 py-1 rounded-full">
 									全年齢対象
 								</span>
 							)}
 						</h2>
 						<p className="text-sm sm:text-base text-muted-foreground">
-							{showR18Content
+							{effectiveShowR18
 								? "涼花みなせさんの最新作品をチェック！"
 								: "年齢制限のない作品をお楽しみください"}
 						</p>


### PR DESCRIPTION
## 概要

ホーム `/` で出ていた **dev 限定エラー2件**を修正（better-auth とは無関係。SPR-156 のログイン確認中に発見）。

Linear: [SPR-162](https://linear.app/nothink/issue/SPR-162/fixweb-ホーム-の-dev-hydration-dynamic-警告を解消ga-new-date-workssection-r18)

## 1) GA の `new Date()` dynamic 警告（Next 16）

`GoogleAnalyticsScript`（Server Component）の dev 専用ログ（`logInfo`/`logWarn`）が `@/lib/logger` 経由で描画中に `new Date()`（timestamp）を呼び、`Route "/" used \`new Date()\` before accessing either uncached data...` 警告になっていた。値を持たないノイズログなので**削除**して解消（logger 自体は変更なし）。

## 2) `WorksSection` の hydration mismatch

`WorksSection` は Cache Components で**ストリーミングされる動的セクション**で、`showR18Content`（クライアントの localStorage 由来）に依存。検証済み成人の場合、静的シェルの hydration で `AgeVerificationProvider` の `useEffect` が先に `showR18Content=true` にした**後**に当セクションが hydrate するため、サーバ HTML（全年齢ビュー＝`全年齢対象` バッジ入り）とクライアントが割れて mismatch していた。

→ **ローカル `mounted` フラグ**を導入し、初回描画（SSR ＝ クライアント初回）を必ず全年齢ビューに揃え、マウント確定後に実際の `showR18Content` で再描画。`worksToShow` / バッジ / 説明文の3箇所を `effectiveShowR18 = mounted && showR18Content` に統一。

> cookie への移行（真の no-flicker）は works-list / settings / overlay 等の content-gating 全体に波及するため本 issue のスコープ外とし、issue 記載の「確定までバッジ描画を遅延」案を採用。

## 検証（Firestore Emulator + seed の dev）

- **未確認** / **検証済み成人** の双方で、ブラウザ console・サーバログともに hydration / `new Date()` 警告**ゼロ**
- 検証済み成人では mount 後に R18 ビューへ正常遷移（`全年齢対象` バッジ消失・説明文切替）を確認
- `pnpm verify` 緑（lint + typecheck + test、カバレッジ閾値含む）

## Door 判定

✅ **Two-Way Door**: UI/表示のみ（dev 警告解消＋初期描画の整合）。Firestore / 認証 / インフラ非該当。

🤖 Generated with [Claude Code](https://claude.com/claude-code)