### PR TITLE
perf(web): Firestore read 削減 — 一覧キャッシュ + セッションのリクエスト内メモ化 (SPR-161)

### DIFF
--- a/apps/web/src/app/circles/actions.ts
+++ b/apps/web/src/app/circles/actions.ts
@@ -2,19 +2,25 @@
 
 import type { CircleDocument, CirclePlainObject } from "@suzumina.click/shared-types";
 import { convertToCirclePlainObject } from "@suzumina.click/shared-types";
+import { unstable_cache } from "next/cache";
 import { getFirestore } from "@/lib/firestore";
 
 /**
- * サークル一覧を取得（ConfigurableList用）
- * @param params パラメータ
- * @returns サークル一覧と総件数
+ * /circles の Firestore 読み込みを 60s revalidate でキャッシュ（SPR-161）。
+ * 全 circles を読むため、未キャッシュだと表示ごとに全件 read していた。
+ * writes は 2h ごとの DLsite 同期と整合 cron のみで低頻度のため鮮度問題なし。
+ * params は unstable_cache が自動でキー化する。
  */
-export async function getCircles(params: {
+type GetCirclesParams = {
 	page?: number;
 	limit?: number;
 	sort?: string;
 	search?: string;
-}): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {
+};
+
+async function fetchCircles(
+	params: GetCirclesParams,
+): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {
 	const { page = 1, limit = 12, sort = "name", search } = params;
 
 	try {
@@ -76,4 +82,20 @@ export async function getCircles(params: {
 		// エラー発生時は空配列を返す
 		return { circles: [], totalCount: 0 };
 	}
+}
+
+const getCirclesCached = unstable_cache(fetchCircles, ["circles-list"], {
+	revalidate: 60,
+	tags: ["circles-list"],
+});
+
+/**
+ * サークル一覧を取得（ConfigurableList用）
+ * @param params パラメータ
+ * @returns サークル一覧と総件数
+ */
+export async function getCircles(
+	params: GetCirclesParams,
+): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {
+	return getCirclesCached(params);
 }

--- a/apps/web/src/app/circles/actions.ts
+++ b/apps/web/src/app/circles/actions.ts
@@ -5,12 +5,6 @@ import { convertToCirclePlainObject } from "@suzumina.click/shared-types";
 import { unstable_cache } from "next/cache";
 import { getFirestore } from "@/lib/firestore";
 
-/**
- * /circles の Firestore 読み込みを 60s revalidate でキャッシュ（SPR-161）。
- * 全 circles を読むため、未キャッシュだと表示ごとに全件 read していた。
- * writes は 2h ごとの DLsite 同期と整合 cron のみで低頻度のため鮮度問題なし。
- * params は unstable_cache が自動でキー化する。
- */
 type GetCirclesParams = {
 	page?: number;
 	limit?: number;
@@ -18,6 +12,11 @@ type GetCirclesParams = {
 	search?: string;
 };
 
+/**
+ * circles 全件を読み込む内部フェッチ。表示ごとの全件 read を避けるため下の `getCircles` で
+ * 60s revalidate キャッシュする（SPR-161）。writes は 2h DLsite 同期と整合 cron のみで低頻度の
+ * ため鮮度問題なし。params は unstable_cache が自動でキー化する。
+ */
 async function fetchCircles(
 	params: GetCirclesParams,
 ): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {

--- a/apps/web/src/app/works/__tests__/actions.test.ts
+++ b/apps/web/src/app/works/__tests__/actions.test.ts
@@ -27,6 +27,11 @@ vi.mock("@/lib/firestore", () => ({
 	}),
 }));
 
+// getPopularGenres が unstable_cache 経由になったため、Next ランタイム外ではパススルーにする。
+vi.mock("next/cache", () => ({
+	unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
 // Mock logger
 vi.mock("@/lib/logger", () => ({
 	info: vi.fn(),

--- a/apps/web/src/app/works/__tests__/genre-filter.test.ts
+++ b/apps/web/src/app/works/__tests__/genre-filter.test.ts
@@ -48,6 +48,11 @@ vi.mock("@/lib/firestore", () => ({
 	})),
 }));
 
+// getPopularGenres が unstable_cache 経由になったため、Next ランタイム外ではパススルーにする。
+vi.mock("next/cache", () => ({
+	unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
 vi.mock("@/lib/logger", () => ({
 	error: vi.fn(),
 	warn: vi.fn(),

--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -2,6 +2,7 @@
 
 import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
 import { workTransformers } from "@suzumina.click/shared-types";
+import { unstable_cache } from "next/cache";
 import { getFirestore } from "@/lib/firestore";
 import { withErrorHandling } from "@/lib/server-action-wrapper";
 
@@ -483,12 +484,9 @@ export async function getPopularVoiceActors(limit = 20): Promise<
 /**
  * 人気ジャンルリストを取得するServer Action
  */
-export async function getPopularGenres(limit = 30): Promise<
-	Array<{
-		genre: string;
-		count: number;
-	}>
-> {
+type PopularGenre = { genre: string; count: number };
+
+async function fetchPopularGenres(limit: number): Promise<PopularGenre[]> {
 	return withErrorHandling(
 		async () => {
 			const firestore = getFirestore();
@@ -521,12 +519,18 @@ export async function getPopularGenres(limit = 30): Promise<
 			errorMessage: "人気ジャンルの取得に失敗しました",
 			logContext: { limit },
 		},
-	).then((result) => {
-		if (result.success) {
-			return result.data;
-		}
-		return [];
-	});
+	).then((result) => (result.success ? result.data : []));
+}
+
+// 全 works を読むためコスト大。ジャンルは works 追加（2h DLsite 同期）時のみ変化する低頻度データのため
+// 10 分キャッシュで /works 表示ごとの全件 read を抑える（SPR-161）。
+const getPopularGenresCached = unstable_cache(fetchPopularGenres, ["popular-genres"], {
+	revalidate: 600,
+	tags: ["works-list"],
+});
+
+export async function getPopularGenres(limit = 30): Promise<PopularGenre[]> {
+	return getPopularGenresCached(limit);
 }
 
 /**

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -6,18 +6,21 @@
  * next/headers・better-auth を動的 import するため実質サーバ専用。
  */
 import type { UserSession } from "@suzumina.click/shared-types";
+import { cache } from "react";
 
 /**
  * 現在のログインユーザー（アプリの UserSession）を返す。未認証/無効ユーザーは null。
+ * React `cache()` でリクエスト内メモ化する（site-header + ページ等で複数回呼んでも
+ * better-auth の getSession＝Firestore read は 1 リクエスト 1 回に集約）（SPR-161）。
  */
-export async function getCurrentUser(): Promise<UserSession | null> {
+export const getCurrentUser = cache(async (): Promise<UserSession | null> => {
 	const [{ auth }, { headers }] = await Promise.all([
 		import("@/lib/better-auth/auth"),
 		import("next/headers"),
 	]);
 	const result = await auth.api.getSession({ headers: await headers() });
 	return result?.appUser ?? null;
-}
+});
 
 /**
  * Discord でサインイン。成功時は OAuth へリダイレクトする（redirect は例外として送出される）。


### PR DESCRIPTION
## 概要

[SPR-161](https://linear.app/nothink/issue/SPR-161)（Firestore read 13.4M/月の削減）。コード側で **未キャッシュの全件スキャン**と**リクエスト内のセッション重複 read** を特定し、**非正規化もインデックスも増やさない**（＝整合性 cron 負債・FAILED_PRECONDITION リスクを増やさない／軸1）安全な削減のみ実施。

## 特定した read 駆動（コードの事実）
- **`getCircles`**（`/circles`）: `collection("circles").get()` を**無キャッシュ**で実行。`page.tsx` と `circles-list.tsx` の両方が呼ぶため1表示で最大2回の全件 read。
- **`getPopularGenres`**（`/works`、works-list で使用）: `collection("works").get()` を**無キャッシュ**で全件 read。
- **`getCurrentUser`**: `site-header`（全ページの layout）＋各ページが呼ぶが **React `cache()` 無し** → ログイン時は1リクエストで複数回 `getSession`（=Firestore read）。

## 変更内容
| 対象 | 変更 | 効果 |
|---|---|---|
| `getCircles` | 既存パターンに沿って `unstable_cache`（60s）化 | /circles 表示ごとの全件 read を 60s に1回へ |
| `getPopularGenres` | `unstable_cache`（600s）化（ジャンルは 2h DLsite 同期時のみ変化） | /works 表示ごとの全件 read を 10分に1回へ |
| `getCurrentUser` | React `cache()` でリクエスト内メモ化 | ログイン時の getSession を 1リクエスト1回に集約 |

いずれも `videos`/`creators` で既に使われている `unstable_cache` パターンに準拠。テストには既存同様 `next/cache` パススルー mock を追加。

## スコープ外（別タスク化）
- **デッドな全件スキャン関数**（`getRelatedWorks`/`getWorkWithRelated`/`getWorksStats`/`getPopularVoiceActors`/`getDataQualityReport`）: 全件 read するが**呼び出し元が無く未描画（read 非駆動）**。撤去は別 PR。
- `/works` complex filter / DLsite cron の全件 read 削減: 複合インデックスや非正規化（One-Way Door）の設計判断が要るため分離。

## 計測について（受け入れ条件の補足）
本番 Monitoring（`firestore.googleapis.com/document/read_count`）の before/after 比較は本番アクセスが要るため**マージ後にご確認ください**。本 PR はコード側で全件 read の発火頻度を下げる確実な施策で、回帰はありません。

## 検証
- `pnpm verify` 緑（lint + typecheck + test、カバレッジ閾値含む）

## Door 判定
✅ **Two-Way Door**（キャッシュ/メモ化のみ・スキーマ/非正規化/インデックス変更なし・戻せる）。鮮度は 60s/600s で実害なし（writes は 2h 同期と低頻度 cron のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)