### PR TITLE
refactor(web): 割引率表示の正本を current/original 算出に一本化 (SPR-187)

### DIFF
--- a/apps/web/src/app/works/[workId]/components/work-detail.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-detail.tsx
@@ -38,6 +38,7 @@ import { PriceHistory } from "@/components/price-history/price-history";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { formatJSTDateTime } from "@/utils/date-format";
 import { generateMockCharacteristicData } from "@/utils/mock-evaluation-data";
+import { calculatePriceInfo } from "../../utils/price-info";
 import SampleImageGallery from "./sample-image-gallery";
 import WorkDescription from "./work-description";
 import { WorkEvaluation } from "./work-evaluation";
@@ -61,22 +62,6 @@ function StarRating({ rating }: { rating: number }) {
 			))}
 		</div>
 	);
-}
-
-// 価格情報を計算
-function calculatePriceInfo(work: WorkPlainObject) {
-	const currentPrice = work.price.current;
-	// セール判定は「実割引（current < original）」を正本とする。
-	// discount フィールドはセール終了後も古い値が残りうるため判定にも表示にも使わない（軸3: 正本の整合性）。
-	const isOnSale = work.price.isDiscounted;
-	const originalPrice = isOnSale ? work.price.original : undefined;
-	// 割引率も current/original から算出し、判定と表示の正本を揃える。
-	const discountRate =
-		isOnSale && originalPrice
-			? Math.round(((originalPrice - currentPrice) / originalPrice) * 100)
-			: undefined;
-
-	return { currentPrice, originalPrice, isOnSale, discountRate };
 }
 
 // シェア処理
@@ -109,7 +94,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 
 	// 価格情報の計算
 	const { currentPrice, originalPrice, isOnSale, discountRate } = useMemo(
-		() => calculatePriceInfo(work),
+		() => calculatePriceInfo(work.price),
 		[work],
 	);
 

--- a/apps/web/src/app/works/components/__tests__/work-card.test.tsx
+++ b/apps/web/src/app/works/components/__tests__/work-card.test.tsx
@@ -86,6 +86,24 @@ describe("WorkCard", () => {
 		expect(screen.getByText("セール中")).toBeInTheDocument();
 	});
 
+	it("OFF 率は current/original から算出し、stale な price.discount は使わない（SPR-187）", () => {
+		// discount フィールドは古い 99 を持つが、表示は current/original 由来の 50% になる
+		const work = createWork({
+			price: {
+				current: 1100,
+				original: 2200,
+				currency: "JPY",
+				discount: 99,
+				isFree: false,
+				isDiscounted: true,
+				formattedPrice: "¥1,100",
+			},
+		});
+		render(<WorkCard work={work} />);
+		expect(screen.getByText("50% OFF")).toBeInTheDocument();
+		expect(screen.queryByText("99% OFF")).not.toBeInTheDocument();
+	});
+
 	it("非セール時は単一価格を表示し、セール中バッジ・OFF を出さない", () => {
 		const work = createWork({
 			price: {

--- a/apps/web/src/app/works/components/work-card.tsx
+++ b/apps/web/src/app/works/components/work-card.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import React from "react";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { normalizeJstDateString } from "@/utils/date-format";
+import { calculatePriceInfo } from "../utils/price-info";
 
 interface WorkCardProps {
 	work: WorkPlainObject;
@@ -122,12 +123,9 @@ const PriceDisplay = ({
 export default function WorkCard({ work, variant = "default", priority = false }: WorkCardProps) {
 	const isCompact = variant === "compact";
 
-	// 価格表示の計算
-	const currentPrice = work.price?.current ?? 0;
-	const originalPrice = work.price?.original ?? 0;
-	// セール判定は「実割引（current < original）」を正本とする。
-	// discount フィールドはセール終了後も古い値が残りうるため判定に使わない（軸3: 正本の整合性）。
-	const isOnSale = work.price?.isDiscounted ?? false;
+	// 価格表示の計算（正本は works/utils/price-info の calculatePriceInfo）。
+	// 割引率は current/original から算出し、stale になりうる price.discount は使わない。
+	const { currentPrice, originalPrice, isOnSale, discountRate } = calculatePriceInfo(work.price);
 
 	// ランキング情報は現在利用できません
 	const latestRank = undefined;
@@ -239,9 +237,9 @@ export default function WorkCard({ work, variant = "default", priority = false }
 								<div>
 									<PriceDisplay
 										currentPrice={currentPrice}
-										originalPrice={originalPrice}
+										originalPrice={originalPrice ?? 0}
 										isOnSale={isOnSale}
-										discount={work.price?.discount}
+										discount={discountRate}
 									/>
 								</div>
 							</div>

--- a/apps/web/src/app/works/utils/__tests__/price-info.test.ts
+++ b/apps/web/src/app/works/utils/__tests__/price-info.test.ts
@@ -1,0 +1,40 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { calculatePriceInfo } from "../price-info";
+
+const price = (p: Partial<WorkPlainObject["price"]>): WorkPlainObject["price"] =>
+	({
+		current: 0,
+		currency: "JPY",
+		isFree: false,
+		isDiscounted: false,
+		formattedPrice: "",
+		...p,
+	}) as WorkPlainObject["price"];
+
+describe("calculatePriceInfo (SPR-187)", () => {
+	it("セール中は current/original から割引率を算出する（price.discount は無視）", () => {
+		const info = calculatePriceInfo(
+			price({ current: 1100, original: 2200, discount: 99, isDiscounted: true }),
+		);
+		expect(info).toEqual({
+			currentPrice: 1100,
+			originalPrice: 2200,
+			isOnSale: true,
+			discountRate: 50,
+		});
+	});
+
+	it("非セール時は originalPrice / discountRate が undefined", () => {
+		const info = calculatePriceInfo(price({ current: 2200, original: 2200, isDiscounted: false }));
+		expect(info.isOnSale).toBe(false);
+		expect(info.originalPrice).toBeUndefined();
+		expect(info.discountRate).toBeUndefined();
+	});
+
+	it("割引率は四捨五入される", () => {
+		// (1980-1000)/1980 = 49.49% → 49
+		const info = calculatePriceInfo(price({ current: 1000, original: 1980, isDiscounted: true }));
+		expect(info.discountRate).toBe(49);
+	});
+});

--- a/apps/web/src/app/works/utils/price-info.ts
+++ b/apps/web/src/app/works/utils/price-info.ts
@@ -1,0 +1,33 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+
+export interface WorkPriceInfo {
+	currentPrice: number;
+	/** セール中のみ定義（割り消し表示用の元値） */
+	originalPrice: number | undefined;
+	isOnSale: boolean;
+	/** セール中のみ定義（current/original から算出した割引率 %） */
+	discountRate: number | undefined;
+}
+
+/**
+ * 作品価格の表示情報を算出する（一覧カード・詳細ページ共通の正本）。
+ *
+ * セール判定・割引率は「実割引（current < original）」= `price.isDiscounted` と
+ * current/original からの算出のみを正本とする。Firestore の `price.discount` フィールドは
+ * セール終了後も古い値が残りうる（sticky）うえ、original あり・discount 未設定の値下げで
+ * 数値なしの「% OFF」を生むため、**判定にも表示にも使わない**（軸3: 正本の整合性）。
+ *
+ * @param price WorkPlainObject の price
+ */
+export function calculatePriceInfo(price: WorkPlainObject["price"] | undefined): WorkPriceInfo {
+	// price 欠落時は ¥0・非セール扱いにフォールバック（一覧カードの防御的挙動を踏襲）
+	const currentPrice = price?.current ?? 0;
+	const isOnSale = price?.isDiscounted ?? false;
+	const originalPrice = isOnSale ? price?.original : undefined;
+	const discountRate =
+		isOnSale && originalPrice
+			? Math.round(((originalPrice - currentPrice) / originalPrice) * 100)
+			: undefined;
+
+	return { currentPrice, originalPrice, isOnSale, discountRate };
+}


### PR DESCRIPTION
## 背景（軸3: コメントの約束と実装のズレ）

`work-detail.tsx` は「discount フィールドは sticky なので判定にも表示にも使わない」と明記し current/original から割引率を算出する一方、`work-card.tsx` は **PriceDisplay へ `discount={work.price?.discount}` と stale になりうる Firestore 値を直渡し**していた。同一数値の正本が一覧と詳細で分裂し、original あり・discount 未設定の値下げで**数値なしの「% OFF」**が出るバグもありえた。

## 変更

- 算出ロジックを **`works/utils/price-info.ts` の `calculatePriceInfo`** に抽出し、work-card / work-detail 双方で使用。PriceDisplay へは**算出した `discountRate`** を渡す（stale な `price.discount` は不使用）。
- 重複コメントを util の JSDoc に集約。
- `price` 欠落時は ¥0・非セール扱いにフォールバック（カードの従来の防御的挙動を踏襲）。
- テスト追加: work-card で stale な `discount: 99` を無視し current/original 由来の `50% OFF` を表示すること、`price-info` の単体テスト（算出 / 非セール / 四捨五入）。

`pnpm verify` green。UI 表示のみの Two-Way Door。

Closes SPR-187

🤖 Generated with [Claude Code](https://claude.com/claude-code)