### PR TITLE
chore(biome): per-package 設定から root 継承分の重複を除去

### DIFF
--- a/apps/functions/biome.json
+++ b/apps/functions/biome.json
@@ -3,26 +3,8 @@
 	"root": false,
 	"linter": {
 		"rules": {
-			"suspicious": {
-				"noConsole": "warn"
-			},
 			"correctness": {
 				"noNodejsModules": "off"
-			},
-			"performance": {
-				"noDelete": "warn"
-			},
-			"style": {
-				"noParameterAssign": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noInferrableTypes": "error",
-				"noUselessElse": "error"
 			}
 		}
 	},
@@ -58,9 +40,6 @@
 			"includes": ["**/*.config.js", "**/*.config.ts"],
 			"linter": {
 				"rules": {
-					"style": {
-						"noDefaultExport": "off"
-					},
 					"suspicious": {
 						"noExplicitAny": "off"
 					}
@@ -68,14 +47,7 @@
 			}
 		},
 		{
-			"includes": [
-				"**/coverage/**",
-				"**/dist/**",
-				"**/build/**",
-				"**/.turbo/**",
-				"**/.cache/**",
-				"**/tools/firestore-local/fixtures/**"
-			],
+			"includes": ["**/tools/firestore-local/fixtures/**"],
 			"linter": {
 				"enabled": false
 			},

--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -3,29 +3,9 @@
 	"root": false,
 	"overrides": [
 		{
-			"includes": [
-				"src/app/**/page.tsx",
-				"src/app/**/layout.tsx",
-				"src/app/**/loading.tsx",
-				"src/app/**/error.tsx",
-				"src/app/**/not-found.tsx",
-				"src/app/**/route.ts"
-			],
-			"linter": {
-				"rules": {
-					"style": {
-						"noDefaultExport": "off"
-					}
-				}
-			}
-		},
-		{
 			"includes": ["**/*.config.js", "**/*.config.ts", "**/*.config.mjs"],
 			"linter": {
 				"rules": {
-					"style": {
-						"noDefaultExport": "off"
-					},
 					"suspicious": {
 						"noExplicitAny": "off"
 					}
@@ -63,16 +43,6 @@
 	"linter": {
 		"rules": {
 			"style": {
-				"noParameterAssign": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noInferrableTypes": "error",
-				"noUselessElse": "error",
 				"noRestrictedImports": {
 					"level": "error",
 					"options": {
@@ -88,12 +58,6 @@
 						}
 					}
 				}
-			},
-			"complexity": {
-				"noExcessiveCognitiveComplexity": "error"
-			},
-			"suspicious": {
-				"noExplicitAny": "error"
 			}
 		}
 	}

--- a/packages/shared-types/biome.json
+++ b/packages/shared-types/biome.json
@@ -3,21 +3,6 @@
 	"root": false,
 	"linter": {
 		"rules": {
-			"suspicious": {
-				"noExplicitAny": "error"
-			},
-			"style": {
-				"noInferrableTypes": "error",
-				"useAsConstAssertion": "error",
-				"noParameterAssign": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noUselessElse": "error"
-			},
 			"correctness": {
 				"noUnusedVariables": "error"
 			}

--- a/packages/ui/biome.json
+++ b/packages/ui/biome.json
@@ -8,23 +8,7 @@
 	"linter": {
 		"rules": {
 			"suspicious": {
-				"noExplicitAny": "error",
 				"noConsole": "off"
-			},
-			"complexity": {
-				"noExcessiveCognitiveComplexity": "error"
-			},
-			"style": {
-				"noParameterAssign": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noInferrableTypes": "error",
-				"noUselessElse": "error"
 			}
 		}
 	},


### PR DESCRIPTION
## 背景

per-package 設定（`extends: "//"`）が root のルールを大量に再宣言していた。Biome の extends は `linter.rules` を **deep-merge** する（root と同名キーは package 値が上書き、未宣言キーは root から継承）。よって **root と同値の再宣言は no-op**。各 package には「root と異なる固有の逸脱」だけを残し、95 行を削減。

## 各 package の override 一覧と理由（＝調査結果）

### apps/web
| 設定 | 区分 | 理由 |
|---|---|---|
| `noRestrictedImports`（better-auth* / @/lib/better-auth* を禁止）| **意図** | SPR-168 の認証抽象境界。実装は `@/lib/auth/*` 経由で使う |
| auth 実装（`src/lib/auth/**` 等）で `noRestrictedImports: off` | **意図** | 境界の内側（実装本体）は直 import が必要 |
| `*.config.*` で `noExplicitAny: off` | **意図** | 設定ファイルは any を許容 |
| test で any/console/non-null/delete off | **意図** | テスト緩和 |
| ~~style 10ルール / noExplicitAny / complexity の再宣言~~ | 除去 | root と同値 |
| ~~pages/config の `noDefaultExport: off`~~ | 除去 | noDefaultExport は非rec＝既定 off で **dead**（no-op）|

### apps/functions
| 設定 | 区分 | 理由 |
|---|---|---|
| `noNodejsModules: off` | **意図** | 唯一の Node 実行環境パッケージ（built-in を使う）|
| `utils/logger.ts` で `noConsole: off` | **意図** | logger は console を使う |
| `src/development/**` で complexity/console/unused 緩和 | **意図** | 開発ツール |
| `data-integrity-check.ts` / `video-mapper.ts` で complexity off | **意図** | 受容済みの複雑度 |
| test / `*.config.*` 緩和 | **意図** | 同上 |
| fixtures を lint/format 除外 | **意図** | 投入用 JSON |
| ~~noConsole=warn / noDelete=warn / style 10ルールの再宣言~~ | 除去 | root と同値 |
| ~~生成物 override の dist/coverage/build/.turbo/.cache~~ | 除去 | root `files.includes` で既に除外済み（fixtures のみ残置）|
| ~~config の `noDefaultExport: off`~~ | 除去 | dead |

### packages/ui
| 設定 | 区分 | 理由 |
|---|---|---|
| `files`（maxSize 1MB / ignoreUnknown）| **意図** | package 固有のファイル設定 |
| `noConsole: off` | **意図** | root の warn と異なる（UI ライブラリ）|
| `*.stories.tsx` で linter off | **意図** | Storybook |
| test 群で any/complexity/useSemanticElements off | **意図** | テスト＋role 付きフィクスチャ（#602）|
| ~~noExplicitAny / complexity / style 10ルールの再宣言~~ | 除去 | root と同値 |

### packages/shared-types
| 設定 | 区分 | 理由 |
|---|---|---|
| `noUnusedVariables: error` | **意図** | recommended 既定 warn からの**昇格**（型定義の未使用を厳格に）|
| test で any/non-null off | **意図** | テスト緩和 |
| ~~noExplicitAny / style 10ルールの再宣言~~ | 除去 | root と同値 |

## 等価性の実証（記憶でなく実測）
- 4 package とも **before/after の lint 診断が完全一致**
- 削除した継承ルール（`useSelfClosingElements` / `noExplicitAny` / `noInferrableTypes`）が各 package で**今も発火**することを実ファイル注入で確認（deep-merge 継承の能動検証。0-violation 盲点を排除）
- `pnpm verify` パス

## 補足
`noDefaultExport` は現状どこでも off（非 recommended）。named-export を強制したい場合は base に `noDefaultExport: error` を追加する別判断が必要（本 PR はスコープ外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)