### PR TITLE
chore(biome): 既定値の冗長な再宣言を root 設定から除去（Tier2 スリム化）

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -35,19 +35,12 @@
 	},
 	"formatter": {
 		"enabled": true,
-		"indentStyle": "tab",
-		"indentWidth": 2,
-		"lineEnding": "lf",
 		"lineWidth": 100
 	},
 	"linter": {
 		"enabled": true,
 		"rules": {
 			"recommended": true,
-			"correctness": {
-				"noNodejsModules": "off",
-				"noUnusedPrivateClassMembers": "warn"
-			},
 			"suspicious": {
 				"noConsole": "warn",
 				"noExplicitAny": "error",
@@ -59,8 +52,6 @@
 					"level": "error",
 					"options": { "filenameCases": ["kebab-case"], "requireAscii": true }
 				},
-				"noDefaultExport": "off",
-				"noNonNullAssertion": "warn",
 				"noParameterAssign": "error",
 				"useAsConstAssertion": "error",
 				"useDefaultParameterLast": "error",
@@ -81,22 +72,12 @@
 		}
 	},
 	"javascript": {
-		"formatter": {
-			"quoteStyle": "double",
-			"jsxQuoteStyle": "double",
-			"trailingCommas": "all",
-			"semicolons": "always",
-			"arrowParentheses": "always"
-		},
 		"globals": ["vi", "process", "global", "globalThis", "Buffer", "console"]
 	},
 	"json": {
 		"parser": {
 			"allowComments": true,
 			"allowTrailingCommas": true
-		},
-		"formatter": {
-			"trailingCommas": "none"
 		}
 	},
 	"overrides": [


### PR DESCRIPTION
## 背景

biome 設定監査の **Tier2「冗長な既定値の再宣言」**。root `biome.json` が Biome 2.4.16 の既定値をそのまま再宣言していた箇所を削除し、**非既定の設定だけを残す**（opinionated/最小設定・CLAUDE.md 軸2 の予測可能性）。

## 除去（いずれも Biome 既定と一致）

| 区分 | 除去項目 |
|---|---|
| formatter | `indentStyle=tab` / `indentWidth=2` / `lineEnding=lf` |
| javascript.formatter | `quoteStyle` / `jsxQuoteStyle` / `trailingCommas` / `semicolons` / `arrowParentheses`（ブロックごと） |
| json.formatter | `trailingCommas=none`（ブロックごと） |
| rules | `noNonNullAssertion`(rec+既定warn) / `noUnusedPrivateClassMembers`(rec+既定warn) / `noDefaultExport`(非rec=既定off) / `noNodejsModules`(非rec=既定off) |

## 残置（既定でない＝意味がある）
`lineWidth=100`、各 `enabled` フラグ、`globals`、`json.parser`、`noExplicitAny=error`（rec既定 warn からの**昇格**）、`noConsole`/`noSkippedTests`/`noDelete`（opt-in 有効化）、`noArrayIndexKey=warn`（#604 の意図的降格）、各 `style:error`（opt-in 厳格化）。

## 等価性の実証（記憶でなく実測）
- **formatter**: 全パッケージで `biome format --write` 実行 → **ソース変更0**（biome.json のみ変更）＝除去した整形オプションは全て既定で挙動不変
- **rules**: 除去前後で lint 診断が**完全一致**（`noArrayIndexKey×15` / `noExplicitAny×4`）＝挙動不変
- `pnpm verify` パス
- 将来 Biome の既定が変わっても `biome check`（CI の lint）が「要再整形」として検知するため、サイレントな挙動変化にはならない（version pin + dependabot cooldown）

## 関連（未着手・任意）
per-package 設定（ui/shared-types/functions）が root の `style:error` 群を重複宣言している点、および `noDefaultExport: off` の override が dead になっている点は別の冗長性。本 PR のスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)