### PR TITLE
refactor(test): 形骸化した素通し SessionProvider ラッパーを撤去 (SPR-170 follow-up)

### DIFF
--- a/apps/web/src/components/audio/__tests__/featured-audio-buttons-carousel.test.tsx
+++ b/apps/web/src/components/audio/__tests__/featured-audio-buttons-carousel.test.tsx
@@ -4,11 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 import { UI_MESSAGES } from "@/constants/ui-messages";
 import { FeaturedAudioButtonsCarousel } from "../featured-audio-buttons-carousel";
 
-// 旧 SessionProvider の素通し置換（テストのラッパー用）
-function SessionProvider({ children }: { children: React.ReactNode; session?: unknown }) {
-	return <>{children}</>;
-}
-
 // AudioButtonWithPlayCount のモック
 vi.mock("../AudioButtonWithPlayCount", () => ({
 	AudioButtonWithPlayCount: ({ audioButton }: { audioButton: AudioButtonPlainObject }) => (
@@ -123,11 +118,7 @@ describe("FeaturedAudioButtonsCarousel", () => {
 	});
 
 	it("音声ボタンが空の場合にローディング状態を表示する", () => {
-		render(
-			<SessionProvider session={null}>
-				<FeaturedAudioButtonsCarousel audioButtons={[]} />
-			</SessionProvider>,
-		);
+		render(<FeaturedAudioButtonsCarousel audioButtons={[]} />);
 
 		expect(screen.getByText(UI_MESSAGES.LOADING.GENERAL)).toBeInTheDocument();
 		expect(screen.queryByTestId("audio-button-with-favorite")).not.toBeInTheDocument();
@@ -135,11 +126,7 @@ describe("FeaturedAudioButtonsCarousel", () => {
 
 	it("単一の音声ボタンも正しく表示される", () => {
 		const singleAudioButton = [mockAudioButtons[0]];
-		render(
-			<SessionProvider session={null}>
-				<FeaturedAudioButtonsCarousel audioButtons={singleAudioButton} />
-			</SessionProvider>,
-		);
+		render(<FeaturedAudioButtonsCarousel audioButtons={singleAudioButton} />);
 
 		expect(screen.getByTestId("audio-button-with-favorite")).toBeInTheDocument();
 		expect(screen.getByTestId("audio-button-title")).toHaveTextContent("テスト音声ボタン1");

--- a/apps/web/src/components/audio/__tests__/like-button.test.tsx
+++ b/apps/web/src/components/audio/__tests__/like-button.test.tsx
@@ -3,10 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockUseSession } from "@/test-utils/auth";
 import { LikeButton } from "../like-button";
 
-// 旧 SessionProvider の素通し置換（テストのラッパー用・session prop は無視）
-function SessionProvider({ children }: { children: React.ReactNode; session?: unknown }) {
-	return <>{children}</>;
-}
 vi.mock("@/lib/auth/client");
 
 // Mock actions
@@ -49,11 +45,7 @@ describe("LikeButton", () => {
 	it("renders with initial like count", () => {
 		mockUseSession(null);
 
-		render(
-			<SessionProvider session={null}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={5} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={5} />);
 
 		expect(screen.getByText("5")).toBeInTheDocument();
 		expect(screen.getByRole("button")).toBeInTheDocument();
@@ -62,11 +54,7 @@ describe("LikeButton", () => {
 	it("disables button for unauthenticated users", () => {
 		mockUseSession(null);
 
-		render(
-			<SessionProvider session={null}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={5} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={5} />);
 
 		const button = screen.getByRole("button");
 		expect(button).toBeDisabled();
@@ -84,11 +72,7 @@ describe("LikeButton", () => {
 		const mockStatusMap = new Map([["test-id", { isLiked: true, isDisliked: false }]]);
 		mockGetLikeDislikeStatusAction.mockResolvedValue(mockStatusMap);
 
-		render(
-			<SessionProvider session={mockSession}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={5} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={5} />);
 
 		await waitFor(() => {
 			expect(mockGetLikeDislikeStatusAction).toHaveBeenCalledWith(["test-id"]);
@@ -111,11 +95,7 @@ describe("LikeButton", () => {
 			isLiked: true,
 		});
 
-		render(
-			<SessionProvider session={mockSession}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={5} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={5} />);
 
 		const button = screen.getByRole("button");
 		fireEvent.click(button);
@@ -145,11 +125,7 @@ describe("LikeButton", () => {
 			error: "Network error",
 		});
 
-		render(
-			<SessionProvider session={mockSession}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={5} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={5} />);
 
 		const button = screen.getByRole("button");
 		fireEvent.click(button);
@@ -175,11 +151,7 @@ describe("LikeButton", () => {
 			new Map([["test-id", { isLiked: true, isDisliked: false }]]),
 		);
 
-		render(
-			<SessionProvider session={mockSession}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={5} initialIsLiked={true} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={5} initialIsLiked={true} />);
 
 		// Check if button has correct styling for liked state
 		const button = screen.getByRole("button");
@@ -194,11 +166,7 @@ describe("LikeButton", () => {
 	it("displays like count in correct format", () => {
 		mockUseSession(null);
 
-		render(
-			<SessionProvider session={null}>
-				<LikeButton audioButtonId="test-id" initialLikeCount={1234} />
-			</SessionProvider>,
-		);
+		render(<LikeButton audioButtonId="test-id" initialLikeCount={1234} />);
 
 		// Should format numbers with locale
 		expect(screen.getByText("1,234")).toBeInTheDocument();


### PR DESCRIPTION
## 概要

[SPR-170](https://linear.app/nothink/issue/SPR-170)（#577）の AI レビューで指摘された nit の対応。認証 mock を `mockUseSession` へ統一した結果、children をそのまま返すだけで `session` prop を使わない**素通しの `SessionProvider` ローカルラッパー**が形骸化していたため撤去する、テストのみの整理。

## 変更内容
- `like-button.test.tsx`: 素通し `SessionProvider` 定義 + 7 箇所のラッパーを撤去し `render(<LikeButton ... />)` に
- `featured-audio-buttons-carousel.test.tsx`: 素通し `SessionProvider` 定義 + 2 箇所を撤去（元々 `@/lib/auth/client` の mock 無し・一部 render は既に未ラップで挙動非依存）

## 据え置き
- `work-evaluation.test.tsx` の `SessionProvider` は `session` prop から `mockUseSession` を設定する**実機能**を持つため撤去せず残置（reviewer 指摘どおり）。

## 検証
- `pnpm verify` 緑（920 tests pass、カバレッジ閾値含む）
- 挙動変更なし（render の wrapper を外しただけ・auth 状態は従来どおり mockUseSession で制御）

## Door 判定
✅ **Two-Way Door**（テストコードのみ・本番挙動の変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)