### PR TITLE
chore(auth): NEXTAUTH 参照の履歴コメントを撤去し grep-zero 化 (SPR-166)

### DIFF
--- a/apps/web/src/app/api/auth/[...all]/route.ts
+++ b/apps/web/src/app/api/auth/[...all]/route.ts
@@ -2,7 +2,7 @@
  * better-auth の Next.js ハンドラ（SPR-158 Phase 3 / 本番唯一）
  *
  * `/api/auth/*` にマウント。Discord redirect URI は `<origin>/api/auth/callback/discord`
- * （NextAuth 撤去前から登録済みの URI をそのまま流用）。
+ * （移行前から登録済みの URI をそのまま流用）。
  */
 import { toNextJsHandler } from "better-auth/next-js";
 import { auth } from "@/lib/better-auth/auth";

--- a/apps/web/src/lib/better-auth/auth.ts
+++ b/apps/web/src/lib/better-auth/auth.ts
@@ -19,7 +19,7 @@ export const auth = betterAuth({
 	// env は BETTER_AUTH_*（Cloud Run が Secret Manager の BETTER_AUTH_SECRET から注入）。
 	secret: process.env.BETTER_AUTH_SECRET,
 	baseURL: process.env.BETTER_AUTH_URL,
-	// NextAuth 撤去後は標準の /api/auth を使用（Discord の既存 redirect URI をそのまま流用）。
+	// 標準の /api/auth にマウント（Discord の既存 redirect URI をそのまま流用）。
 	basePath: "/api/auth",
 	database: firestoreAdapter({ debugLogs: false }),
 

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -99,7 +99,7 @@ resource "google_cloud_run_v2_service" "nextjs_app" {
         value = "1"
       }
 
-      # better-auth のベース URL（SPR-158 で NextAuth から移行）
+      # better-auth のベース URL（SPR-158 で移行）
       # 注: env は lifecycle.ignore_changes 対象で、実値は GitHub Actions の gcloud deploy が管理する。
       env {
         name  = "BETTER_AUTH_URL"


### PR DESCRIPTION
## 概要

[SPR-166](https://linear.app/nothink/issue/SPR-166)（NEXTAUTH_* 安全網の撤去）。**機能的な撤去は [SPR-159](https://linear.app/nothink/issue/SPR-159) (#570) で完了済み**:
- `auth.ts` の `|| NEXTAUTH_*` フォールバック撤去 → 済（`secret/baseURL` は `BETTER_AUTH_*` のみ）
- Secret Manager の `NEXTAUTH_SECRET` → `BETTER_AUTH_SECRET` 正式リネーム → 済（terraform + 本番 apply 済み・同値で再ログイン不要だった）
- `.env.example` の `BETTER_AUTH_*` 化 → 済

残っていた非 docs の `nextauth` 参照は**履歴コメント3つのみ**だったため、受け入れ条件「`grep -ri nextauth` がヒットしない（docs 除く）」を満たすよう言い換え。

## 変更内容
- `app/api/auth/[...all]/route.ts` / `lib/better-auth/auth.ts`: コメントの「NextAuth 撤去前/後…」を「移行前/標準の…」に（意図は維持）
- `terraform/cloud_run.tf`: コメント「SPR-158 で NextAuth から移行」→「SPR-158 で移行」

## 検証
- `grep -ri nextauth`（docs/md/lock 除く）= **ゼロ**
- `pnpm verify` 緑 / `terraform fmt -check` clean

## terraform について
`cloud_run.tf` の変更は **HCL コメントのみ**でリソース定義に影響しません。マージで terraform-apply ゲートが起動しても **`terraform plan` は "No changes"**（コメントは state に無関係）。no-op を確認のうえ承認で問題ありません。

## Door 判定
✅ **Two-Way Door**（コメントのみ・挙動/インフラ変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)