### PR TITLE
fix(ui): globals.css の死んでいる @source 行を撤去（#590 レビュー nit）

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,8 +1,9 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@source "../../../apps/**/*.{ts,tsx}";
-@source "../../../components/**/*.{ts,tsx}";
+/* ui は consumer から node_modules 経由（symlink）で読まれ、Tailwind v4 の自動コンテンツ
+   検出は node_modules を走査しないため、ここで自前のコンポーネントを明示的に source 登録する。
+   consumer 側（apps/web 等）のソースは各ビルドの cwd 起点で自動検出されるため指定不要。 */
 @source "../**/*.{ts,tsx}";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## 背景
#590 のレビューで指摘された nit（`packages/ui/src/styles/globals.css` の `@source` がディレクトリ構造に脆く結合している）を調査したところ、**単なる将来の脆さではなく現時点で既にパスが死んでいる**ことが判明したため別 PR で修正。

## 調査結果（ビルド実験で確定）
`@source` は **CSS ファイル相対**で解決される。globals.css は `packages/ui/src/styles/` にあるため：

| 行 | 記述 | 解決先 | 実態 |
|---|---|---|---|
| `../../../apps/**` | apps を拾うつもり | `packages/apps`（**不在**） | off-by-one（本来 `../../../../apps`）で死亡。apps はビルド cwd 起点の **Tailwind v4 自動検出**が拾うため、そもそも明示不要 |
| `../../../components/**` | — | `packages/components`（**不在**） | 完全に無意味 |
| `../**` | ui 自身 | `packages/ui/src` | **必須**（symlink 配下の ui コンポーネントは自動検出が届かない） |

apps/web の本番ビルドで生成 CSS を比較：
- 現状（壊れた @source）: 132504 bytes / 1228 セレクタ
- 行4を正しいパスに修正 or 行4,5削除: **完全に同一**（差分ゼロ）→ apps は自動検出で既にカバー済み
- 全 @source 削除: 76083 bytes / 851 セレクタ（**377 セレクタ消失**）→ `../**` のみが ui 由来クラスを担っている

## 変更
死んでいる2行を撤去し、必須の `../**` のみ残す。なぜ ui だけ明示登録が要るのか（node_modules symlink 経由で自動検出対象外）をコメントで明示。

## 検証
- apps/web 本番ビルドの生成 CSS が修正前ベースラインと**バイト単位で完全一致**（132504 bytes / 1228 セレクタ / 差分ゼロ）＝機能影響なし
- `pnpm verify`（lint + typecheck + test 2750件）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)