### PR TITLE
fix(web): 403/404 エラー画面の扱いを統一（403 ページは設けない） (SPR-169)

### DIFF
--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -1,5 +1,15 @@
+import { Badge } from "@suzumina.click/ui/components/ui/badge";
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { Card, CardContent } from "@suzumina.click/ui/components/ui/card";
+import { AlertTriangle, Home, RotateCw } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
+
+export const metadata: Metadata = {
+	title: "エラー | すずみなくりっく！",
+	description: "認証中にエラーが発生しました。",
+};
 
 interface AuthErrorPageProps {
 	searchParams: Promise<{ error?: string }>;
@@ -24,6 +34,13 @@ function getErrorMessage(error: string | undefined): {
 					"このサイトは「すずみなふぁみりー」Discordサーバーのメンバー限定です。先にDiscordサーバーにご参加してからお試しください。",
 				showRetry: true,
 			};
+		case "AccountDisabled":
+			return {
+				title: "アカウントが無効です",
+				description:
+					"このアカウントは現在ご利用いただけません。心当たりがない場合はお問い合わせください。",
+				showRetry: false,
+			};
 		case "Verification":
 			return {
 				title: "認証エラー",
@@ -44,79 +61,72 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 	const errorInfo = getErrorMessage(error);
 
 	return (
-		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-red-50 to-pink-50">
-			<div className="max-w-md w-full space-y-8 p-8 bg-white rounded-xl shadow-lg text-center">
-				<div>
-					<div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-						<svg
-							className="w-8 h-8 text-red-600"
-							fill="none"
-							viewBox="0 0 24 24"
-							stroke="currentColor"
-						>
-							<title>エラー警告アイコン</title>
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								strokeWidth={2}
-								d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
-							/>
-						</svg>
+		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-suzuka-50 to-minase-50 px-4">
+			<Card className="max-w-md w-full shadow-xl animate-in fade-in-0 zoom-in-95 duration-500">
+				<CardContent className="p-8 text-center space-y-6">
+					{/* エラーアイコン */}
+					<div className="mx-auto w-16 h-16 bg-gradient-to-br from-suzuka-100 to-minase-100 rounded-full flex items-center justify-center">
+						<AlertTriangle className="w-8 h-8 text-suzuka-600" />
 					</div>
 
-					<h2 className="text-2xl font-bold text-gray-900 mb-2">{errorInfo.title}</h2>
+					{/* エラーメッセージ */}
+					<div className="space-y-2">
+						<h1 className="text-2xl font-bold text-foreground">{errorInfo.title}</h1>
+						<p className="text-muted-foreground">{errorInfo.description}</p>
+					</div>
 
-					<p className="text-gray-600 mb-6">{errorInfo.description}</p>
-				</div>
-
-				<div className="space-y-4">
-					{errorInfo.showRetry && (
-						<Link
-							href="/auth/signin"
-							className="w-full inline-flex items-center justify-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-3 px-4 rounded-lg transition-colors duration-200"
-						>
-							<svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-								<title>リトライアイコン</title>
-								<path
-									strokeLinecap="round"
-									strokeLinejoin="round"
-									strokeWidth={2}
-									d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-								/>
-							</svg>
-							再度ログインを試す
-						</Link>
+					{/* AccessDenied のみ: Discord サーバー案内 */}
+					{error === "AccessDenied" && (
+						<div className="p-4 bg-minase-50 border border-minase-200 rounded-lg text-left">
+							<p className="text-sm font-medium text-foreground mb-1">
+								すずみなふぁみりー Discord サーバーについて
+							</p>
+							<p className="text-sm text-muted-foreground">
+								涼花みなせさんのファンコミュニティサーバーです。参加方法は涼花みなせさんの配信やSNSでご確認ください。
+							</p>
+						</div>
 					)}
 
-					<Link
-						href="/"
-						className="w-full inline-flex items-center justify-center gap-2 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium py-3 px-4 rounded-lg transition-colors duration-200"
-					>
-						<svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-							<title>ホームアイコン</title>
-							<path
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								strokeWidth={2}
-								d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-							/>
-						</svg>
-						ホームに戻る
-					</Link>
-				</div>
+					{/* アクションボタン */}
+					<div className="space-y-3">
+						{errorInfo.showRetry && (
+							<Button asChild className="w-full group">
+								<Link href="/auth/signin" className="flex items-center gap-2">
+									<RotateCw className="h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
+									再度ログインを試す
+								</Link>
+							</Button>
+						)}
 
-				{error === "AccessDenied" && (
-					<div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-						<p className="text-blue-800 text-sm font-medium mb-2">
-							すずみなふぁみりーDiscordサーバーについて
-						</p>
-						<p className="text-blue-700 text-sm">
-							涼花みなせさんのファンコミュニティサーバーです。
-							参加方法については、涼花みなせさんの配信やSNSでご確認ください。
-						</p>
+						<Button variant="outline" asChild className="w-full group">
+							<Link href="/" className="flex items-center gap-2">
+								<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
+								ホームに戻る
+							</Link>
+						</Button>
 					</div>
-				)}
-			</div>
+
+					{/* 追加のヘルプ */}
+					<div className="space-y-2 pt-4 border-t">
+						<p className="text-sm text-muted-foreground">解決しない場合は</p>
+						<Button variant="link" size="sm" asChild>
+							<Link href="/contact">お問い合わせページ</Link>
+						</Button>
+					</div>
+
+					{/* 追加情報 */}
+					<div className="pt-4 border-t">
+						<div className="flex items-center justify-center gap-2">
+							<Badge variant="outline" className="text-xs">
+								涼花みなせ
+							</Badge>
+							<Badge variant="outline" className="text-xs">
+								非公式ファンサイト
+							</Badge>
+						</div>
+					</div>
+				</CardContent>
+			</Card>
 		</div>
 	);
 }
@@ -125,10 +135,10 @@ export default function AuthErrorPage({ searchParams }: AuthErrorPageProps) {
 	return (
 		<Suspense
 			fallback={
-				<div className="min-h-screen flex items-center justify-center">
+				<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-suzuka-50 to-minase-50">
 					<div className="text-center">
-						<div className="animate-spin rounded-full h-12 w-12 border-b-2 border-red-600 mx-auto" />
-						<p className="mt-4 text-gray-600">読み込み中...</p>
+						<div className="animate-spin rounded-full h-12 w-12 border-b-2 border-suzuka-600 mx-auto" />
+						<p className="mt-4 text-muted-foreground">読み込み中...</p>
 					</div>
 				</div>
 			}

--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -15,17 +15,21 @@ interface AuthErrorPageProps {
 	searchParams: Promise<{ error?: string }>;
 }
 
-function getErrorMessage(error: string | undefined): {
+interface ErrorInfo {
 	title: string;
 	description: string;
 	showRetry: boolean;
-} {
+	showDiscordInfo: boolean;
+}
+
+function getErrorMessage(error: string | undefined): ErrorInfo {
 	switch (error) {
 		case "Configuration":
 			return {
 				title: "設定エラー",
 				description: "認証設定に問題があります。管理者にお問い合わせください。",
 				showRetry: false,
+				showDiscordInfo: false,
 			};
 		case "AccessDenied":
 			return {
@@ -33,6 +37,7 @@ function getErrorMessage(error: string | undefined): {
 				description:
 					"このサイトは「すずみなふぁみりー」Discordサーバーのメンバー限定です。先にDiscordサーバーにご参加してからお試しください。",
 				showRetry: true,
+				showDiscordInfo: true,
 			};
 		case "AccountDisabled":
 			return {
@@ -40,18 +45,21 @@ function getErrorMessage(error: string | undefined): {
 				description:
 					"このアカウントは現在ご利用いただけません。心当たりがない場合はお問い合わせください。",
 				showRetry: false,
+				showDiscordInfo: false,
 			};
 		case "Verification":
 			return {
 				title: "認証エラー",
 				description: "認証プロセスでエラーが発生しました。時間をおいてから再度お試しください。",
 				showRetry: true,
+				showDiscordInfo: false,
 			};
 		default:
 			return {
 				title: "ログインエラー",
 				description: "ログイン中にエラーが発生しました。もう一度お試しください。",
 				showRetry: true,
+				showDiscordInfo: false,
 			};
 	}
 }
@@ -64,19 +72,16 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 		<div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-suzuka-50 to-minase-50 px-4">
 			<Card className="max-w-md w-full shadow-xl animate-in fade-in-0 zoom-in-95 duration-500">
 				<CardContent className="p-8 text-center space-y-6">
-					{/* エラーアイコン */}
 					<div className="mx-auto w-16 h-16 bg-gradient-to-br from-suzuka-100 to-minase-100 rounded-full flex items-center justify-center">
 						<AlertTriangle className="w-8 h-8 text-suzuka-600" />
 					</div>
 
-					{/* エラーメッセージ */}
 					<div className="space-y-2">
 						<h1 className="text-2xl font-bold text-foreground">{errorInfo.title}</h1>
 						<p className="text-muted-foreground">{errorInfo.description}</p>
 					</div>
 
-					{/* AccessDenied のみ: Discord サーバー案内 */}
-					{error === "AccessDenied" && (
+					{errorInfo.showDiscordInfo && (
 						<div className="p-4 bg-minase-50 border border-minase-200 rounded-lg text-left">
 							<p className="text-sm font-medium text-foreground mb-1">
 								すずみなふぁみりー Discord サーバーについて
@@ -87,7 +92,6 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 						</div>
 					)}
 
-					{/* アクションボタン */}
 					<div className="space-y-3">
 						{errorInfo.showRetry && (
 							<Button asChild className="w-full group">
@@ -106,7 +110,6 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 						</Button>
 					</div>
 
-					{/* 追加のヘルプ */}
 					<div className="space-y-2 pt-4 border-t">
 						<p className="text-sm text-muted-foreground">解決しない場合は</p>
 						<Button variant="link" size="sm" asChild>
@@ -114,7 +117,6 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 						</Button>
 					</div>
 
-					{/* 追加情報 */}
 					<div className="pt-4 border-t">
 						<div className="flex items-center justify-center gap-2">
 							<Badge variant="outline" className="text-xs">

--- a/apps/web/src/app/buttons/[id]/edit/page.tsx
+++ b/apps/web/src/app/buttons/[id]/edit/page.tsx
@@ -29,10 +29,11 @@ export default async function AudioButtonEditPage({ params }: AudioButtonEditPag
 		redirect(`/auth/signin?callbackUrl=${encodeURIComponent(`/buttons/${id}/edit`)}`);
 	}
 
-	// 権限チェック：作成者本人のみ編集可能
+	// 権限チェック：作成者本人のみ編集可能。非作成者には編集ルートを露出せず 404 を返す
+	// （作品自体は詳細ページで閲覧可能。「閲覧も不可」ではないため専用 403 は設けない）。
 	const canEdit = audioButton.creatorId === user.discordId;
 	if (!canEdit) {
-		redirect(`/buttons/${id}`);
+		notFound();
 	}
 
 	// 動画情報を取得して実際の動画長を取得

--- a/apps/web/src/components/system/__tests__/protected-route.test.tsx
+++ b/apps/web/src/components/system/__tests__/protected-route.test.tsx
@@ -99,10 +99,10 @@ describe("requireAuth", () => {
 		expect(redirect).toHaveBeenCalledWith("/auth/signin");
 	});
 
-	it("非アクティブユーザーは signin にリダイレクトする", async () => {
+	it("無効アカウントは AccountDisabled エラーページにリダイレクトする", async () => {
 		mockCurrentUser(makeUser({ isActive: false }));
 
-		await expect(requireAuth()).rejects.toThrow("REDIRECT:/auth/signin");
-		expect(redirect).toHaveBeenCalledWith("/auth/signin");
+		await expect(requireAuth()).rejects.toThrow("REDIRECT:");
+		expect(redirect).toHaveBeenCalledWith("/auth/error?error=AccountDisabled");
 	});
 });

--- a/apps/web/src/components/system/__tests__/protected-route.test.tsx
+++ b/apps/web/src/components/system/__tests__/protected-route.test.tsx
@@ -71,11 +71,11 @@ describe("ProtectedRoute", () => {
 		expect(redirect).toHaveBeenCalledWith("/login?callbackUrl=%2Fbuttons%2Fcreate");
 	});
 
-	it("非アクティブユーザーは AccessDenied にリダイレクトする", async () => {
+	it("無効アカウントは AccountDisabled エラーページにリダイレクトする", async () => {
 		mockCurrentUser(makeUser({ isActive: false }));
 
 		await expect(ProtectedRoute({ children: <div>x</div> })).rejects.toThrow("REDIRECT:");
-		expect(redirect).toHaveBeenCalledWith("/auth/error?error=AccessDenied");
+		expect(redirect).toHaveBeenCalledWith("/auth/error?error=AccountDisabled");
 	});
 });
 

--- a/apps/web/src/components/system/protected-route.tsx
+++ b/apps/web/src/components/system/protected-route.tsx
@@ -40,13 +40,18 @@ export default async function ProtectedRoute({
 }
 
 /**
- * 認証ステータスチェック用のユーティリティ関数
+ * Server Action 等で認証必須を担保するユーティリティ。誘導先は ProtectedRoute と統一。
+ * - 未認証: `/auth/signin` へ
+ * - 無効アカウント（`isActive=false`、防御的・通常到達せず）: `/auth/error?error=AccountDisabled` へ
  */
 export async function requireAuth(): Promise<UserSession> {
 	const user = await getCurrentUser();
 
-	if (!user?.isActive) {
+	if (!user) {
 		redirect("/auth/signin");
+	}
+	if (!user.isActive) {
+		redirect("/auth/error?error=AccountDisabled");
 	}
 
 	return user;

--- a/apps/web/src/components/system/protected-route.tsx
+++ b/apps/web/src/components/system/protected-route.tsx
@@ -10,9 +10,12 @@ interface ProtectedRouteProps {
 }
 
 /**
- * 認証が必要なページ用のコンポーネント
- * 未認証ユーザーはサインインページにリダイレクト
- * 非アクティブユーザーは403エラーページにリダイレクト
+ * 認証が必要なページ用のラッパー（Server Component）。
+ *
+ * - 未認証: サインインページへリダイレクト（元 URL を callbackUrl に付与）。
+ * - 認証済みだが無効アカウント（`isActive=false`）: 汎用エラーページ `/auth/error?error=AccountDisabled` へ。
+ *   無効化の手段が現状無いため通常は到達しない防御的ゲート。ロールベース認可も無いため
+ *   専用の 403 ページは設けず、到達時のみ汎用エラーページで理由を説明する方針（SPR-169）。
  */
 export default async function ProtectedRoute({
 	children,
@@ -28,9 +31,9 @@ export default async function ProtectedRoute({
 		redirect(`${fallbackUrl}?callbackUrl=${encodeURIComponent(currentUrl)}`);
 	}
 
-	// 非アクティブユーザーの場合
+	// 無効アカウントの場合（防御的・通常は到達しない）
 	if (!user.isActive) {
-		redirect("/auth/error?error=AccessDenied");
+		redirect("/auth/error?error=AccountDisabled");
 	}
 
 	return <>{children}</>;

--- a/docs/reference/application-architecture.md
+++ b/docs/reference/application-architecture.md
@@ -163,6 +163,22 @@ Firestore
 - サーバーサイドセッション管理
 - Guild所属による認可
 
+### エラーページ / アクセス制御の応答方針（SPR-169）
+ロールベース認可は廃止済み（admin/moderator なし。ユーザーは認証 + `isActive` のみで区別）。
+そのため「認証済みだが権限不足」の典型 403 シナリオが存在せず、**専用の 403 ページは設けない**。
+
+| 状況 | 応答 | 実装 |
+|---|---|---|
+| 未認証で要認証ページ | サインインへ誘導（callbackUrl 付き） | `ProtectedRoute` が `/auth/signin` へ redirect |
+| 認証済みだが無効アカウント（`isActive=false`、防御的・通常到達せず） | 汎用エラーページで理由を説明 | `/auth/error?error=AccountDisabled` |
+| 認証フロー上のエラー（OAuth 拒否・設定不備など） | 汎用エラーページ | `/auth/error?error=...`（AccessDenied / Configuration / Verification） |
+| リソース不在・閲覧者に出してはいけない非公開ルート（例: 他人の編集ページ） | 404 | `notFound()` → `not-found.tsx` |
+| 取得時の予期せぬ例外 | 500 相当 | 各 `error.tsx`（reset 付き） |
+
+- 専用の 403/`forbidden()`（Next の `authInterrupts` 実験 API）は採用しない（本番安定性優先・該当シナリオ不在）。
+- エラー画面のデザインは全て同一系統（`Card` + suzuka/minase グラデーション + lucide）。`/auth/error` も `not-found.tsx`・各 `error.tsx` に揃える。
+- 「閲覧は可能だが編集は不可」のような非作成者アクセスは 403 ではなく `notFound()`（編集ルートを露出しない／作品自体は詳細ページで閲覧可）。
+
 ### データ保護
 - Firestore Security Rules
 - Server Actions経由のデータアクセス


### PR DESCRIPTION
## 概要

[SPR-169](https://linear.app/nothink/issue/SPR-169)。「403 ページが必要か」をコードで検証した結果、**専用 403 ページは作らない**方針に。

### なぜ 403 ページを作らないか
- ロールベース認可は SPR-164 で廃止（admin/moderator 無し）→「認証済みだが権限不足」の典型 403 が存在しない。
- `isActive=false` にする書き込みコードが無い（ban/無効化ツールも無し）→ 非アクティブ拒否ゲートは**到達不能に近い防御的分岐**。
- 「403 相当」の実パスは2つだけで、いずれも 403 UI が最適でない:
  - 編集ページ非作成者 → 作品は閲覧可能なので 404（編集ルートを露出しない）が自然。
  - 非アクティブ → エッジ。汎用エラーページで「アカウント無効」を説明すれば十分。
- → 新規 403 ページは**ほぼ死にコード**を増やす（軸1）。Next の `forbidden()`（`authInterrupts` 実験 API）も本番安定性優先で不採用。

## 変更内容（現状の不整合・不正確さ・デザイン不統一の是正）
1. **`ProtectedRoute`**: JSDoc を実挙動に合わせて修正。無効アカウントの誘導先を `AccessDenied`（=「Discord メンバー限定」で**無効アカウントには誤誘導**）→ **`AccountDisabled`** に変更。
2. **編集ページ非作成者**: サイレント `redirect("/buttons/{id}")` → **`notFound()`**（編集ルートを leak しない・サイレント挙動を解消）。
3. **`auth/error` ページ**: 1つだけ別系統だったデザイン（red/pink・生 SVG・indigo）を、`not-found.tsx`・各 `error.tsx` と同じ系統（**Card + suzuka/minase + lucide**）に統一。`AccountDisabled` ケースを追加。
4. **docs**: `application-architecture.md` に **401/403/404/500 の応答方針**を明文化（403 を作らない理由含む）。
5. `protected-route` テストを `AccountDisabled` に追従。

## 受け入れ条件
- ✅ 401/403/404 の使い分け方針を docs 化
- ✅ サイレントリダイレクト解消（編集ページ → notFound）
- ✅ `ProtectedRoute` の JSDoc と実挙動の不一致を解消
- ✅ エラー画面のデザイン/文言/導線を統一（auth/error を他と同系統に）
- ✅ `pnpm verify` 緑

## 検証
- `pnpm verify` 緑
- dev で `/auth/error?error=AccountDisabled` / `?error=AccessDenied` を実機スクショ確認（新デザインで描画・retry 有無も意図どおり）

## Door 判定
✅ **Two-Way Door**（UI/表示・誘導の整理。認可ロジックの新規追加なし・本番挙動は等価〜改善）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)