### PR TITLE
fix(functions): updateUnifiedMetadata の undefined 黙殺を解消 (SPR-179)

### DIFF
--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -21,6 +21,7 @@ import {
 } from "../services/dlsite/unified-data-processor";
 import { collectWorkIdsForProduction } from "../services/dlsite/work-id-collector";
 import { chunkArray } from "../shared/array-utils";
+import { withClearedUndefined } from "../shared/firestore-write";
 import * as logger from "../shared/logger";
 
 // 統合メタデータ保存用の定数
@@ -81,10 +82,14 @@ async function getOrCreateUnifiedMetadata(): Promise<CollectionMetadata> {
 
 /**
  * 統合データ収集メタデータの更新
+ *
+ * undefined フィールドは FieldValue.delete() へ変換してから書き込む。
+ * ignoreUndefinedProperties 環境では undefined がスキップされ旧値が残る（sticky）ため、
+ * メタデータをクリア可能にする（`withClearedUndefined` 参照）。
  */
 async function updateUnifiedMetadata(update: Partial<CollectionMetadata>): Promise<void> {
 	const metadataRef = firestore.collection(METADATA_COLLECTION).doc(UNIFIED_METADATA_DOC_ID);
-	await metadataRef.update(update);
+	await metadataRef.update(withClearedUndefined(update));
 }
 
 /**

--- a/apps/functions/src/shared/__tests__/firestore-write.test.ts
+++ b/apps/functions/src/shared/__tests__/firestore-write.test.ts
@@ -1,0 +1,21 @@
+import { FieldValue } from "@google-cloud/firestore";
+import { describe, expect, it } from "vitest";
+import { withClearedUndefined } from "../firestore-write";
+
+describe("withClearedUndefined (SPR-179: sticky フィールドのクリア)", () => {
+	it("undefined フィールドは FieldValue.delete() に変換される（旧値を残さずクリア）", () => {
+		const result = withClearedUndefined({ totalWorks: 100, lastError: undefined });
+
+		expect(result.totalWorks).toBe(100);
+		const del = result.lastError as ReturnType<typeof FieldValue.delete>;
+		expect(del.isEqual(FieldValue.delete())).toBe(true);
+	});
+
+	it("定義済みの値（0 / false / 空文字を含む）はそのまま渡す", () => {
+		expect(withClearedUndefined({ a: 0, b: false, c: "" })).toEqual({ a: 0, b: false, c: "" });
+	});
+
+	it("空オブジェクトは空オブジェクトを返す", () => {
+		expect(withClearedUndefined({})).toEqual({});
+	});
+});

--- a/apps/functions/src/shared/firestore-write.ts
+++ b/apps/functions/src/shared/firestore-write.ts
@@ -1,0 +1,17 @@
+import { FieldValue } from "@google-cloud/firestore";
+
+/**
+ * 更新オブジェクトの undefined フィールドを FieldValue.delete() に変換する。
+ *
+ * クライアントが `ignoreUndefinedProperties: true` の環境では、`update()` / `set(merge)` に
+ * 渡した undefined フィールドは「スキップ」されるだけで「削除」されず旧値が残る（sticky）。
+ * 「不在」を表す undefined を明示的に delete してフィールドをクリア可能にする
+ * （既知の Firestore merge sticky 問題 / works 側 `toWorkWriteData` と同系統）。
+ */
+export function withClearedUndefined(update: object): Record<string, unknown> {
+	const normalized: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(update)) {
+		normalized[key] = value === undefined ? FieldValue.delete() : value;
+	}
+	return normalized;
+}


### PR DESCRIPTION
## 背景（軸3 / 既知の Firestore merge sticky 問題）

`updateUnifiedMetadata` の `metadataRef.update(update)` は、クライアントの `ignoreUndefinedProperties: true` により **undefined フィールドがスキップされ旧値が残る**（sticky）。一度設定したメタデータがクリア不能だった。works 側（`toWorkWriteData`）は既に `FieldValue.delete()` で修正済みで、メタデータ側に同パターンが残存していた。

## 変更

- 汎用ユーティリティ **`withClearedUndefined`** を `shared/firestore-write.ts` に新設。`update` の undefined フィールドを `FieldValue.delete()` へ変換してから書き込み、「不在」を確実に反映する。
- `updateUnifiedMetadata` がこれを通すよう変更。
- クリア動作のテストを追加（undefined→delete / 定義値はそのまま / 空オブジェクト）。

> 補足: ヘルパを小モジュールへ切り出したのは、テストが 670 行のエンドポイントを import するとカバレッジ集計（Vitest 4 は import 済みファイルを計上）が崩れるため。util 単独テストで集計は不変。

`pnpm verify` green。

Closes SPR-179

🤖 Generated with [Claude Code](https://claude.com/claude-code)