### PR TITLE
refactor(web): 作品リスト双子コンポーネントと一覧ページ定型を統合 (SPR-191)

### DIFF
--- a/apps/web/src/app/circles/[circleId]/components/circle-works-list.tsx
+++ b/apps/web/src/app/circles/[circleId]/components/circle-works-list.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList } from "@suzumina.click/ui/components/custom";
-import { useCallback, useMemo } from "react";
-import { ListWrapper } from "@/components/list/list-wrapper";
-import { WorkListItem } from "@/components/work/work-list-item";
+import type { WorkListResultPlain } from "@suzumina.click/shared-types";
+import { useCallback } from "react";
 import {
-	DEFAULT_ITEMS_PER_PAGE_OPTIONS,
-	DEFAULT_LIST_PROPS,
-	GRID_COLUMNS_4,
-	WORK_SORT_OPTIONS,
-} from "@/constants/list-options";
-import { createBasicToParams } from "@/utils/list-adapters";
+	type OwnerWorksListParams,
+	WorksListForOwner,
+} from "@/components/work/works-list-for-owner";
 import { getCircleWorksList } from "../actions";
 
 interface CircleWorksListProps {
@@ -20,52 +14,9 @@ interface CircleWorksListProps {
 }
 
 export default function CircleWorksList({ circleId, initialData }: CircleWorksListProps) {
-	// 初期データを変換
-	const transformedInitialData = useMemo(() => {
-		if (!initialData) return null;
-		return {
-			items: initialData.works,
-			total: initialData.totalCount || 0,
-			page: 1,
-			itemsPerPage: initialData.works.length,
-		};
-	}, [initialData]);
-
-	// データアダプター
-	const dataAdapter = useMemo(
-		() => ({
-			toParams: createBasicToParams("newest", () => ({ circleId })),
-			fromResult: (result: unknown) => result as { items: WorkPlainObject[]; total: number },
-		}),
+	const fetchWorks = useCallback(
+		(params: OwnerWorksListParams) => getCircleWorksList({ ...params, circleId }),
 		[circleId],
 	);
-
-	// フェッチ関数
-	const fetchFn = useCallback(async (params: unknown) => {
-		const typedParams = params as Parameters<typeof getCircleWorksList>[0];
-		const result = await getCircleWorksList(typedParams);
-		return {
-			items: result.works,
-			total: result.totalCount || 0,
-		};
-	}, []);
-
-	return (
-		<ListWrapper>
-			<ConfigurableList<WorkPlainObject>
-				items={transformedInitialData?.items || []}
-				initialTotal={transformedInitialData?.total || 0}
-				renderItem={(work) => <WorkListItem work={work} />}
-				listHeading="作品一覧"
-				fetchFn={fetchFn}
-				dataAdapter={dataAdapter}
-				{...DEFAULT_LIST_PROPS}
-				layout="grid"
-				gridColumns={GRID_COLUMNS_4}
-				sorts={WORK_SORT_OPTIONS}
-				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
-				emptyMessage="作品が見つかりませんでした"
-			/>
-		</ListWrapper>
-	);
+	return <WorksListForOwner initialData={initialData} fetchWorks={fetchWorks} />;
 }

--- a/apps/web/src/app/creators/[creatorId]/components/creator-works-list.tsx
+++ b/apps/web/src/app/creators/[creatorId]/components/creator-works-list.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList } from "@suzumina.click/ui/components/custom";
-import { useCallback, useMemo } from "react";
-import { ListWrapper } from "@/components/list/list-wrapper";
-import { WorkListItem } from "@/components/work/work-list-item";
+import type { WorkListResultPlain } from "@suzumina.click/shared-types";
+import { useCallback } from "react";
 import {
-	DEFAULT_ITEMS_PER_PAGE_OPTIONS,
-	DEFAULT_LIST_PROPS,
-	GRID_COLUMNS_4,
-	WORK_SORT_OPTIONS,
-} from "@/constants/list-options";
-import { createBasicToParams } from "@/utils/list-adapters";
+	type OwnerWorksListParams,
+	WorksListForOwner,
+} from "@/components/work/works-list-for-owner";
 import { getCreatorWorksList } from "../actions";
 
 interface CreatorWorksListProps {
@@ -20,55 +14,9 @@ interface CreatorWorksListProps {
 }
 
 export default function CreatorWorksList({ creatorId, initialData }: CreatorWorksListProps) {
-	// 初期データを変換
-	const transformedInitialData = useMemo(() => {
-		if (!initialData) return null;
-		return {
-			items: initialData.works,
-			total:
-				initialData.hasMore !== undefined
-					? (initialData.filteredCount ?? initialData.totalCount ?? 0)
-					: initialData.totalCount || 0,
-			page: 1,
-			itemsPerPage: DEFAULT_ITEMS_PER_PAGE_OPTIONS[0], // デフォルトのページサイズ
-		};
-	}, [initialData]);
-
-	// データアダプター
-	const dataAdapter = useMemo(
-		() => ({
-			toParams: createBasicToParams("newest", () => ({ creatorId })),
-			fromResult: (result: unknown) => result as { items: WorkPlainObject[]; total: number },
-		}),
+	const fetchWorks = useCallback(
+		(params: OwnerWorksListParams) => getCreatorWorksList({ ...params, creatorId }),
 		[creatorId],
 	);
-
-	// フェッチ関数
-	const fetchFn = useCallback(async (params: unknown) => {
-		const typedParams = params as Parameters<typeof getCreatorWorksList>[0];
-		const result = await getCreatorWorksList(typedParams);
-		return {
-			items: result.works,
-			total: result.filteredCount ?? result.totalCount ?? 0,
-		};
-	}, []);
-
-	return (
-		<ListWrapper>
-			<ConfigurableList<WorkPlainObject>
-				items={transformedInitialData?.items || []}
-				initialTotal={transformedInitialData?.total || 0}
-				renderItem={(work) => <WorkListItem work={work} />}
-				listHeading="作品一覧"
-				fetchFn={fetchFn}
-				dataAdapter={dataAdapter}
-				{...DEFAULT_LIST_PROPS}
-				layout="grid"
-				gridColumns={GRID_COLUMNS_4}
-				sorts={WORK_SORT_OPTIONS}
-				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
-				emptyMessage="作品が見つかりませんでした"
-			/>
-		</ListWrapper>
-	);
+	return <WorksListForOwner initialData={initialData} fetchWorks={fetchWorks} />;
 }

--- a/apps/web/src/components/content/circles-page-client.tsx
+++ b/apps/web/src/components/content/circles-page-client.tsx
@@ -1,13 +1,8 @@
 "use client";
 
 import type { CirclePlainObject } from "@suzumina.click/shared-types";
-import {
-	ListPageContent,
-	ListPageHeader,
-	ListPageLayout,
-} from "@suzumina.click/ui/components/custom";
-import { Suspense } from "react";
 import CirclesList from "@/app/circles/components/circles-list";
+import { ListPageShell } from "./list-page-shell";
 
 interface CirclesPageClientProps {
 	initialData: {
@@ -18,24 +13,11 @@ interface CirclesPageClientProps {
 
 export function CirclesPageClient({ initialData }: CirclesPageClientProps) {
 	return (
-		<ListPageLayout>
-			<ListPageHeader
-				title="サークル一覧"
-				description="DLsiteで活動するサークルの一覧。作品数やサークル名で検索・並び替えができます"
-			/>
-
-			<ListPageContent>
-				<Suspense
-					fallback={
-						<div className="text-center py-12">
-							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-							<p className="mt-2 text-muted-foreground">読み込み中...</p>
-						</div>
-					}
-				>
-					<CirclesList initialData={initialData} />
-				</Suspense>
-			</ListPageContent>
-		</ListPageLayout>
+		<ListPageShell
+			title="サークル一覧"
+			description="DLsiteで活動するサークルの一覧。作品数やサークル名で検索・並び替えができます"
+		>
+			<CirclesList initialData={initialData} />
+		</ListPageShell>
 	);
 }

--- a/apps/web/src/components/content/creators-page-client.tsx
+++ b/apps/web/src/components/content/creators-page-client.tsx
@@ -1,13 +1,8 @@
 "use client";
 
 import type { CreatorPageInfo } from "@suzumina.click/shared-types";
-import {
-	ListPageContent,
-	ListPageHeader,
-	ListPageLayout,
-} from "@suzumina.click/ui/components/custom";
-import { Suspense } from "react";
 import CreatorsList from "@/app/creators/components/creators-list";
+import { ListPageShell } from "./list-page-shell";
 
 interface CreatorsPageClientProps {
 	initialData: {
@@ -18,24 +13,11 @@ interface CreatorsPageClientProps {
 
 export function CreatorsPageClient({ initialData }: CreatorsPageClientProps) {
 	return (
-		<ListPageLayout>
-			<ListPageHeader
-				title="クリエイター一覧"
-				description="音声作品を手がけるクリエイターの一覧。声優、イラストレーター、シナリオライターなど、役割別に検索・並び替えができます"
-			/>
-
-			<ListPageContent>
-				<Suspense
-					fallback={
-						<div className="text-center py-12">
-							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-							<p className="mt-2 text-muted-foreground">読み込み中...</p>
-						</div>
-					}
-				>
-					<CreatorsList initialData={initialData} />
-				</Suspense>
-			</ListPageContent>
-		</ListPageLayout>
+		<ListPageShell
+			title="クリエイター一覧"
+			description="音声作品を手がけるクリエイターの一覧。声優、イラストレーター、シナリオライターなど、役割別に検索・並び替えができます"
+		>
+			<CreatorsList initialData={initialData} />
+		</ListPageShell>
 	);
 }

--- a/apps/web/src/components/content/list-page-shell.tsx
+++ b/apps/web/src/components/content/list-page-shell.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+	ListPageContent,
+	ListPageHeader,
+	ListPageLayout,
+} from "@suzumina.click/ui/components/custom";
+import { type ReactNode, Suspense } from "react";
+
+interface ListPageShellProps {
+	title: string;
+	description: string;
+	children: ReactNode;
+}
+
+/**
+ * 一覧ページ（サークル / クリエイター等）共通の組み立て。
+ *
+ * circles-page-client / creators-page-client が同型の
+ * ListPageLayout + ListPageHeader + ListPageContent + Suspense フォールバックを
+ * 重複実装していたため共通化（SPR-191）。差分はタイトル・説明・中身（リスト）だけ。
+ */
+export function ListPageShell({ title, description, children }: ListPageShellProps) {
+	return (
+		<ListPageLayout>
+			<ListPageHeader title={title} description={description} />
+			<ListPageContent>
+				<Suspense
+					fallback={
+						<div className="text-center py-12">
+							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+							<p className="mt-2 text-muted-foreground">読み込み中...</p>
+						</div>
+					}
+				>
+					{children}
+				</Suspense>
+			</ListPageContent>
+		</ListPageLayout>
+	);
+}

--- a/apps/web/src/components/work/works-list-for-owner.tsx
+++ b/apps/web/src/components/work/works-list-for-owner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
+import { ConfigurableList } from "@suzumina.click/ui/components/custom";
+import { useCallback, useMemo } from "react";
+import { ListWrapper } from "@/components/list/list-wrapper";
+import { WorkListItem } from "@/components/work/work-list-item";
+import {
+	DEFAULT_ITEMS_PER_PAGE_OPTIONS,
+	DEFAULT_LIST_PROPS,
+	GRID_COLUMNS_4,
+	WORK_SORT_OPTIONS,
+} from "@/constants/list-options";
+import { createBasicToParams } from "@/utils/list-adapters";
+
+/** circle / creator の作品取得 action が返す形（owner 共通） */
+export interface OwnerWorksResult {
+	works: WorkPlainObject[];
+	totalCount?: number;
+	filteredCount?: number;
+}
+
+export interface OwnerWorksListParams {
+	page?: number;
+	limit?: number;
+	sort?: string;
+	search?: string;
+}
+
+interface WorksListForOwnerProps {
+	initialData?: WorkListResultPlain;
+	/** owner の作品取得関数（owner id は呼び出し側で束縛して渡す） */
+	fetchWorks: (params: OwnerWorksListParams) => Promise<OwnerWorksResult>;
+}
+
+/**
+ * circle / creator の作品一覧（ConfigurableList ラッパー）。
+ *
+ * CircleWorksList / CreatorWorksList の双子コンポーネントを統合した共通実体（SPR-191）。
+ * 差分は「どの owner の作品を取るか」だけなので fetchWorks のみ受け取る。
+ */
+export function WorksListForOwner({ initialData, fetchWorks }: WorksListForOwnerProps) {
+	const initialItems = initialData?.works ?? [];
+	// 検索適用時は filteredCount を優先（フィルタ後の件数）
+	const initialTotal = initialData ? (initialData.filteredCount ?? initialData.totalCount ?? 0) : 0;
+
+	const dataAdapter = useMemo(
+		() => ({
+			toParams: createBasicToParams("newest"),
+			fromResult: (result: unknown) => result as { items: WorkPlainObject[]; total: number },
+		}),
+		[],
+	);
+
+	const fetchFn = useCallback(
+		async (params: unknown) => {
+			const result = await fetchWorks(params as OwnerWorksListParams);
+			return {
+				items: result.works,
+				total: result.filteredCount ?? result.totalCount ?? 0,
+			};
+		},
+		[fetchWorks],
+	);
+
+	return (
+		<ListWrapper>
+			<ConfigurableList<WorkPlainObject>
+				items={initialItems}
+				initialTotal={initialTotal}
+				renderItem={(work) => <WorkListItem work={work} />}
+				listHeading="作品一覧"
+				fetchFn={fetchFn}
+				dataAdapter={dataAdapter}
+				{...DEFAULT_LIST_PROPS}
+				layout="grid"
+				gridColumns={GRID_COLUMNS_4}
+				sorts={WORK_SORT_OPTIONS}
+				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
+				emptyMessage="作品が見つかりませんでした"
+			/>
+		</ListWrapper>
+	);
+}


### PR DESCRIPTION
## 背景（軸2: 同型コードの併存）

`circle-works-list.tsx` と `creator-works-list.tsx` は9割同一の双子。`circles-page-client` と `creators-page-client` も同型のレイアウト + Suspense フォールバックを重複実装していた。

## 変更

- **双子コンポーネントの統合**: 共通実体を `components/work/works-list-for-owner.tsx` に抽出。実差分は「どの owner の作品を取るか」だけなので **`fetchWorks` のみ**受け取る（owner id は呼び出し側で束縛）。`CircleWorksList` / `CreatorWorksList` は**薄いラッパー**へ縮約し、page-client / page.test の import 契約を維持。初期 total は `filteredCount ?? totalCount` に統一（検索適用後の件数を優先）。
- **一覧ページ定型の共通化**: `circles-page-client` / `creators-page-client` の `ListPageLayout + Header + Content + Suspense(フォールバック)` を `components/content/list-page-shell.tsx` に集約。差分はタイトル・説明・中身のリストのみ。

「無理な抽象化はしない」方針に従い、差分が小さい（2-3）箇所のみ統合。`pnpm verify` green（既存テスト不変）。

> SPR-185（[#616](https://github.com/nothink-jp/suzumina.click/pull/616)）の actions dedup と対をなすコンポーネント側。コンポーネントは 185 の actions 変更に依存しないため main から分岐。

Closes SPR-191

🤖 Generated with [Claude Code](https://claude.com/claude-code)