### PR TITLE
chore(terraform): firestore_rules の dead な検証関数を撤去

### DIFF
--- a/terraform/firestore_rules.tf
+++ b/terraform/firestore_rules.tf
@@ -23,23 +23,18 @@ resource "google_firestore_document" "firestore_rules" {
               return request.auth != null;
             }
             
-            // リクエスト元のユーザーとリソース所有者が一致するか確認
-            function isOwner(userId) {
-              return isAuthenticated() && request.auth.uid == userId;
-            }
-            
             // 動画コレクション
             match /videos/{videoId} {
-              // 誰でも読み取り可能、書き込みは管理者のみ
+              // 誰でも読み取り可能、書き込みは Cloud Functions（Admin SDK）のみ
               allow read;
-              allow write: if false; // 管理者APIのみ書き込み可能
+              allow write: if false; // Admin SDK のみ書き込み可能
             }
             
             // DLsite作品コレクション
             match /works/{workId} {
-              // 誰でも読み取り可能、書き込みは管理者のみ
+              // 誰でも読み取り可能、書き込みは Cloud Functions（Admin SDK）のみ
               allow read;
-              allow write: if false; // 管理者APIのみ書き込み可能
+              allow write: if false; // Admin SDK のみ書き込み可能
             }
             
             // 音声ボタンコレクション（統一システム）
@@ -47,24 +42,6 @@ resource "google_firestore_document" "firestore_rules" {
               // 公開音声ボタンは誰でも読み取り可能、非公開は作成者のみ読み取り可能
               allow read: if resource.data.isPublic == true || 
                            (isAuthenticated() && resource.data.createdBy == request.auth.uid);
-              
-              // データ検証関数（Discord ID対応）
-              function isValidAudioButton() {
-                return request.resource.data.keys().hasAll(['title', 'startTime', 'endTime', 'sourceVideoId', 'isPublic', 'createdBy', 'createdByName', 'createdAt']) &&
-                       request.resource.data.title is string &&
-                       request.resource.data.title.size() > 0 &&
-                       request.resource.data.title.size() <= 100 &&
-                       request.resource.data.startTime is number &&
-                       request.resource.data.endTime is number &&
-                       request.resource.data.startTime >= 0 &&
-                       request.resource.data.endTime > request.resource.data.startTime &&
-                       request.resource.data.sourceVideoId is string &&
-                       request.resource.data.sourceVideoId.size() > 0 &&
-                       request.resource.data.isPublic is bool &&
-                       request.resource.data.createdBy is string &&
-                       request.resource.data.createdByName is string &&
-                       request.resource.data.createdAt is string;
-              }
               
               // 作成・更新・削除はServer Actionsのみで操作
               allow create, update, delete: if false; // Server Actionsのみで操作
@@ -75,16 +52,6 @@ resource "google_firestore_document" "firestore_rules" {
               // 公開プロフィールは誰でも読み取り可能、プライベートは所有者のみ
               allow read: if resource.data.isPublicProfile == true || 
                            (isAuthenticated() && request.auth.token.discord_id == discordId);
-              
-              // ユーザーデータ検証関数
-              function isValidUserData() {
-                return request.resource.data.keys().hasAll(['discordId', 'username', 'displayName', 'isActive', 'createdAt']) &&
-                       request.resource.data.discordId is string &&
-                       request.resource.data.username is string &&
-                       request.resource.data.displayName is string &&
-                       request.resource.data.isActive is bool &&
-                       request.resource.data.createdAt is string;
-              }
               
               // 作成・更新はServer Actionsのみ
               allow create, update: if false; // Server Actionsのみで操作


### PR DESCRIPTION
## 概要

[SPR-164](https://linear.app/nothink/issue/SPR-164) (#573) の Claude AI レビューで指摘された **pre-existing dead code** を整理する小さなクリーンアップ。

書き込みは Server Actions / Cloud Functions（Admin SDK）経由でセキュリティルールをバイパスするため、`audioButtons` / `users` の `create/update/delete` はすべて `if false`。その結果、検証関数が**どのルールからも呼ばれない dead code**になっていた。

## 変更内容

- `isOwner()` を削除（未参照）
- `isValidAudioButton()` を削除（`audioButtons` の write が `if false` で未呼び出し）
- `isValidUserData()` を削除（`users` の write が `if false` で未呼び出し）
- `isAuthenticated()` は read ルールで使用中のため**温存**
- SPR-164 で撤去した admin に言及する「管理者APIのみ」コメントを Admin SDK 実態に修正

## 影響

**挙動変更なし**（未呼び出し関数の削除 + コメント修正のみ）。`google_firestore_document.firestore_rules` の rules テキストが更新される。

## Door 判定 / マージ手順

⚠️ **One-Way Door**（Firestore セキュリティルール）。マージで `terraform-apply` ゲートが起動するため、plan が **rules ドキュメントの更新のみ**（他リソースに影響なし）であることを確認してから承認してください。

## 検証

- `terraform fmt -check -recursive` clean
- dead 関数の参照ゼロ・`isAuthenticated()` の定義と2箇所の使用を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)