### PR TITLE
refactor(auth): 認証レイヤ堅牢化 — cast 除去・lint 境界・設定ガード (SPR-168)

### DIFF
--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -48,6 +48,16 @@
 					}
 				}
 			}
+		},
+		{
+			"includes": ["src/lib/auth/**", "src/lib/better-auth/**", "src/app/api/auth/**"],
+			"linter": {
+				"rules": {
+					"style": {
+						"noRestrictedImports": "off"
+					}
+				}
+			}
 		}
 	],
 	"linter": {
@@ -62,7 +72,22 @@
 				"noUnusedTemplateLiteral": "error",
 				"useNumberNamespace": "error",
 				"noInferrableTypes": "error",
-				"noUselessElse": "error"
+				"noUselessElse": "error",
+				"noRestrictedImports": {
+					"level": "error",
+					"options": {
+						"paths": {
+							"better-auth": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"better-auth/react": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"better-auth/client/plugins": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"better-auth/plugins": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"better-auth/next-js": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"better-auth/adapters": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"@/lib/better-auth/auth": "better-auth 実装の直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
+							"@/lib/better-auth/firestore-adapter": "better-auth 実装の直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。"
+						}
+					}
+				}
 			},
 			"complexity": {
 				"noExcessiveCognitiveComplexity": "error"

--- a/apps/web/src/lib/auth/better-auth-client.ts
+++ b/apps/web/src/lib/auth/better-auth-client.ts
@@ -25,6 +25,5 @@ const authClient = createAuthClient({
  */
 export function useBetterAuthAppUser(): UserSession | null {
 	const { data } = authClient.useSession();
-	const appUser = (data as { appUser?: UserSession | null } | null)?.appUser;
-	return appUser ?? null;
+	return data?.appUser ?? null;
 }

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -15,9 +15,7 @@ export async function getCurrentUser(): Promise<UserSession | null> {
 		import("@/lib/better-auth/auth"),
 		import("next/headers"),
 	]);
-	const result = (await auth.api.getSession({ headers: await headers() })) as {
-		appUser?: UserSession | null;
-	} | null;
+	const result = await auth.api.getSession({ headers: await headers() });
 	return result?.appUser ?? null;
 }
 

--- a/apps/web/src/lib/better-auth/__tests__/auth-config.test.ts
+++ b/apps/web/src/lib/better-auth/__tests__/auth-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { auth } from "../auth";
+
+/**
+ * better-auth の「重要設定ガード」テスト（SPR-168）。
+ *
+ * 移行中に実機でしか捕捉できなかったクラスのバグ（nextCookies 欠落による
+ * state_mismatch / basePath 不一致）を CI で検出するための回帰ガード。
+ */
+describe("better-auth 重要設定ガード（SPR-168）", () => {
+	const pluginIds = (auth.options.plugins ?? []).map((p) => p.id);
+
+	it("basePath が /api/auth（Discord redirect URI と一致）", () => {
+		expect(auth.options.basePath).toBe("/api/auth");
+	});
+
+	it("nextCookies プラグインが存在し、配列の最後に置かれている", () => {
+		// nextCookies は Set-Cookie を Next の cookies() に書き戻すため必ず最後（欠落/順序違反は state_mismatch を招く）。
+		expect(pluginIds).toContain("next-cookies");
+		expect(pluginIds.at(-1)).toBe("next-cookies");
+	});
+
+	it("customSession プラグインが存在する（appUser エンリッチ）", () => {
+		expect(pluginIds).toContain("custom-session");
+	});
+});

--- a/apps/web/src/lib/better-auth/__tests__/auth-config.test.ts
+++ b/apps/web/src/lib/better-auth/__tests__/auth-config.test.ts
@@ -6,6 +6,11 @@ import { auth } from "../auth";
  *
  * 移行中に実機でしか捕捉できなかったクラスのバグ（nextCookies 欠落による
  * state_mismatch / basePath 不一致）を CI で検出するための回帰ガード。
+ *
+ * 注: better-auth インスタンスの `auth.options`（解決済み設定）を参照する。これは
+ * better-auth のメジャーバージョンアップで構造が変わり得るため、依存更新で本テストが
+ * クラッシュした場合は「設定が壊れた」ではなく参照（options.basePath / options.plugins[].id）の
+ * 見直しを先に疑うこと。
  */
 describe("better-auth 重要設定ガード（SPR-168）", () => {
 	const pluginIds = (auth.options.plugins ?? []).map((p) => p.id);


### PR DESCRIPTION
## 概要

[SPR-168](https://linear.app/nothink/issue/SPR-168)（better-auth 移行の教訓を反映した認証レイヤ堅牢化）のうち、**cast 除去（Medium）+ lint 境界・設定ガード（High）**を実施。レビュー容易性のため、24 テストの mock 共通化（High「抽象 mock 標準化」）は [SPR-170](https://linear.app/nothink/issue/SPR-170) に分離。

## 変更内容

### 1. 型キャスト除去（Medium）
`server.ts` / `better-auth-client.ts` の `as { appUser?: UserSession | null }` を撤去。better-auth の `customSession` 推論が `appUser` を値レベルで通すため、抽象層を **cast レス**にできた（TS2883 は authClient 非 export の wrapper パターンで回避済みのため別問題）。

### 2. 抽象境界の lint 強制（High）
biome `noRestrictedImports` で `better-auth` / `better-auth/*` / `@/lib/better-auth/*` の直接 import を禁止し、`src/lib/auth/**` ・ `src/lib/better-auth/**` ・ `src/app/api/auth/**` の境界 dir のみ override で許可。**境界外からの直接 import を CI で検出**（temp 違反ファイルで検出を確認済み）。

### 3. 重要設定のガードテスト（High）
`lib/better-auth/__tests__/auth-config.test.ts` を追加し、移行中に**実機でしか捕捉できなかった**クラスのバグを CI で回帰ガード:
- `basePath === "/api/auth"`（Discord redirect URI と一致）
- `nextCookies` がプラグイン配列の**最後**（欠落/順序違反は `state_mismatch` を招く）
- `customSession` プラグインの存在

## スコープ外（フォロー）
- **mock 共通ヘルパ化 → [SPR-170](https://linear.app/nothink/issue/SPR-170)**: 認証 mock テスト 24 ファイルの retarget。調査の結果**プロバイダ直接 mock は既に 0**（差し替え耐性は達成済み）で、残りは DRY/一貫性のためのテスト専用スイープのため独立 PR が適切。
- CompatSession 解消 / auth.ts 分割 / dev:clean は SPR-168 の Medium・Low として別途。

## Door 判定
⚠️ **One-Way Door**（認証）。ただし本 PR は cast 除去（型のみ）・lint 設定・追加テストが中心で**ランタイム挙動の変更なし**。

## 検証
- `pnpm verify` 緑（lint + typecheck + test、カバレッジ閾値含む）
- lint 境界: 境界 dir は pass、境界外の `better-auth` 直接 import を日本語メッセージ付きで検出
- ガードテスト 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)