### PR TITLE
fix(web): next/image の quality 警告を解消 (SPR-165)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -51,6 +51,9 @@ const nextConfig = {
 	images: {
 		// 画像形式の最適化（AVIF優先でWebPフォールバック）
 		formats: ["image/avif", "image/webp"],
+		// 許可する quality 値（Next.js 16 以降は既定 [75] のみ。未設定値は警告になる）
+		// アプリで使用する値: avatar 75 / card 通常 80 / thumbnail 85 / card priority 90
+		qualities: [75, 80, 85, 90],
 		// 画像サイズの最適化
 		deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
 		imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],


### PR DESCRIPTION
## 概要

ローカル/本番問わず `next/image` 経由の画像リクエストごとに大量に出ていた quality 警告を解消する。

```
Image with src "..." is using quality "80" which is not configured in images.qualities [75].
Please update your config to [75, 80].
```

Next.js 16 で `images.qualities` の既定が `[75]` のみになったのが原因。アプリは複数の quality 値を使っているため、未設定値として警告が出ていた。

## 変更

`apps/web/next.config.mjs` の `images.qualities` に、実際に使用する値を明示:

| 値 | 用途 |
|----|------|
| 75 | 小サイズアバター (`user-avatar.tsx`) |
| 80 | 通常カード (`work-card.tsx` / `video-card.tsx`) |
| 85 | サムネイル既定 (`thumbnail-image.tsx`) / 大サイズアバター |
| 90 | カード `priority` 時 |

## 検証

- `pnpm verify` 通過 (lint + typecheck + test)

Two-Way Door（戻せる設定変更）。

Closes SPR-165

🤖 Generated with [Claude Code](https://claude.com/claude-code)