### PR TITLE
fix(web): お気に入り数を stats.favoriteCount に書き込む (SPR-175)

### DIFF
--- a/apps/web/src/lib/__tests__/favorites-firestore.test.ts
+++ b/apps/web/src/lib/__tests__/favorites-firestore.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { addFavorite, removeFavorite } from "../favorites-firestore";
+
+// updateCounter（正本パスへの原子的更新）をスパイ化
+const updateCounter = vi.fn();
+vi.mock("../firestore-helpers", () => ({
+	updateCounter: (...args: unknown[]) => updateCounter(...args),
+}));
+
+const getFirestore = vi.fn();
+vi.mock("../firestore", () => ({ getFirestore: () => getFirestore() }));
+vi.mock("../logger", () => ({ error: vi.fn() }));
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	updateCounter.mockResolvedValue({ success: true, newValue: 1 });
+});
+
+describe("favorites-firestore のお気に入り数更新", () => {
+	it("addFavorite は stats.favoriteCount を +1（updateCounter 経由・min:0）", async () => {
+		const add = vi.fn().mockResolvedValue({ id: "fav1" });
+		const favorites = {
+			where: () => ({ limit: () => ({ get: () => Promise.resolve({ empty: true }) }) }),
+			add,
+		};
+		getFirestore.mockReturnValue({
+			collection: () => ({ doc: () => ({ collection: () => favorites }) }),
+		});
+
+		const result = await addFavorite("user1", { audioButtonId: "ab1" });
+
+		expect(result).toEqual({ success: true, favoriteId: "fav1" });
+		expect(updateCounter).toHaveBeenCalledWith("audioButtons", "ab1", "stats.favoriteCount", 1, {
+			min: 0,
+		});
+	});
+
+	it("removeFavorite は stats.favoriteCount を -1（updateCounter 経由・min:0）", async () => {
+		const deleteFn = vi.fn().mockResolvedValue(undefined);
+		const favorites = {
+			where: () => ({
+				limit: () => ({
+					get: () =>
+						Promise.resolve({
+							empty: false,
+							docs: [{ id: "fav1", ref: { delete: deleteFn } }],
+						}),
+				}),
+			}),
+		};
+		getFirestore.mockReturnValue({
+			collection: () => ({ doc: () => ({ collection: () => favorites }) }),
+		});
+
+		const result = await removeFavorite("user1", { audioButtonId: "ab1" });
+
+		expect(result).toEqual({ success: true });
+		expect(deleteFn).toHaveBeenCalled();
+		expect(updateCounter).toHaveBeenCalledWith("audioButtons", "ab1", "stats.favoriteCount", -1, {
+			min: 0,
+		});
+	});
+
+	it("既にお気に入り済みなら追加せずカウンターも触らない", async () => {
+		const favorites = {
+			where: () => ({
+				limit: () => ({ get: () => Promise.resolve({ empty: false }) }),
+			}),
+			add: vi.fn(),
+		};
+		getFirestore.mockReturnValue({
+			collection: () => ({ doc: () => ({ collection: () => favorites }) }),
+		});
+
+		const result = await addFavorite("user1", { audioButtonId: "ab1" });
+
+		expect(result).toEqual({ success: false });
+		expect(updateCounter).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/lib/favorites-firestore.ts
+++ b/apps/web/src/lib/favorites-firestore.ts
@@ -3,7 +3,6 @@
  */
 
 import type { Query } from "@google-cloud/firestore";
-import { FieldValue } from "@google-cloud/firestore";
 import type {
 	AddFavoriteInput,
 	FavoriteListResult,
@@ -13,6 +12,7 @@ import type {
 	RemoveFavoriteInput,
 } from "@suzumina.click/shared-types";
 import { getFirestore } from "./firestore";
+import { updateCounter } from "./firestore-helpers";
 import { error as logError } from "./logger";
 
 /**
@@ -78,17 +78,12 @@ export async function addFavorite(
 			.add(favoriteData);
 
 		// 音声ボタンのお気に入り数を増加 (Fire-and-Forget パターン)
-		// revalidatePath を使用せず、バックグラウンドで非同期実行
-		firestore
-			.collection("audioButtons")
-			.doc(input.audioButtonId)
-			.update({
-				favoriteCount: FieldValue.increment(1),
-				updatedAt: new Date().toISOString(),
-			})
-			.catch((error) => {
+		// 正本は stats.favoriteCount（読み手が優先するドットパス）。like/play と同じ updateCounter を使う
+		updateCounter("audioButtons", input.audioButtonId, "stats.favoriteCount", 1, { min: 0 }).catch(
+			(error) => {
 				handleFireAndForgetError("お気に入り数増加", { audioButtonId: input.audioButtonId }, error);
-			});
+			},
+		);
 
 		return { success: true, favoriteId: docRef.id };
 	} catch (error) {
@@ -128,17 +123,11 @@ export async function removeFavorite(
 		await favoriteDoc.ref.delete();
 
 		// 音声ボタンのお気に入り数を減少 (Fire-and-Forget パターン)
-		// revalidatePath を使用せず、バックグラウンドで非同期実行
-		firestore
-			.collection("audioButtons")
-			.doc(input.audioButtonId)
-			.update({
-				favoriteCount: FieldValue.increment(-1),
-				updatedAt: new Date().toISOString(),
-			})
-			.catch((error) => {
+		updateCounter("audioButtons", input.audioButtonId, "stats.favoriteCount", -1, { min: 0 }).catch(
+			(error) => {
 				handleFireAndForgetError("お気に入り数減少", { audioButtonId: input.audioButtonId }, error);
-			});
+			},
+		);
 
 		return { success: true };
 	} catch (error) {


### PR DESCRIPTION
## 背景（軸3: 書き込みパスと正本のズレ）

`apps/web/src/lib/favorites-firestore.ts` の `addFavorite` / `removeFavorite` が audioButtons ドキュメントの**トップレベル** `favoriteCount` を `FieldValue.increment` していた。一方:

- `createAudioButton` は `stats.favoriteCount: 0` で初期化
- 読み手（shared-types `transformers/audio-button.ts`、`lib/audio-buttons-firestore.ts`）は `stats.favoriteCount` を優先

→ stats 側が 0 で存在する限りトップレベルの増分は**永遠に読まれず、新規ボタンのお気に入り数は常に 0 表示**だった。like/play は既に `updateCounter` で正しいドットパスを使っており、favorite だけ乖離していた。

## 変更

- 2箇所を `updateCounter("audioButtons", id, "stats.favoriteCount", ±1, { min: 0 })` に置き換え（like/play と同じ正本パス・原子的更新）
- fire-and-forget 挙動は `.catch` で維持
- 未使用になった `FieldValue` import を削除
- `__tests__/favorites-firestore.test.ts` を追加（+1 / -1 / 既存時は触らない の3ケース）

## 補足

- トップレベル `favoriteCount` に溜まった過去増分のバックフィルは**別 PR（One-Way Door）**で扱う。本 PR は書き込みパス修正のみで劣化を止める。
- `pnpm verify` green（web カバレッジ閾値クリア）

Closes SPR-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)