### PR TITLE
refactor: 評価 Firestore Timestamp を構造型に精密化し二重キャスト解消 (SPR-199)

### DIFF
--- a/apps/web/src/app/works/[workId]/evaluation-actions.ts
+++ b/apps/web/src/app/works/[workId]/evaluation-actions.ts
@@ -7,6 +7,7 @@ import {
 	type EvaluationInput,
 	EvaluationInputSchema,
 	type EvaluationResult,
+	type FirestoreTimestamp,
 	type FirestoreWorkEvaluation,
 	type FrontendUserTop10List,
 	type FrontendWorkEvaluation,
@@ -15,6 +16,14 @@ import {
 import { revalidatePath } from "next/cache";
 import { getCurrentUser } from "@/lib/auth/server";
 import { getFirestore } from "@/lib/firestore";
+
+/**
+ * 書き込み境界のヘルパー: serverTimestamp() は FieldValue で読み取り Timestamp と型が
+ * 一致しないため、ここで 1 箇所だけ FirestoreTimestamp へキャストする（SPR-199）。
+ * サーバー書き込み後に実 Timestamp になる前提の、境界での明示キャスト。
+ */
+const serverNow = (): FirestoreTimestamp =>
+	FieldValue.serverTimestamp() as unknown as FirestoreTimestamp;
 
 /**
  * 評価の更新（作成・変更）- revalidatePath使用（重要データ操作）
@@ -119,7 +128,7 @@ function insertWorkToTop10(
 	tempRankings[targetRank] = {
 		workId,
 		workTitle,
-		updatedAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
+		updatedAt: serverNow(),
 	};
 
 	// 既存作品を配置（シフト処理）
@@ -168,7 +177,7 @@ async function handleEvaluationRemove(
 				userId,
 				rankings: newRankings,
 				totalCount: Object.keys(newRankings).length,
-				lastUpdatedAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
+				lastUpdatedAt: serverNow(),
 			});
 		}
 	}
@@ -206,7 +215,7 @@ async function handleTop10Update(
 		userId,
 		rankings,
 		totalCount: Object.keys(rankings).length,
-		lastUpdatedAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
+		lastUpdatedAt: serverNow(),
 	});
 
 	// 押し出された作品を星3つ評価に変換
@@ -220,10 +229,10 @@ async function handleTop10Update(
 			userId,
 			evaluationType: "star" as const,
 			starRating: 3,
-			updatedAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
+			updatedAt: serverNow(),
 			createdAt: removedWorkEvalData.exists
 				? (removedWorkEvalData.data() as FirestoreWorkEvaluation).createdAt
-				: (FieldValue.serverTimestamp() as unknown as { toDate(): Date }),
+				: serverNow(),
 		};
 
 		transaction.set(removedEvalRef, evaluationData);
@@ -255,7 +264,7 @@ async function handleEvaluationTypeChange(
 				userId,
 				rankings: newRankings,
 				totalCount: Object.keys(newRankings).length,
-				lastUpdatedAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
+				lastUpdatedAt: serverNow(),
 			});
 		}
 	}
@@ -373,8 +382,8 @@ async function performEvaluationUpdate(
 			evaluationType: evaluation.type as "top10" | "star" | "ng",
 			...(evaluation.type === "top10" && { top10Rank: evaluation.top10Rank }),
 			...(evaluation.type === "star" && { starRating: evaluation.starRating }),
-			updatedAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
-			createdAt: FieldValue.serverTimestamp() as unknown as { toDate(): Date },
+			updatedAt: serverNow(),
+			createdAt: serverNow(),
 		};
 
 		// 既存の評価がある場合は作成日時を保持

--- a/packages/shared-types/src/entities/work-evaluation.ts
+++ b/packages/shared-types/src/entities/work-evaluation.ts
@@ -5,6 +5,18 @@ import { z } from "zod";
 // =====================
 
 /**
+ * Firestore Timestamp の読み取り用構造型（環境非依存・firebase-admin に依存しない）。
+ *
+ * 読み取った Firestore ドキュメントの日時フィールドはこの型で受け、`.toDate()` で Date 化する。
+ * 書き込み時の `FieldValue.serverTimestamp()` は別物（型が一致しない）ため、書き込みペイロード側で
+ * 1 箇所だけ構造型へキャストする（evaluation-actions の `serverNow()` ヘルパー）。
+ * 以前は `unknown` で退避し利用側で二重キャストが増殖していた（SPR-199）。
+ */
+export interface FirestoreTimestamp {
+	toDate(): Date;
+}
+
+/**
  * 作品評価のFirestoreデータ型
  */
 export interface FirestoreWorkEvaluation {
@@ -21,8 +33,8 @@ export interface FirestoreWorkEvaluation {
 	starRating?: 1 | 2 | 3; // 星評価 (evaluationType === 'star'の時のみ)
 
 	// メタデータ
-	createdAt: unknown; // 初回評価日時 (Firestore.Timestamp)
-	updatedAt: unknown; // 最終更新日時 (Firestore.Timestamp)
+	createdAt: FirestoreTimestamp; // 初回評価日時
+	updatedAt: FirestoreTimestamp; // 最終更新日時
 }
 
 /**
@@ -35,10 +47,10 @@ export interface UserTop10List {
 			// キー: 1-10の順位
 			workId: string; // 作品ID
 			workTitle?: string; // 作品タイトル（表示用キャッシュ）
-			updatedAt: unknown; // この順位に設定された日時 (Firestore.Timestamp)
+			updatedAt: FirestoreTimestamp; // この順位に設定された日時
 		} | null; // null = その順位は空き
 	};
-	lastUpdatedAt: unknown; // 最終更新日時 (Firestore.Timestamp)
+	lastUpdatedAt: FirestoreTimestamp; // 最終更新日時
 	totalCount: number; // 現在の10選登録数（0-10）
 }
 
@@ -204,10 +216,6 @@ export function isNgEvaluation(evaluation: FrontendWorkEvaluation): boolean {
 export function convertToFrontendEvaluation(
 	firestoreData: FirestoreWorkEvaluation,
 ): FrontendWorkEvaluation {
-	// Firestore Timestampの型定義
-	const createdAtTimestamp = firestoreData.createdAt as { toDate(): Date };
-	const updatedAtTimestamp = firestoreData.updatedAt as { toDate(): Date };
-
 	return {
 		id: firestoreData.id,
 		workId: firestoreData.workId,
@@ -215,8 +223,8 @@ export function convertToFrontendEvaluation(
 		evaluationType: firestoreData.evaluationType,
 		top10Rank: firestoreData.top10Rank,
 		starRating: firestoreData.starRating,
-		createdAt: createdAtTimestamp.toDate().toISOString(),
-		updatedAt: updatedAtTimestamp.toDate().toISOString(),
+		createdAt: firestoreData.createdAt.toDate().toISOString(),
+		updatedAt: firestoreData.updatedAt.toDate().toISOString(),
 	};
 }
 
@@ -226,28 +234,22 @@ export function convertToFrontendEvaluation(
 export function convertToFrontendTop10List(firestoreData: UserTop10List): FrontendUserTop10List {
 	const frontendRankings: FrontendUserTop10List["rankings"] = {};
 
-	// Firestore Timestampの型定義
-	type FirestoreTimestamp = { toDate(): Date };
-
 	for (const [rank, data] of Object.entries(firestoreData.rankings)) {
 		if (data === null) {
 			frontendRankings[Number(rank)] = null;
 		} else {
-			const updatedAtTimestamp = data.updatedAt as FirestoreTimestamp;
 			frontendRankings[Number(rank)] = {
 				workId: data.workId,
 				workTitle: data.workTitle,
-				updatedAt: updatedAtTimestamp.toDate().toISOString(),
+				updatedAt: data.updatedAt.toDate().toISOString(),
 			};
 		}
 	}
 
-	const lastUpdatedAtTimestamp = firestoreData.lastUpdatedAt as FirestoreTimestamp;
-
 	return {
 		userId: firestoreData.userId,
 		rankings: frontendRankings,
-		lastUpdatedAt: lastUpdatedAtTimestamp.toDate().toISOString(),
+		lastUpdatedAt: firestoreData.lastUpdatedAt.toDate().toISOString(),
 		totalCount: firestoreData.totalCount,
 	};
 }


### PR DESCRIPTION
## 背景（軸3: 型情報がコメントに退避され、キャストが複製され続ける）

shared-types が `createdAt: unknown; // (Firestore.Timestamp)` と型をコメントに退避していたため、利用側で二重キャストが増殖していた（書き込み `as unknown as { toDate(): Date }` ×8、converter の再キャスト ×3）。

## 変更

- shared-types に**読み取り用構造型 `FirestoreTimestamp`**（`{ toDate(): Date }`・環境非依存）を定義し、`FirestoreWorkEvaluation` / `UserTop10List` の4つの `unknown` 日時フィールドを置換。
- `convertToFrontend*` の `as { toDate(): Date }` 再キャスト3箇所を削除（型で解決）。
- `evaluation-actions` の8箇所の `serverTimestamp() as unknown as {...}` を**書き込み境界の `serverNow()` ヘルパー1箇所**に集約（FieldValue→Timestamp の境界キャストは1箇所のみ）。
- `.data() as X` の読み取りは Firestore DocumentData の標準パターンとして残置（既存 Zod スキーマは ISO 文字列の frontend 形を検証するもので、Firestore Timestamp 形の検証には不適合のため）。

### 自己レビュー（shared-types 変更 = One-Way Door）
- 型の**narrowing**（`unknown` → `FirestoreTimestamp`）のみ。利用者は `evaluation-actions`（更新済み）と modal（frontend 型を使用）の2つで、外部破壊なし。挙動変更なし・型精密化のみ。`pnpm verify` green。

Closes SPR-199

🤖 Generated with [Claude Code](https://claude.com/claude-code)