### PR TITLE
refactor(web): getVideoBadgeInfo を _computed.videoType に一本化 (SPR-186)

### DIFF
--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-detail.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-detail.test.tsx
@@ -333,32 +333,33 @@ describe("VideoDetail", () => {
 		});
 	});
 
-	describe("動画タイプバッジ", () => {
-		it("配信中（live）はライブ配信バッジを表示する", () => {
-			render(<VideoDetail video={createMockVideo({ liveBroadcastContent: "live" })} />);
+	// SPR-186: 詳細ページのバッジ判定も card と同じ _computed.videoType を正本にする。
+	describe("動画タイプバッジ（_computed.videoType が正本）", () => {
+		it("videoType=live はライブ配信バッジを表示する", () => {
+			render(<VideoDetail video={createMockVideo({ _computed: { videoType: "live" } })} />);
 			expect(screen.getByLabelText("現在配信中のライブ配信")).toBeInTheDocument();
 		});
 
-		it("配信予告（upcoming）は配信予定バッジを表示する", () => {
-			render(<VideoDetail video={createMockVideo({ liveBroadcastContent: "upcoming" })} />);
+		it("videoType=upcoming は配信予定バッジを表示する", () => {
+			render(<VideoDetail video={createMockVideo({ _computed: { videoType: "upcoming" } })} />);
 			expect(screen.getByLabelText("配信予定のライブ配信")).toBeInTheDocument();
 		});
 
 		it("videoType=archived は配信アーカイブバッジを表示する", () => {
-			render(
-				<VideoDetail
-					video={createMockVideo({ liveBroadcastContent: "none", videoType: "archived" })}
-				/>,
-			);
+			render(<VideoDetail video={createMockVideo({ _computed: { videoType: "archived" } })} />);
 			expect(screen.getByLabelText("ライブ配信のアーカイブ")).toBeInTheDocument();
 		});
 
-		it("liveStreamingDetails に開始・終了がある none は配信アーカイブ扱い", () => {
+		it("videoType=premiere はプレミア公開バッジを表示する", () => {
+			render(<VideoDetail video={createMockVideo({ _computed: { videoType: "premiere" } })} />);
+			expect(screen.getByLabelText("プレミア公開動画")).toBeInTheDocument();
+		});
+
+		it("liveStreamingDetails があっても _computed.videoType=normal なら通常動画（正本は _computed）", () => {
 			render(
 				<VideoDetail
 					video={createMockVideo({
-						liveBroadcastContent: "none",
-						videoType: "normal",
+						_computed: { videoType: "normal" },
 						liveStreamingDetails: {
 							actualStartTime: "2024-01-01T12:00:00Z",
 							actualEndTime: "2024-01-01T14:00:00Z",
@@ -366,12 +367,12 @@ describe("VideoDetail", () => {
 					})}
 				/>,
 			);
-			expect(screen.getByLabelText("ライブ配信のアーカイブ")).toBeInTheDocument();
+			expect(screen.getByLabelText("通常動画コンテンツ")).toBeInTheDocument();
 		});
 
-		it("通常動画は動画コンテンツバッジを表示する", () => {
+		it("通常動画は通常動画バッジを表示する", () => {
 			render(<VideoDetail video={createMockVideo()} />);
-			expect(screen.getByLabelText("動画コンテンツ")).toBeInTheDocument();
+			expect(screen.getByLabelText("通常動画コンテンツ")).toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/app/videos/[videoId]/components/video-detail.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/video-detail.tsx
@@ -6,20 +6,11 @@ import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card } from "@suzumina.click/ui/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@suzumina.click/ui/components/ui/tabs";
-import {
-	Calendar,
-	Clock,
-	ExternalLink,
-	Eye,
-	PlayCircle,
-	Plus,
-	Radio,
-	Timer,
-	Video,
-} from "lucide-react";
+import { Calendar, ExternalLink, Eye, PlayCircle, Plus, Timer } from "lucide-react";
 import Link from "next/link";
 import React, { type ReactNode, useMemo } from "react";
 import { ThumbnailImage } from "@/components/ui";
+import { getVideoBadgeInfo } from "@/components/video/video-badge";
 import { useSession } from "@/lib/auth/client";
 import { formatDescriptionText } from "@/lib/text-utils";
 import { VideoUserTagEditor } from "./video-user-tag-editor";
@@ -98,52 +89,6 @@ const formatDuration = (duration?: string) => {
 	// 常にhh:mm:ssフォーマットで表示
 	return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
 };
-
-// 動画タイプバッジの情報を取得
-function getVideoBadgeInfo(video: VideoPlainObject) {
-	switch (video.liveBroadcastContent) {
-		case "live":
-			return {
-				text: "配信中",
-				icon: Radio,
-				className: "bg-red-600/80 text-white border-none",
-				ariaLabel: "現在配信中のライブ配信",
-			};
-		case "upcoming":
-			return {
-				text: "配信予告",
-				icon: Clock,
-				className: "bg-blue-600/80 text-white border-none",
-				ariaLabel: "配信予定のライブ配信",
-			};
-		case "none":
-			// videoType が"archived"の場合、または liveStreamingDetails に actualStartTime と actualEndTime がある場合は配信アーカイブ
-			if (
-				video.videoType === "archived" ||
-				(video.liveStreamingDetails?.actualStartTime && video.liveStreamingDetails?.actualEndTime)
-			) {
-				return {
-					text: "配信アーカイブ",
-					icon: Radio,
-					className: "bg-gray-600/80 text-white border-none",
-					ariaLabel: "ライブ配信のアーカイブ",
-				};
-			}
-			return {
-				text: "動画",
-				icon: Video,
-				className: "bg-black/80 text-white border-none",
-				ariaLabel: "動画コンテンツ",
-			};
-		default:
-			return {
-				text: "動画",
-				icon: Video,
-				className: "bg-black/80 text-white border-none",
-				ariaLabel: "動画コンテンツ",
-			};
-	}
-}
 
 // 音声ボタン作成可能判定
 function getCanCreateButtonData(video: VideoPlainObject, user: UserSession | null) {
@@ -288,7 +233,10 @@ export default function VideoDetail({
 							</div>
 
 							<div className="absolute top-4 right-4">
-								<Badge className={videoBadgeInfo.className} aria-label={videoBadgeInfo.ariaLabel}>
+								<Badge
+									className={`${videoBadgeInfo.className} border-none`}
+									aria-label={videoBadgeInfo.ariaLabel}
+								>
 									{React.createElement(videoBadgeInfo.icon, {
 										className: "h-3 w-3 mr-1",
 										"aria-hidden": "true",

--- a/apps/web/src/app/videos/components/video-card.tsx
+++ b/apps/web/src/app/videos/components/video-card.tsx
@@ -3,62 +3,13 @@ import { HighlightText } from "@suzumina.click/ui/components/custom/highlight-te
 import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
-import { Calendar, Clock, Lock, Radio, Video } from "lucide-react";
+import { Calendar, Lock } from "lucide-react";
 import Link from "next/link";
 import React from "react";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
+import { getVideoBadgeInfo } from "@/components/video/video-badge";
 import { buildTagSearchHref } from "@/lib/tag-search";
 import VideoCardActions from "./video-card-actions";
-
-// 動画タイプ別バッジ情報（純関数）
-function getVideoBadgeInfo(video: VideoPlainObject) {
-	// VideoPlainObject は常に_computedプロパティを持つ
-	const { videoType } = video._computed;
-	switch (videoType) {
-		case "live":
-			return {
-				text: "配信中",
-				icon: Radio,
-				className: "bg-red-600/90 text-white",
-				ariaLabel: "現在配信中のライブ配信",
-			};
-		case "upcoming":
-			return {
-				text: "配信予告",
-				icon: Clock,
-				className: "bg-blue-600/90 text-white",
-				ariaLabel: "配信予定のライブ配信",
-			};
-		case "possibly_live":
-			return {
-				text: "配信中（推定）",
-				icon: Radio,
-				className: "bg-red-600/90 text-white",
-				ariaLabel: "配信中の可能性があるライブ配信",
-			};
-		case "archived":
-			return {
-				text: "配信アーカイブ",
-				icon: Radio,
-				className: "bg-gray-600/90 text-white",
-				ariaLabel: "ライブ配信のアーカイブ",
-			};
-		case "premiere":
-			return {
-				text: "プレミア公開",
-				icon: Video,
-				className: "bg-purple-600/90 text-white",
-				ariaLabel: "プレミア公開動画",
-			};
-		default:
-			return {
-				text: "通常動画",
-				icon: Video,
-				className: "bg-black/70 text-white",
-				ariaLabel: "通常動画コンテンツ",
-			};
-	}
-}
 
 // 表示日付（純関数）: ライブ配信は配信開始時間を優先し、無効なら公開時間にフォールバック
 function getDisplayDate(video: VideoPlainObject) {

--- a/apps/web/src/components/video/video-badge.ts
+++ b/apps/web/src/components/video/video-badge.ts
@@ -1,0 +1,65 @@
+import type { VideoPlainObject } from "@suzumina.click/shared-types";
+import { Clock, type LucideIcon, Radio, Video } from "lucide-react";
+
+export interface VideoBadgeInfo {
+	text: string;
+	icon: LucideIcon;
+	className: string;
+	ariaLabel: string;
+}
+
+/**
+ * 動画タイプ別バッジ情報（純関数）。
+ *
+ * 正本は `VideoPlainObject._computed.videoType`（shared-types の determineVideoType 由来）。
+ * 一覧（video-card）と詳細（video-detail）で判定が二重化し表示が乖離していたため、
+ * 双方をこの関数に統一する（SPR-186）。className の濃度差・border 有無・icon 表示は
+ * 呼び出し側のクラス合成で吸収する。
+ */
+export function getVideoBadgeInfo(video: VideoPlainObject): VideoBadgeInfo {
+	const { videoType } = video._computed;
+	switch (videoType) {
+		case "live":
+			return {
+				text: "配信中",
+				icon: Radio,
+				className: "bg-red-600/90 text-white",
+				ariaLabel: "現在配信中のライブ配信",
+			};
+		case "upcoming":
+			return {
+				text: "配信予告",
+				icon: Clock,
+				className: "bg-blue-600/90 text-white",
+				ariaLabel: "配信予定のライブ配信",
+			};
+		case "possibly_live":
+			return {
+				text: "配信中（推定）",
+				icon: Radio,
+				className: "bg-red-600/90 text-white",
+				ariaLabel: "配信中の可能性があるライブ配信",
+			};
+		case "archived":
+			return {
+				text: "配信アーカイブ",
+				icon: Radio,
+				className: "bg-gray-600/90 text-white",
+				ariaLabel: "ライブ配信のアーカイブ",
+			};
+		case "premiere":
+			return {
+				text: "プレミア公開",
+				icon: Video,
+				className: "bg-purple-600/90 text-white",
+				ariaLabel: "プレミア公開動画",
+			};
+		default:
+			return {
+				text: "通常動画",
+				icon: Video,
+				className: "bg-black/70 text-white",
+				ariaLabel: "通常動画コンテンツ",
+			};
+	}
+}


### PR DESCRIPTION
## 背景（軸3: 二重正本）

同名 `getVideoBadgeInfo` が2箇所にあり判定が違った:
- `video-card.tsx`: 正本 `_computed.videoType` で switch
- `video-detail.tsx`: `liveBroadcastContent` + 独自ヒューリスティック（`liveStreamingDetails` の actualStart/EndTime 推定）

結果、「プレミア公開 vs 配信アーカイブ」「通常動画 vs 動画」のような表示乖離が実在した。

## 変更

- card の `_computed.videoType` ベース実装を **`components/video/video-badge.ts`** に抽出し、card / detail 双方から import。detail の独自実装を削除。
- className 濃度差・`border-none` は呼び出し側で合成（detail は `border-none` を付与）。
- `video-detail.test.tsx` のバッジテストを **`_computed.videoType` 駆動**に更新。

## 挙動変更（意図的・単一正本化）

- 詳細ページも `_computed.videoType` を正本にするため、`liveStreamingDetails` だけで「配信アーカイブ」と推定する旧ヒューリスティックは**廃止**。`_computed.videoType` が "normal" の動画は詳細でも「通常動画」と表示される（card と一致）。
- 文言を card に統一（"動画" → "通常動画"、aria も一致）。premiere も詳細で正しく「プレミア公開」表示。

`pnpm verify` green。

Closes SPR-186

🤖 Generated with [Claude Code](https://claude.com/claude-code)