### PR TITLE
chore(biome): スキーマを 2.4.16 に更新し optional-chain を整形

### DIFF
--- a/apps/web/src/app/buttons/actions.ts
+++ b/apps/web/src/app/buttons/actions.ts
@@ -347,7 +347,7 @@ export async function getAudioButtonById(
 			}
 
 			const data = doc.data();
-			if (!data || !data.isPublic) {
+			if (!data?.isPublic) {
 				throw new Error("この音声ボタンは非公開です");
 			}
 

--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock conversion helper function
 const mockConvertToWorkPlainObject = (data: any) => {
-	if (!data || !data.id || !data.productId) return null;
+	if (!data?.id || !data.productId) return null;
 	return {
 		...data,
 		price: data.price || {
@@ -59,7 +59,7 @@ vi.mock("@suzumina.click/shared-types", () => ({
 		fromFirestore: vi.fn((data) => {
 			// Use the mock helper function to transform data
 			const mockConvertToWorkPlainObject = (data: any) => {
-				if (!data || !data.id || !data.productId) return null;
+				if (!data?.id || !data.productId) return null;
 				return {
 					...data,
 					price: data.price || {

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // convertToWorkPlainObjectのモック実装を別関数として定義
 const mockConvertToWorkPlainObject = (data: any) => {
-	if (!data || !data.id || !data.productId) return null;
+	if (!data?.id || !data.productId) return null;
 	const creators = data.creators || {};
 	const mapCreators = (arr: any[] = []) =>
 		arr.map((item: any) => ({ id: item.id, name: item.name }));
@@ -75,7 +75,7 @@ vi.mock("@suzumina.click/shared-types", () => ({
 		fromFirestore: vi.fn((data) => {
 			// Use the mock helper function to transform data
 			const mockConvertToWorkPlainObject = (data: any) => {
-				if (!data || !data.id || !data.productId) return null;
+				if (!data?.id || !data.productId) return null;
 				return {
 					...data,
 					price: data.price || { current: 0, currency: "JPY" },

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/packages/shared-types/src/value-objects/work/price.ts
+++ b/packages/shared-types/src/value-objects/work/price.ts
@@ -104,7 +104,7 @@ export class PriceValueObject
 			return { isValid: false, error: "Amount must be a non-negative integer" };
 		}
 
-		if (!data.currency || data.currency.length !== 3 || !/^[A-Z]{3}$/.test(data.currency)) {
+		if (data.currency?.length !== 3 || !/^[A-Z]{3}$/.test(data.currency)) {
 			return { isValid: false, error: "Currency must be a 3-letter uppercase ISO 4217 code" };
 		}
 


### PR DESCRIPTION
## 背景

root `biome.json` の `$schema`（2.3.13）が CLI `@biomejs/biome`（2.4.16）と版ズレしており、pre-commit / `biome migrate` で毎回 info 警告が出ていた（CLAUDE.md 軸1の「版ズレ＝負債」）。#600 のレビュー時に範囲外既知事項として確認したもの。

## 変更

### 1. スキーマ更新
- `$schema` 2.3.13 → 2.4.16（`biome migrate --write` が提案する差分はこの1行のみ）
- ※ `$schema` はエディタ検証用で実行時ルールには影響しない（`recommended:true` は元々 CLI 2.4.16 として解決済み）。版ズレ表示の解消が主目的。

### 2. ルール見直しの結論（新規ルールは不採用）
biome 2.4.0→2.4.16 の新規ルールは**全て `nursery`（実験的・semver 保証外）**。Biome の opinionated 姿勢（recommended を使い nursery に依存しない）を尊重し、当初検討した `useMathMinMax` / `noIdenticalTestTitle` / `useTestHooksInOrder` の採用は**見送り**。高価値な `useStringStartsEndsWith` 等は type-aware（`types` ドメイン要・best-effort）でこれも見送り。

### 3. ルール適用に伴うコード差分
`useOptionalChain` の安全な整形 4 件のみ:
- `!data || !data.isPublic` → `!data?.isPublic`（actions.ts / テスト2件）
- `!data.currency || data.currency.length !== 3` → `data.currency?.length !== 3`（price.ts、空文字・undefined ケースも等価を確認）

**意図的に適用しなかったもの**: `audio-player.tsx` の `useExhaustiveDependencies` unsafe-fix は、YouTube player pool の `useCallback`/`useEffect` 依存配列から `pool.*` を除去するもので、メモ化タイミング＝挙動を変えうるため不採用（`warn` のまま据え置き。軸1）。

## 確認
- `pnpm verify`（lint + typecheck + test）パス
- pre-commit の schema 版ズレ info 警告が解消

## 関連 follow-up（別 PR 予定）
biome 設定監査で判明した recommended ルールの降格・無効化（`noDangerouslySetInnerHtml` の全体 off、packages/ui の a11y off、`useExhaustiveDependencies`/`noArrayIndexKey` の warn 降格）の是正は別 PR で対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)