### PR TITLE
fix(web): お気に入り一覧のページ送りを実装 (SPR-176)

### DIFF
--- a/apps/web/src/app/favorites/actions.ts
+++ b/apps/web/src/app/favorites/actions.ts
@@ -32,18 +32,17 @@ interface FavoriteAudioButtonsResult {
 export async function getFavoritesList(
 	params: FetchFavoriteAudioButtonsParams,
 ): Promise<FavoriteAudioButtonsResult> {
-	const { limit = 20, sort = "newest", userId } = params;
+	const { page = 1, limit = 20, sort = "newest", userId } = params;
 
 	try {
 		// 総件数を取得
 		const totalCount = await getUserFavoritesCount(userId);
 
-		// お気に入り一覧を取得（ページネーション対応）
+		// お気に入り一覧を取得（ページ番号 → offset エミュレーションで getUserFavorites がページ送り）
 		const favoritesList = await getUserFavorites(userId, {
+			page,
 			limit,
 			orderBy: sort as "newest" | "oldest",
-			// ページ番号からオフセットを計算
-			// TODO: Firestoreのcursor-based paginationに対応する必要がある
 		});
 
 		// 音声ボタンデータを取得

--- a/apps/web/src/lib/__tests__/favorites-firestore-pagination.test.ts
+++ b/apps/web/src/lib/__tests__/favorites-firestore-pagination.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserFavorites } from "../favorites-firestore";
+
+const getFirestore = vi.fn();
+vi.mock("../firestore", () => ({ getFirestore: () => getFirestore() }));
+vi.mock("../logger", () => ({ error: vi.fn() }));
+
+type DocSnap = { data: () => { audioButtonId: string; addedAt: string } };
+type Query = {
+	orderBy: () => Query;
+	limit: (n: number) => Query;
+	startAfter: (doc: unknown) => Query;
+	get: () => Promise<{ docs: DocSnap[] }>;
+};
+
+const fav = (audioButtonId: string, addedAt: string): DocSnap => ({
+	data: () => ({ audioButtonId, addedAt }),
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("getUserFavorites のページ送り（offset エミュレーション）", () => {
+	it("page=2 は offset 分を skip read して startAfter で 2 ページ目を返す", async () => {
+		const startAfterArgs: unknown[] = [];
+		const skipDocs = Array.from({ length: 20 }, (_, i) => fav(`skip${i}`, `2024-01-${i + 1}`));
+		const lastSkipped = skipDocs[skipDocs.length - 1];
+		const pageDocs = [fav("p2a", "2023-12-31"), fav("p2b", "2023-12-30")];
+
+		const makeQuery = (): Query => {
+			const state: { startAfter?: unknown } = {};
+			const q: Query = {
+				orderBy: () => q,
+				limit: () => q,
+				startAfter: (doc) => {
+					state.startAfter = doc;
+					startAfterArgs.push(doc);
+					return q;
+				},
+				get: () => Promise.resolve({ docs: state.startAfter !== undefined ? pageDocs : skipDocs }),
+			};
+			return q;
+		};
+		const favoritesCollection = {
+			orderBy: () => makeQuery(),
+			doc: () => ({ get: () => Promise.resolve({ exists: false }) }),
+		};
+		getFirestore.mockReturnValue({
+			collection: () => ({ doc: () => ({ collection: () => favoritesCollection }) }),
+		});
+
+		const result = await getUserFavorites("user1", { page: 2, limit: 20, orderBy: "newest" });
+
+		// skip read の最後の doc を startAfter に渡している
+		expect(startAfterArgs).toEqual([lastSkipped]);
+		// 1 ページ目の skipDocs ではなく 2 ページ目のデータが返る
+		expect(result.favorites.map((f) => f.audioButtonId)).toEqual(["p2a", "p2b"]);
+	});
+
+	it("page=1 は skip read も startAfter もせず先頭ページを返す", async () => {
+		const startAfterArgs: unknown[] = [];
+		const pageDocs = [fav("a", "2024-01-02"), fav("b", "2024-01-01")];
+		const makeQuery = (): Query => {
+			const q: Query = {
+				orderBy: () => q,
+				limit: () => q,
+				startAfter: (doc) => {
+					startAfterArgs.push(doc);
+					return q;
+				},
+				get: () => Promise.resolve({ docs: pageDocs }),
+			};
+			return q;
+		};
+		const favoritesCollection = {
+			orderBy: () => makeQuery(),
+			doc: () => ({ get: () => Promise.resolve({ exists: false }) }),
+		};
+		getFirestore.mockReturnValue({
+			collection: () => ({ doc: () => ({ collection: () => favoritesCollection }) }),
+		});
+
+		const result = await getUserFavorites("user1", { page: 1, limit: 20, orderBy: "newest" });
+
+		expect(startAfterArgs).toEqual([]);
+		expect(result.favorites.map((f) => f.audioButtonId)).toEqual(["a", "b"]);
+		expect(result.hasMore).toBe(false);
+	});
+});

--- a/apps/web/src/lib/favorites-firestore.ts
+++ b/apps/web/src/lib/favorites-firestore.ts
@@ -266,28 +266,27 @@ export async function getUserFavorites(
 ): Promise<FavoriteListResult> {
 	try {
 		const firestore = getFirestore();
-		let firestoreQuery: Query = firestore.collection("users").doc(userId).collection("favorites");
+		const favoritesCollection = firestore.collection("users").doc(userId).collection("favorites");
 
-		// ソート設定
-		switch (query.orderBy) {
-			case "newest":
-				firestoreQuery = firestoreQuery.orderBy("addedAt", "desc");
-				break;
-			case "oldest":
-				firestoreQuery = firestoreQuery.orderBy("addedAt", "asc");
-				break;
-			default:
-				firestoreQuery = firestoreQuery.orderBy("addedAt", "desc");
-		}
+		// ソート設定（addedAt 単一フィールドのため複合インデックス不要）
+		const direction = query.orderBy === "oldest" ? "asc" : "desc";
+		let firestoreQuery: Query = favoritesCollection.orderBy("addedAt", direction);
 
 		// ページネーション
-		if (query.startAfter) {
-			const startAfterDoc = await firestore
-				.collection("users")
-				.doc(userId)
-				.collection("favorites")
-				.doc(query.startAfter)
+		// page 指定時は offset エミュレーション（getAudioButtonsList と同方式: skip 読み → startAfter）
+		const offset = query.page && query.page > 1 ? (query.page - 1) * query.limit : 0;
+		if (offset > 0) {
+			const skipSnapshot = await favoritesCollection
+				.orderBy("addedAt", direction)
+				.limit(offset)
 				.get();
+			const lastSkipped = skipSnapshot.docs[skipSnapshot.docs.length - 1];
+			if (lastSkipped) {
+				firestoreQuery = firestoreQuery.startAfter(lastSkipped);
+			}
+		} else if (query.startAfter) {
+			// page 未指定時の後方互換: doc-ID カーソル
+			const startAfterDoc = await favoritesCollection.doc(query.startAfter).get();
 			if (startAfterDoc.exists) {
 				firestoreQuery = firestoreQuery.startAfter(startAfterDoc);
 			}

--- a/packages/shared-types/src/entities/favorite.ts
+++ b/packages/shared-types/src/entities/favorite.ts
@@ -39,6 +39,9 @@ export type RemoveFavoriteInput = z.infer<typeof RemoveFavoriteInputSchema>;
 export const FavoriteQuerySchema = z.object({
 	limit: z.number().min(1).max(100).default(20),
 	orderBy: z.enum(["newest", "oldest"]).default("newest"),
+	/** ページ番号（1始まり）。指定時は offset エミュレーションでページ送りする */
+	page: z.number().min(1).optional(),
+	/** doc-ID カーソル（page 未指定時の後方互換） */
 	startAfter: z.string().optional(),
 });
 


### PR DESCRIPTION
## 背景（軸3: 型の約束と実装のズレ）

`getFavoritesList`（`app/favorites/actions.ts`）が受け取った `page` を破棄し `getUserFavorites` に渡していなかった。`getUserFavorites` も `startAfter` を渡されず、「TODO: cursor-based pagination」が放置されていた。

クライアント（`createBasicToParams`）と SSR（`favorites/page.tsx`）の双方が `page` を送っているため、**お気に入りが 20 件超のユーザーは 2 ページ目を開いても 1 ページ目と同一データ**が返り、`?page=2` のディープリンクも壊れていた。

## 変更

- `getUserFavorites` に **offset エミュレーション**（`getAudioButtonsList` と同方式: skip 読み → `startAfter`）を実装
- `FavoriteQuery` スキーマに `page`（1始まり・optional）を追加。`page` 未指定時は従来の `startAfter`（doc-ID カーソル）に後方互換でフォールバック
- `getFavoritesList` で `page` を honor して渡す
- `__tests__/favorites-firestore-pagination.test.ts` を追加（page=2 は skip read→startAfter / page=1 は skip しない）

## 補足

- orderBy は `addedAt` 単一フィールドのため**新規複合インデックス不要**（インデックスリスク低）
- `pnpm verify` green

Closes SPR-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)