### PR TITLE
fix(functions): 整合性cron の Creator 復元を正本スキーマ(roles 配列)に一致 (SPR-178)

### DIFF
--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.integration.test.ts
@@ -174,9 +174,20 @@ describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", (
 		expect(result.checks.creatorWorkRestore?.creatorsCreated).toBeGreaterThanOrEqual(1);
 
 		expect((await db.collection("creators").doc("CR1").get()).exists).toBe(true);
-		expect(
-			(await db.collection("creators").doc("CR1").collection("works").doc("RJ001").get()).exists,
-		).toBe(true);
+		const relationDoc = await db
+			.collection("creators")
+			.doc("CR1")
+			.collection("works")
+			.doc("RJ001")
+			.get();
+		expect(relationDoc.exists).toBe(true);
+		// 正本スキーマ（CreatorWorkRelation）の roles 配列を含むこと（旧フラット形式でないこと）
+		expect(relationDoc.data()?.roles).toEqual(["voice"]);
+		expect(relationDoc.data()?.circleId).toBe("RG001");
+		// recomputeCreatorStats により denormalized stats が同期されること
+		const creatorDoc = await db.collection("creators").doc("CR1").get();
+		expect(creatorDoc.data()?.workCount).toBe(1);
+		expect(creatorDoc.data()?.types).toEqual(["voice"]);
 	});
 
 	it("dry-run では不整合を検出するが Firestore を変更しない", async () => {

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
@@ -325,6 +325,8 @@ describe("checkDataIntegrity", () => {
 
 		const mockSubCollection = vi.fn(() => ({
 			doc: mockSubDoc,
+			// recomputeCreatorStats が復元後に works サブコレクションを読む
+			get: vi.fn().mockResolvedValue({ empty: true, size: 0, docs: [] }),
 		}));
 
 		// 空のスナップショット
@@ -344,6 +346,7 @@ describe("checkDataIntegrity", () => {
 					doc: vi.fn((_id: string) => ({
 						get: mockCreatorExists,
 						collection: mockSubCollection,
+						update: vi.fn(), // recomputeCreatorStats の stats 書き戻し
 					})),
 				};
 			}

--- a/apps/functions/src/endpoints/data-integrity-check.ts
+++ b/apps/functions/src/endpoints/data-integrity-check.ts
@@ -12,14 +12,14 @@
  *   本番データを汚さずに「整合性関数が何を直すか」を確認するための観測専用モード。
  */
 
-import type {
-	DocumentData,
-	DocumentReference,
-	QueryDocumentSnapshot,
-	WriteBatch,
-} from "@google-cloud/firestore";
+import type { DocumentReference, WriteBatch } from "@google-cloud/firestore";
 import type { CloudEvent } from "@google-cloud/functions-framework";
+import type { CreatorType, CreatorWorkRelation } from "@suzumina.click/shared-types";
 import firestore, { Timestamp } from "../infrastructure/database/firestore";
+import {
+	extractCreatorMappingsFromWorkDocument,
+	recomputeCreatorStats,
+} from "../services/dlsite/creator-firestore";
 import * as logger from "../shared/logger";
 
 // メタデータ保存用の定数
@@ -279,33 +279,34 @@ async function ensureCreatorExists(
  */
 async function restoreCreatorWorkMapping(
 	creatorRef: DocumentReference,
-	workDoc: QueryDocumentSnapshot,
-	workData: DocumentData,
-	creator: { id: string; name: string },
-	type: string,
+	workId: string,
+	roles: CreatorType[],
+	circleId: string,
 	batch: WriteBatch,
 	stats: RestoreStats,
-): Promise<void> {
-	const mappingRef = creatorRef.collection("works").doc(workDoc.id);
+): Promise<boolean> {
+	const mappingRef = creatorRef.collection("works").doc(workId);
 	const mappingDoc = await mappingRef.get();
 
-	if (!mappingDoc.exists) {
-		logger.info(`マッピング復元: Creator ${creator.id} - Work ${workDoc.id} (${type})`);
-
-		batch.set(mappingRef, {
-			workId: workDoc.id,
-			workTitle: workData.title,
-			circleId: workData.circleId,
-			circleName: workData.circle,
-			creatorName: creator.name,
-			creatorType: type,
-			createdAt: Timestamp.now(),
-			updatedAt: Timestamp.now(),
-		});
-
-		stats.restoredCount++;
-		stats.batchCount++;
+	if (mappingDoc.exists) {
+		return false;
 	}
+
+	logger.info(`マッピング復元: Creator ${creatorRef.id} - Work ${workId} (${roles.join(", ")})`);
+
+	// 正本スキーマ（CreatorWorkRelation）に一致させる: roles 配列を必ず含める。
+	// web の読み手は workRelation.roles を参照するため、旧フラット形式では役割ゼロ扱いになる。
+	const relation: CreatorWorkRelation = {
+		workId,
+		roles,
+		circleId: circleId || "UNKNOWN",
+		updatedAt: Timestamp.now(),
+	};
+	batch.set(mappingRef, relation);
+
+	stats.restoredCount++;
+	stats.batchCount++;
+	return true;
 }
 
 /**
@@ -343,6 +344,7 @@ async function restoreCreatorWorkRelations(
 	const worksSnapshot = await firestore.collection("works").get();
 	let batch = firestore.batch();
 	const processedCreators = new Set<string>();
+	const creatorsToRecompute = new Set<string>();
 
 	const stats: RestoreStats = {
 		restoredCount: 0,
@@ -350,51 +352,63 @@ async function restoreCreatorWorkRelations(
 		batchCount: 0,
 	};
 
-	// クリエイタータイプの定義
-	const creatorTypes = [
-		{ field: "voice_by", type: "voice" },
-		{ field: "scenario_by", type: "scenario" },
-		{ field: "illust_by", type: "illustration" },
-		{ field: "music_by", type: "music" },
-		{ field: "others_by", type: "other" },
-	];
-
 	for (const workDoc of worksSnapshot.docs) {
 		const workData = workDoc.data();
-		const creators = workData.creators;
 
-		if (!creators) continue;
+		// WorkDocument.creators からクリエイターごとに役割を集約（正本スキーマに一致させる）。
+		// フィールド表は creator-firestore に一本化（created_by 含む WorkDocument 用）。
+		const creatorMappings = extractCreatorMappingsFromWorkDocument(workData.creators);
+		if (creatorMappings.size === 0) {
+			continue;
+		}
 
-		for (const { field, type } of creatorTypes) {
-			const creatorList = creators[field] || [];
+		for (const [creatorId, mapping] of creatorMappings) {
+			// Creatorドキュメントの確認・作成
+			const creatorRef = await ensureCreatorExists(
+				creatorId,
+				mapping.name,
+				mapping.roles[0] ?? "other",
+				batch,
+				processedCreators,
+				stats,
+			);
 
-			for (const creator of creatorList) {
-				if (!creator.id || !creator.name) continue;
+			// バッチサイズチェック
+			batch = await commitBatchIfNeeded(batch, stats, false, dryRun);
 
-				// Creatorドキュメントの確認・作成
-				const creatorRef = await ensureCreatorExists(
-					creator.id,
-					creator.name,
-					type,
-					batch,
-					processedCreators,
-					stats,
-				);
-
-				// バッチサイズチェック
-				batch = await commitBatchIfNeeded(batch, stats, false, dryRun);
-
-				// Creator-Workマッピングの復元
-				await restoreCreatorWorkMapping(creatorRef, workDoc, workData, creator, type, batch, stats);
-
-				// バッチサイズチェック
-				batch = await commitBatchIfNeeded(batch, stats, false, dryRun);
+			// Creator-Workマッピングの復元（roles 配列を含む正本スキーマで書く）
+			const restored = await restoreCreatorWorkMapping(
+				creatorRef,
+				workDoc.id,
+				mapping.roles,
+				workData.circleId,
+				batch,
+				stats,
+			);
+			if (restored) {
+				creatorsToRecompute.add(creatorId);
 			}
+
+			// バッチサイズチェック
+			batch = await commitBatchIfNeeded(batch, stats, false, dryRun);
 		}
 	}
 
 	// 残りのバッチをコミット
 	batch = await commitBatchIfNeeded(batch, stats, true, dryRun);
+
+	// 復元したクリエイターの denormalized stats（workCount/types/primaryRole）を同期する。
+	// /creators の読み込みパスがこれらを使うため、復元時にも正本ライタと同様に再計算が必要。
+	// dryRun では書き込まないので再計算もしない（未コミットの relation を読んでしまうため）。
+	if (!dryRun && creatorsToRecompute.size > 0) {
+		const recomputeResults = await Promise.allSettled(
+			Array.from(creatorsToRecompute).map((creatorId) => recomputeCreatorStats(creatorId)),
+		);
+		const failed = recomputeResults.filter((r) => r.status === "rejected").length;
+		if (failed > 0) {
+			logger.warn(`クリエイター集計再計算で ${failed} 件失敗`);
+		}
+	}
 
 	// 結果に追加
 	result.checks.creatorWorkRestore = {

--- a/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
@@ -10,6 +10,7 @@ import type {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as logger from "../../../shared/logger";
 import {
+	extractCreatorMappingsFromWorkDocument,
 	getCreatorWithWorks,
 	getCreatorWorkCount,
 	recomputeCreatorStats,
@@ -509,6 +510,49 @@ describe("creator-firestore", () => {
 			expect(updateArg.workCount).toBe(0);
 			expect(updateArg.types).toEqual([]);
 			expect(updateArg.primaryRole).toBeUndefined();
+		});
+	});
+
+	describe("extractCreatorMappingsFromWorkDocument", () => {
+		it("WorkDocument.creators の各フィールドを CreatorType にマッピングする（created_by を含む）", () => {
+			const mappings = extractCreatorMappingsFromWorkDocument({
+				voice_by: [{ id: "CR1", name: "声優" }],
+				scenario_by: [{ id: "CR2", name: "脚本" }],
+				illust_by: [{ id: "CR3", name: "絵" }],
+				music_by: [{ id: "CR4", name: "音楽" }],
+				others_by: [{ id: "CR5", name: "その他" }],
+				created_by: [{ id: "CR6", name: "制作" }],
+			});
+
+			expect(mappings.get("CR1")?.roles).toEqual(["voice"]);
+			expect(mappings.get("CR2")?.roles).toEqual(["scenario"]);
+			expect(mappings.get("CR3")?.roles).toEqual(["illustration"]);
+			expect(mappings.get("CR4")?.roles).toEqual(["music"]);
+			expect(mappings.get("CR5")?.roles).toEqual(["other"]);
+			// created_by を取りこぼさず other に集約する（旧 cron は未対応だった）
+			expect(mappings.get("CR6")?.roles).toEqual(["other"]);
+		});
+
+		it("同一クリエイターが複数役割を持つ場合は roles に集約する", () => {
+			const mappings = extractCreatorMappingsFromWorkDocument({
+				voice_by: [{ id: "CR1", name: "万能" }],
+				scenario_by: [{ id: "CR1", name: "万能" }],
+			});
+
+			expect(mappings.size).toBe(1);
+			expect(mappings.get("CR1")?.roles).toEqual(["voice", "scenario"]);
+		});
+
+		it("id または name 欠落のエントリはスキップする", () => {
+			const mappings = extractCreatorMappingsFromWorkDocument({
+				voice_by: [{ id: "CR1", name: "正常" }, { name: "id無し" }, { id: "CR3", name: "" }],
+			});
+
+			expect(Array.from(mappings.keys())).toEqual(["CR1"]);
+		});
+
+		it("creators が undefined のときは空の Map を返す", () => {
+			expect(extractCreatorMappingsFromWorkDocument(undefined).size).toBe(0);
 		});
 	});
 });

--- a/apps/functions/src/services/dlsite/creator-firestore.ts
+++ b/apps/functions/src/services/dlsite/creator-firestore.ts
@@ -103,6 +103,56 @@ function extractCreatorMappings(apiData: DLsiteApiResponse): Map<string, Extract
 }
 
 /**
+ * WorkDocument.creators フィールド名 → CreatorType のマッピング。
+ *
+ * 注意: これは Firestore work doc に保存された `creators` フィールド用（`created_by` を含む）。
+ * DLsite API レスポンス用の CREATOR_TYPE_MAP（`directed_by` を含む）とは別物なので混同しない。
+ */
+const WORK_DOCUMENT_CREATOR_FIELD_MAP: ReadonlyArray<[string, CreatorType]> = [
+	["voice_by", "voice"],
+	["scenario_by", "scenario"],
+	["illust_by", "illustration"],
+	["music_by", "music"],
+	["others_by", "other"],
+	["created_by", "other"],
+];
+
+/**
+ * WorkDocument.creators（Firestore work doc の creators フィールド）から
+ * クリエイターごとに役割を集約する。
+ *
+ * 整合性 cron の Creator-Work 復元が正本スキーマ（CreatorWorkRelation の
+ * `roles: CreatorType[]`）に一致した文書を書くための共通関数。一作品で複数役割を
+ * 持つクリエイターは roles に集約される。API レスポンスではなく保存済み work doc が
+ * 入力源である点が extractCreatorMappings との違い。
+ *
+ * @param creators WorkDocument の creators フィールド
+ * @returns クリエイターIDをキーとした Map（roles を集約済み）
+ */
+export function extractCreatorMappingsFromWorkDocument(
+	creators: Record<string, { id?: string; name?: string }[] | undefined> | undefined,
+): Map<string, ExtractedCreator> {
+	const mappings = new Map<string, ExtractedCreator>();
+	if (!creators || typeof creators !== "object") {
+		return mappings;
+	}
+
+	for (const [field, role] of WORK_DOCUMENT_CREATOR_FIELD_MAP) {
+		const list = creators[field];
+		if (!Array.isArray(list)) {
+			continue;
+		}
+		for (const creator of list) {
+			if (creator?.id && isValidCreatorId(creator.id) && creator.name) {
+				addOrUpdateCreatorMapping(mappings, creator.id, creator.name, role);
+			}
+		}
+	}
+
+	return mappings;
+}
+
+/**
  * 作品の既存クリエイターマッピングを取得
  *
  * @param workId 作品ID


### PR DESCRIPTION
## 背景（軸1×軸3: 修復 cron 自体がスキーマドリフトを生む）

整合性 cron の `restoreCreatorWorkMapping` が、正本 `CreatorWorkRelation` `{workId, roles: CreatorType[], circleId, updatedAt}` ではなく **roles 配列なしの旧フラット形式** `{workId, workTitle, circleId, circleName, creatorName, creatorType(単数), createdAt, updatedAt}` を `batch.set` していた。

web の読み手は `workRelation.roles?.forEach` を使うため、**復元された文書は workCount に数えられつつ役割ゼロ扱い＝表示バグに直結**。修復するはずの cron が新たな不整合を作っていた。

## 変更

1. **WorkDocument.creators → roles 集約の共通関数** `extractCreatorMappingsFromWorkDocument` を `creator-firestore.ts` に抽出。
   - フィールド表を一本化。`WORK_DOCUMENT_CREATOR_FIELD_MAP` は **`created_by` を含む WorkDocument 用**で、DLsite API レスポンス用の `CREATOR_TYPE_MAP`（`directed_by` を含む）とは別物として明示。旧 cron が取りこぼしていた **`created_by` も other として復元**されるようになる。
   - 一作品で複数役割を持つクリエイターは `roles` に集約。
2. **復元書き込みを `CreatorWorkRelation` 型で行う**（roles 配列を必ず含む）。
3. **復元後に `recomputeCreatorStats` を呼ぶ**（denormalized workCount/types/primaryRole を同期）。dryRun では未コミットの relation を読まないよう呼ばない。
4. テスト追加: 単体（roles 集約 / created_by / id・name 欠落 / undefined）、integration（roles 配列・circleId・stats 同期の実機 assert）。

## 自己レビュー観点（One-Way Door: 整合性 cron）

- dryRun のセマンティクス維持: `commitBatchIfNeeded(dryRun)` は従来どおり、recompute も dryRun では実行しない。
- `restoreCreatorWorkMapping` は既存マッピングがあれば `false` を返し再計算対象に含めない（冪等）。
- `creatorWorkRestore` の集計（checked/restored/creatorsCreated）は従来意味を維持。

## 残作業（本 PR 外・ADC 直結の手動オペレーション）

- [ ] 本番 `creators/*/works/*` に**旧スキーマ（roles 欠落 / creatorType 単数）で復元済みの文書**が残っていないか ADC 直結で確認。あれば one-shot tool で `roles` 形式へ移行 + `recomputeCreatorStats`。本 PR は書き込みパスを正本化し**今後のドリフトを止める**もので、過去に書かれた文書の移行は含まない。
- バッチコミット様式の二系統統一（issue の任意項目）は別 PR。

`pnpm verify` green。

Closes SPR-178

🤖 Generated with [Claude Code](https://claude.com/claude-code)