### PR TITLE
fix(web): top10 順位モーダルの取得失敗を明示エラー表示にする

### DIFF
--- a/apps/web/src/app/works/[workId]/components/__tests__/top10-rank-modal.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/top10-rank-modal.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// 取得アクションをモック（成功/失敗を切り替える）
+vi.mock("../../evaluation-actions", () => ({
+	getUserTop10List: vi.fn(),
+}));
+
+// ロガーをモック（失敗時に呼ばれることを検証）
+vi.mock("@/lib/logger", () => ({
+	error: vi.fn(),
+}));
+
+import { error as logError } from "@/lib/logger";
+import { getUserTop10List } from "../../evaluation-actions";
+import { Top10RankModal } from "../top10-rank-modal";
+
+const baseProps = {
+	isOpen: true,
+	onClose: () => {},
+	onSelect: () => {},
+	workTitle: "テスト作品",
+	workId: "RJ123",
+};
+
+describe("Top10RankModal", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("取得失敗時はエラー表示にし、ログ出力する（空スロットで誤解させない）", async () => {
+		vi.mocked(getUserTop10List).mockRejectedValue(new Error("boom"));
+
+		render(<Top10RankModal {...baseProps} />);
+
+		expect(await screen.findByText("10選リストの読み込みに失敗しました")).toBeTruthy();
+		expect(logError).toHaveBeenCalled();
+		// エラー時は順位スロット（選択不可/空き）を描画しない
+		expect(screen.queryByText("選択不可")).toBeNull();
+	});
+
+	it("取得成功時は順位リストを表示する", async () => {
+		vi.mocked(getUserTop10List).mockResolvedValue({ rankings: {}, totalCount: 0 } as any);
+
+		render(<Top10RankModal {...baseProps} />);
+
+		// totalCount=0 のため 2 位以降は「選択不可」で描画される＝リスト分岐
+		expect((await screen.findAllByText("選択不可")).length).toBeGreaterThan(0);
+		expect(screen.queryByText("10選リストの読み込みに失敗しました")).toBeNull();
+		expect(logError).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/app/works/[workId]/components/top10-rank-modal.tsx
+++ b/apps/web/src/app/works/[workId]/components/top10-rank-modal.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { AlertTriangle } from "lucide-react";
 import { useEffect, useState } from "react";
+import { error as logError } from "@/lib/logger";
 import { getUserTop10List } from "../evaluation-actions";
 
 interface Top10RankModalProps {
@@ -32,16 +33,24 @@ export function Top10RankModal({
 }: Top10RankModalProps) {
 	const [top10List, setTop10List] = useState<FrontendUserTop10List | null>(null);
 	const [loading, setLoading] = useState(false);
+	const [loadError, setLoadError] = useState(false);
 
 	useEffect(() => {
 		if (isOpen) {
 			setLoading(true);
-			void getUserTop10List()
+			setLoadError(false);
+			getUserTop10List()
 				.then(setTop10List)
+				.catch((e) => {
+					// 取得失敗時は空スロット表示で誤解させず、明示的にエラー状態にする
+					logError("Top10 リストの取得に失敗しました", e);
+					setLoadError(true);
+				})
 				.finally(() => setLoading(false));
 		} else {
 			// モーダルが閉じられた時に状態をリセット
 			setTop10List(null);
+			setLoadError(false);
 			setLoading(false);
 		}
 	}, [isOpen]);
@@ -162,6 +171,12 @@ export function Top10RankModal({
 					{loading ? (
 						<div className="flex h-40 items-center justify-center">
 							<div className="text-sm text-gray-500">読み込み中...</div>
+						</div>
+					) : loadError ? (
+						<div className="flex h-40 flex-col items-center justify-center gap-2 text-center">
+							<AlertTriangle className="h-6 w-6 text-orange-600" />
+							<p className="text-sm text-gray-700">10選リストの読み込みに失敗しました</p>
+							<p className="text-xs text-gray-500">時間をおいて再度お試しください</p>
 						</div>
 					) : (
 						<div className="space-y-2">


### PR DESCRIPTION
## 背景

[#608](https://github.com/nothink-jp/suzumina.click/pull/608) のレビュー指摘 follow-up。

`Top10RankModal` で `getUserTop10List()` が reject すると、`top10List` が `null` のまま `loading` だけ解除され、**全スロットが「空き」表示**になる。実際は取得失敗なのに「10選が空」と誤解させ、ユーザーが誤った順位選択をしかねない。#608 で付けた `void` は fire-and-forget を明示しただけで、この無音失敗は残っていた。

## 変更
- `void` をやめ `.catch()` で rejection を処理:
  - `logError` でサーバ取得失敗を記録
  - `loadError` 状態にし、**「10選リストの読み込みに失敗しました」を明示表示**（空きスロットを出さない）
- モーダルを開くたびに `loadError` をリセット
- `.catch()` で rejection を扱うため `noFloatingPromises` も満たし、`void` は不要に（適切なエラー処理が fire-and-forget の明示より望ましい）

## テスト追加
このモーダルは未テストだったため新規追加:
- 取得失敗 → エラー表示＋ `logError` 呼び出し、順位スロットを描画しない
- 取得成功 → 順位リスト表示、エラー非表示

## 確認
- `pnpm verify`（lint + typecheck + test）パス
- 新規テスト 2 ケース green

🤖 Generated with [Claude Code](https://claude.com/claude-code)