### PR TITLE
refactor(shared-types): 言語判定を detectWorkLanguage に一本化 (SPR-184)

### DIFF
--- a/packages/shared-types/src/entities/work/language-detection.ts
+++ b/packages/shared-types/src/entities/work/language-detection.ts
@@ -303,8 +303,11 @@ export function supportsLanguage(work: WorkDocument, language: WorkLanguage): bo
 }
 
 /**
- * 言語でフィルタリング (後方互換性のため)
- * @deprecated Use custom filtering logic with detectWorkLanguage
+ * 言語で作品をフィルタリングする。
+ *
+ * `detectWorkLanguage`（言語判定の正本）を用いる唯一のフィルタ経路。
+ * transformer の `_computed.primaryLanguage` も同じ `detectWorkLanguage` を使うため、
+ * 「フィルタで選んだ言語」と「詳細表示の言語」は一致する（SPR-184）。
  */
 export function filterWorksByLanguage(
 	works: WorkDocument[],

--- a/packages/shared-types/src/entities/work/work-constants.ts
+++ b/packages/shared-types/src/entities/work/work-constants.ts
@@ -114,6 +114,7 @@ export const LANGUAGE_CODE_MAPPING: Record<string, WorkLanguage> = {
 	"ja-jp": "ja",
 	japanese: "ja",
 	jpn: "ja",
+	jp: "ja", // SPR-184: transformer LANGUAGE_CODE_MAP から統合
 
 	// 英語
 	en: "en",
@@ -128,6 +129,11 @@ export const LANGUAGE_CODE_MAPPING: Record<string, WorkLanguage> = {
 	chinese_simplified: "zh-cn",
 	chs: "zh-cn",
 	chi_hans: "zh-cn",
+	// SPR-184: transformer LANGUAGE_CODE_MAP から統合
+	zho: "zh-cn",
+	zh: "zh-cn",
+	chi: "zh-cn",
+	chn: "zh-cn",
 
 	// 繁体中文
 	"zh-tw": "zh-tw",
@@ -135,6 +141,9 @@ export const LANGUAGE_CODE_MAPPING: Record<string, WorkLanguage> = {
 	chinese_traditional: "zh-tw",
 	cht: "zh-tw",
 	chi_hant: "zh-tw",
+	// SPR-184: transformer LANGUAGE_CODE_MAP から統合
+	zht: "zh-tw",
+	tw: "zh-tw",
 
 	// 韓国語
 	ko: "ko",
@@ -142,6 +151,7 @@ export const LANGUAGE_CODE_MAPPING: Record<string, WorkLanguage> = {
 	ko_kr: "ko",
 	korean: "ko",
 	kor: "ko",
+	kr: "ko", // SPR-184: transformer LANGUAGE_CODE_MAP から統合
 
 	// スペイン語
 	es: "es",
@@ -184,6 +194,7 @@ export const LANGUAGE_CODE_MAPPING: Record<string, WorkLanguage> = {
 	vi: "vi",
 	vietnamese: "vi",
 	vie: "vi",
+	vn: "vi", // SPR-184: transformer LANGUAGE_CODE_MAP から統合
 
 	// インドネシア語
 	id: "id",

--- a/packages/shared-types/src/transformers/__tests__/work-firestore-final.test.ts
+++ b/packages/shared-types/src/transformers/__tests__/work-firestore-final.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { detectWorkLanguage, getSupportedLanguages } from "../../entities/work/language-detection";
+import type { WorkDocument } from "../../entities/work/work-document-schema";
+import { fromFirestore } from "../work-firestore-final";
+
+const createWorkDocument = (overrides: Partial<WorkDocument> = {}): WorkDocument => ({
+	id: "RJ123456",
+	productId: "RJ123456",
+	title: "Test Work",
+	circle: "Test Circle",
+	description: "Test description",
+	category: "SOU",
+	workUrl: "https://example.com",
+	thumbnailUrl: "https://example.com/thumb.jpg",
+	price: { current: 1000, currency: "JPY" },
+	genres: [],
+	customGenres: [],
+	sampleImages: [],
+	lastFetchedAt: "2024-01-01T00:00:00Z",
+	createdAt: "2024-01-01T00:00:00Z",
+	updatedAt: "2024-01-01T00:00:00Z",
+	...overrides,
+});
+
+// SPR-184: transformer の _computed が言語判定の正本（detectWorkLanguage /
+// getSupportedLanguages）に委譲していること、すなわち「詳細表示」と「フィルタ」で
+// 同じ言語が得られることを固定する。
+describe("work-firestore-final fromFirestore の言語判定（detectWorkLanguage への委譲）", () => {
+	const cases: Array<{ name: string; doc: WorkDocument }> = [
+		{ name: "デフォルト(ja)", doc: createWorkDocument() },
+		{ name: "英語タイトル", doc: createWorkDocument({ title: "English Version" }) },
+		{ name: "繁体中文版タイトル", doc: createWorkDocument({ title: "作品名 繁体中文版" }) },
+		{ name: "genres 由来(English)", doc: createWorkDocument({ genres: ["English"] }) },
+		{
+			name: "languageDownloads 由来(ko)",
+			doc: createWorkDocument({
+				languageDownloads: [
+					{
+						workno: "RJ123456",
+						label: "한국어",
+						lang: "ko",
+						dlCount: "10",
+						displayLabel: "한국어",
+					},
+				],
+			}),
+		},
+	];
+
+	for (const { name, doc } of cases) {
+		it(`${name}: _computed.primaryLanguage が detectWorkLanguage と一致`, () => {
+			const plain = fromFirestore(doc);
+			expect(plain._computed.primaryLanguage).toBe(detectWorkLanguage(doc) ?? "ja");
+		});
+
+		it(`${name}: _computed.availableLanguages が getSupportedLanguages と一致`, () => {
+			const plain = fromFirestore(doc);
+			expect(plain._computed.availableLanguages).toEqual(getSupportedLanguages(doc));
+		});
+	}
+
+	it("統合エイリアス(lang:'kr')も韓国語として判定される", () => {
+		const doc = createWorkDocument({
+			languageDownloads: [
+				{ workno: "RJ123456", label: "Korean", lang: "kr", dlCount: "10", displayLabel: "Korean" },
+			],
+		});
+		expect(fromFirestore(doc)._computed.primaryLanguage).toBe("ko");
+	});
+});

--- a/packages/shared-types/src/transformers/work-firestore-final.ts
+++ b/packages/shared-types/src/transformers/work-firestore-final.ts
@@ -4,153 +4,9 @@
  * Minimal implementation that only maps fields that exist in both WorkDocument and WorkPlainObject.
  */
 
-import type { WorkLanguage } from "../entities/work";
+import { detectWorkLanguage, getSupportedLanguages } from "../entities/work/language-detection";
 import type { WorkDocument } from "../entities/work/work-document-schema";
 import type { WorkPlainObject } from "../plain-objects/work-plain";
-
-/**
- * Language code mapping
- */
-const LANGUAGE_CODE_MAP: Record<string, WorkLanguage> = {
-	// Japanese
-	jpn: "ja",
-	ja: "ja",
-	jp: "ja",
-	// English
-	eng: "en",
-	en: "en",
-	// Chinese (Simplified)
-	zho: "zh-cn",
-	zh: "zh-cn",
-	chi: "zh-cn",
-	chn: "zh-cn",
-	// Chinese (Traditional)
-	zht: "zh-tw",
-	"zh-tw": "zh-tw",
-	tw: "zh-tw",
-	// Korean
-	kor: "ko",
-	ko: "ko",
-	kr: "ko",
-	// Spanish
-	spa: "es",
-	es: "es",
-	// Thai
-	tha: "th",
-	th: "th",
-	// German
-	deu: "de",
-	de: "de",
-	// French
-	fra: "fr",
-	fr: "fr",
-	// Italian
-	ita: "it",
-	it: "it",
-	// Portuguese
-	por: "pt",
-	pt: "pt",
-	// Russian
-	rus: "ru",
-	ru: "ru",
-	// Vietnamese
-	vie: "vi",
-	vi: "vi",
-	vn: "vi",
-	// Indonesian
-	ind: "id",
-	id: "id",
-};
-
-/**
- * Map language code to WorkLanguage type
- */
-function mapLanguageCode(lang: string | undefined): WorkLanguage | null {
-	if (!lang) return null;
-	const code = lang.toLowerCase();
-	return LANGUAGE_CODE_MAP[code] || null;
-}
-
-/**
- * Detect language from title
- */
-function detectLanguageFromTitle(title: string): WorkLanguage | null {
-	if (!title) return null;
-
-	if (title.includes("【繁体中文版】") || title.includes("【繁體中文版】")) {
-		return "zh-tw";
-	}
-	if (title.includes("【简体中文版】") || title.includes("【簡体中文版】")) {
-		return "zh-cn";
-	}
-	if (title.includes("【英語版】") || title.includes("【English】")) {
-		return "en";
-	}
-	if (title.includes("【韓国語版】") || title.includes("【한국어】")) {
-		return "ko";
-	}
-
-	return null;
-}
-
-/**
- * Determine primary language for a work
- */
-function determinePrimaryLanguage(doc: WorkDocument): WorkLanguage {
-	// First priority: detect from title for translations
-	const titleLang = detectLanguageFromTitle(doc.title);
-	if (titleLang) return titleLang;
-
-	// Second priority: check translation info
-	const translationLang = mapLanguageCode(doc.translationInfo?.lang);
-	if (translationLang) return translationLang;
-
-	// Third priority: check language downloads
-	if (doc.languageDownloads && doc.languageDownloads.length > 0) {
-		const firstDownload = doc.languageDownloads[0];
-		if (firstDownload) {
-			const firstLang = mapLanguageCode(firstDownload.lang);
-			if (firstLang) return firstLang;
-		}
-	}
-
-	// Default to Japanese
-	return "ja";
-}
-
-/**
- * Collect all available languages for a work
- */
-function collectAvailableLanguages(doc: WorkDocument): WorkLanguage[] {
-	const languages = new Set<WorkLanguage>();
-
-	// Detect from title first for translations
-	const titleLang = detectLanguageFromTitle(doc.title);
-	if (titleLang) {
-		languages.add(titleLang);
-	}
-
-	// Always include Japanese as it's usually available
-	languages.add("ja");
-
-	// Add translation language if exists
-	const translationLang = mapLanguageCode(doc.translationInfo?.lang);
-	if (translationLang) {
-		languages.add(translationLang);
-	}
-
-	// Add languages from language downloads
-	if (doc.languageDownloads && doc.languageDownloads.length > 0) {
-		for (const ld of doc.languageDownloads) {
-			const mapped = mapLanguageCode(ld.lang);
-			if (mapped) {
-				languages.add(mapped);
-			}
-		}
-	}
-
-	return Array.from(languages);
-}
 
 /**
  * Get display name for work category
@@ -407,9 +263,9 @@ export function fromFirestore(doc: WorkDocument): WorkPlainObject {
 			})(),
 			isPopular: (doc.rating?.count || 0) > 100,
 
-			// Language-related
-			primaryLanguage: determinePrimaryLanguage(doc),
-			availableLanguages: collectAvailableLanguages(doc),
+			// Language-related（正本は entities/work/language-detection の detectWorkLanguage）
+			primaryLanguage: detectWorkLanguage(doc) ?? "ja",
+			availableLanguages: getSupportedLanguages(doc),
 
 			// Search and filtering
 			searchableText: [doc.title, doc.circle, doc.description].filter(Boolean).join(" "),


### PR DESCRIPTION
## 背景（軸3: 正本の曖昧さ — 表示とフィルタで結果が乖離しうる）

言語判定が2系統あった:
- **transformer 系**: `work-firestore-final.ts` の独自 `LANGUAGE_CODE_MAP` / `determinePrimaryLanguage` / `collectAvailableLanguages`（優先順位: タイトル→translationInfo→languageDownloads[0]、【】付き4言語）
- **entities 系**: `detectWorkLanguage`（優先順位: genres→languageDownloads(workno一致優先)→タイトル、13言語）

詳細ページは transformer 産 `_computed.primaryLanguage`、一覧フィルタは entities 産 `filterWorksByLanguage` を使うため、**「フィルタで選んだ言語と詳細表示の言語が食い違う」**ことが構造上起こりえた。

## 変更

- `detectWorkLanguage` / `getSupportedLanguages` を**言語判定の正本**と宣言し、transformer の独自実装4関数 + `LANGUAGE_CODE_MAP` を削除して**委譲に置換**（`_computed.primaryLanguage` = `detectWorkLanguage(doc) ?? "ja"`、`availableLanguages` = `getSupportedLanguages(doc)`）。
- transformer 固有だった別名（**jp / zho / zh / chi / chn / zht / tw / kr / vn**）を `LANGUAGE_CODE_MAPPING` に統合し、`normalizeLanguageCode` で一元的に扱う。
- `filterWorksByLanguage` の `@deprecated` を解消（正本のフィルタ経路と明記）。
- **transformer に `__tests__` 新設**（従来ゼロ）。`_computed` が `detectWorkLanguage`/`getSupportedLanguages` と一致すること、統合エイリアス（`kr`→`ko`）を固定。

## 意図的な挙動変更（Two-Way Door: `_computed` は読み取り時計算で Firestore 非永続 → migration 不要）

- 判定優先順位が **genres→downloads→title** に統一（旧 transformer はタイトル優先）。
- `availableLanguages` は entities 流に**「ja を常に追加」しない** → 非日本語の翻訳作品でバッジから日本語が消える場合がある。
- `primaryLanguage` は `"other"`（表示名「その他言語」、`WORK_LANGUAGE_DISPLAY_NAMES` 確認済み）を取りうる。
- **詳細表示とフィルタは同じ `detectWorkLanguage` を使うため一致する**（本 Issue の主目的）。

`pnpm verify` green（shared-types branches 81.75% ≥ 78、transformer のテスト追加で改善）。

Closes SPR-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)