### PR TITLE
refactor(web): work-detail.tsx の制作陣/年齢バッジ重複を解消 (SPR-194)

### DIFF
--- a/apps/web/src/app/works/[workId]/components/__tests__/age-rating-badge.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/age-rating-badge.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// checkAgeRating / getAgeRatingDisplayName の内部に依存せず分岐を検証
+const { mockCheck, mockDisplay } = vi.hoisted(() => ({ mockCheck: vi.fn(), mockDisplay: vi.fn() }));
+vi.mock("@suzumina.click/shared-types", () => ({
+	checkAgeRating: mockCheck,
+	getAgeRatingDisplayName: mockDisplay,
+}));
+
+const { AgeRatingBadge } = await import("../age-rating-badge");
+
+describe("AgeRatingBadge", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockDisplay.mockReturnValue("表示名");
+	});
+
+	it("R18 は赤バッジ", () => {
+		mockCheck.mockReturnValue({ isR18: true, isAllAges: false });
+		render(<AgeRatingBadge ageRating="R18" />);
+		expect(screen.getByText("表示名").className).toContain("bg-red-600");
+	});
+
+	it("全年齢は緑バッジ", () => {
+		mockCheck.mockReturnValue({ isR18: false, isAllAges: true });
+		render(<AgeRatingBadge ageRating="全年齢" />);
+		expect(screen.getByText("表示名").className).toContain("border-green-500");
+	});
+
+	it("その他はグレー、size=sm で小サイズ class", () => {
+		mockCheck.mockReturnValue({ isR18: false, isAllAges: false });
+		render(<AgeRatingBadge ageRating="R15" size="sm" />);
+		const badge = screen.getByText("表示名");
+		expect(badge.className).toContain("bg-gray-100");
+		expect(badge.className).toContain("text-sm px-3 py-1");
+	});
+
+	it("size 既定（base）は大サイズ class", () => {
+		mockCheck.mockReturnValue({ isR18: true, isAllAges: false });
+		render(<AgeRatingBadge ageRating="R18" />);
+		expect(screen.getByText("表示名").className).toContain("text-base px-4 py-2");
+	});
+});

--- a/apps/web/src/app/works/[workId]/components/__tests__/work-creators.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/work-creators.test.tsx
@@ -1,0 +1,55 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CreatorBadges, CreatorList } from "../work-creators";
+
+vi.mock("next/link", () => ({
+	default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+		<a href={href}>{children}</a>
+	),
+}));
+
+const creators = {
+	voiceActors: [{ id: "VA1", name: "声優A" }, { name: "声優B" }],
+	scenario: [{ id: "SC1", name: "脚本A" }],
+	illustration: [],
+	music: [],
+	others: [{ name: "その他A" }],
+	voiceActorNames: [],
+	scenarioNames: [],
+	illustrationNames: [],
+	musicNames: [],
+	otherNames: [],
+} as unknown as WorkPlainObject["creators"];
+
+describe("CreatorBadges（詳細タブの制作陣）", () => {
+	it("声優のみ creator リンク付き、id 無し声優・他職種はリンクなし（従来挙動）", () => {
+		render(<CreatorBadges creators={creators} />);
+		expect(screen.getByText("声優A").closest("a")).toHaveAttribute("href", "/creators/VA1");
+		expect(screen.getByText("声優B").closest("a")).toBeNull();
+		// シナリオは id があってもリンクしない
+		expect(screen.getByText("脚本A").closest("a")).toBeNull();
+	});
+
+	it("空の職種は見出しを出さない", () => {
+		render(<CreatorBadges creators={creators} />);
+		expect(screen.getByText("声優")).toBeInTheDocument();
+		expect(screen.getByText("その他")).toBeInTheDocument();
+		expect(screen.queryByText("イラスト")).not.toBeInTheDocument();
+		expect(screen.queryByText("音楽")).not.toBeInTheDocument();
+	});
+});
+
+describe("CreatorList（サイドバー）", () => {
+	it("全職種 id ありで creator リンク、id 無しはリンクなし", () => {
+		render(<CreatorList creators={creators} />);
+		expect(screen.getByText("声優（CV）")).toBeInTheDocument();
+		expect(screen.getByText("声優A").closest("a")).toHaveAttribute("href", "/creators/VA1");
+		expect(screen.getByText("声優B").closest("a")).toBeNull();
+	});
+
+	it("creators が undefined でもクラッシュしない", () => {
+		const { container } = render(<CreatorList creators={undefined} />);
+		expect(container).toBeTruthy();
+	});
+});

--- a/apps/web/src/app/works/[workId]/components/age-rating-badge.tsx
+++ b/apps/web/src/app/works/[workId]/components/age-rating-badge.tsx
@@ -1,0 +1,43 @@
+import { checkAgeRating, getAgeRatingDisplayName } from "@suzumina.click/shared-types";
+import { Badge } from "@suzumina.click/ui/components/ui/badge";
+
+interface AgeRatingBadgeProps {
+	ageRating: string;
+	/** "base"=主表示（大）, "sm"=詳細タブ（小）。従来の2実装の差はサイズだけ */
+	size?: "base" | "sm";
+}
+
+/**
+ * 年齢レーティングバッジ（R18=赤 / 全年齢=緑 / その他=グレー）。
+ *
+ * work-detail.tsx の主表示と詳細タブで二重実装されていたものを統合（SPR-194）。
+ * 差はサイズclassのみ。
+ */
+export function AgeRatingBadge({ ageRating, size = "base" }: AgeRatingBadgeProps) {
+	const check = checkAgeRating(ageRating);
+	const sizeClass = size === "base" ? "text-base px-4 py-2" : "text-sm px-3 py-1";
+	const label = getAgeRatingDisplayName(ageRating);
+
+	if (check.isR18) {
+		return (
+			<Badge variant="destructive" className={`bg-red-600 text-white font-bold ${sizeClass}`}>
+				{label}
+			</Badge>
+		);
+	}
+	if (check.isAllAges) {
+		return (
+			<Badge
+				variant="outline"
+				className={`border-green-500 text-green-700 bg-green-50 font-medium ${sizeClass}`}
+			>
+				{label}
+			</Badge>
+		);
+	}
+	return (
+		<Badge variant="secondary" className={`text-gray-700 bg-gray-100 font-medium ${sizeClass}`}>
+			{label}
+		</Badge>
+	);
+}

--- a/apps/web/src/app/works/[workId]/components/work-creators.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-creators.tsx
@@ -1,0 +1,115 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+import { Badge } from "@suzumina.click/ui/components/ui/badge";
+import Link from "next/link";
+
+type Creators = WorkPlainObject["creators"];
+type CreatorEntry = { id?: string; name: string };
+
+interface RoleDef {
+	key: "voiceActors" | "scenario" | "illustration" | "music" | "others";
+	/** 詳細タブ（制作陣 Badge）の見出し */
+	badgeLabel: string;
+	/** サイドバー（クリエイター情報）の見出し */
+	sidebarLabel: string;
+	/** 詳細タブの Badge で creator リンクを張るか（従来は声優のみ） */
+	badgeLinked: boolean;
+}
+
+// 5職種を1箇所に定数化（従来は職種×表示箇所で約330行の準重複だった）。
+const CREATOR_ROLES: RoleDef[] = [
+	{ key: "voiceActors", badgeLabel: "声優", sidebarLabel: "声優（CV）", badgeLinked: true },
+	{ key: "scenario", badgeLabel: "シナリオ", sidebarLabel: "シナリオ", badgeLinked: false },
+	{ key: "illustration", badgeLabel: "イラスト", sidebarLabel: "イラスト", badgeLinked: false },
+	{ key: "music", badgeLabel: "音楽", sidebarLabel: "音楽", badgeLinked: false },
+	{ key: "others", badgeLabel: "その他", sidebarLabel: "その他", badgeLinked: false },
+];
+
+function getEntries(creators: Creators | undefined, key: RoleDef["key"]): CreatorEntry[] {
+	return (creators?.[key] as CreatorEntry[] | undefined) ?? [];
+}
+
+/**
+ * 詳細タブの制作陣バッジ表示（5職種を map）。
+ * 声優のみ creator ページへリンク、他職種はプレーンな Badge（従来挙動を踏襲）。
+ */
+export function CreatorBadges({ creators }: { creators: Creators | undefined }) {
+	return (
+		<div className="space-y-4">
+			{CREATOR_ROLES.map((role) => {
+				const entries = getEntries(creators, role.key);
+				if (entries.length === 0) return null;
+				return (
+					<div key={role.key}>
+						<div className="text-sm text-gray-700 mb-2">{role.badgeLabel}</div>
+						<div className="flex flex-wrap gap-2">
+							{entries.map((creator, index) =>
+								role.badgeLinked && creator.id ? (
+									<Link key={creator.id} href={`/creators/${creator.id}`} className="inline-block">
+										<Badge
+											variant="secondary"
+											className="text-xs hover:bg-secondary/80 cursor-pointer"
+											title={`ID: ${creator.id}`}
+										>
+											{creator.name}
+										</Badge>
+									</Link>
+								) : (
+									<Badge
+										key={creator.id || creator.name || index}
+										variant="secondary"
+										className="text-xs"
+										title={creator.id ? `ID: ${creator.id}` : undefined}
+									>
+										{creator.name}
+									</Badge>
+								),
+							)}
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+/**
+ * サイドバーのクリエイター情報（5職種を map・avatar + リンク）。
+ * 全職種で id があれば creator ページへリンク（従来挙動を踏襲）。
+ */
+export function CreatorList({ creators }: { creators: Creators | undefined }) {
+	return (
+		<div className="space-y-4">
+			{CREATOR_ROLES.map((role) => {
+				const entries = getEntries(creators, role.key);
+				if (entries.length === 0) return null;
+				return (
+					<div key={role.key}>
+						<h5 className="text-sm font-medium text-gray-700 mb-2">{role.sidebarLabel}</h5>
+						<div className="space-y-2">
+							{entries.map((creator, index) => (
+								<div key={creator.id || creator.name || index} className="flex items-center gap-3">
+									<div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
+										<span className="text-foreground font-bold text-xs">
+											{creator.name.charAt(0)}
+										</span>
+									</div>
+									{creator.id ? (
+										<Link
+											href={`/creators/${creator.id}`}
+											className="text-gray-900 text-sm hover:text-primary hover:underline"
+											title={`ID: ${creator.id}`}
+										>
+											{creator.name}
+										</Link>
+									) : (
+										<span className="text-gray-900 text-sm">{creator.name}</span>
+									)}
+								</div>
+							))}
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/web/src/app/works/[workId]/components/work-detail.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-detail.tsx
@@ -2,9 +2,7 @@
 
 import type { WorkPlainObject } from "@suzumina.click/shared-types";
 import {
-	checkAgeRating,
 	type FrontendWorkEvaluation,
-	getAgeRatingDisplayName,
 	getWorkCategoryDisplayText,
 	getWorkLanguageDisplayName,
 } from "@suzumina.click/shared-types";
@@ -38,7 +36,9 @@ import { PriceHistory } from "@/components/price-history/price-history";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { formatJSTDateTime } from "@/utils/date-format";
 import { generateMockCharacteristicData } from "@/utils/mock-evaluation-data";
+import { AgeRatingBadge } from "./age-rating-badge";
 import SampleImageGallery from "./sample-image-gallery";
+import { CreatorBadges, CreatorList } from "./work-creators";
 import WorkDescription from "./work-description";
 import { WorkEvaluation } from "./work-evaluation";
 
@@ -101,11 +101,6 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 		() => generateMockCharacteristicData(work.productId),
 		[work.productId],
 	);
-
-	// 年齢制限の判定
-	const ageRatingCheck = useMemo(() => {
-		return checkAgeRating(work.ageRating);
-	}, [work.ageRating]);
 
 	// 価格情報の計算
 	const { currentPrice, originalPrice, isOnSale, discountRate } = useMemo(
@@ -229,28 +224,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 								<div className="text-sm font-medium text-gray-700">年齢指定</div>
 								<div className="flex items-center gap-2">
 									<Shield className="h-4 w-4 text-muted-foreground" />
-									{ageRatingCheck.isR18 ? (
-										<Badge
-											variant="destructive"
-											className="bg-red-600 text-white font-bold text-base px-4 py-2"
-										>
-											{getAgeRatingDisplayName(work.ageRating)}
-										</Badge>
-									) : ageRatingCheck.isAllAges ? (
-										<Badge
-											variant="outline"
-											className="border-green-500 text-green-700 bg-green-50 font-medium text-base px-4 py-2"
-										>
-											{getAgeRatingDisplayName(work.ageRating)}
-										</Badge>
-									) : (
-										<Badge
-											variant="secondary"
-											className="text-gray-700 bg-gray-100 font-medium text-base px-4 py-2"
-										>
-											{getAgeRatingDisplayName(work.ageRating)}
-										</Badge>
-									)}
+									<AgeRatingBadge ageRating={work.ageRating} size="base" />
 								</div>
 							</div>
 						)}
@@ -420,28 +394,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 													<div>
 														<div className="text-sm text-gray-700">年齢指定</div>
 														<div className="flex items-center gap-2">
-															{ageRatingCheck.isR18 ? (
-																<Badge
-																	variant="destructive"
-																	className="bg-red-600 text-white font-bold text-sm px-3 py-1"
-																>
-																	{getAgeRatingDisplayName(work.ageRating)}
-																</Badge>
-															) : ageRatingCheck.isAllAges ? (
-																<Badge
-																	variant="outline"
-																	className="border-green-500 text-green-700 bg-green-50 font-medium text-sm px-3 py-1"
-																>
-																	{getAgeRatingDisplayName(work.ageRating)}
-																</Badge>
-															) : (
-																<Badge
-																	variant="secondary"
-																	className="text-gray-700 bg-gray-100 font-medium text-sm px-3 py-1"
-																>
-																	{getAgeRatingDisplayName(work.ageRating)}
-																</Badge>
-															)}
+															<AgeRatingBadge ageRating={work.ageRating} size="sm" />
 														</div>
 													</div>
 												</div>
@@ -550,143 +503,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 										</div>
 
 										{/* 制作陣情報（Individual Info API準拠・段階的活用） */}
-										<div className="space-y-4">
-											{/* 声優 */}
-											{(() => {
-												const displayVoiceActors = work.creators?.voiceActors || [];
-
-												if (displayVoiceActors.length === 0) return null;
-
-												return (
-													<div>
-														<div className="text-sm text-gray-700 mb-2">声優</div>
-														<div className="flex flex-wrap gap-2">
-															{displayVoiceActors.map((actor, index) =>
-																actor.id ? (
-																	<Link
-																		key={actor.id}
-																		href={`/creators/${actor.id}`}
-																		className="inline-block"
-																	>
-																		<Badge
-																			variant="secondary"
-																			className="text-xs hover:bg-secondary/80 cursor-pointer"
-																			title={`ID: ${actor.id}`}
-																		>
-																			{actor.name}
-																		</Badge>
-																	</Link>
-																) : (
-																	<Badge
-																		key={actor.name || index}
-																		variant="secondary"
-																		className="text-xs"
-																	>
-																		{actor.name}
-																	</Badge>
-																),
-															)}
-														</div>
-													</div>
-												);
-											})()}
-
-											{/* シナリオ */}
-											{(() => {
-												const displayScenarioWriters = work.creators?.scenario || [];
-
-												if (displayScenarioWriters.length === 0) return null;
-
-												return (
-													<div>
-														<div className="text-sm text-gray-700 mb-2">シナリオ</div>
-														<div className="flex flex-wrap gap-2">
-															{displayScenarioWriters.map((writer, index) => (
-																<Badge
-																	key={writer.id || writer.name || index}
-																	variant="secondary"
-																	className="text-xs"
-																	title={writer.id ? `ID: ${writer.id}` : undefined}
-																>
-																	{writer.name}
-																</Badge>
-															))}
-														</div>
-													</div>
-												);
-											})()}
-
-											{/* イラスト */}
-											{(() => {
-												const displayIllustrators = work.creators?.illustration || [];
-
-												if (displayIllustrators.length === 0) return null;
-
-												return (
-													<div>
-														<div className="text-sm text-gray-700 mb-2">イラスト</div>
-														<div className="flex flex-wrap gap-2">
-															{displayIllustrators.map((illustrator, index) => (
-																<Badge
-																	key={illustrator.id || illustrator.name || index}
-																	variant="secondary"
-																	className="text-xs"
-																	title={illustrator.id ? `ID: ${illustrator.id}` : undefined}
-																>
-																	{illustrator.name}
-																</Badge>
-															))}
-														</div>
-													</div>
-												);
-											})()}
-
-											{/* 音楽 */}
-											{(() => {
-												const displayMusicians = work.creators?.music || [];
-
-												if (displayMusicians.length === 0) return null;
-
-												return (
-													<div>
-														<div className="text-sm text-gray-700 mb-2">音楽</div>
-														<div className="flex flex-wrap gap-2">
-															{displayMusicians.map((musician, index) => (
-																<Badge
-																	key={musician.id || musician.name || index}
-																	variant="secondary"
-																	className="text-xs"
-																	title={musician.id ? `ID: ${musician.id}` : undefined}
-																>
-																	{musician.name}
-																</Badge>
-															))}
-														</div>
-													</div>
-												);
-											})()}
-
-											{/* その他制作者（Individual Info API専用） */}
-											{work.creators?.others && work.creators.others.length > 0 && (
-												<div>
-													<div className="text-sm text-gray-700 mb-2">その他</div>
-													<div className="flex flex-wrap gap-2">
-														{work.creators.others.map((creator, index) => (
-															<Badge
-																key={creator.id || creator.name || index}
-																variant="secondary"
-																className="text-xs"
-																title={creator.id ? `ID: ${creator.id}` : undefined}
-															>
-																{creator.name}
-															</Badge>
-														))}
-													</div>
-												</div>
-											)}
-
-											{/* created_byはcreators構造に含まれていないため削除 */}
-										</div>
+										<CreatorBadges creators={work.creators} />
 									</div>
 								</CardContent>
 							</Card>
@@ -796,191 +613,7 @@ export default function WorkDetail({ work, initialEvaluation = null }: WorkDetai
 									</CardTitle>
 								</CardHeader>
 								<CardContent>
-									<div className="space-y-4">
-										{/* 声優（Individual Info API優先） */}
-										{(() => {
-											const displayVoiceActors = work.creators?.voiceActors || [];
-
-											if (displayVoiceActors.length === 0) return null;
-
-											return (
-												<div>
-													<h5 className="text-sm font-medium text-gray-700 mb-2">声優（CV）</h5>
-													<div className="space-y-2">
-														{displayVoiceActors.map((actor, index) => (
-															<div
-																key={actor.id || actor.name || index}
-																className="flex items-center gap-3"
-															>
-																<div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
-																	<span className="text-foreground font-bold text-xs">
-																		{actor.name.charAt(0)}
-																	</span>
-																</div>
-																{actor.id ? (
-																	<Link
-																		href={`/creators/${actor.id}`}
-																		className="text-gray-900 text-sm hover:text-primary hover:underline"
-																		title={`ID: ${actor.id}`}
-																	>
-																		{actor.name}
-																	</Link>
-																) : (
-																	<span className="text-gray-900 text-sm">{actor.name}</span>
-																)}
-															</div>
-														))}
-													</div>
-												</div>
-											);
-										})()}
-
-										{/* シナリオ */}
-										{(() => {
-											const displayScenarioWriters = work.creators?.scenario || [];
-
-											if (displayScenarioWriters.length === 0) return null;
-
-											return (
-												<div>
-													<h5 className="text-sm font-medium text-gray-700 mb-2">シナリオ</h5>
-													<div className="space-y-2">
-														{displayScenarioWriters.map((writer, index) => (
-															<div
-																key={writer.id || writer.name || index}
-																className="flex items-center gap-3"
-															>
-																<div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
-																	<span className="text-foreground font-bold text-xs">
-																		{writer.name.charAt(0)}
-																	</span>
-																</div>
-																{writer.id ? (
-																	<Link
-																		href={`/creators/${writer.id}`}
-																		className="text-gray-900 text-sm hover:text-primary hover:underline"
-																		title={`ID: ${writer.id}`}
-																	>
-																		{writer.name}
-																	</Link>
-																) : (
-																	<span className="text-gray-900 text-sm">{writer.name}</span>
-																)}
-															</div>
-														))}
-													</div>
-												</div>
-											);
-										})()}
-
-										{/* イラスト */}
-										{(() => {
-											const displayIllustrators = work.creators?.illustration || [];
-
-											if (displayIllustrators.length === 0) return null;
-
-											return (
-												<div>
-													<h5 className="text-sm font-medium text-gray-700 mb-2">イラスト</h5>
-													<div className="space-y-2">
-														{displayIllustrators.map((illustrator, index) => (
-															<div
-																key={illustrator.id || illustrator.name || index}
-																className="flex items-center gap-3"
-															>
-																<div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
-																	<span className="text-foreground font-bold text-xs">
-																		{illustrator.name.charAt(0)}
-																	</span>
-																</div>
-																{illustrator.id ? (
-																	<Link
-																		href={`/creators/${illustrator.id}`}
-																		className="text-gray-900 text-sm hover:text-primary hover:underline"
-																		title={`ID: ${illustrator.id}`}
-																	>
-																		{illustrator.name}
-																	</Link>
-																) : (
-																	<span className="text-gray-900 text-sm">{illustrator.name}</span>
-																)}
-															</div>
-														))}
-													</div>
-												</div>
-											);
-										})()}
-
-										{/* 音楽 */}
-										{(() => {
-											const displayMusicians = work.creators?.music || [];
-
-											if (displayMusicians.length === 0) return null;
-
-											return (
-												<div>
-													<h5 className="text-sm font-medium text-gray-700 mb-2">音楽</h5>
-													<div className="space-y-2">
-														{displayMusicians.map((musician, index) => (
-															<div
-																key={musician.id || musician.name || index}
-																className="flex items-center gap-3"
-															>
-																<div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
-																	<span className="text-foreground font-bold text-xs">
-																		{musician.name.charAt(0)}
-																	</span>
-																</div>
-																{musician.id ? (
-																	<Link
-																		href={`/creators/${musician.id}`}
-																		className="text-gray-900 text-sm hover:text-primary hover:underline"
-																		title={`ID: ${musician.id}`}
-																	>
-																		{musician.name}
-																	</Link>
-																) : (
-																	<span className="text-gray-900 text-sm">{musician.name}</span>
-																)}
-															</div>
-														))}
-													</div>
-												</div>
-											);
-										})()}
-
-										{/* その他制作者（Individual Info API専用） */}
-										{work.creators?.others && work.creators.others.length > 0 && (
-											<div>
-												<h5 className="text-sm font-medium text-gray-700 mb-2">その他</h5>
-												<div className="space-y-2">
-													{work.creators.others.map((creator, index) => (
-														<div
-															key={creator.id || creator.name || index}
-															className="flex items-center gap-3"
-														>
-															<div className="w-6 h-6 bg-muted rounded-full flex items-center justify-center">
-																<span className="text-foreground font-bold text-xs">
-																	{creator.name.charAt(0)}
-																</span>
-															</div>
-															{creator.id ? (
-																<Link
-																	href={`/creators/${creator.id}`}
-																	className="text-gray-900 text-sm hover:text-primary hover:underline"
-																	title={`ID: ${creator.id}`}
-																>
-																	{creator.name}
-																</Link>
-															) : (
-																<span className="text-gray-900 text-sm">{creator.name}</span>
-															)}
-														</div>
-													))}
-												</div>
-											</div>
-										)}
-									</div>
+									<CreatorList creators={work.creators} />
 								</CardContent>
 							</Card>
 						)}


### PR DESCRIPTION
## 背景（軸2: web 最大コンポーネントの内部準重複）

`work-detail.tsx`（991行）は web 最大で直接テストがなくカバレッジを下げ続けていた。行数の主因は内部の準重複: クリエイター表示が **5職種 × 2箇所（詳細タブの Badge / サイドバーの avatar）≈ 330行** 繰り返され、年齢レーティング Badge も二重実装だった。

## 変更（991 → 625行）

- **クリエイター表示の dedup**: 職種を `CREATOR_ROLES` 定数に1本化し、`work-creators.tsx` の **`CreatorBadges`**（詳細タブ）/ **`CreatorList`**（サイドバー）が map で展開。新抽象ではなく既存 JSX の重複除去。従来挙動を踏襲（声優のみ creator リンク、サイドバーは全職種 id リンク）。
- **年齢バッジの統合**: 主表示・詳細タブの二重実装を `age-rating-badge.tsx` の **`AgeRatingBadge`** に統合（差はサイズclassのみ → `size` prop）。`ageRatingCheck` useMemo と未使用化した `checkAgeRating`/`getAgeRatingDisplayName` import を撤去。
- **テスト追加**: 抽出した両コンポーネントに `__tests__`（計8件）。
- `"use client"` 境界は不変。

`pnpm verify` green。UI 表示のみの Two-Way Door。SPR-187（価格領域）とは別領域のため非衝突。

Closes SPR-194

🤖 Generated with [Claude Code](https://claude.com/claude-code)