### PR TITLE
fix(ui): 小粒 UI バグ3件（TagInput a11y / AudioButton isLoading / tag-display 正本）(SPR-200)

### DIFF
--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
@@ -25,7 +25,7 @@ vi.mock("next/navigation", () => ({
 // 子コンポーネントは本体ロジックの検証外なのでスタブ化する。
 // onTagClick / onUpdateTags のコールバックを発火できるようにしておく。
 vi.mock("@suzumina.click/ui/components/custom/three-layer-tag-display", () => ({
-	ThreeLayerTagDisplay: ({
+	VideoTagDisplay: ({
 		onTagClick,
 	}: {
 		onTagClick: (tag: string, layer: "playlist" | "user" | "category") => void;
@@ -204,7 +204,7 @@ describe("VideoUserTagEditor", () => {
 		mockUseSession(loggedIn);
 		render(<VideoUserTagEditor video={createVideo()} />);
 
-		// ThreeLayerTagDisplay スタブが onTagClick("ASMR", "user") を発火する
+		// VideoTagDisplay スタブが onTagClick("ASMR", "user") を発火する
 		fireEvent.click(screen.getByText("tag-display"));
 
 		expect(mockPush).toHaveBeenCalledWith(buildTagSearchHref("ASMR", "user"));

--- a/apps/web/src/app/videos/[videoId]/components/video-user-tag-editor.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/video-user-tag-editor.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
-import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
+import { VideoTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
 import { Edit } from "lucide-react";
@@ -74,7 +74,7 @@ export function VideoUserTagEditor({ video }: VideoUserTagEditorProps) {
 	return (
 		<div className="space-y-6">
 			{/* 動画タグ表示 */}
-			<ThreeLayerTagDisplay
+			<VideoTagDisplay
 				playlistTags={video.tags?.playlistTags || []}
 				userTags={video.tags?.userTags || []}
 				categoryId={video.categoryId}

--- a/apps/web/src/app/videos/components/video-card.tsx
+++ b/apps/web/src/app/videos/components/video-card.tsx
@@ -1,6 +1,6 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { HighlightText } from "@suzumina.click/ui/components/custom/highlight-text";
-import { ThreeLayerTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
+import { VideoTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
 import { Calendar, Clock, Lock, Radio, Video } from "lucide-react";
@@ -211,7 +211,7 @@ function VideoCard({ video, variant = "grid", priority = false, searchQuery }: V
 
 					{/* タグ表示（一列・コンパクト） */}
 					<div className="mb-4">
-						<ThreeLayerTagDisplay
+						<VideoTagDisplay
 							playlistTags={video.tags?.playlistTags || []}
 							userTags={video.tags?.userTags || []}
 							categoryId={video.categoryId}

--- a/apps/web/src/lib/tag-search.ts
+++ b/apps/web/src/lib/tag-search.ts
@@ -1,6 +1,6 @@
 /**
  * 3層タグ → 動画一覧ページの href ビルダー（純関数）。
- * 層に応じたフィルターパラメータを付与し、ThreeLayerTagDisplay の tagHref に渡す。
+ * 層に応じたフィルターパラメータを付与し、VideoTagDisplay の tagHref に渡す。
  * VideoCard・動画タグ表示のタグ遷移先を一元化する（正本）。
  * 遷移先は /videos で、getVideosList の filterVideos が各層タグで絞り込む。
  */

--- a/packages/ui/src/components/custom/__tests__/tag-input.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/tag-input.test.tsx
@@ -297,7 +297,7 @@ describe("TagInput", () => {
 			expect(input).toHaveAttribute("aria-invalid", "false");
 		});
 
-		it("エラー時にaria-invalidが適切に設定される", async () => {
+		it("エラー時に aria-describedby がエラーメッセージ要素の実 ID と一致する（SPR-200）", async () => {
 			const user = userEvent.setup();
 			render(<TagInput {...defaultProps} />);
 
@@ -308,7 +308,11 @@ describe("TagInput", () => {
 			await user.keyboard("{Enter}");
 
 			expect(input).toHaveAttribute("aria-invalid", "true");
-			expect(input).toHaveAttribute("aria-describedby", "tag-input-error");
+			// 以前は固定文字列 "tag-input-error" を指していたが、エラー要素の id は useId 生成値で
+			// 不一致だった。aria-describedby が実エラー要素の id を指すことを検証する。
+			const errorEl = screen.getByText("タグを入力してください");
+			expect(errorEl.id).toBeTruthy();
+			expect(input).toHaveAttribute("aria-describedby", errorEl.id);
 		});
 
 		it("削除ボタンに適切なaria-labelが設定されている", () => {

--- a/packages/ui/src/components/custom/__tests__/three-layer-tag-display.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/three-layer-tag-display.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { ThreeLayerTagDisplay, VideoTagDisplay } from "../three-layer-tag-display";
+import { VideoTagDisplay } from "../three-layer-tag-display";
 
 describe("VideoTagDisplay", () => {
 	// 基本的な表示テスト
@@ -443,20 +443,6 @@ describe("VideoTagDisplay", () => {
 			await user.click(badge);
 
 			expect(onTagClick).toHaveBeenCalledWith("配信", "playlist");
-		});
-	});
-
-	// 後方互換性テスト
-	describe("Backward compatibility", () => {
-		it("should export ThreeLayerTagDisplay as alias", () => {
-			expect(ThreeLayerTagDisplay).toBe(VideoTagDisplay);
-		});
-
-		it("should work with ThreeLayerTagDisplay component name", () => {
-			render(<ThreeLayerTagDisplay playlistTags={["配信"]} userTags={["可愛い"]} />);
-
-			expect(screen.getByText("配信")).toBeInTheDocument();
-			expect(screen.getByText("可愛い")).toBeInTheDocument();
 		});
 	});
 });

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -467,6 +467,9 @@ export function AudioButton({
 			if (isPlaying) {
 				audioPlayerRef.current?.pause();
 			} else {
+				// 再生開始までの読み込み中はスピナーを出す（onPlay=handlePlayStart で解除）。
+				// 以前は setIsLoading(true) の経路が無くスピナーが不達だった（SPR-200）。
+				setIsLoading(true);
 				audioPlayerRef.current?.play();
 			}
 		},

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -44,7 +44,7 @@ export { NotImplementedOverlay } from "./not-implemented-overlay";
 export type { TagSuggestion } from "./tag-input";
 export { TagInput } from "./tag-input";
 export { TagList } from "./tag-list";
-export { ThreeLayerTagDisplay } from "./three-layer-tag-display";
+export { VideoTagDisplay } from "./three-layer-tag-display";
 
 // Time and validation components
 export type { TimeDisplayProps } from "./time-display";

--- a/packages/ui/src/components/custom/tag-input.tsx
+++ b/packages/ui/src/components/custom/tag-input.tsx
@@ -396,7 +396,7 @@ export function TagInput({
 						)}
 						maxLength={maxTagLength}
 						aria-invalid={!!error}
-						aria-describedby={error ? "tag-input-error" : undefined}
+						aria-describedby={error ? errorId : undefined}
 						aria-expanded={showSuggestions}
 						aria-autocomplete="list"
 						aria-haspopup="listbox"

--- a/packages/ui/src/components/custom/three-layer-tag-display.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display.tsx
@@ -1,7 +1,7 @@
 /**
  * VideoTagDisplay - 動画タグ表示コンポーネント
  * 配信タイプ、みんなのタグ、ジャンルを統合表示
- * 旧名: ThreeLayerTagDisplay（後方互換性のため名前は残す）
+ * 正本は VideoTagDisplay（旧名 ThreeLayerTagDisplay の別名は SPR-200 で撤去）
  */
 
 "use client";
@@ -181,7 +181,3 @@ export function VideoTagDisplay({
 		</div>
 	);
 }
-
-// 後方互換性のため旧名も残す
-export const ThreeLayerTagDisplay = VideoTagDisplay;
-export type ThreeLayerTagDisplayProps = VideoTagDisplayProps;


### PR DESCRIPTION
packages/ui の独立した小粒バグ3件。

## 1. TagInput の a11y 欠陥
`aria-describedby` が固定文字列 `"tag-input-error"` を指していたが、エラーメッセージ `<p>` の id は `useId()` 生成値で**不一致** → スクリーンリーダーにエラーが通知されなかった。`errorId` に統一し、テストを「実エラー要素の id と一致」を検証する形に修正。

## 2. AudioButton の死に状態
`isLoading` が **`true` になる経路が無く**（`setIsLoading(false)` のみ3箇所）、`Loader2` スピナー UI が永久不達だった。再生開始時に `setIsLoading(true)` を配線（`onPlay=handlePlayStart` で解除）。型約束（ローディング状態あり）を実態に合わせた。

## 3. 後方互換エイリアスの正本逆転
正本は `VideoTagDisplay`（実関数）だが、**全コンシューマが @deprecated 旧名 `ThreeLayerTagDisplay`**（エイリアス）を使用、新名は Storybook のみ使用という逆転状態だった。コンシューマ（`video-card` / `video-user-tag-editor` / barrel export / `tag-search` コメント）を `VideoTagDisplay` に移行し、**旧名エイリアスを撤去**（正本を1つに）。

`pnpm verify` green（tag-input/audio-button/tag-display テスト追従）。packages/ui 閉域・Two-Way Door。一覧/タグ UI の回帰は Chromatic で検出可能。

Closes SPR-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)