### PR TITLE
fix(web): 設定リセットの偽装挙動を解消 (SPR-177)

### DIFF
--- a/apps/web/src/app/settings/components/__tests__/unified-settings-content.test.tsx
+++ b/apps/web/src/app/settings/components/__tests__/unified-settings-content.test.tsx
@@ -1,0 +1,89 @@
+import type { FrontendUserData } from "@suzumina.click/shared-types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UnifiedSettingsContent } from "../unified-settings-content";
+
+const { updateAgeVerification, resetAllConsent, updateUserProfile, getCurrentConsentState } =
+	vi.hoisted(() => ({
+		updateAgeVerification: vi.fn(),
+		resetAllConsent: vi.fn(),
+		updateUserProfile: vi.fn(),
+		getCurrentConsentState: vi.fn(() => null),
+	}));
+
+// このコンポーネントが使う lucide アイコンはグローバルモックに揃っていないため、
+// 必要なアイコンを no-op コンポーネントとして明示的に上書きする
+vi.mock("lucide-react", () => {
+	const Icon = () => null;
+	return {
+		Calendar: Icon,
+		ChevronRight: Icon,
+		Cookie: Icon,
+		Eye: Icon,
+		EyeOff: Icon,
+		Info: Icon,
+		Lock: Icon,
+		RotateCcw: Icon,
+		Settings: Icon,
+		Shield: Icon,
+		User: Icon,
+		UserCheck: Icon,
+	};
+});
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/contexts/age-verification-context", () => ({
+	useAgeVerification: () => ({ isAdult: true, updateAgeVerification }),
+}));
+vi.mock("@/lib/consent/google-consent-mode", () => ({
+	getCurrentConsentState,
+	resetAllConsent,
+}));
+vi.mock("../../actions", () => ({ updateUserProfile }));
+
+const user = {
+	discordId: "123",
+	username: "tester",
+	displayName: "テスター",
+	isPublicProfile: true,
+} as unknown as FrontendUserData;
+
+describe("UnifiedSettingsContent のリセット挙動（SPR-177）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.stubGlobal(
+			"confirm",
+			vi.fn(() => true),
+		);
+	});
+
+	it("リセットはブラウザローカル設定のみ初期化し、サーバープロフィールを更新しない", async () => {
+		render(<UnifiedSettingsContent user={user} />);
+
+		const resetButton = await screen.findByRole("button", { name: /ブラウザ設定をリセット/ });
+		fireEvent.click(resetButton);
+
+		// ブラウザローカル設定（年齢確認・Cookie同意）はリセットされる
+		expect(updateAgeVerification).toHaveBeenCalledWith(false);
+		expect(resetAllConsent).toHaveBeenCalledTimes(1);
+		// サーバー永続のプロフィール設定には触れない（旧実装の偽リセットを解消）
+		expect(updateUserProfile).not.toHaveBeenCalled();
+	});
+
+	it("confirm をキャンセルすると何もしない", async () => {
+		vi.stubGlobal(
+			"confirm",
+			vi.fn(() => false),
+		);
+		render(<UnifiedSettingsContent user={user} />);
+
+		const resetButton = await screen.findByRole("button", { name: /ブラウザ設定をリセット/ });
+		fireEvent.click(resetButton);
+
+		expect(updateAgeVerification).not.toHaveBeenCalled();
+		expect(resetAllConsent).not.toHaveBeenCalled();
+		expect(updateUserProfile).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/app/settings/components/unified-settings-content.tsx
+++ b/apps/web/src/app/settings/components/unified-settings-content.tsx
@@ -103,9 +103,10 @@ export function UnifiedSettingsContent({ user }: UnifiedSettingsContentProps) {
 		});
 	};
 
-	// 全設定をリセット
+	// ブラウザに保存された設定（年齢確認・Cookie同意）をリセットする。
+	// プロフィール公開設定はサーバー永続のため対象外（別途プロフィールタブで変更する）。
 	const handleResetAll = () => {
-		if (confirm("全ての設定をリセットしますか？この操作は元に戻せません。")) {
+		if (confirm("このブラウザに保存された設定（年齢確認・Cookie同意）をリセットしますか？")) {
 			updateAgeVerification(false);
 			resetAllConsent();
 			setConsentState({
@@ -113,8 +114,7 @@ export function UnifiedSettingsContent({ user }: UnifiedSettingsContentProps) {
 				functional: true,
 				personalization: false,
 			});
-			setIsPublicProfile(true);
-			toast.success("全ての設定をリセットしました");
+			toast.success("ブラウザ設定をリセットしました");
 		}
 	};
 
@@ -291,13 +291,15 @@ export function UnifiedSettingsContent({ user }: UnifiedSettingsContentProps) {
 							{/* リセット */}
 							<Card className="border-destructive/20">
 								<CardHeader>
-									<CardTitle className="text-destructive">危険な操作</CardTitle>
-									<CardDescription>これらの操作は元に戻すことができません</CardDescription>
+									<CardTitle>ブラウザ設定のリセット</CardTitle>
+									<CardDescription>
+										このブラウザに保存された設定（年齢確認・Cookie同意）を初期化します。プロフィールの公開設定には影響しません。
+									</CardDescription>
 								</CardHeader>
 								<CardContent>
 									<Button variant="destructive" onClick={handleResetAll} className="w-full">
 										<RotateCcw className="h-4 w-4 mr-2" />
-										全ての設定をリセット
+										ブラウザ設定をリセット
 									</Button>
 								</CardContent>
 							</Card>


### PR DESCRIPTION
## 背景（軸3: 名前と実挙動のズレ）

`handleResetAll` が `setIsPublicProfile(true)` で**ローカル state を書き換えるだけ**で `updateUserProfile` を呼ばないのに「全ての設定をリセットしました」と表示していた。`isPublicProfile` はこのページ唯一のサーバー永続設定（年齢確認・Cookie同意は localStorage）で、リロードすると表示が元に戻る偽リセットだった。

## 変更（推奨案: リセット＝ブラウザローカルのみ）

- `setIsPublicProfile(true)` を削除し、リセットの責務を**ブラウザローカル設定（年齢確認・Cookie同意）のみ**に明確化。
- confirm / カードタイトル / 説明 / ボタン文言を実態に合わせて修正（「プロフィールの公開設定には影響しません」と明記）。「危険な操作 / 元に戻せません」の誤誘導も解消。
- リセット挙動のテストを追加: `updateUserProfile` を呼ばないこと、`updateAgeVerification(false)`/`resetAllConsent` を呼ぶこと、confirm キャンセル時は無操作。

`pnpm verify` green。

Closes SPR-177

🤖 Generated with [Claude Code](https://claude.com/claude-code)