### PR TITLE
chore(ci): trivy の冗長な再スキャンを撤去し SARIF に一本化

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -122,9 +122,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
         continue-on-error: true
       
-      # 脆弱性の確認は SARIF(GitHub Security タブ)が正本。
-      # 旧「Generate Trivy summary」は同一イメージを aquasec/trivy:latest で再スキャンする
-      # 冗長ステップ（未固定イメージ・二重スキャン）だったため撤去した（SARIF に一本化）。
+      # 脆弱性確認の正本は SARIF（GitHub Security タブ）。旧ステップは同一イメージの再スキャン＋未固定イメージ（aquasec/trivy:latest）だったため撤去。
 
       - name: Upload container scan results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -122,22 +122,10 @@ jobs:
           sarif_file: 'trivy-results.sarif'
         continue-on-error: true
       
-      - name: Generate Trivy summary
-        run: |
-          echo "## Container Security Scan Results" > trivy-summary.md
-          echo "" >> trivy-summary.md
-          
-          # Run Trivy again for summary output
-          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-            aquasec/trivy:latest image --severity HIGH,CRITICAL --no-progress \
-            suzumina-click:latest > trivy-output.txt || true
-          
-          if [ -f trivy-output.txt ]; then
-            echo '```' >> trivy-summary.md
-            cat trivy-output.txt >> trivy-summary.md
-            echo '```' >> trivy-summary.md
-          fi
-      
+      # 脆弱性の確認は SARIF(GitHub Security タブ)が正本。
+      # 旧「Generate Trivy summary」は同一イメージを aquasec/trivy:latest で再スキャンする
+      # 冗長ステップ（未固定イメージ・二重スキャン）だったため撤去した（SARIF に一本化）。
+
       - name: Upload container scan results
         uses: actions/upload-artifact@v7
         if: always()
@@ -145,8 +133,6 @@ jobs:
           name: container-scan-results
           path: |
             trivy-results.sarif
-            trivy-summary.md
-            trivy-output.txt
           retention-days: 7
 
   secret-scan:
@@ -218,13 +204,10 @@ jobs:
             cat security-results/dependency-audit-results/audit-summary.md >> security-summary.md
             echo "" >> security-summary.md
           fi
-          
-          # Include container scan summary if available
-          if [ -f "security-results/container-scan-results/trivy-summary.md" ]; then
-            cat security-results/container-scan-results/trivy-summary.md >> security-summary.md
-            echo "" >> security-summary.md
-          fi
-          
+
+          # コンテナ脆弱性の詳細は SARIF(GitHub Security タブ)が正本。
+          # ステータスは上の「Container Scan」行で表示し、ここでは本文を二重掲載しない。
+
           echo "## Next Steps" >> security-summary.md
           echo "1. Review security alerts in the GitHub Security tab" >> security-summary.md
           echo "2. Update vulnerable dependencies" >> security-summary.md


### PR DESCRIPTION
## 概要
`security-scan.yml` の container-scan ジョブ「Generate Trivy summary」ステップが、直前の `trivy-action@v0.36.0` でスキャン済みの**同一イメージを再スキャン**していた。二重スキャン＋未固定イメージ（`aquasec/trivy:latest`）の二重の負債だったため撤去し、**SARIF（GitHub Security タブ）に一本化**する。

[#595](https://github.com/nothink-jp/suzumina.click/pull/595) のレビュー nit の follow-up（候補B＝再スキャン撤去を採用）。

## なぜ
1. **冗長な再スキャン**: 1回目の `trivy-action`（SARIF 生成→Security タブ）で既にスキャン済み。2回目は人間可読テキストを得るためだけに同一イメージを丸ごと再スキャンしジョブ時間を二重消費していた
2. **`aquasec/trivy:latest` が未固定**: インラインの `docker run` で `uses:` ではないため Dependabot github-actions エコシステムの追跡対象外。固定しても自動更新は乗らず stale 化する

## 変更
- 「Generate Trivy summary」ステップを削除（再スキャン廃止・未固定イメージ撤去）
- container-scan の artifact を `trivy-results.sarif` のみに（`trivy-summary.md` / `trivy-output.txt` を除去）
- security-summary から `trivy-summary.md` の二重掲載ブロックを撤去（ステータス行「Container Scan: <result>」は維持）

差分: **+8 / −25行**。脆弱性確認の正本は SARIF（GitHub Security タブ）。

## 挙動への影響
- ✅ SARIF→GitHub Security タブのアップロード（`Run Trivy vulnerability scanner` → `Upload Trivy scan results`）は**不変**
- ⚠️ 集約 `security-summary.md` から container 脆弱性の human-readable テーブルが消える（重複のため）。ステータス行と Security タブで確認する運用に集約
- コンテナスキャンが**1回**になりジョブ時間短縮

## レビュー観点（⚠️ One-Way Door: `.github/workflows` 変更）
- container-scan は push(main, deps変更時) / 週次 cron で発火。マージ後の次回実行で **Security タブへの SARIF アップロードが従来どおり機能すること**を確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)