### PR TITLE
refactor(web): circle/creator 作品リストの sort・検索・変換を共通化 第1段 (SPR-185)

### DIFF
--- a/apps/web/src/app/circles/[circleId]/actions.ts
+++ b/apps/web/src/app/circles/[circleId]/actions.ts
@@ -6,65 +6,10 @@ import type {
 	WorkDocument,
 	WorkPlainObject,
 } from "@suzumina.click/shared-types";
-import {
-	convertToCirclePlainObject,
-	isValidCircleId,
-	workTransformers,
-} from "@suzumina.click/shared-types";
+import { convertToCirclePlainObject, isValidCircleId } from "@suzumina.click/shared-types";
+import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
 import { getFirestore } from "@/lib/firestore";
-import { warn } from "@/lib/logger";
-
-/**
- * Compare works by date (newest or oldest)
- */
-function compareByDate(a: WorkPlainObject, b: WorkPlainObject, isOldest = false): number {
-	const dateA = a.releaseDateISO || "1900-01-01";
-	const dateB = b.releaseDateISO || "1900-01-01";
-	if (dateA === dateB) {
-		return isOldest
-			? a.productId.localeCompare(b.productId)
-			: b.productId.localeCompare(a.productId);
-	}
-	return isOldest ? dateA.localeCompare(dateB) : dateB.localeCompare(dateA);
-}
-
-/**
- * Compare works by rating (popular)
- */
-function compareByRating(a: WorkPlainObject, b: WorkPlainObject): number {
-	const ratingA = a.rating?.stars || 0;
-	const ratingB = b.rating?.stars || 0;
-	return ratingB - ratingA;
-}
-
-/**
- * Compare works by price
- */
-function compareByPrice(a: WorkPlainObject, b: WorkPlainObject, isHighToLow = false): number {
-	const priceA = a.price?.current || 0;
-	const priceB = b.price?.current || 0;
-	return isHighToLow ? priceB - priceA : priceA - priceB;
-}
-
-/**
- * Works sorting comparison function
- */
-function compareWorks(a: WorkPlainObject, b: WorkPlainObject, sort: string): number {
-	switch (sort) {
-		case "newest":
-			return compareByDate(a, b, false);
-		case "oldest":
-			return compareByDate(a, b, true);
-		case "popular":
-			return compareByRating(a, b);
-		case "price_low":
-			return compareByPrice(a, b, false);
-		case "price_high":
-			return compareByPrice(a, b, true);
-		default:
-			return compareByDate(a, b, false);
-	}
-}
+import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
 
 /**
  * サークル情報を取得
@@ -140,38 +85,11 @@ export async function getCircleWorksList(params: {
 				return work.circleId === circleId || work.circle === circleName;
 			});
 
-		// WorkPlainObjectに変換
-		const convertedWorks: WorkPlainObject[] = [];
-		for (const work of allMatchingWorks) {
-			try {
-				const converted = workTransformers.fromFirestore(work);
-				convertedWorks.push(converted);
-			} catch (error) {
-				// Log warning but continue processing other items
-				warn(`Failed to convert work ${work.id}`, {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			}
-		}
+		// WorkPlainObjectに変換（work-converters の正本を共用）
+		const convertedWorks = convertWorksToPlainObjects(allMatchingWorks);
 
-		// 検索フィルタリング
-		let filteredWorks = convertedWorks;
-		if (search) {
-			const searchLower = search.toLowerCase();
-			filteredWorks = convertedWorks.filter((work) => {
-				const searchableText = [
-					work.title,
-					work.description,
-					...(work.creators?.voiceActors?.map((actor) => actor.name) || []),
-					...(work.customGenres || []),
-					...(work.genres || []),
-				]
-					.filter(Boolean)
-					.join(" ")
-					.toLowerCase();
-				return searchableText.includes(searchLower);
-			});
-		}
+		// 検索フィルタリング（circle/creator 共通）
+		const { filtered: filteredWorks, count: filteredCount } = searchWorks(convertedWorks, search);
 
 		// ソート処理
 		filteredWorks.sort((a, b) => compareWorks(a, b, sort));
@@ -184,7 +102,7 @@ export async function getCircleWorksList(params: {
 		return {
 			works: paginatedWorks,
 			totalCount: convertedWorks.length,
-			filteredCount: search ? filteredWorks.length : undefined,
+			filteredCount,
 		};
 	} catch (_error) {
 		// エラー発生時は空配列を返す

--- a/apps/web/src/app/creators/[creatorId]/actions.ts
+++ b/apps/web/src/app/creators/[creatorId]/actions.ts
@@ -7,61 +7,10 @@ import type {
 	WorkDocument,
 	WorkPlainObject,
 } from "@suzumina.click/shared-types";
-import { isValidCreatorId, workTransformers } from "@suzumina.click/shared-types";
+import { isValidCreatorId } from "@suzumina.click/shared-types";
+import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
 import { getFirestore } from "@/lib/firestore";
-import { warn } from "@/lib/logger";
-
-/**
- * Compare works by date (newest or oldest)
- */
-function compareByDate(a: WorkPlainObject, b: WorkPlainObject, isOldest = false): number {
-	const dateA = a.releaseDateISO || a.registDate || "1900-01-01";
-	const dateB = b.releaseDateISO || b.registDate || "1900-01-01";
-	if (dateA === dateB) {
-		return isOldest
-			? a.productId.localeCompare(b.productId)
-			: b.productId.localeCompare(a.productId);
-	}
-	return isOldest ? dateA.localeCompare(dateB) : dateB.localeCompare(dateA);
-}
-
-/**
- * Compare works by rating (popular)
- */
-function compareByRating(a: WorkPlainObject, b: WorkPlainObject): number {
-	const ratingA = a.rating?.stars || 0;
-	const ratingB = b.rating?.stars || 0;
-	return ratingB - ratingA;
-}
-
-/**
- * Compare works by price
- */
-function compareByPrice(a: WorkPlainObject, b: WorkPlainObject, isHighToLow = false): number {
-	const priceA = a.price?.current || 0;
-	const priceB = b.price?.current || 0;
-	return isHighToLow ? priceB - priceA : priceA - priceB;
-}
-
-/**
- * Works sorting comparison function
- */
-function compareWorks(a: WorkPlainObject, b: WorkPlainObject, sort: string): number {
-	switch (sort) {
-		case "newest":
-			return compareByDate(a, b, false);
-		case "oldest":
-			return compareByDate(a, b, true);
-		case "popular":
-			return compareByRating(a, b);
-		case "price_low":
-			return compareByPrice(a, b, false);
-		case "price_high":
-			return compareByPrice(a, b, true);
-		default:
-			return compareByDate(a, b, false);
-	}
-}
+import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
 
 /**
  * クリエイター情報を取得
@@ -168,59 +117,6 @@ async function fetchWorkDocuments(
 }
 
 /**
- * 作品をWorkPlainObjectに変換
- */
-function convertWorksToPlainObjects(allWorks: WorkDocument[]): WorkPlainObject[] {
-	const convertedWorks: WorkPlainObject[] = [];
-	for (const work of allWorks) {
-		try {
-			const converted = workTransformers.fromFirestore(work);
-			convertedWorks.push(converted);
-		} catch (error) {
-			// Log warning but continue processing other items
-			warn(`Failed to convert work ${work.id}`, {
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-	}
-	return convertedWorks;
-}
-
-/**
- * 検索フィルター適用
- */
-function applySearchFilter(
-	works: WorkPlainObject[],
-	search?: string,
-): { filtered: WorkPlainObject[]; count?: number } {
-	if (!search) {
-		return { filtered: works };
-	}
-
-	const searchLower = search.toLowerCase();
-	const filtered = works.filter((work) => {
-		// タイトルで検索
-		if (work.title?.toLowerCase().includes(searchLower)) return true;
-
-		// 説明で検索
-		if (work.description?.toLowerCase().includes(searchLower)) return true;
-
-		// 声優名で検索（WorkPlainObjectでは voiceActors フィールド）
-		if (work.creators?.voiceActors?.some((va) => va.name?.toLowerCase().includes(searchLower))) {
-			return true;
-		}
-
-		// ジャンルで検索（WorkPlainObjectでは genres は string[] ）
-		if (work.genres?.some((genre) => genre.toLowerCase().includes(searchLower))) return true;
-		if (work.customGenres?.some((genre) => genre.toLowerCase().includes(searchLower))) return true;
-
-		return false;
-	});
-
-	return { filtered, count: filtered.length };
-}
-
-/**
  * クリエイター作品リストを取得（ConfigurableList用）
  * @param params パラメータ
  * @returns 作品一覧と総件数
@@ -258,10 +154,7 @@ export async function getCreatorWorksList(params: {
 		const convertedWorks = convertWorksToPlainObjects(allWorks);
 
 		// 検索フィルター適用
-		const { filtered: filteredWorks, count: filteredCount } = applySearchFilter(
-			convertedWorks,
-			search,
-		);
+		const { filtered: filteredWorks, count: filteredCount } = searchWorks(convertedWorks, search);
 
 		// ソート処理
 		filteredWorks.sort((a, b) => compareWorks(a, b, sort));

--- a/apps/web/src/lib/__tests__/circle-creator-works.test.ts
+++ b/apps/web/src/lib/__tests__/circle-creator-works.test.ts
@@ -1,0 +1,76 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { compareWorks, searchWorks } from "../circle-creator-works";
+
+const work = (overrides: Partial<WorkPlainObject>): WorkPlainObject =>
+	({
+		productId: "RJ000000",
+		title: "",
+		description: "",
+		releaseDateISO: undefined,
+		registDate: undefined,
+		rating: undefined,
+		price: undefined,
+		genres: [],
+		customGenres: [],
+		creators: { voiceActors: [] },
+		...overrides,
+	}) as unknown as WorkPlainObject;
+
+describe("circle-creator-works compareWorks", () => {
+	it("newest: releaseDateISO 降順", () => {
+		const a = work({ productId: "RJ1", releaseDateISO: "2025-01-01" });
+		const b = work({ productId: "RJ2", releaseDateISO: "2025-02-01" });
+		expect([a, b].sort((x, y) => compareWorks(x, y, "newest"))[0]).toBe(b);
+	});
+
+	it("oldest: releaseDateISO 昇順", () => {
+		const a = work({ productId: "RJ1", releaseDateISO: "2025-01-01" });
+		const b = work({ productId: "RJ2", releaseDateISO: "2025-02-01" });
+		expect([b, a].sort((x, y) => compareWorks(x, y, "oldest"))[0]).toBe(a);
+	});
+
+	it("releaseDateISO 欠落時は registDate にフォールバックする", () => {
+		const a = work({ productId: "RJ1", registDate: "2025-01-01" });
+		const b = work({ productId: "RJ2", registDate: "2025-02-01" });
+		// newest 降順 → registDate が新しい b が先頭
+		expect([a, b].sort((x, y) => compareWorks(x, y, "newest"))[0]).toBe(b);
+	});
+
+	it("popular: rating.stars 降順（count ではない）", () => {
+		const a = work({ productId: "RJ1", rating: { stars: 3, count: 999 } as never });
+		const b = work({ productId: "RJ2", rating: { stars: 5, count: 1 } as never });
+		expect([a, b].sort((x, y) => compareWorks(x, y, "popular"))[0]).toBe(b);
+	});
+
+	it("price_low / price_high", () => {
+		const cheap = work({ productId: "RJ1", price: { current: 100 } as never });
+		const pricey = work({ productId: "RJ2", price: { current: 999 } as never });
+		expect([pricey, cheap].sort((x, y) => compareWorks(x, y, "price_low"))[0]).toBe(cheap);
+		expect([cheap, pricey].sort((x, y) => compareWorks(x, y, "price_high"))[0]).toBe(pricey);
+	});
+});
+
+describe("circle-creator-works searchWorks", () => {
+	const works = [
+		work({ productId: "RJ1", title: "魔法少女の冒険" }),
+		work({ productId: "RJ2", description: "勇者の物語", title: "別作品" }),
+		work({ productId: "RJ3", creators: { voiceActors: [{ id: "c", name: "田中" }] } as never }),
+		work({ productId: "RJ4", genres: ["ファンタジー"] }),
+	];
+
+	it("検索なしは全件・count undefined", () => {
+		expect(searchWorks(works)).toEqual({ filtered: works });
+	});
+
+	it("タイトル / 説明 / 声優名 / ジャンルを横断検索する", () => {
+		expect(searchWorks(works, "魔法").filtered.map((w) => w.productId)).toEqual(["RJ1"]);
+		expect(searchWorks(works, "勇者").filtered.map((w) => w.productId)).toEqual(["RJ2"]);
+		expect(searchWorks(works, "田中").filtered.map((w) => w.productId)).toEqual(["RJ3"]);
+		expect(searchWorks(works, "ファンタジー").filtered.map((w) => w.productId)).toEqual(["RJ4"]);
+	});
+
+	it("ヒット時は count を返す", () => {
+		expect(searchWorks(works, "作品").count).toBe(1);
+	});
+});

--- a/apps/web/src/lib/circle-creator-works.ts
+++ b/apps/web/src/lib/circle-creator-works.ts
@@ -1,0 +1,79 @@
+/**
+ * circle / creator の作品リストページ共通ロジック（WorkPlainObject 対象）。
+ *
+ * works 一覧（`app/works/lib/`）のソート・フィルタは WorkDocument 対象で
+ * レイヤーが異なるため共用しない。本モジュールは circle/creator 間の重複解消に限定する（SPR-185）。
+ *
+ * 「人気順(popular)」は rating.stars 基準。works 一覧（rating.count 基準）との
+ * 意味統一は SPR-190 で別途扱う。
+ */
+
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+
+function compareByDate(a: WorkPlainObject, b: WorkPlainObject, isOldest = false): number {
+	// releaseDateISO → registDate → "1900-01-01" の順でフォールバック。
+	// 旧 circle 版は registDate フォールバックを欠いていたが、より頑健な creator 版に統一。
+	const dateA = a.releaseDateISO || a.registDate || "1900-01-01";
+	const dateB = b.releaseDateISO || b.registDate || "1900-01-01";
+	if (dateA === dateB) {
+		return isOldest
+			? a.productId.localeCompare(b.productId)
+			: b.productId.localeCompare(a.productId);
+	}
+	return isOldest ? dateA.localeCompare(dateB) : dateB.localeCompare(dateA);
+}
+
+function compareByRating(a: WorkPlainObject, b: WorkPlainObject): number {
+	return (b.rating?.stars || 0) - (a.rating?.stars || 0);
+}
+
+function compareByPrice(a: WorkPlainObject, b: WorkPlainObject, isHighToLow = false): number {
+	const priceA = a.price?.current || 0;
+	const priceB = b.price?.current || 0;
+	return isHighToLow ? priceB - priceA : priceA - priceB;
+}
+
+/**
+ * circle / creator 共通のソート比較関数。
+ */
+export function compareWorks(a: WorkPlainObject, b: WorkPlainObject, sort: string): number {
+	switch (sort) {
+		case "oldest":
+			return compareByDate(a, b, true);
+		case "popular":
+			return compareByRating(a, b);
+		case "price_low":
+			return compareByPrice(a, b, false);
+		case "price_high":
+			return compareByPrice(a, b, true);
+		default:
+			return compareByDate(a, b, false); // newest
+	}
+}
+
+/**
+ * circle / creator 共通の検索フィルタ（タイトル / 説明 / 声優名 / ジャンル）。
+ * @returns filtered と、検索時のみ件数 count
+ */
+export function searchWorks(
+	works: WorkPlainObject[],
+	search?: string,
+): { filtered: WorkPlainObject[]; count?: number } {
+	if (!search) {
+		return { filtered: works };
+	}
+
+	const searchLower = search.toLowerCase();
+	const filtered = works.filter((work) => {
+		if (work.title?.toLowerCase().includes(searchLower)) return true;
+		if (work.description?.toLowerCase().includes(searchLower)) return true;
+		if (work.creators?.voiceActors?.some((va) => va.name?.toLowerCase().includes(searchLower))) {
+			return true;
+		}
+		if (work.genres?.some((genre) => genre.toLowerCase().includes(searchLower))) return true;
+		if (work.customGenres?.some((genre) => genre.toLowerCase().includes(searchLower))) return true;
+		return false;
+	});
+
+	return { filtered, count: filtered.length };
+}


### PR DESCRIPTION
## 背景（軸3: 同名関数の挙動差・画面別挙動差）

circle / creator の作品リスト action が **compareWorks / 検索 predicate / 変換ループ**をそれぞれ重複実装していた（`convertWorksToPlainObjects` は work-converters.ts 正本・creator コピー・circle インラインの3実装）。

## 変更（第1段 = 純粋な dedup）

- WorkPlainObject 対象の共通ロジックを **`lib/circle-creator-works.ts`**（`compareWorks` / `searchWorks`）に集約。
- 変換は **`work-converters.ts` の `convertWorksToPlainObjects`** を共用（creator コピーと circle インラインを削除）。`id ||= productId` フォールバックの差は両呼び出し元が `doc.id` 設定済みのため実害なし。
- **registDate フォールバックの確定**: creator 版（`releaseDateISO → registDate → 1900`）に統一。旧 circle 版はこのフォールバックを欠いていたが、実データで `releaseDateISO` 欠落作品の並びがわずかに改善するのみ（既存テストは両日付同値のため不変・Two-Way Door）。
- 共通モジュールの単体テストを追加。**既存の circle/creator actions テスト31件は無変更で通過**。

## スコープ外（後続）

- 「人気順」の意味統一（circle/creator の `rating.stars` ↔ works 一覧の `rating.count`）→ **SPR-190**（本 PR では従来どおり `rating.stars` 基準を維持）。
- `works/lib`（WorkDocument 対象）はレイヤーが異なるため共用せず、circle/creator 間の dedup に限定（issue 記載どおり）。

`pnpm verify` green。

Closes SPR-185

🤖 Generated with [Claude Code](https://claude.com/claude-code)