### PR TITLE
refactor(ui): YouTube IFrame API ローダーの一本化 (SPR-188)

### DIFF
--- a/packages/ui/src/components/custom/youtube-player.tsx
+++ b/packages/ui/src/components/custom/youtube-player.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { loadYouTubeIframeAPI } from "../../lib/youtube-api-loader";
 import type { YTPlayer } from "./youtube-types";
 
 // 外部で使用するための型をエクスポート
@@ -24,8 +25,6 @@ export interface YouTubePlayerProps {
 	startTime?: number;
 	/** End time in seconds */
 	endTime?: number;
-	/** Loop the video */
-	loop?: boolean;
 	/** Modest branding */
 	modestBranding?: boolean;
 	/** Related videos */
@@ -55,7 +54,6 @@ export function YouTubePlayer({
 	controls = true,
 	startTime,
 	endTime,
-	loop: _loop = false,
 	modestBranding = true,
 	rel = false,
 	className = "",
@@ -67,7 +65,6 @@ export function YouTubePlayer({
 	const playerRef = useRef<YTPlayer | null>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [isAPIReady, setIsAPIReady] = useState(false);
-	const [playerReady, setPlayerReady] = useState(false);
 	const timeUpdateIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
 	// Store callback refs to avoid re-initialization
@@ -80,39 +77,17 @@ export function YouTubePlayer({
 	onStateChangeRef.current = onStateChange;
 	onErrorRef.current = onError;
 
-	// YouTube API の読み込み
+	// YouTube API の読み込み（共通ローダー経由・script 除去はしない）。
+	// unmount 後の setState を避けるため mounted フラグで握る。
 	useEffect(() => {
-		// すでにAPIが読み込まれている場合
-		if (window.YT?.Player) {
-			setIsAPIReady(true);
-			return;
-		}
-
-		// API読み込み中の場合は待機
-		if (window.onYouTubeIframeAPIReady) {
-			const originalCallback = window.onYouTubeIframeAPIReady;
-			window.onYouTubeIframeAPIReady = () => {
-				originalCallback();
+		let mounted = true;
+		loadYouTubeIframeAPI(() => {
+			if (mounted) {
 				setIsAPIReady(true);
-			};
-			return;
-		}
-
-		// APIスクリプトの読み込み
-		const script = document.createElement("script");
-		script.src = "https://www.youtube.com/iframe_api";
-		script.async = true;
-
-		window.onYouTubeIframeAPIReady = () => {
-			setIsAPIReady(true);
-		};
-
-		document.body.appendChild(script);
-
-		return () => {
-			if (script.parentNode) {
-				script.parentNode.removeChild(script);
 			}
+		});
+		return () => {
+			mounted = false;
 		};
 	}, []);
 
@@ -156,25 +131,6 @@ export function YouTubePlayer({
 		}
 	}, []);
 
-	// プレイヤー制御メソッドの公開
-	const playerControls = useMemo(
-		() => ({
-			play: () => playerRef.current?.playVideo(),
-			pause: () => playerRef.current?.pauseVideo(),
-			stop: () => playerRef.current?.stopVideo(),
-			seekTo: (seconds: number) => playerRef.current?.seekTo(seconds, true),
-			getCurrentTime: () => playerRef.current?.getCurrentTime() || 0,
-			getDuration: () => playerRef.current?.getDuration() || 0,
-			getPlayerState: () => playerRef.current?.getPlayerState() || -1,
-			setVolume: (volume: number) => playerRef.current?.setVolume(volume),
-			getVolume: () => playerRef.current?.getVolume() || 50,
-			mute: () => playerRef.current?.mute(),
-			unmute: () => playerRef.current?.unMute(),
-			isMuted: () => playerRef.current?.isMuted() || false,
-		}),
-		[],
-	);
-
 	// プレイヤーの初期化
 	useEffect(() => {
 		if (!isAPIReady || !containerRef.current || !videoId) {
@@ -215,7 +171,6 @@ export function YouTubePlayer({
 			events: {
 				onReady: (event) => {
 					playerRef.current = event.target;
-					setPlayerReady(true);
 					onReadyRef.current?.(event.target);
 				},
 				onStateChange: (event) => {
@@ -239,7 +194,6 @@ export function YouTubePlayer({
 			if (player && typeof player.destroy === "function") {
 				player.destroy();
 			}
-			setPlayerReady(false);
 		};
 	}, [
 		isAPIReady,
@@ -254,22 +208,6 @@ export function YouTubePlayer({
 		stopTimeUpdateInterval,
 		// Note: onReady, onStateChange, onError are not included in deps to prevent re-initialization
 	]);
-
-	// 親コンポーネントに制御メソッドを公開
-	useEffect(() => {
-		if (playerReady && onReady && playerRef.current) {
-			// プレイヤーインスタンスに追加のメソッドのみ追加（既存メソッドは上書きしない）
-			const additionalMethods = {
-				play: playerControls.play,
-				pause: playerControls.pause,
-				stop: playerControls.stop,
-				// getCurrentTime は既存のメソッドを保持
-				// getDuration は既存のメソッドを保持
-				// seekTo は既存のメソッドを保持
-			};
-			Object.assign(playerRef.current, additionalMethods);
-		}
-	}, [playerReady, onReady, playerControls]);
 
 	if (!videoId) {
 		return (

--- a/packages/ui/src/lib/__tests__/youtube-api-loader.test.ts
+++ b/packages/ui/src/lib/__tests__/youtube-api-loader.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadYouTubeIframeAPI } from "../youtube-api-loader";
+
+// window.YT / onYouTubeIframeAPIReady の型は youtube-types.ts でグローバル宣言済み。
+// テストでの差し替えは緩い別名経由で行う（再宣言による型衝突を避ける）。
+const w = window as unknown as {
+	YT?: { Player?: unknown };
+	onYouTubeIframeAPIReady?: () => void;
+};
+
+describe("loadYouTubeIframeAPI (SPR-188)", () => {
+	beforeEach(() => {
+		// 各テストで API 未ロード状態に戻す
+		w.YT = undefined;
+		w.onYouTubeIframeAPIReady = undefined;
+		for (const el of document.querySelectorAll('script[src*="youtube.com/iframe_api"]')) {
+			el.remove();
+		}
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("API が既に準備済みなら onReady を即時実行する", () => {
+		w.YT = { Player: () => {} };
+		const onReady = vi.fn();
+		loadYouTubeIframeAPI(onReady);
+		expect(onReady).toHaveBeenCalledTimes(1);
+	});
+
+	it("読み込み中は既存の onYouTubeIframeAPIReady をチェーンする（上書きしない）", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		loadYouTubeIframeAPI(first);
+		loadYouTubeIframeAPI(second);
+
+		// API ロード完了をシミュレート
+		w.onYouTubeIframeAPIReady?.();
+
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).toHaveBeenCalledTimes(1);
+	});
+
+	it("script タグを挿入し、複数回呼んでも重複挿入しない", () => {
+		loadYouTubeIframeAPI(vi.fn());
+		loadYouTubeIframeAPI(vi.fn());
+		expect(document.querySelectorAll('script[src*="youtube.com/iframe_api"]').length).toBe(1);
+	});
+});

--- a/packages/ui/src/lib/youtube-api-loader.ts
+++ b/packages/ui/src/lib/youtube-api-loader.ts
@@ -1,0 +1,44 @@
+/**
+ * YouTube IFrame API ローダー（一元化）。
+ *
+ * YouTubePlayer と YouTubePlayerPool が個別にスクリプト読み込みと
+ * `window.onYouTubeIframeAPIReady` を実装し、上書き / unmount 時の script 除去で
+ * 競合していた（cold load で API 読込中に unmount すると後続初期化が「読み込み中…」で
+ * 止まる回帰）。本モジュールに統一する（SPR-188）。
+ *
+ * 設計:
+ * - 既に `window.YT.Player` があれば即 `onReady`。
+ * - 読み込み中は `window.onYouTubeIframeAPIReady` を**チェーン**する（既存を潰さない）。
+ * - script タグは**除去しない**（unmount 競合の回避）。
+ */
+export function loadYouTubeIframeAPI(onReady: () => void): void {
+	if (typeof window === "undefined") {
+		return;
+	}
+
+	// 既に API 準備済み
+	if (window.YT?.Player) {
+		onReady();
+		return;
+	}
+
+	// 既存の callback をチェーン（上書きしない）
+	const previous = window.onYouTubeIframeAPIReady;
+	window.onYouTubeIframeAPIReady = () => {
+		previous?.();
+		onReady();
+	};
+
+	// スクリプトは未挿入のときだけ挿入し、以後は除去しない
+	if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
+		const tag = document.createElement("script");
+		tag.src = "https://www.youtube.com/iframe_api";
+		tag.async = true;
+		const firstScriptTag = document.getElementsByTagName("script")[0];
+		if (firstScriptTag?.parentNode) {
+			firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+		} else {
+			document.body.appendChild(tag);
+		}
+	}
+}

--- a/packages/ui/src/lib/youtube-player-pool.ts
+++ b/packages/ui/src/lib/youtube-player-pool.ts
@@ -9,6 +9,7 @@
 
 // 既存のyoutube-typesを再利用
 import type { YTPlayer, YTPlayerConfig } from "../components/custom/youtube-types";
+import { loadYouTubeIframeAPI } from "./youtube-api-loader";
 
 interface PlayerData {
 	player: YTPlayer;
@@ -59,33 +60,13 @@ export class YouTubePlayerPool {
 	}
 
 	/**
-	 * YouTube IFrame APIの初期化
+	 * YouTube IFrame APIの初期化（共通ローダー経由・callback はチェーン）
 	 */
 	private initializeYouTubeAPI(): void {
-		if (typeof window === "undefined") return;
-
-		// 既にAPIが読み込まれている場合
-		if (window.YT?.Player) {
+		loadYouTubeIframeAPI(() => {
 			this.isAPIReady = true;
 			this.executeReadyCallbacks();
-			return;
-		}
-
-		// APIの読み込み
-		if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
-			const tag = document.createElement("script");
-			tag.src = "https://www.youtube.com/iframe_api";
-			const firstScriptTag = document.getElementsByTagName("script")[0];
-			if (firstScriptTag?.parentNode) {
-				firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
-			}
-		}
-
-		// グローバルコールバックの設定
-		window.onYouTubeIframeAPIReady = () => {
-			this.isAPIReady = true;
-			this.executeReadyCallbacks();
-		};
+		});
 	}
 
 	/**


### PR DESCRIPTION
## 背景（軸3）

YouTube IFrame API のスクリプト読み込みが `youtube-player.tsx` と `youtube-player-pool.ts` の2箇所に重複し、`window.onYouTubeIframeAPIReady` の扱いが食い違っていた。実害バグ: **cold load で YouTubePlayer がマウント → API 読込完了前に unmount（script 除去）→ 後続の初期化が「読み込み中…」のまま停止**しうる。

## 変更

- **`lib/youtube-api-loader.ts`** に `loadYouTubeIframeAPI` を新設。既存 callback を**チェーン**（上書きしない）し、**script タグは除去しない**設計に統一。pool / player 双方がこれを使用。
- `YouTubePlayer` のローダーを共通化し、**unmount 時の script 除去を廃止**（バグの直接原因）。unmount 後の setState は `mounted` フラグで握る。
- 型約束と実装の一致: 無視される `loop` オプション（呼び出し元ゼロを確認）、apps/web 利用ゼロの `Object.assign` 後付け `play/pause/stop` と未使用 `playerControls` を削除。
- loader のチェーン挙動（既存 callback を潰さない / 重複 script 挿入しない）を固定するテストを追加。

`pnpm verify` green（既存の youtube-player / pool テスト 26 件は無変更で通過）。packages/ui 閉域・Two-Way Door。

Closes SPR-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)