### PR TITLE
chore(ci): Node 20 アクションを最新メジャーへ更新（node24 化）(SPR-173)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,8 +30,8 @@ jobs:
     outputs:
       ui: ${{ steps.changes.outputs.ui }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -48,13 +48,13 @@ jobs:
     if: needs.changes.outputs.ui == 'true'
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           # TurboSnap は変更検出に git 履歴を使うため全履歴を取得する
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
     # fork からの PR では OAuth Secret を渡さない（漏洩防止）。draft は対象外。
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/dependency-update-check.yml
+++ b/.github/workflows/dependency-update-check.yml
@@ -19,10 +19,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -47,10 +47,10 @@ jobs:
     if: needs.check-pr-status.outputs.skip-checks == 'false'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -82,10 +82,10 @@ jobs:
     if: always() && !failure() && !cancelled()
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -57,10 +57,10 @@ jobs:
     if: needs.check-pr-status.outputs.skip-checks == 'false'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
       
@@ -108,7 +108,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       # Google Cloud authentication - 早期に実行
       - name: Authenticate to Google Cloud
@@ -128,7 +128,7 @@ jobs:
       
       # Set up Docker Buildx with advanced caching
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: |
             image=moby/buildkit:v0.23.2
@@ -136,7 +136,7 @@ jobs:
       
       # Build and push using docker/build-push-action for better performance
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/web/Dockerfile

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -25,8 +25,8 @@ jobs:
     outputs:
       ui_or_web: ${{ steps.changes.outputs.ui_or_web }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -52,10 +52,10 @@ jobs:
       NEXT_PUBLIC_GA_MEASUREMENT_ID: ""
       NEXT_PUBLIC_GTM_ID: ""
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: apps/web/playwright-report/

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/moderate.yml
+++ b/.github/workflows/moderate.yml
@@ -19,7 +19,7 @@ jobs:
     name: Moderate Content
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: github/ai-moderator@v1
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -35,10 +35,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Detect changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -87,10 +87,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
       
@@ -211,10 +211,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 
@@ -226,7 +226,7 @@ jobs:
 
       # gcloud 版 Firestore Emulator は JVM 上で動くため Java が必要（firebase CLI は使わない）
       - name: Setup Java (Firestore Emulator 用)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -258,10 +258,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
       
@@ -300,16 +300,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # push せず build のみ。cache の export は行わない
       # （GHA cache へのアップロードがジョブ時間の 60% を占めていたため）
       # cache は deploy-web.yml が registry に維持するため PR 側で書き戻す必要がない
       - name: Build web image (no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/web/Dockerfile
@@ -326,10 +326,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
       
@@ -353,10 +353,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,10 +26,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
@@ -73,7 +73,7 @@ jobs:
           cat audit-summary.md
       
       - name: Upload audit results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: dependency-audit-results
@@ -88,10 +88,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
       
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
@@ -138,7 +138,7 @@ jobs:
           fi
       
       - name: Upload container scan results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: container-scan-results
@@ -154,10 +154,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
@@ -192,7 +192,7 @@ jobs:
     
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: security-results
       
@@ -233,7 +233,7 @@ jobs:
           cat security-summary.md
       
       - name: Upload security summary
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: security-summary
           path: security-summary.md

--- a/.github/workflows/storybook-test.yml
+++ b/.github/workflows/storybook-test.yml
@@ -25,8 +25,8 @@ jobs:
     outputs:
       ui: ${{ steps.changes.outputs.ui }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -43,10 +43,10 @@ jobs:
     if: needs.changes.outputs.ui == 'true'
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -50,14 +50,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Authenticate (read-only plan SA)
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'terraform-plan-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.13.5'
           terraform_wrapper: false
@@ -81,7 +81,7 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload plan artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tfplan
           path: terraform/tfplan.bin
@@ -96,14 +96,14 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Authenticate (privileged apply SA / main 限定)
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
           service_account: 'terraform-apply-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.13.5'
           terraform_wrapper: false
@@ -112,7 +112,7 @@ jobs:
       - name: Select production workspace
         run: terraform workspace select production
       - name: Download plan artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tfplan
           path: terraform

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Authenticate to Google Cloud (read-only plan SA)
         uses: google-github-actions/auth@v3
@@ -60,7 +60,7 @@ jobs:
           service_account: 'terraform-plan-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: '1.13.5'
           terraform_wrapper: false


### PR DESCRIPTION
## 概要

GitHub Actions の Node.js 20 非推奨警告（`Node.js 20 actions are deprecated`）への対応。2026-06-16 から JS アクションが Node 24 強制、2026-09-16 に Node 20 がランナーから削除されるため、node20 ランタイムの全アクションと checkout を**最新メジャー**へ更新する。

各アクションの使用パラメータ互換性を全件確認済み（いずれも実質「node24 ランタイム化」で API 非互換なし）。

## 変更

| アクション | 更新 | 互換性確認 |
|---|---|---|
| `actions/checkout` | v5→**v6** | 変更は creds の別ファイル保存のみ（透過的）。`fetch-depth` 不変 |
| `pnpm/action-setup` | v4→**v6** | `packageManager: pnpm@11.3.0` 設定済 → `version:` 入力不要のまま動作 |
| `actions/upload-artifact` | v4,v5→**v7** | ESM化・`archive` は opt-in。name/path/retention 不変 |
| `actions/download-artifact` | v4,v6→**v8** | **hash 不一致が既定で error 化**（より安全）。zip 自動展開は維持 |
| `dorny/paths-filter` | v3→**v4** | node24化のみ。`filters` 不変 |
| `hashicorp/setup-terraform` | v3→**v4** | node24化のみ |
| `docker/setup-buildx-action` | v3→**v4** | `driver-opts` は v4.1.0 でも有効と確認 |
| `docker/build-push-action` | v6→**v7** | 削除された `DOCKER_BUILD_*` env は未使用と確認 |
| `actions/setup-java` | v4→**v5** | node24化のみ。distribution/java-version 不変 |

`setup-node@v6` / `google-*@v3` / `codeql-action@v4` / `chromatic@v17` 等は既に node24 のため据え置き。

## レビュー観点（One-Way Door: `.github/workflows`）

- `terraform-apply.yml` の upload(v7)/download(v8) ペアは両方同時更新済み（相互互換）。
- **`download-artifact@v8` の hash 不一致 error 化**は挙動変更のため、初回の `terraform-apply` / `security-scan` 実行でアーティファクト取得が通ることを要確認。

## 関連

- `github/ai-moderator` は最新 `v1.1.4` でも `node16` 宣言で、バージョン更新では警告を解消できないため本 PR の対象外。利用継続可否は SPR-173 で別途判断。
- GitHub 非推奨告知: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

🤖 Generated with [Claude Code](https://claude.com/claude-code)