### PR TITLE
chore(deps): Dependabot に cooldown 2日を設定（pnpm minimumReleaseAge との衝突回避）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       time: "06:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
+    # pnpm 11 の minimumReleaseAge（公開後24時間はインストール拒否）と衝突しないよう、
+    # 公開から2日未満のバージョンは提案しない（#598 の全ジョブ install 失敗の再発防止）
+    cooldown:
+      default-days: 2
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"


### PR DESCRIPTION
## 背景

[#598](https://github.com/nothink-jp/suzumina.click/pull/598) で全 CI ジョブが `pnpm install` の段階で失敗した。原因は Dependabot が **公開6分後**の `next@16.2.9` を提案し、pnpm 11 の supply-chain policy（`minimumReleaseAge` 既定24時間）が `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` で install を拒否したため。

## 変更

npm エコシステムに [`cooldown`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown) を追加：

- `default-days: 2` — 公開から2日未満のバージョンは Dependabot が提案しない（pnpm の24時間ガードより長く取り、タイムゾーン/実行タイミングの境界も吸収）

これにより「リリース直後のパッケージを Dependabot が拾う → pnpm が弾く → 全ジョブ赤」という構造的な衝突が解消される。供給網攻撃直後の取り込み防止という pnpm 側ポリシーの意図にも沿う。

## #598 の扱い

#598 自体は `next@16.2.9` の公開から24時間経過後（2026-06-10 23:02 UTC 以降）に CI をリランすれば通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)