### PR TITLE
fix(auth): signInWithDiscord が OAuth URL を返さない場合に明示エラー (SPR-167)

### DIFF
--- a/apps/web/src/lib/auth/__tests__/server.test.ts
+++ b/apps/web/src/lib/auth/__tests__/server.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+// server.ts は better-auth と next/navigation を動的 import する。境界（server.ts 自身）の
+// テストなので、ここではプロバイダ（@/lib/better-auth/auth）を mock してよい。
+const signInSocial = vi.fn();
+vi.mock("@/lib/better-auth/auth", () => ({ auth: { api: { signInSocial } } }));
+
+// redirect は実装上 throw して以降を止める。テストでも同じ挙動にする。
+const redirect = vi.fn((url: string) => {
+	throw new Error(`REDIRECT:${url}`);
+});
+vi.mock("next/navigation", () => ({ redirect }));
+
+import { signInWithDiscord } from "../server";
+
+describe("signInWithDiscord", () => {
+	it("OAuth URL が返ればその URL へ redirect する", async () => {
+		signInSocial.mockResolvedValue({ url: "https://discord.com/oauth" });
+
+		await expect(signInWithDiscord("/")).rejects.toThrow("REDIRECT:https://discord.com/oauth");
+		expect(redirect).toHaveBeenCalledWith("https://discord.com/oauth");
+	});
+
+	it("OAuth URL が無ければ明示的にエラーを投げる（無言 return しない）", async () => {
+		redirect.mockClear();
+		signInSocial.mockResolvedValue({ url: undefined });
+
+		await expect(signInWithDiscord("/")).rejects.toThrow(/OAuth URL/);
+		expect(redirect).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -21,6 +21,7 @@ export async function getCurrentUser(): Promise<UserSession | null> {
 
 /**
  * Discord でサインイン。成功時は OAuth へリダイレクトする（redirect は例外として送出される）。
+ * @throws OAuth URL が得られなかった場合（無言 return せず明示的にエラー化し、呼び出し側でログ/通知できるようにする）
  */
 export async function signInWithDiscord(callbackURL = "/"): Promise<void> {
 	const [{ auth }, { redirect }] = await Promise.all([
@@ -28,7 +29,10 @@ export async function signInWithDiscord(callbackURL = "/"): Promise<void> {
 		import("next/navigation"),
 	]);
 	const res = await auth.api.signInSocial({ body: { provider: "discord", callbackURL } });
-	if (res?.url) redirect(res.url);
+	if (!res?.url) {
+		throw new Error("Discord サインインの OAuth URL を取得できませんでした");
+	}
+	redirect(res.url);
 }
 
 /**


### PR DESCRIPTION
## 概要

[SPR-167](https://linear.app/nothink/issue/SPR-167)。`signInWithDiscord` で `res?.url` が falsy のとき、例外もリダイレクトも無く**無言 return** していたため、ユーザーがサインインページに留まり原因が分からなかった。防御的に明示エラー化する。

## 変更内容
- `apps/web/src/lib/auth/server.ts`: `if (res?.url) redirect(...)` → `if (!res?.url) throw ...; redirect(...)`。呼び出し側 `signInAction` は throw を catch してログ + 再送出するため、エラーが表面化する。
- `apps/web/src/lib/auth/__tests__/server.test.ts`（新規）: URL 返却→redirect 呼び出し / URL 不在→明示 throw・redirect 未呼び出し を検証。

## 補足
- better-auth の `signInSocial` は通常必ず URL を返すため実害は薄い（移行時 e2e でも確認済み）。本 PR は堅牢化。
- server.ts は認証抽象の境界そのもののため、テストでは例外的にプロバイダ（`@/lib/better-auth/auth`）を mock している（境界自身のテスト）。lint 境界（`noRestrictedImports`）は import 文が対象で `vi.mock` 文字列引数は対象外、かつ `src/lib/auth/**` は許可ディレクトリ。

## 検証
- `pnpm verify` 緑（923 tests pass、カバレッジ閾値含む）

## Door 判定
✅ **Two-Way Door**（サーバ認証の防御的エラー化 + テスト追加。正常系の挙動は不変）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)