### PR TITLE
refactor(test): 認証 mock を共通ヘルパ/手動 mock へ全面 retarget (SPR-170)

### DIFF
--- a/apps/web/src/actions/__tests__/favorites.test.ts
+++ b/apps/web/src/actions/__tests__/favorites.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 import {
 	addFavoriteAction,
 	getFavoriteStatusAction,
@@ -7,7 +8,7 @@ import {
 	toggleFavoriteAction,
 } from "../favorites";
 
-vi.mock("@/lib/auth/server", () => ({ getCurrentUser: vi.fn() }));
+vi.mock("@/lib/auth/server");
 vi.mock("@/lib/favorites-firestore", () => ({
 	addFavorite: vi.fn(),
 	removeFavorite: vi.fn(),
@@ -16,11 +17,10 @@ vi.mock("@/lib/favorites-firestore", () => ({
 	getFavoritesStatus: vi.fn(),
 }));
 
-const getCurrentUser = vi.mocked(await import("@/lib/auth/server")).getCurrentUser;
 const fs = vi.mocked(await import("@/lib/favorites-firestore"));
 
-const login = () => getCurrentUser.mockResolvedValue({ discordId: "u1" } as never);
-const logout = () => getCurrentUser.mockResolvedValue(null as never);
+const login = () => mockCurrentUser({ discordId: "u1" });
+const logout = () => mockCurrentUser(null);
 
 beforeEach(() => {
 	vi.clearAllMocks();

--- a/apps/web/src/actions/__tests__/user-tags.test.ts
+++ b/apps/web/src/actions/__tests__/user-tags.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 import { updateUserTagsAction } from "../user-tags";
 
-vi.mock("@/lib/auth/server", () => ({ getCurrentUser: vi.fn() }));
+vi.mock("@/lib/auth/server");
 vi.mock("@/lib/video-firestore", () => ({ updateVideoUserTags: vi.fn() }));
 
-const getCurrentUser = vi.mocked(await import("@/lib/auth/server")).getCurrentUser;
 const { updateVideoUserTags } = vi.mocked(await import("@/lib/video-firestore"));
 
-const login = () => getCurrentUser.mockResolvedValue({ discordId: "u1" } as never);
+const login = () => mockCurrentUser({ discordId: "u1" });
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -16,7 +16,7 @@ beforeEach(() => {
 
 describe("updateUserTagsAction: 検証分岐", () => {
 	it("未ログインはエラー", async () => {
-		getCurrentUser.mockResolvedValue(null as never);
+		mockCurrentUser(null);
 		expect(await updateUserTagsAction({ videoId: "v", userTags: [] })).toEqual({
 			success: false,
 			error: "ログインが必要です",

--- a/apps/web/src/actions/__tests__/video-actions.test.ts
+++ b/apps/web/src/actions/__tests__/video-actions.test.ts
@@ -6,9 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getVideoAction, getVideosAction } from "../video-actions";
 
 // モジュールのモック
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: vi.fn(),
-}));
+vi.mock("@/lib/auth/server");
 
 vi.mock("@/lib/video-firestore", () => ({
 	getVideoByIdFromFirestore: vi.fn(),
@@ -16,8 +14,8 @@ vi.mock("@/lib/video-firestore", () => ({
 }));
 
 // モックのインポート
-import { getCurrentUser } from "@/lib/auth/server";
 import { getVideoByIdFromFirestore, getVideosByIdsFromFirestore } from "@/lib/video-firestore";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 
 describe("video-actions", () => {
 	beforeEach(() => {
@@ -134,7 +132,7 @@ describe("video-actions", () => {
 	describe("updateVideoAction", () => {
 		it("認証されていない場合エラーを返す", async () => {
 			const { updateVideoAction } = await import("../video-actions");
-			vi.mocked(getCurrentUser).mockResolvedValue(null);
+			mockCurrentUser(null);
 
 			const result = await updateVideoAction("video-123", {});
 
@@ -144,11 +142,7 @@ describe("video-actions", () => {
 
 		it("認証されている場合成功を返す", async () => {
 			const { updateVideoAction } = await import("../video-actions");
-			vi.mocked(getCurrentUser).mockResolvedValue({
-				id: "user-123",
-				discordId: "discord-123",
-				role: "user",
-			} as any);
+			mockCurrentUser({ discordId: "discord-123" });
 
 			const result = await updateVideoAction("video-123", {});
 

--- a/apps/web/src/app/auth/__tests__/actions.test.ts
+++ b/apps/web/src/app/auth/__tests__/actions.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { signInAction, signOutAction } from "../actions";
 
-vi.mock("@/lib/auth/server", () => ({
-	signInWithDiscord: vi.fn(),
-	signOutCurrent: vi.fn(),
-}));
+vi.mock("@/lib/auth/server");
 vi.mock("@/lib/logger", () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }));
 
 const { signInWithDiscord, signOutCurrent } = vi.mocked(await import("@/lib/auth/server"));

--- a/apps/web/src/app/buttons/__tests__/actions.test.ts
+++ b/apps/web/src/app/buttons/__tests__/actions.test.ts
@@ -1,5 +1,6 @@
 import type { CreateAudioButtonInput } from "@suzumina.click/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 import {
 	createAudioButton,
 	decrementDislikeCount,
@@ -75,16 +76,8 @@ vi.mock("next/cache", () => ({
 	unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
 }));
 
-// Mock auth
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: vi.fn().mockResolvedValue({
-		discordId: "123456789012345678",
-		username: "testuser",
-		displayName: "Test User",
-		role: "member",
-		isActive: true,
-	}),
-}));
+// Mock auth（既定ログイン済みは beforeEach で設定）
+vi.mock("@/lib/auth/server");
 
 // Mock protected route
 vi.mock("@/components/system/protected-route", () => ({
@@ -99,6 +92,12 @@ vi.mock("@/components/system/protected-route", () => ({
 describe("Audio Button Server Actions", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockCurrentUser({
+			discordId: "123456789012345678",
+			username: "testuser",
+			displayName: "Test User",
+			isActive: true,
+		});
 
 		// Mock YouTube API key
 		process.env.YOUTUBE_API_KEY = "test-api-key";

--- a/apps/web/src/app/buttons/__tests__/page.test.tsx
+++ b/apps/web/src/app/buttons/__tests__/page.test.tsx
@@ -12,9 +12,7 @@ vi.mock("next/server", () => ({
 }));
 
 // Mock 認証抽象（未ログイン）
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: () => Promise.resolve(null),
-}));
+vi.mock("@/lib/auth/server");
 
 // Mock the server actions
 vi.mock("../actions", () => ({
@@ -82,10 +80,8 @@ vi.mock("@suzumina.click/ui/components/custom/audio-button", () => ({
 	),
 }));
 
-// Mock 認証クライアント（未ログイン）
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(() => null),
-}));
+// Mock 認証クライアント（未ログイン・__mocks__ の既定が null を返す）
+vi.mock("@/lib/auth/client");
 
 // Mock AudioButtonsList component
 vi.mock("../components/audio-buttons-list", () => ({

--- a/apps/web/src/app/buttons/__tests__/tag-filter.test.ts
+++ b/apps/web/src/app/buttons/__tests__/tag-filter.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { getPopularAudioButtonTags } from "../lib/audio-button-stats";
 
-// Mock auth
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: vi.fn(),
-}));
+// Mock auth（既定は未ログイン）
+vi.mock("@/lib/auth/server");
 
 // getPopularAudioButtonTags が unstable_cache 経由になったため、Next ランタイム外では
 // ラップ対象の関数をそのまま返すパススルーにする。

--- a/apps/web/src/app/settings/__tests__/actions.test.ts
+++ b/apps/web/src/app/settings/__tests__/actions.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 import { updateUserProfile } from "../actions";
 
-vi.mock("@/lib/auth/server", () => ({ getCurrentUser: vi.fn() }));
+vi.mock("@/lib/auth/server");
 vi.mock("@/lib/user-firestore", () => ({ updateUser: vi.fn() }));
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
-const getCurrentUser = vi.mocked(await import("@/lib/auth/server")).getCurrentUser;
 const { updateUser } = vi.mocked(await import("@/lib/user-firestore"));
 const { revalidatePath } = vi.mocked(await import("next/cache"));
 
@@ -15,7 +15,7 @@ beforeEach(() => {
 
 describe("updateUserProfile", () => {
 	it("未認証はエラー", async () => {
-		getCurrentUser.mockResolvedValue(null);
+		mockCurrentUser(null);
 		expect(await updateUserProfile({ isPublicProfile: true })).toEqual({
 			success: false,
 			error: "認証が必要です",
@@ -24,7 +24,7 @@ describe("updateUserProfile", () => {
 	});
 
 	it("認証済みは updateUser を呼びキャッシュを再検証する", async () => {
-		getCurrentUser.mockResolvedValue({ discordId: "u1" } as never);
+		mockCurrentUser({ discordId: "u1" });
 		updateUser.mockResolvedValue(undefined as never);
 		expect(await updateUserProfile({ isPublicProfile: false })).toEqual({ success: true });
 		expect(updateUser).toHaveBeenCalledWith({ discordId: "u1", isPublicProfile: false });
@@ -33,7 +33,7 @@ describe("updateUserProfile", () => {
 	});
 
 	it("例外時はエラーを返す", async () => {
-		getCurrentUser.mockResolvedValue({ discordId: "u1" } as never);
+		mockCurrentUser({ discordId: "u1" });
 		updateUser.mockRejectedValue(new Error("db down"));
 		expect(await updateUserProfile({ isPublicProfile: true })).toEqual({
 			success: false,

--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-detail.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-detail.test.tsx
@@ -2,17 +2,11 @@ import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useSession } from "@/lib/auth/client";
+import { mockUseSession } from "@/test-utils/auth";
 import VideoDetail from "../video-detail";
 
-// 認証抽象のモック
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(() => ({
-		id: "test-user",
-		name: "Test User",
-		email: "test@example.com",
-	})),
-}));
+// 認証抽象のモック（既定はログイン済み。未ログインは各テストで mockUseSession(null)）
+vi.mock("@/lib/auth/client");
 
 // Next.js routerのモック
 vi.mock("next/navigation", () => ({
@@ -117,6 +111,7 @@ function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 describe("VideoDetail", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockUseSession({ discordId: "test-user", displayName: "Test User" });
 	});
 
 	describe("動画時間フォーマット境界テスト", () => {
@@ -382,7 +377,7 @@ describe("VideoDetail", () => {
 
 	describe("音声ボタン作成可否（getCanCreateButtonData）", () => {
 		it("未ログインは作成ボタンが無効でログイン理由が title に出る", () => {
-			(useSession as any).mockReturnValue(null);
+			mockUseSession(null);
 			render(<VideoDetail video={createMockVideo()} />);
 
 			const createButton = screen.getByText("ボタンを作成").closest("button");
@@ -391,7 +386,7 @@ describe("VideoDetail", () => {
 		});
 
 		it("埋め込み制限（embeddable=false）は作成不可で理由が title に出る", () => {
-			(useSession as any).mockReturnValue({ discordId: "1" });
+			mockUseSession({ discordId: "1" });
 			// embeddable=false は canCreateAudioButton より先に判定されるため _computed は不要
 			render(<VideoDetail video={createMockVideo({ status: { embeddable: false } })} />);
 
@@ -401,7 +396,7 @@ describe("VideoDetail", () => {
 		});
 
 		it("作成可能な動画はボタンが Link になり、サイドバーに新規作成リンクが出る", () => {
-			(useSession as any).mockReturnValue({ discordId: "1" });
+			mockUseSession({ discordId: "1" });
 			render(<VideoDetail video={createMockVideo({ _computed: { canCreateButton: true } })} />);
 
 			const createLink = screen.getByText("ボタンを作成").closest("a");

--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
@@ -2,13 +2,11 @@ import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { updateUserTagsAction } from "@/actions/user-tags";
-import { useSession } from "@/lib/auth/client";
 import { buildTagSearchHref } from "@/lib/tag-search";
+import { mockUseSession } from "@/test-utils/auth";
 import { VideoUserTagEditor } from "../video-user-tag-editor";
 
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/client");
 
 vi.mock("@/actions/user-tags", () => ({
 	updateUserTagsAction: vi.fn(),
@@ -88,7 +86,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("未ログイン時は編集セクションを出さずログイン誘導を表示する", () => {
-		(useSession as any).mockReturnValue(loggedOut);
+		mockUseSession(loggedOut);
 		render(<VideoUserTagEditor video={createVideo()} />);
 
 		expect(screen.getByText(/ログインしてください/)).toBeInTheDocument();
@@ -96,7 +94,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("ログイン時は編集セクションと編集ボタンを表示する", () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		render(<VideoUserTagEditor video={createVideo()} />);
 
 		expect(screen.getByText("みんなのタグ編集")).toBeInTheDocument();
@@ -106,7 +104,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("編集ボタンでエディタを開き、保存成功でエディタを閉じる", async () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		(updateUserTagsAction as any).mockResolvedValue({ success: true });
 		render(<VideoUserTagEditor video={createVideo()} />);
 
@@ -131,7 +129,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("保存失敗（error あり）はそのエラーメッセージを返す", async () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		(updateUserTagsAction as any).mockResolvedValue({ success: false, error: "権限がありません" });
 		render(<VideoUserTagEditor video={createVideo()} />);
 
@@ -144,7 +142,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("保存失敗（error なし）は既定メッセージを返す", async () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		(updateUserTagsAction as any).mockResolvedValue({ success: false });
 		render(<VideoUserTagEditor video={createVideo()} />);
 
@@ -160,7 +158,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("アクションが Error を throw した場合はその message を返す", async () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		(updateUserTagsAction as any).mockRejectedValue(new Error("ネットワークエラー"));
 		render(<VideoUserTagEditor video={createVideo()} />);
 
@@ -173,7 +171,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("アクションが Error 以外を throw した場合は既定メッセージを返す", async () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		(updateUserTagsAction as any).mockRejectedValue("文字列エラー");
 		render(<VideoUserTagEditor video={createVideo()} />);
 
@@ -189,13 +187,13 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("tags / categoryId が無くてもフォールバックして描画できる", () => {
-		(useSession as any).mockReturnValue(loggedOut);
+		mockUseSession(loggedOut);
 		expect(() => render(<VideoUserTagEditor video={createVideoWithoutTags()} />)).not.toThrow();
 		expect(screen.getByText("tag-display")).toBeInTheDocument();
 	});
 
 	it("tags が無い状態でも編集エディタを開ける（プロップのフォールバック）", () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		render(<VideoUserTagEditor video={createVideoWithoutTags()} />);
 
 		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
@@ -203,7 +201,7 @@ describe("VideoUserTagEditor", () => {
 	});
 
 	it("タグクリックで buildTagSearchHref の URL に router.push する", () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		render(<VideoUserTagEditor video={createVideo()} />);
 
 		// ThreeLayerTagDisplay スタブが onTagClick("ASMR", "user") を発火する

--- a/apps/web/src/app/videos/__tests__/page.test.tsx
+++ b/apps/web/src/app/videos/__tests__/page.test.tsx
@@ -11,10 +11,8 @@ vi.mock("next/server", () => ({
 	headers: vi.fn(() => new Map()),
 }));
 
-// Mock 認証抽象
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: () => Promise.resolve(null),
-}));
+// Mock 認証抽象（既定は未ログイン）
+vi.mock("@/lib/auth/server");
 
 // Mock the server actions
 vi.mock("../actions", () => ({

--- a/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
@@ -1,12 +1,10 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useSession } from "@/lib/auth/client";
+import { mockUseSession } from "@/test-utils/auth";
 import VideoCardActions from "../video-card-actions";
 
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/client");
 
 function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 	const base = {
@@ -37,7 +35,7 @@ function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 	return { ...base, ...overrides } as VideoPlainObject;
 }
 
-const loggedIn = { id: "user123", name: "テストユーザー" };
+const loggedIn = { discordId: "user123", displayName: "テストユーザー" };
 const loggedOut = null;
 
 describe("VideoCardActions", () => {
@@ -46,7 +44,7 @@ describe("VideoCardActions", () => {
 	});
 
 	it("sidebar variant では『動画を見る』リンクのみ表示する", () => {
-		(useSession as any).mockReturnValue(loggedOut);
+		mockUseSession(loggedOut);
 		render(<VideoCardActions video={createMockVideo()} variant="sidebar" />);
 
 		const link = screen.getByText("動画を見る").closest("a");
@@ -55,7 +53,7 @@ describe("VideoCardActions", () => {
 	});
 
 	it("ログイン済み・作成可能ならボタン作成リンクを表示する", () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
 
 		const createLink = screen.getByText("ボタン作成").closest("a");
@@ -64,7 +62,7 @@ describe("VideoCardActions", () => {
 	});
 
 	it("未ログインならログイン導線を表示する（callbackUrl 付き）", () => {
-		(useSession as any).mockReturnValue(loggedOut);
+		mockUseSession(loggedOut);
 		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
 
 		const loginLink = screen.getByText("ログイン").closest("a");
@@ -76,7 +74,7 @@ describe("VideoCardActions", () => {
 	});
 
 	it("ログイン済みでも作成不可なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		const video = createMockVideo({
 			liveBroadcastContent: "live",
 			_computed: {
@@ -99,7 +97,7 @@ describe("VideoCardActions", () => {
 	});
 
 	it("埋め込み制限がある場合は理由として埋め込み制限を表示する", () => {
-		(useSession as any).mockReturnValue(loggedIn);
+		mockUseSession(loggedIn);
 		const video = createMockVideo({ status: { embeddable: false } });
 		render(<VideoCardActions video={video} variant="grid" />);
 

--- a/apps/web/src/app/videos/components/__tests__/video-card.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card.test.tsx
@@ -1,13 +1,11 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useSession } from "@/lib/auth/client";
+import { mockUseSession } from "@/test-utils/auth";
 import VideoCard from "../video-card";
 
 // モックの設定（認証ゲートは VideoCardActions client island が useSession を使う）
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/client");
 
 vi.mock("@/components/ui/thumbnail-image", () => ({
 	// biome-ignore lint/performance/noImgElement: モックコンポーネントでは<img>の使用を許可
@@ -69,7 +67,7 @@ function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 describe("VideoCard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		(useSession as any).mockReturnValue({ data: null });
+		mockUseSession(null);
 	});
 
 	it("動画の基本情報が表示される", () => {

--- a/apps/web/src/app/works/[workId]/__tests__/evaluation-actions.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/evaluation-actions.test.ts
@@ -7,9 +7,7 @@ import {
 } from "../evaluation-actions";
 
 // Mock dependencies
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: vi.fn(),
-}));
+vi.mock("@/lib/auth/server");
 
 vi.mock("@/lib/firestore", () => ({
 	getFirestore: vi.fn(),

--- a/apps/web/src/app/works/[workId]/components/__tests__/work-evaluation.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/work-evaluation.test.tsx
@@ -1,10 +1,11 @@
+import type { UserSession } from "@suzumina.click/shared-types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
+import { mockUseSession } from "@/test-utils/auth";
 import { WorkEvaluation } from "../work-evaluation";
 
 // useSession（認証抽象）をモック。session prop 付き素通しラッパーで値を切替える。
-const mockUseSession = vi.fn();
-vi.mock("@/lib/auth/client", () => ({ useSession: () => mockUseSession() }));
+vi.mock("@/lib/auth/client");
 
 // 旧 SessionProvider の置換: render 時に session prop から useSession の戻りを設定する。
 function SessionProvider({
@@ -12,9 +13,9 @@ function SessionProvider({
 	session,
 }: {
 	children: React.ReactNode;
-	session: { user?: unknown } | null;
+	session: { user?: Partial<UserSession> } | null;
 }) {
-	mockUseSession.mockReturnValue(session?.user ?? null);
+	mockUseSession(session?.user ?? null);
 	return <>{children}</>;
 }
 

--- a/apps/web/src/app/works/__tests__/page.test.tsx
+++ b/apps/web/src/app/works/__tests__/page.test.tsx
@@ -12,10 +12,8 @@ vi.mock("next/server", () => ({
 	headers: vi.fn(() => new Map()),
 }));
 
-// Mock 認証抽象
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: () => Promise.resolve(null),
-}));
+// Mock 認証抽象（既定は未ログイン）
+vi.mock("@/lib/auth/server");
 
 // Mock the server actions
 vi.mock("../actions", () => ({

--- a/apps/web/src/components/audio/__tests__/audio-button-card.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-card.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRouter } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
-import { useSession } from "@/lib/auth/client";
+import { mockUseSession } from "@/test-utils/auth";
 import AudioButtonCard from "../audio-button-card";
 
 // モックの設定
@@ -15,9 +15,7 @@ vi.mock("next/navigation", () => ({
 	useRouter: vi.fn(),
 }));
 
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/client");
 
 // lucide-reactアイコンのモック
 vi.mock("lucide-react", () => ({
@@ -128,7 +126,7 @@ describe("AudioButtonCard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		(useRouter as any).mockReturnValue(mockRouter);
-		(useSession as any).mockReturnValue(null);
+		mockUseSession(null);
 	});
 
 	it("音声ボタンの基本情報が表示される", () => {
@@ -234,7 +232,7 @@ describe("AudioButtonCard", () => {
 	});
 
 	it("ログインしている場合、アクションボタンが有効になる", () => {
-		(useSession as any).mockReturnValue({ id: "user123", name: "テストユーザー" });
+		mockUseSession({ discordId: "user123", displayName: "テストユーザー" });
 
 		const audioButton = createMockAudioButton();
 		render(<AudioButtonCard audioButton={audioButton} />);
@@ -245,7 +243,7 @@ describe("AudioButtonCard", () => {
 	});
 
 	it("お気に入りボタンのトグル状態が正しく表示される", () => {
-		(useSession as any).mockReturnValue({ id: "user123", name: "テストユーザー" });
+		mockUseSession({ discordId: "user123", displayName: "テストユーザー" });
 
 		const audioButton = createMockAudioButton();
 		const { rerender } = render(<AudioButtonCard audioButton={audioButton} isFavorited={false} />);
@@ -258,7 +256,7 @@ describe("AudioButtonCard", () => {
 
 	it("アクションボタンのコールバックが呼ばれる", async () => {
 		const user = userEvent.setup();
-		(useSession as any).mockReturnValue({ id: "user123", name: "テストユーザー" });
+		mockUseSession({ discordId: "user123", displayName: "テストユーザー" });
 
 		const handleFavorite = vi.fn();
 		const handleLike = vi.fn();

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockUseSession } from "@/test-utils/auth";
 import { AudioButtonCreator } from "../audio-button-creator";
 
 // Mock the actions
@@ -33,14 +34,8 @@ vi.mock("next/navigation", () => ({
 	}),
 }));
 
-// Mock 認証抽象
-vi.mock("@/lib/auth/client", () => ({
-	useSession: () => ({
-		discordId: "test-user-id",
-		username: "Test User",
-		displayName: "Test User",
-	}),
-}));
+// Mock 認証抽象（既定はログイン済み。beforeEach で設定）
+vi.mock("@/lib/auth/client");
 
 // Mock YouTubePlayer with player methods
 const mockYouTubePlayer = {
@@ -92,6 +87,7 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockUseSession({ discordId: "test-user-id", username: "Test User", displayName: "Test User" });
 		mockYouTubePlayer.seekTo.mockClear();
 		mockYouTubePlayer.playVideo.mockClear();
 		mockYouTubePlayer.pauseVideo.mockClear();

--- a/apps/web/src/components/audio/__tests__/audio-button-list.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-list.test.tsx
@@ -6,7 +6,7 @@ import {
 import { render, screen } from "@testing-library/react";
 import { useRouter } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
-import { useSession } from "@/lib/auth/client";
+import { mockUseSession } from "@/test-utils/auth";
 import { AudioButtonList } from "../audio-button-list";
 
 // モックの設定
@@ -14,9 +14,7 @@ vi.mock("next/navigation", () => ({
 	useRouter: vi.fn(),
 }));
 
-vi.mock("@/lib/auth/client", () => ({
-	useSession: vi.fn(),
-}));
+vi.mock("@/lib/auth/client");
 
 // lucide-reactアイコンのモック
 vi.mock("lucide-react", () => ({
@@ -95,7 +93,7 @@ describe("AudioButtonList", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		(useRouter as any).mockReturnValue(mockRouter);
-		(useSession as any).mockReturnValue(null);
+		mockUseSession(null);
 	});
 
 	it("音声ボタンリストが正しく表示される", () => {

--- a/apps/web/src/components/audio/__tests__/like-button.test.tsx
+++ b/apps/web/src/components/audio/__tests__/like-button.test.tsx
@@ -1,16 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockUseSession } from "@/test-utils/auth";
 import { LikeButton } from "../like-button";
 
 // 旧 SessionProvider の素通し置換（テストのラッパー用・session prop は無視）
 function SessionProvider({ children }: { children: React.ReactNode; session?: unknown }) {
 	return <>{children}</>;
 }
-// useSession は認証抽象から取得するためそちらをモックする
-const mockUseSession = vi.fn();
-vi.mock("@/lib/auth/client", () => ({
-	useSession: () => mockUseSession(),
-}));
+vi.mock("@/lib/auth/client");
 
 // Mock actions
 const mockToggleLikeAction = vi.fn();
@@ -50,7 +47,7 @@ describe("LikeButton", () => {
 	});
 
 	it("renders with initial like count", () => {
-		mockUseSession.mockReturnValue(null);
+		mockUseSession(null);
 
 		render(
 			<SessionProvider session={null}>
@@ -63,7 +60,7 @@ describe("LikeButton", () => {
 	});
 
 	it("disables button for unauthenticated users", () => {
-		mockUseSession.mockReturnValue(null);
+		mockUseSession(null);
 
 		render(
 			<SessionProvider session={null}>
@@ -82,7 +79,7 @@ describe("LikeButton", () => {
 			expires: "2024-01-01",
 		};
 
-		mockUseSession.mockReturnValue(mockSession.user);
+		mockUseSession(mockSession.user);
 
 		const mockStatusMap = new Map([["test-id", { isLiked: true, isDisliked: false }]]);
 		mockGetLikeDislikeStatusAction.mockResolvedValue(mockStatusMap);
@@ -104,7 +101,7 @@ describe("LikeButton", () => {
 			expires: "2024-01-01",
 		};
 
-		mockUseSession.mockReturnValue(mockSession.user);
+		mockUseSession(mockSession.user);
 
 		mockGetLikeDislikeStatusAction.mockResolvedValue(
 			new Map([["test-id", { isLiked: false, isDisliked: false }]]),
@@ -138,7 +135,7 @@ describe("LikeButton", () => {
 			expires: "2024-01-01",
 		};
 
-		mockUseSession.mockReturnValue(mockSession.user);
+		mockUseSession(mockSession.user);
 
 		mockGetLikeDislikeStatusAction.mockResolvedValue(
 			new Map([["test-id", { isLiked: false, isDisliked: false }]]),
@@ -172,7 +169,7 @@ describe("LikeButton", () => {
 			expires: "2024-01-01",
 		};
 
-		mockUseSession.mockReturnValue(mockSession.user);
+		mockUseSession(mockSession.user);
 
 		mockGetLikeDislikeStatusAction.mockResolvedValue(
 			new Map([["test-id", { isLiked: true, isDisliked: false }]]),
@@ -195,7 +192,7 @@ describe("LikeButton", () => {
 	});
 
 	it("displays like count in correct format", () => {
-		mockUseSession.mockReturnValue(null);
+		mockUseSession(null);
 
 		render(
 			<SessionProvider session={null}>

--- a/apps/web/src/components/layout/__tests__/site-header.test.tsx
+++ b/apps/web/src/components/layout/__tests__/site-header.test.tsx
@@ -35,10 +35,8 @@ vi.mock("next/link", () => ({
 	),
 }));
 
-// Mock 認証抽象
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: vi.fn(),
-}));
+// Mock 認証抽象（既定は未ログイン）
+vi.mock("@/lib/auth/server");
 
 // Mock AuthButton
 vi.mock("./AuthButton", () => ({

--- a/apps/web/src/components/system/__tests__/protected-route.test.tsx
+++ b/apps/web/src/components/system/__tests__/protected-route.test.tsx
@@ -1,11 +1,9 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getCurrentUser } from "@/lib/auth/server";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 import ProtectedRoute, { requireAuth } from "../protected-route";
 
-vi.mock("@/lib/auth/server", () => ({
-	getCurrentUser: vi.fn(),
-}));
+vi.mock("@/lib/auth/server");
 
 // next/headers の headers() を制御する
 const { headersStore } = vi.hoisted(() => ({
@@ -39,7 +37,7 @@ describe("ProtectedRoute", () => {
 	});
 
 	it("認証済み・アクティブ・権限十分なら children を描画する", async () => {
-		(getCurrentUser as any).mockResolvedValue(makeUser());
+		mockCurrentUser(makeUser());
 
 		const element = await ProtectedRoute({ children: <div>secret</div> });
 		const { getByText } = render(element);
@@ -49,7 +47,7 @@ describe("ProtectedRoute", () => {
 	});
 
 	it("未認証なら fallback へ x-url を callbackUrl 付きでリダイレクトする", async () => {
-		(getCurrentUser as any).mockResolvedValue(null);
+		mockCurrentUser(null);
 		headersStore.xUrl = "/works/RJ123456";
 
 		await expect(ProtectedRoute({ children: <div>secret</div> })).rejects.toThrow("REDIRECT:");
@@ -57,7 +55,7 @@ describe("ProtectedRoute", () => {
 	});
 
 	it("未認証かつ x-url ヘッダが無い場合は /buttons/create を callbackUrl に使う", async () => {
-		(getCurrentUser as any).mockResolvedValue(null);
+		mockCurrentUser(null);
 		headersStore.xUrl = null;
 
 		await expect(ProtectedRoute({ children: <div>x</div> })).rejects.toThrow("REDIRECT:");
@@ -65,7 +63,7 @@ describe("ProtectedRoute", () => {
 	});
 
 	it("fallbackUrl を指定するとその URL にリダイレクトする", async () => {
-		(getCurrentUser as any).mockResolvedValue(null);
+		mockCurrentUser(null);
 
 		await expect(ProtectedRoute({ children: <div>x</div>, fallbackUrl: "/login" })).rejects.toThrow(
 			"REDIRECT:",
@@ -74,7 +72,7 @@ describe("ProtectedRoute", () => {
 	});
 
 	it("非アクティブユーザーは AccessDenied にリダイレクトする", async () => {
-		(getCurrentUser as any).mockResolvedValue(makeUser({ isActive: false }));
+		mockCurrentUser(makeUser({ isActive: false }));
 
 		await expect(ProtectedRoute({ children: <div>x</div> })).rejects.toThrow("REDIRECT:");
 		expect(redirect).toHaveBeenCalledWith("/auth/error?error=AccessDenied");
@@ -88,21 +86,21 @@ describe("requireAuth", () => {
 
 	it("アクティブユーザーなら user を返す", async () => {
 		const user = makeUser();
-		(getCurrentUser as any).mockResolvedValue(user);
+		mockCurrentUser(user);
 
 		await expect(requireAuth()).resolves.toEqual(user);
 		expect(redirect).not.toHaveBeenCalled();
 	});
 
 	it("セッションが無ければ signin にリダイレクトする", async () => {
-		(getCurrentUser as any).mockResolvedValue(null);
+		mockCurrentUser(null);
 
 		await expect(requireAuth()).rejects.toThrow("REDIRECT:/auth/signin");
 		expect(redirect).toHaveBeenCalledWith("/auth/signin");
 	});
 
 	it("非アクティブユーザーは signin にリダイレクトする", async () => {
-		(getCurrentUser as any).mockResolvedValue(makeUser({ isActive: false }));
+		mockCurrentUser(makeUser({ isActive: false }));
 
 		await expect(requireAuth()).rejects.toThrow("REDIRECT:/auth/signin");
 		expect(redirect).toHaveBeenCalledWith("/auth/signin");

--- a/apps/web/src/lib/__tests__/server-action-wrapper.test.ts
+++ b/apps/web/src/lib/__tests__/server-action-wrapper.test.ts
@@ -1,14 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mockCurrentUser } from "@/test-utils/auth-server";
 import {
 	withAuthenticatedAction,
 	withErrorHandling,
 	withValidation,
 } from "../server-action-wrapper";
 
-vi.mock("@/lib/auth/server", () => ({ getCurrentUser: vi.fn() }));
+vi.mock("@/lib/auth/server");
 vi.mock("@/lib/logger", () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }));
-
-const getCurrentUser = vi.mocked(await import("@/lib/auth/server")).getCurrentUser;
 const opts = { action: "testAction", errorMessage: "失敗しました" };
 
 beforeEach(() => {
@@ -38,13 +37,13 @@ describe("withErrorHandling", () => {
 
 describe("withAuthenticatedAction", () => {
 	it("未認証は authErrorMessage（既定文言）", async () => {
-		getCurrentUser.mockResolvedValue(null as never);
+		mockCurrentUser(null);
 		const r = await withAuthenticatedAction(async () => "x", opts);
 		expect(r).toEqual({ success: false, error: "ログインが必要です" });
 	});
 
 	it("authErrorMessage 指定時はそれを使う", async () => {
-		getCurrentUser.mockResolvedValue(null as never);
+		mockCurrentUser(null);
 		const r = await withAuthenticatedAction(async () => "x", {
 			...opts,
 			authErrorMessage: "要ログイン",
@@ -54,13 +53,13 @@ describe("withAuthenticatedAction", () => {
 	});
 
 	it("認証済みは user を渡して実行", async () => {
-		getCurrentUser.mockResolvedValue({ discordId: "u1" } as never);
+		mockCurrentUser({ discordId: "u1" });
 		const r = await withAuthenticatedAction(async (user) => `hi ${user.discordId}`, opts);
 		expect(r).toEqual({ success: true, data: "hi u1" });
 	});
 
 	it("本処理の例外は catch する", async () => {
-		getCurrentUser.mockResolvedValue({ discordId: "u1" } as never);
+		mockCurrentUser({ discordId: "u1" });
 		const r = await withAuthenticatedAction(async () => {
 			throw new Error("boom");
 		}, opts);

--- a/apps/web/src/lib/auth/__mocks__/client.ts
+++ b/apps/web/src/lib/auth/__mocks__/client.ts
@@ -1,0 +1,9 @@
+/**
+ * `@/lib/auth/client` の手動 mock（Vitest）。
+ *
+ * テストは `vi.mock("@/lib/auth/client")` で本ファイルを使い、戻り値は
+ * `@/test-utils/auth` の `mockUseSession()` で設定する（プロバイダ非依存・SPR-168/170）。
+ */
+import { vi } from "vitest";
+
+export const useSession = vi.fn(() => null);

--- a/apps/web/src/lib/auth/__mocks__/server.ts
+++ b/apps/web/src/lib/auth/__mocks__/server.ts
@@ -1,0 +1,12 @@
+/**
+ * `@/lib/auth/server` の手動 mock（Vitest）。
+ *
+ * テストは `vi.mock("@/lib/auth/server")` で本ファイルを使い、戻り値は
+ * `@/test-utils/auth` の `mockCurrentUser()` で設定する。プロバイダ（better-auth）に
+ * 依存しない抽象 mock に統一することで、認証実装の差し替えでテストを触らずに済む（SPR-168/170）。
+ */
+import { vi } from "vitest";
+
+export const getCurrentUser = vi.fn(async () => null);
+export const signInWithDiscord = vi.fn(async () => {});
+export const signOutCurrent = vi.fn(async () => {});

--- a/apps/web/src/test-utils/auth-server.ts
+++ b/apps/web/src/test-utils/auth-server.ts
@@ -1,0 +1,15 @@
+/**
+ * サーバ認証 mock の共通ヘルパ（SPR-168/170）。
+ *
+ * テスト側で `vi.mock("@/lib/auth/server")`（bare）を宣言した上で、本ヘルパで戻り値を設定する。
+ * 認証抽象（`@/lib/auth/server`）だけを mock し、プロバイダ（better-auth）を直接 mock しないことで、
+ * 認証実装の差し替えでテストを触らずに済む。client 側は `@/test-utils/auth` を使う。
+ */
+import type { UserSession } from "@suzumina.click/shared-types";
+import { vi } from "vitest";
+import { getCurrentUser } from "@/lib/auth/server";
+
+/** サーバ認証抽象 `getCurrentUser()` の戻りを設定する（UserSession の部分形を許容）。 */
+export function mockCurrentUser(user: Partial<UserSession> | null): void {
+	vi.mocked(getCurrentUser).mockResolvedValue(user as UserSession | null);
+}

--- a/apps/web/src/test-utils/auth-server.ts
+++ b/apps/web/src/test-utils/auth-server.ts
@@ -2,6 +2,7 @@
  * サーバ認証 mock の共通ヘルパ（SPR-168/170）。
  *
  * テスト側で `vi.mock("@/lib/auth/server")`（bare）を宣言した上で、本ヘルパで戻り値を設定する。
+ * 宣言を忘れると getCurrentUser が mock 化されず `mockResolvedValue is not a function` で落ちる（silently wrong にはならない）。
  * 認証抽象（`@/lib/auth/server`）だけを mock し、プロバイダ（better-auth）を直接 mock しないことで、
  * 認証実装の差し替えでテストを触らずに済む。client 側は `@/test-utils/auth` を使う。
  */

--- a/apps/web/src/test-utils/auth.ts
+++ b/apps/web/src/test-utils/auth.ts
@@ -2,6 +2,7 @@
  * クライアント認証 mock の共通ヘルパ（SPR-168/170）。
  *
  * テスト側で `vi.mock("@/lib/auth/client")`（bare）を宣言した上で、本ヘルパで戻り値を設定する。
+ * 宣言を忘れると useSession が mock 化されず `mockReturnValue is not a function` で落ちる（silently wrong にはならない）。
  * 認証抽象（`@/lib/auth/client`）だけを mock し、プロバイダ（better-auth）を直接 mock しないことで、
  * 認証実装の差し替えでテストを触らずに済む。サーバ側は `@/test-utils/auth-server` を使う
  * （client.ts は "use client" で better-auth client を即時生成するため、node 環境テストへ巻き込まない）。

--- a/apps/web/src/test-utils/auth.ts
+++ b/apps/web/src/test-utils/auth.ts
@@ -1,0 +1,20 @@
+/**
+ * クライアント認証 mock の共通ヘルパ（SPR-168/170）。
+ *
+ * テスト側で `vi.mock("@/lib/auth/client")`（bare）を宣言した上で、本ヘルパで戻り値を設定する。
+ * 認証抽象（`@/lib/auth/client`）だけを mock し、プロバイダ（better-auth）を直接 mock しないことで、
+ * 認証実装の差し替えでテストを触らずに済む。サーバ側は `@/test-utils/auth-server` を使う
+ * （client.ts は "use client" で better-auth client を即時生成するため、node 環境テストへ巻き込まない）。
+ */
+import type { UserSession } from "@suzumina.click/shared-types";
+import { vi } from "vitest";
+import { useSession } from "@/lib/auth/client";
+
+// テストは UserSession の一部フィールド（discordId / displayName 等）だけを使うことが多いため、
+// 部分形を受け取り内部で UserSession として扱う（テストヘルパ内に cast を局所化）。
+type PartialUser = Partial<UserSession> | null;
+
+/** クライアント認証抽象 `useSession()` の戻りを設定する。 */
+export function mockUseSession(user: PartialUser): void {
+	vi.mocked(useSession).mockReturnValue(user as UserSession | null);
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
 				"**/*.config.{js,ts,mjs,cjs,mts,cts}",
 				"**/*.stories.{ts,tsx}",
 				"**/__tests__/**",
+				"**/__mocks__/**", // Vitest 手動 mock（テスト基盤・SPR-170）
+				"src/test-utils/**", // テスト共通ヘルパ（SPR-170）
 				"**/e2e/**",
 				"src/**/layout.tsx", // App Router boilerplate
 				// 認証フレームワークの glue（インスタンス生成 / クライアント / ルートハンドラ）はロジックを持たない（SPR-156）


### PR DESCRIPTION
## 概要

[SPR-170](https://linear.app/nothink/issue/SPR-170)（[SPR-168](https://linear.app/nothink/issue/SPR-168) High「抽象 mock の標準化」）。認証を mock する **24 テスト**を ad-hoc な `vi.mock` factory から共通の手動 mock + ヘルパへ統一する、テスト専用スイープ。次回の認証実装差し替えでテストを触らずに済む基盤にする。

レビュー容易性のため、cast 除去・lint 境界・設定ガード（#575）と CompatSession 解消・auth.ts 分割（#576）とは独立 PR に分離した最後のピース。

## 変更内容

### 共通 mock 基盤（新規）
- `src/lib/auth/__mocks__/server.ts` / `client.ts` — Vitest 手動 mock。テストは bare `vi.mock("@/lib/auth/server")` / `vi.mock("@/lib/auth/client")` で利用。
- `src/test-utils/auth.ts` → `mockUseSession(user)` / `src/test-utils/auth-server.ts` → `mockCurrentUser(user)`。
  - **client/server を分離**: `client.ts` は `"use client"` で better-auth client を即時生成するため、node 環境のサーバテストに巻き込まないよう別ファイルに。
  - `Partial<UserSession>` を受け取り cast をヘルパ内に局所化（各テストの `as never`/`as any` を撤去）。

### 24 テストの retarget（client 10 / server 14）
- すべて bare `vi.mock(...)` + 共通ヘルパ経由に。**ad-hoc な `vi.mock(..., () => ({...}))` factory はゼロ**（grep 確認）。
- 旧 NextAuth 由来の mock 形（`{ id, name }` / `{ data: { user } }`）を `UserSession` 実フィールドへ是正。
- プロバイダ（better-auth / `@/lib/better-auth/*`）の直接 mock は**元々ゼロ**（差し替え耐性は達成済み）。本 PR は DRY/一貫性の統一。

### coverage
- `__mocks__` / `test-utils` を coverage 除外に追加（テスト基盤のため計上対象外）。

## 受け入れ条件（SPR-170）
- ✅ 認証 mock テストが全て共通ヘルパ/手動 mock 経由（ad-hoc factory ゼロ）
- ✅ knip に新規の未使用なし（ヘルパ・手動 mock は使用認識／既存検出は pre-existing のみ）
- ✅ `pnpm verify` 緑（920 tests pass、カバレッジ閾値含む）

## Door 判定
✅ **Two-Way Door**（テストコードのみ・本番挙動の変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)