### PR TITLE
refactor(web): ソート「人気順」を rating.count に意味統一 (SPR-190 再)

### DIFF
--- a/apps/web/src/lib/__tests__/circle-creator-works.test.ts
+++ b/apps/web/src/lib/__tests__/circle-creator-works.test.ts
@@ -37,9 +37,10 @@ describe("circle-creator-works compareWorks", () => {
 		expect([a, b].sort((x, y) => compareWorks(x, y, "newest"))[0]).toBe(b);
 	});
 
-	it("popular: rating.stars 降順（count ではない）", () => {
-		const a = work({ productId: "RJ1", rating: { stars: 3, count: 999 } as never });
-		const b = work({ productId: "RJ2", rating: { stars: 5, count: 1 } as never });
+	it("popular: rating.count 降順（works 一覧と統一・stars ではない）", () => {
+		const a = work({ productId: "RJ1", rating: { stars: 5, count: 1 } as never });
+		const b = work({ productId: "RJ2", rating: { stars: 3, count: 999 } as never });
+		// count が多い b が先頭（stars 基準なら a が先頭になるはず）
 		expect([a, b].sort((x, y) => compareWorks(x, y, "popular"))[0]).toBe(b);
 	});
 

--- a/apps/web/src/lib/circle-creator-works.ts
+++ b/apps/web/src/lib/circle-creator-works.ts
@@ -4,8 +4,7 @@
  * works 一覧（`app/works/lib/`）のソート・フィルタは WorkDocument 対象で
  * レイヤーが異なるため共用しない。本モジュールは circle/creator 間の重複解消に限定する（SPR-185）。
  *
- * 「人気順(popular)」は rating.stars 基準。works 一覧（rating.count 基準）との
- * 意味統一は SPR-190 で別途扱う。
+ * 「人気順(popular)」は rating.count（評価数）基準で works 一覧と統一済み（SPR-190）。
  */
 
 import type { WorkPlainObject } from "@suzumina.click/shared-types";
@@ -24,7 +23,8 @@ function compareByDate(a: WorkPlainObject, b: WorkPlainObject, isOldest = false)
 }
 
 function compareByRating(a: WorkPlainObject, b: WorkPlainObject): number {
-	return (b.rating?.stars || 0) - (a.rating?.stars || 0);
+	// 「人気順」は rating.count（評価数）基準で works 一覧と統一（SPR-190）。
+	return (b.rating?.count || 0) - (a.rating?.count || 0);
 }
 
 function compareByPrice(a: WorkPlainObject, b: WorkPlainObject, isHighToLow = false): number {


### PR DESCRIPTION
SPR-190。元 PR #625 は親 #616(185) のブランチ削除時に GitHub が retarget せず close したため、#190 の単一コミットを main に cherry-pick して作り直したもの（内容は #625 と同一）。

「人気順」の正本を rating.count に確定し circle/creator を統一（works 一覧は既に rating.count）。

Closes SPR-190

🤖 Generated with [Claude Code](https://claude.com/claude-code)