### PR TITLE
fix(biome): 無効化されていた recommended の security/a11y ルールを復帰

### DIFF
--- a/apps/web/src/app/works/[workId]/components/work-description.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-description.tsx
@@ -53,6 +53,7 @@ export default function WorkDescription({ description, title }: WorkDescriptionP
 				) : (
 					<div>
 						<div
+							// biome-ignore lint/security/noDangerouslySetInnerHtml: formatWorkDescription がユーザー入力を escapeHtml 済みで、注入されるタグは自前の信頼できるマークアップのみ
 							dangerouslySetInnerHTML={{ __html: formattedDescription }}
 							className="prose prose-sm max-w-none prose-gray [&_a]:text-primary [&_a]:no-underline [&_a]:hover:underline [&_strong]:text-gray-900 [&_ul]:my-2 [&_li]:my-1"
 						/>

--- a/apps/web/src/components/analytics/__tests__/google-tag-manager.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/google-tag-manager.test.tsx
@@ -6,6 +6,7 @@ import { GoogleTagManager, GoogleTagManagerNoscript } from "../google-tag-manage
 vi.mock("next/script", () => ({
 	default: ({ children, dangerouslySetInnerHTML, ...props }: any) => {
 		if (dangerouslySetInnerHTML) {
+			// biome-ignore lint/security/noDangerouslySetInnerHtml: next/script のモックで受け取った prop をそのまま透過するテスト専用コード
 			return <script {...props} dangerouslySetInnerHTML={dangerouslySetInnerHTML} />;
 		}
 		return <script {...props}>{children}</script>;

--- a/apps/web/src/components/analytics/google-analytics-script.tsx
+++ b/apps/web/src/components/analytics/google-analytics-script.tsx
@@ -27,6 +27,7 @@ export function GoogleAnalyticsScript() {
 			<Script
 				id="google-analytics"
 				strategy="lazyOnload"
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: env 由来の measurementId を埋め込む標準の GA ブートストラップ（ユーザー入力なし）
 				dangerouslySetInnerHTML={{
 					__html: `
 						window.dataLayer = window.dataLayer || [];

--- a/apps/web/src/components/analytics/google-tag-manager.tsx
+++ b/apps/web/src/components/analytics/google-tag-manager.tsx
@@ -21,6 +21,7 @@ export function GoogleTagManager() {
 			<Script
 				id="google-tag-manager"
 				strategy="lazyOnload"
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: env 由来の gtmId を埋め込む標準の GTM ブートストラップ（ユーザー入力なし）
 				dangerouslySetInnerHTML={{
 					__html: `
 						(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/biome.json
+++ b/biome.json
@@ -79,9 +79,6 @@
 			},
 			"complexity": {
 				"noExcessiveCognitiveComplexity": "error"
-			},
-			"security": {
-				"noDangerouslySetInnerHtml": "off"
 			}
 		}
 	},

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -12,12 +12,6 @@
 				"noConsole": "off",
 				"noArrayIndexKey": "off"
 			},
-			"a11y": {
-				"useButtonType": "off",
-				"useValidAnchor": "off",
-				"noLabelWithoutControl": "off",
-				"useSemanticElements": "off"
-			},
 			"correctness": {
 				"noUnusedFunctionParameters": "off"
 			},
@@ -60,6 +54,9 @@
 					},
 					"complexity": {
 						"noExcessiveCognitiveComplexity": "off"
+					},
+					"a11y": {
+						"useSemanticElements": "off"
 					}
 				}
 			}

--- a/packages/ui/src/components/custom/configurable-list/components/filter-panel.tsx
+++ b/packages/ui/src/components/custom/configurable-list/components/filter-panel.tsx
@@ -17,7 +17,7 @@ export function FilterPanel({ filters, values, onChange }: FilterPanelProps) {
 		<div className="space-y-4">
 			{Object.entries(filters).map(([key, config]) => (
 				<div key={key}>
-					<label className="text-sm font-medium">{config.label || key}</label>
+					<span className="text-sm font-medium">{config.label || key}</span>
 					{/* フィルタータイプに応じたコンポーネントを表示 */}
 					<div className="mt-1 text-muted-foreground text-xs">Filter type: {config.type}</div>
 				</div>

--- a/packages/ui/src/components/ui/carousel.tsx
+++ b/packages/ui/src/components/ui/carousel.tsx
@@ -114,6 +114,7 @@ function Carousel({
 				canScrollNext,
 			}}
 		>
+			{/* biome-ignore lint/a11y/useSemanticElements: aria-roledescription="carousel" を伴う shadcn/ui 標準パターン（div+role）。section 化は upstream と乖離するため踏襲 */}
 			<div
 				onKeyDownCapture={handleKeyDown}
 				className={cn("relative", className)}
@@ -145,6 +146,7 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
 	const { orientation } = useCarousel();
 
 	return (
+		// biome-ignore lint/a11y/useSemanticElements: aria-roledescription="slide" を伴う shadcn/ui 標準パターン（div+role）。踏襲して upstream との乖離を避ける
 		<div
 			role="group"
 			aria-roledescription="slide"


### PR DESCRIPTION
## 背景

#601 のレビュー時に行った biome 設定監査で、**Biome の opinionated 姿勢（recommended ルールを尊重する）に反して recommended ルールが全体無効化されている**箇所が判明した。その是正の第1弾（security / a11y）。

## 変更

### security（root biome.json）
`noDangerouslySetInnerHtml`（recommended・error）の**リポジトリ全体 off を撤去**。実使用は4箇所で、全体 off ではなく**スコープ化した `biome-ignore`** に置換（理由を明記）:
| 箇所 | 安全性の根拠 |
|---|---|
| `work-description.tsx` | `formatWorkDescription` がユーザー入力を `escapeHtml` 済みで、注入は自前の信頼タグのみ |
| `google-tag-manager.tsx` / `google-analytics-script.tsx` | env 由来 id を埋め込む標準ブートストラップ（ユーザー入力なし） |
| `__tests__/google-tag-manager.test.tsx` | `next/script` モックの prop 透過（テスト専用） |

### a11y（packages/ui biome.json）
4つの recommended a11y ルールの off を撤去し、違反は個別に是正:
| ルール | 対応 |
|---|---|
| `useButtonType` / `useValidAnchor` | 違反0＝不要な off だったため**そのまま復帰** |
| `noLabelWithoutControl` | stub の `filter-panel.tsx` で制御要素を持たない `<label>` を `<span>` に修正（意味的にも正しい） |
| `useSemanticElements` | テストの `role` 付き div は **test override に集約**して off。vendored carousel（shadcn/ui の `div+role+aria-roledescription` 標準パターン）は upstream 乖離を避け `biome-ignore` でスコープ抑制 |

## 本 PR で扱わないもの（別フェーズ）
correctness の warn 降格（`useExhaustiveDependencies` / `noArrayIndexKey`、ui の `noUnusedFunctionParameters: off`）は、error 昇格に伴う違反修正のリスク評価が必要（特に `useExhaustiveDependencies` は player pool の依存配列改変を強制し挙動を変えうる）。本 PR では据え置き、別 PR で段階対応する。

## 確認
- `pnpm verify`（lint + typecheck + test）パス
- `--only` を使わない実 lint で security / a11y とも違反0（config override・suppression が有効）

🤖 Generated with [Claude Code](https://claude.com/claude-code)