### PR TITLE
chore(web): 冗長な tailwind devDependencies を撤去（knip）

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -53,7 +53,6 @@
 		"@next/bundle-analyzer": "^16.2.7",
 		"@playwright/test": "^1.60.0",
 		"@suzumina.click/typescript-config": "workspace:*",
-		"@tailwindcss/postcss": "^4.3.0",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
 		"@testing-library/user-event": "^14.6.1",
@@ -66,7 +65,6 @@
 		"happy-dom": "^20.10.2",
 		"playwright": "^1.60.0",
 		"rimraf": "^6.1.3",
-		"tailwindcss": "^4.3.0",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.8"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,6 @@ importers:
       '@suzumina.click/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config
-      '@tailwindcss/postcss':
-        specifier: ^4.3.0
-        version: 4.3.0
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -198,9 +195,6 @@ importers:
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
-      tailwindcss:
-        specifier: ^4.3.0
-        version: 4.3.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## 概要
`knip --dependencies` が `apps/web` の未使用 devDependencies として検出した `tailwindcss` と `@tailwindcss/postcss` を撤去。

これらは web 自身からは一切参照されておらず、Tailwind の取り込みは **`@suzumina.click/ui` 経由**で完結している：
- [apps/web/postcss.config.mjs](apps/web/postcss.config.mjs) は `@suzumina.click/ui/postcss.config` を re-export するだけ（プラグイン本体 `@tailwindcss/postcss` は ui の devDep から解決）
- Tailwind 本体は [layout.tsx](apps/web/src/app/layout.tsx) で import する `@suzumina.click/ui/globals.css`（＝ui 内の `@import "tailwindcss"`）経由
- web には自前の `tailwind.config` も `@import "tailwindcss"` も存在しない

両者は `packages/ui` が自前で devDependencies に保持しているため、web 側の宣言は冗長。

## 検証
- 削除 → `pnpm install` で web の `node_modules` から両者のシンボリックリンクが消失（pnpm strict 解決で借用なしの状態）
- `pnpm --filter @suzumina.click/web build` **成功**。生成 CSS（132KB）に Tailwind ユーティリティ（`.flex` `.grid` `.rounded-lg` `.text-sm` `.bg-*` 等）が正しく含まれることを確認＝CSS が空に落ちていない
- `pnpm verify`（lint + typecheck + test 2750件）**green**

🤖 Generated with [Claude Code](https://claude.com/claude-code)