### PR TITLE
chore(ci): trivy-action を @master から v0.36.0 に固定

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -107,7 +107,8 @@ jobs:
           docker build -f apps/web/Dockerfile -t suzumina-click:latest .
       
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # @master は未検証の最新 commit 追跡になるためタグ固定（Dependabot github-actions が自動更新する）
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'suzumina-click:latest'
           format: 'sarif'


### PR DESCRIPTION
## 概要
`security-scan.yml` の container-scan ジョブで `aquasecurity/trivy-action@master` が**バージョン未固定（unpinned action）**だったため、安定版タグ **v0.36.0**（2026-04-22 リリース）に固定する。

[#593](https://github.com/nothink-jp/suzumina.click/pull/593) の Claude レビューで指摘された nit の follow-up。

## なぜ
- `@master` は最新 commit を**無検証で追跡**する supply-chain リスク
- #593 で `dependabot.yml` に `github-actions` エコシステムの自動更新を追加したため、**タグ固定にすれば今後 Dependabot が自動で版上げ PR を出す**（`@master` のままだと自動更新対象に乗らない）

## 変更
```diff
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        # @master は未検証の最新 commit 追跡になるためタグ固定（Dependabot github-actions が自動更新する）
+        uses: aquasecurity/trivy-action@v0.36.0
```

- 最新安定タグは `gh api repos/aquasecurity/trivy-action/releases/latest` で確認（v0.36.0）。ref 表記も `v0.36.0` で存在を検証済み
- 他の workflow に `@master` / `@main` の未固定アクションは**なし**（grep 確認済み）

## レビュー観点（⚠️ One-Way Door: `.github/workflows` 変更）
- container-scan は push(main, deps変更時) / 週次 cron で発火。マージ後の次回スキャンで v0.36.0 が正しく動くか確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)