### PR TITLE
refactor(better-auth): firestore-adapter の複雑度を分解し park を撤去

### DIFF
--- a/apps/web/src/lib/better-auth/__tests__/firestore-adapter.test.ts
+++ b/apps/web/src/lib/better-auth/__tests__/firestore-adapter.test.ts
@@ -140,6 +140,25 @@ describe("firestore-adapter pure helpers", () => {
 			);
 			expect(evalClause(rec, { ...w("name", ["ALICE"], "in"), mode: "insensitive" })).toBe(true);
 		});
+		it("insensitive: ne / contains / ends_with / not_in", () => {
+			expect(evalClause(rec, { ...w("name", "ALICE", "ne"), mode: "insensitive" })).toBe(false);
+			expect(evalClause(rec, { ...w("name", "LIC", "contains"), mode: "insensitive" })).toBe(true);
+			expect(evalClause(rec, { ...w("name", "CE", "ends_with"), mode: "insensitive" })).toBe(true);
+			expect(evalClause(rec, { ...w("name", ["BOB"], "not_in"), mode: "insensitive" })).toBe(true);
+			expect(evalClause(rec, { ...w("name", ["ALICE"], "not_in"), mode: "insensitive" })).toBe(
+				false,
+			);
+		});
+		it("数値比較で value が null なら false", () => {
+			expect(evalClause(rec, w("age", null, "gt"))).toBe(false);
+			expect(evalClause(rec, w("age", null, "lte"))).toBe(false);
+		});
+		it("contains 系は非文字列 recordVal で false（sensitive）", () => {
+			// rec.age=30(number) に対する文字列演算は型ガードで false
+			expect(evalClause(rec, w("age", "3", "contains"))).toBe(false);
+			expect(evalClause(rec, w("age", "3", "starts_with"))).toBe(false);
+			expect(evalClause(rec, w("age", "0", "ends_with"))).toBe(false);
+		});
 	});
 
 	describe("matchesWhere", () => {
@@ -183,6 +202,34 @@ describe("firestore-adapter pure helpers", () => {
 		it("sortBy 無しはそのまま", () => {
 			const rows = [{ n: 2 }, { n: 1 }];
 			expect(applySort(rows)).toBe(rows);
+		});
+		it("boolean を扱える（false<true）", () => {
+			const rows = [{ b: true }, { b: false }, { b: true }];
+			expect(applySort(rows, { field: "b", direction: "asc" }).map((r) => r.b)).toEqual([
+				false,
+				true,
+				true,
+			]);
+			expect(applySort(rows, { field: "b", direction: "desc" }).map((r) => r.b)).toEqual([
+				true,
+				true,
+				false,
+			]);
+		});
+		it("both null は順序維持（cmp 0）", () => {
+			const rows = [
+				{ x: null, id: 1 },
+				{ x: null, id: 2 },
+			];
+			expect(applySort(rows, { field: "x", direction: "asc" }).map((r) => r.id)).toEqual([1, 2]);
+		});
+		it("型混在は String 比較にフォールバック", () => {
+			const rows = [{ v: 2 }, { v: "10" }];
+			// String(2)="2", String("10")="10" → "10" < "2"
+			expect(applySort(rows, { field: "v", direction: "asc" }).map((r) => String(r.v))).toEqual([
+				"10",
+				"2",
+			]);
 		});
 	});
 

--- a/apps/web/src/lib/better-auth/firestore-adapter.ts
+++ b/apps/web/src/lib/better-auth/firestore-adapter.ts
@@ -161,7 +161,12 @@ function compareBoolean(a: boolean, b: boolean): number {
 	return a ? 1 : -1;
 }
 
-/** null/undefined を含む比較。両者が非 null なら null を返し、型別比較へ委譲する */
+/**
+ * null/undefined を含む比較。
+ * both-null → 0、av のみ null → -1（先頭）、bv のみ null → 1。
+ * 両者が非 null のときだけ null を返し、型別比較（compareTyped）へ委譲する。
+ * （戻り 0 は falsy だが `??` は素通りするため、null 委譲とは区別される）
+ */
 function compareNullable(av: unknown, bv: unknown): number | null {
 	if (av == null && bv == null) return 0;
 	if (av == null) return -1;

--- a/apps/web/src/lib/better-auth/firestore-adapter.ts
+++ b/apps/web/src/lib/better-auth/firestore-adapter.ts
@@ -75,6 +75,56 @@ function lower(v: unknown): string {
 	return typeof v === "string" ? v.toLowerCase() : "";
 }
 
+/** in/not_in は配列必須。memory-adapter と同じく非配列はエラー */
+function requireArray(value: AdapterWhere["value"], op: "in" | "not_in"): unknown[] {
+	if (!Array.isArray(value)) throw new Error(`${op} 演算子の value は配列である必要があります`);
+	return value;
+}
+
+type ClauseHandler = (
+	recordVal: unknown,
+	value: AdapterWhere["value"],
+	insensitive: boolean,
+) => boolean;
+
+/**
+ * 演算子ごとの評価ロジック（memory-adapter の評価規則に対応）。
+ * 1 演算子 = 1 ハンドラに分解し、evalClause の複雑度を抑える。挙動は switch 版と等価。
+ */
+const CLAUSE_HANDLERS: Record<WhereOperator, ClauseHandler> = {
+	in: (recordVal, value, insensitive) => {
+		const arr = requireArray(value, "in");
+		return insensitive ? arr.some((v) => lower(recordVal) === lower(v)) : arr.includes(recordVal);
+	},
+	not_in: (recordVal, value, insensitive) => {
+		const arr = requireArray(value, "not_in");
+		return insensitive ? !arr.some((v) => lower(recordVal) === lower(v)) : !arr.includes(recordVal);
+	},
+	contains: (recordVal, value, insensitive) =>
+		insensitive
+			? lower(recordVal).includes(lower(value))
+			: typeof recordVal === "string" && recordVal.includes(value as string),
+	starts_with: (recordVal, value, insensitive) =>
+		insensitive
+			? lower(recordVal).startsWith(lower(value))
+			: typeof recordVal === "string" && recordVal.startsWith(value as string),
+	ends_with: (recordVal, value, insensitive) =>
+		insensitive
+			? lower(recordVal).endsWith(lower(value))
+			: typeof recordVal === "string" && recordVal.endsWith(value as string),
+	ne: (recordVal, value, insensitive) =>
+		insensitive ? lower(recordVal) !== lower(value) : recordVal !== value,
+	gt: (recordVal, value) => value != null && (recordVal as number) > (value as number),
+	gte: (recordVal, value) => value != null && (recordVal as number) >= (value as number),
+	lt: (recordVal, value) => value != null && (recordVal as number) < (value as number),
+	lte: (recordVal, value) => value != null && (recordVal as number) <= (value as number),
+	eq: (recordVal, value, insensitive) => {
+		if (insensitive) return lower(recordVal) === lower(value);
+		if (value === null) return recordVal == null;
+		return recordVal === value;
+	},
+};
+
 /** 単一 where 条件の評価（memory-adapter と同じ規則） */
 export function evalClause(record: Row, clause: AdapterWhere): boolean {
 	const { field, value, operator } = clause;
@@ -83,46 +133,9 @@ export function evalClause(record: Row, clause: AdapterWhere): boolean {
 		clause.mode === "insensitive" &&
 		(typeof value === "string" ||
 			(Array.isArray(value) && value.every((v) => typeof v === "string")));
-
-	switch (operator) {
-		case "in":
-			if (!Array.isArray(value)) throw new Error("in 演算子の value は配列である必要があります");
-			return insensitive
-				? value.some((v) => lower(recordVal) === lower(v))
-				: (value as unknown[]).includes(recordVal);
-		case "not_in":
-			if (!Array.isArray(value))
-				throw new Error("not_in 演算子の value は配列である必要があります");
-			return insensitive
-				? !value.some((v) => lower(recordVal) === lower(v))
-				: !(value as unknown[]).includes(recordVal);
-		case "contains":
-			return insensitive
-				? lower(recordVal).includes(lower(value))
-				: typeof recordVal === "string" && recordVal.includes(value as string);
-		case "starts_with":
-			return insensitive
-				? lower(recordVal).startsWith(lower(value))
-				: typeof recordVal === "string" && recordVal.startsWith(value as string);
-		case "ends_with":
-			return insensitive
-				? lower(recordVal).endsWith(lower(value))
-				: typeof recordVal === "string" && recordVal.endsWith(value as string);
-		case "ne":
-			return insensitive ? lower(recordVal) !== lower(value) : recordVal !== value;
-		case "gt":
-			return value != null && (recordVal as number) > (value as number);
-		case "gte":
-			return value != null && (recordVal as number) >= (value as number);
-		case "lt":
-			return value != null && (recordVal as number) < (value as number);
-		case "lte":
-			return value != null && (recordVal as number) <= (value as number);
-		default:
-			if (insensitive) return lower(recordVal) === lower(value);
-			if (value === null) return recordVal == null;
-			return recordVal === value;
-	}
+	// 未知の演算子は switch 版の default と同じく eq 相当で評価
+	const handler = CLAUSE_HANDLERS[operator] ?? CLAUSE_HANDLERS.eq;
+	return handler(recordVal, value, insensitive);
 }
 
 /** where 配列の畳み込み（先頭を起点に各 clause を connector で結合：memory-adapter 準拠） */
@@ -142,6 +155,34 @@ export function matchesWhere(record: Row, where?: AdapterWhere[]): boolean {
 	return result;
 }
 
+/** boolean 比較（false < true） */
+function compareBoolean(a: boolean, b: boolean): number {
+	if (a === b) return 0;
+	return a ? 1 : -1;
+}
+
+/** null/undefined を含む比較。両者が非 null なら null を返し、型別比較へ委譲する */
+function compareNullable(av: unknown, bv: unknown): number | null {
+	if (av == null && bv == null) return 0;
+	if (av == null) return -1;
+	if (bv == null) return 1;
+	return null;
+}
+
+/** 同型優先の比較（string/Date/number/boolean、それ以外は文字列化して比較） */
+function compareTyped(av: unknown, bv: unknown): number {
+	if (typeof av === "string" && typeof bv === "string") return av.localeCompare(bv);
+	if (av instanceof Date && bv instanceof Date) return av.getTime() - bv.getTime();
+	if (typeof av === "number" && typeof bv === "number") return av - bv;
+	if (typeof av === "boolean" && typeof bv === "boolean") return compareBoolean(av, bv);
+	return String(av).localeCompare(String(bv));
+}
+
+/** 2 値比較（null 優先 → 型別）。旧 applySort の if/else 連鎖と等価 */
+function compareValues(av: unknown, bv: unknown): number {
+	return compareNullable(av, bv) ?? compareTyped(av, bv);
+}
+
 /** sortBy をメモリ上で適用 */
 export function applySort(
 	records: Row[],
@@ -150,18 +191,7 @@ export function applySort(
 	if (!sortBy) return records;
 	const { field, direction } = sortBy;
 	return [...records].sort((a, b) => {
-		const av = a[field];
-		const bv = b[field];
-		let cmp = 0;
-		if (av == null && bv == null) cmp = 0;
-		else if (av == null) cmp = -1;
-		else if (bv == null) cmp = 1;
-		else if (typeof av === "string" && typeof bv === "string") cmp = av.localeCompare(bv);
-		else if (av instanceof Date && bv instanceof Date) cmp = av.getTime() - bv.getTime();
-		else if (typeof av === "number" && typeof bv === "number") cmp = av - bv;
-		else if (typeof av === "boolean" && typeof bv === "boolean")
-			cmp = av === bv ? 0 : av ? 1 : -1;
-		else cmp = String(av).localeCompare(String(bv));
+		const cmp = compareValues(a[field], b[field]);
 		return direction === "asc" ? cmp : -cmp;
 	});
 }

--- a/biome.json
+++ b/biome.json
@@ -19,7 +19,6 @@
 			"!!**/dist",
 			"!!**/.next",
 			"!!apps/functions/lib",
-			"!!**/lib/better-auth/firestore-adapter.ts",
 			"!!**/storybook-static",
 			"!!**/coverage",
 			"!!**/build",


### PR DESCRIPTION
## 背景

セッション最初の #600 で、`apps/web/src/lib/better-auth/firestore-adapter.ts` の `noExcessiveCognitiveComplexity` 違反（`evalClause` 31 / `applySort` のコンパレータ 28、max 15）を一時 park（biome 除外）していた。その解消。方針は **refactor（複雑度を下げる）** を選択。

> ⚠️ **One-Way Door**（better-auth アダプタ＝認証のフィルタ/ソート挙動）。挙動の完全等価を最優先。

## 変更

### `evalClause`: switch → ディスパッチテーブル
巨大 `switch (operator)` を「演算子 → ハンドラ関数」の `CLAUSE_HANDLERS` テーブルに分解。1 演算子 = 1 小関数で複雑度を局所化。`in`/`not_in` の配列ガードは `requireArray` に集約。未知演算子は旧 `default` と同じく eq 相当（`?? CLAUSE_HANDLERS.eq`）。

### `applySort`: if/else 連鎖 → 小関数合成
インラインコンパレータの if/else を `compareNullable`（null 優先）/ `compareTyped`（型別）/ `compareBoolean` に分解し `compareValues` に集約。`compareNullable` は両者非 null で `null` を返し型別比較へ委譲（`0` は `??` を素通りするため等価）。

## 等価性の担保（One-Way Door）
1. **refactor 前**に全分岐を覆うテストを追加し、**旧実装で 35/35 green**（挙動を固定）
2. refactor 後も **35/35 green**

追加した分岐テスト: insensitive の `ne`/`contains`/`ends_with`/`not_in`、数値比較の `value=null`、文字列演算の非文字列 `recordVal`、boolean ソート、both-null、型混在の String フォールバック。

## 確認
- `pnpm verify`（lint + typecheck + test）パス
- `biome check firestore-adapter.ts` 複雑度クリア（park 撤去後も lint 対象として green）
- biome 除外行 `"!!**/lib/better-auth/firestore-adapter.ts"` を撤去

🤖 Generated with [Claude Code](https://claude.com/claude-code)