### PR TITLE
fix(biome): noArrayIndexKey の ui 全体無効化を撤去し warn に統一

### DIFF
--- a/apps/web/src/app/works/[workId]/components/sample-image-gallery.tsx
+++ b/apps/web/src/app/works/[workId]/components/sample-image-gallery.tsx
@@ -188,7 +188,7 @@ export default function SampleImageGallery({ sampleImages, workTitle }: SampleIm
 			<CardContent>
 				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
 					{sampleImages.map((image, index) => (
-						<Dialog key={`sample-${index}-${image.thumb.slice(-10)}`}>
+						<Dialog key={image.thumb}>
 							<DialogTrigger asChild>
 								<button
 									type="button"

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -9,8 +9,7 @@
 		"rules": {
 			"suspicious": {
 				"noExplicitAny": "error",
-				"noConsole": "off",
-				"noArrayIndexKey": "off"
+				"noConsole": "off"
 			},
 			"complexity": {
 				"noExcessiveCognitiveComplexity": "error"


### PR DESCRIPTION
## 背景

biome 設定監査（#601）で判明した recommended ルール降格の是正、Tier1 **Phase 2b**（#603 から分離）。`noArrayIndexKey` は root が `warn`、**packages/ui が `off`（＝違反15件が完全に隠蔽）**という不整合だった。

## 方針（consistent warn）

`noArrayIndexKey` は本リポジトリでは index 利用が大半正当（16件中15件）。`error` 昇格は過剰な `biome-ignore` を招くため、**ui の `off` を撤去して root の `warn` に統一**し、隠れていた違反を可視化（非ブロッキング）する方針を採用。

| 区分 | 件数 | 対応 |
|---|---|---|
| 一意キーで実修正可能 | 1 | `sample-image-gallery`: `sample-${index}-${thumb.slice(-10)}` → `image.thumb`（一意 URL） |
| 正当な index 利用（warn 据え置き） | 15 | loading skeleton ×5 / slider thumb（値と位置が1:1）/ highlight-text のテキスト分割 ×2 / タグの `${content}-${index}` 合成キー（重複時の tiebreaker）×6 |

## 変更
- `packages/ui/biome.json`: `noArrayIndexKey: "off"` を撤去（root の warn を継承）
- `sample-image-gallery.tsx`: key を一意な `image.thumb` に

## 確認
- `pnpm verify` パス（warn は非ブロッキング）
- web の該当違反 0、ui は 15 件が warn として可視化（従来は off で隠蔽）

## 残（別タスク）
firestore-adapter.ts の `noExcessiveCognitiveComplexity`（park 中）は One-Way Door のため別途方針判断のうえ対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)