### PR TITLE
chore(ci): Dependabot PR では Chromatic を skip

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -45,7 +45,9 @@ jobs:
     name: Visual regression (Chromatic)
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.ui == 'true'
+    # Dependabot run には Actions secrets（CHROMATIC_PROJECT_TOKEN）が注入されず必ず失敗するため除外する。
+    # 依存 bump は packages/ui の見た目に影響しない（lock 変更で発火するだけ）ので視覚回帰の対象外でよい。
+    if: needs.changes.outputs.ui == 'true' && github.actor != 'dependabot[bot]'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## 概要
Dependabot PR [#594](https://github.com/nothink-jp/suzumina.click/pull/594)（better-auth 1.6.15 bump）で Chromatic が **`✖ Missing project token`** で失敗していた。原因は Dependabot 由来の run には Actions secrets が注入されない GitHub の仕様で、`CHROMATIC_PROJECT_TOKEN` が空になるため。

## 原因
- 2021年9月以降、Dependabot がトリガーした workflow run は**制限コンテキスト**で動作し、`GITHUB_TOKEN` は read-only・**通常の Actions secrets は注入されない**（secret 窃取攻撃の防止）。利用するには別ストアの「Dependabot secrets」に登録が必要
- `chromatic.yml` の発火フィルタは `pnpm-lock.yaml` を含むため、**全依存 PR で Chromatic が起動** → token 無しで**必ず失敗**する構造

## 変更（候補B＝skip 方針）
chromatic ジョブに `github.actor != 'dependabot[bot]'` ガードを追加：
```yaml
    if: needs.changes.outputs.ui == 'true' && github.actor != 'dependabot[bot]'
```
- 依存 bump は `packages/ui` の Storybook 視覚に影響しない（lock 変更で発火するだけ）ため、視覚回帰の対象外でよい
- Chromatic 無料枠（snapshot）の節約にもなる
- secret を Dependabot 側に複製する運用負担・露出面の増加を回避

## トレードオフ
- 依存更新で UI の見た目を担保したい場合はカバーできない。その場合は代わりに Settings → Dependabot secrets に `CHROMATIC_PROJECT_TOKEN` を登録する（候補A）。今回は影響可能性が低いため skip を選択

## 確認
- YAML 構文検証済み
- ⚠️ One-Way Door（`.github/workflows`）: 最終マージは人がレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)