### PR TITLE
test(functions): テストを typecheck 対象に戻す（SPR-193 / functions 分・PR1）

### DIFF
--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
@@ -3,7 +3,7 @@
  */
 
 import type { CloudEvent } from "@google-cloud/functions-framework";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 // Firestoreモック
 vi.mock("../../infrastructure/database/firestore", () => {
@@ -35,8 +35,8 @@ import firestore from "../../infrastructure/database/firestore";
 import { checkDataIntegrity, runIntegrityCheck } from "../data-integrity-check";
 
 // モック関数をvitestから取得
-const mockCollection = vi.mocked(firestore.collection);
-const mockBatch = vi.mocked(firestore.batch);
+const mockCollection = vi.mocked(firestore.collection) as unknown as Mock;
+const mockBatch = vi.mocked(firestore.batch) as unknown as Mock;
 
 // その他のモック関数
 const mockDoc = vi.fn();
@@ -388,7 +388,7 @@ describe("checkDataIntegrity", () => {
 		expect(mockCommit).toHaveBeenCalled();
 
 		// 結果に復元情報が含まれることを確認
-		const lastSetCall = mockSet.mock.calls[mockSet.mock.calls.length - 2]; // 最後から2番目が結果保存
+		const lastSetCall = mockSet.mock.calls[mockSet.mock.calls.length - 2]!; // 最後から2番目が結果保存
 		expect(lastSetCall[0]).toMatchObject({
 			latest: expect.objectContaining({
 				checks: expect.objectContaining({

--- a/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
+++ b/apps/functions/src/endpoints/__tests__/data-integrity-check.test.ts
@@ -35,8 +35,10 @@ import firestore from "../../infrastructure/database/firestore";
 import { checkDataIntegrity, runIntegrityCheck } from "../data-integrity-check";
 
 // モック関数をvitestから取得
-const mockCollection = vi.mocked(firestore.collection) as unknown as Mock;
-const mockBatch = vi.mocked(firestore.batch) as unknown as Mock;
+const mockCollection = vi.mocked(firestore.collection) as unknown as Mock<
+	(collectionPath: string) => unknown
+>;
+const mockBatch = vi.mocked(firestore.batch) as unknown as Mock<() => unknown>;
 
 // その他のモック関数
 const mockDoc = vi.fn();

--- a/apps/functions/src/infrastructure/management/__tests__/user-agent-manager.test.ts
+++ b/apps/functions/src/infrastructure/management/__tests__/user-agent-manager.test.ts
@@ -211,7 +211,7 @@ describe("generateDLsiteHeaders", () => {
 
 	it("ブラウザ固有のヘッダーが一貫している", () => {
 		const headers = generateDLsiteHeaders();
-		const userAgent = headers["User-Agent"];
+		const userAgent = headers["User-Agent"]!;
 
 		// ChromeベースのUser-Agentの場合
 		if (userAgent.includes("Chrome/")) {

--- a/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
@@ -75,9 +75,11 @@ describe("creator-firestore", () => {
 	beforeEach(async () => {
 		// Firestoreのdefaultインスタンスのモックを設定
 		const firestoreMock = await import("../../../infrastructure/database/firestore");
-		firestoreMock.default.collection = mockCollection;
-		firestoreMock.default.collectionGroup = mockCollectionGroup;
-		firestoreMock.default.batch = mockBatch;
+		Object.assign(firestoreMock.default, {
+			collection: mockCollection,
+			collectionGroup: mockCollectionGroup,
+			batch: mockBatch,
+		});
 
 		// バッチモック
 		mockBatch.mockReturnValue({

--- a/apps/functions/src/services/dlsite/__tests__/dlsite-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/dlsite-firestore.test.ts
@@ -73,19 +73,13 @@ const sampleWork: WorkDocument = {
 	workUrl: "https://www.dlsite.com/maniax/work/=/product_id/RJ12345.html",
 	thumbnailUrl: "https://img.dlsite.jp/thumbnail.jpg",
 	sampleImages: [],
-	tags: ["ASMR", "癒し"],
 	description: "テスト用の作品説明",
 	releaseDate: "2024-01-01",
 	releaseDateISO: "2024-01-01",
 	releaseDateDisplay: "2024年01月01日",
 	ageRating: "全年齢",
-	voiceActors: ["涼花みなせ"],
-	scenario: [],
-	illustration: [],
-	music: [],
-	author: [],
 	genres: ["ASMR", "癒し"],
-	isExclusive: false,
+	customGenres: [],
 	dataSources: {
 		searchResult: {
 			lastFetched: "2024-01-01T00:00:00Z",
@@ -122,7 +116,7 @@ describe("dlsite-firestore", () => {
 
 			await saveWorksToFirestore([workAfterSale]);
 
-			const payload = mockBatch.set.mock.calls[0][1] as { price: Record<string, unknown> };
+			const payload = mockBatch.set.mock.calls[0]![1] as { price: Record<string, unknown> };
 			expect((payload.price.discount as any).isEqual(FieldValue.delete())).toBe(true);
 			expect((payload.price.original as any).isEqual(FieldValue.delete())).toBe(true);
 			expect((payload.price.point as any).isEqual(FieldValue.delete())).toBe(true);
@@ -138,7 +132,7 @@ describe("dlsite-firestore", () => {
 
 			await saveWorksToFirestore([workOnSale]);
 
-			const payload = mockBatch.set.mock.calls[0][1] as { price: Record<string, unknown> };
+			const payload = mockBatch.set.mock.calls[0]![1] as { price: Record<string, unknown> };
 			expect(payload.price.discount).toBe(20);
 			expect(payload.price.original).toBe(1650);
 			expect(payload.price.current).toBe(1320);
@@ -169,7 +163,7 @@ describe("dlsite-firestore", () => {
 
 			const result = await getWorkFromFirestore("RJ12345");
 
-			expect(result).toEqual({ id: "RJ12345", ...sampleWork });
+			expect(result).toEqual({ ...sampleWork });
 		});
 
 		it("存在しない作品の場合はnullを返す", async () => {

--- a/apps/functions/src/services/dlsite/__tests__/failure-tracker.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/failure-tracker.test.ts
@@ -89,7 +89,6 @@ const firestoreMock = vi.mocked(await import("../../../infrastructure/database/f
 const mockQuery = (firestoreMock as any).__mockQuery;
 const mockDoc = (firestoreMock as any).__mockDoc;
 const mockBatch = (firestoreMock as any).__mockBatch;
-const _mockCollection = (firestoreMock as any).__mockCollection;
 
 describe("failure-tracker", () => {
 	beforeEach(() => {
@@ -171,10 +170,10 @@ describe("failure-tracker", () => {
 	describe("trackMultipleFailedWorks", () => {
 		it("複数の失敗作品を一括記録できる", async () => {
 			const failures = [
-				{ workId: "RJ12345", reason: FAILURE_REASONS.TIMEOUT as const },
+				{ workId: "RJ12345", reason: FAILURE_REASONS.TIMEOUT },
 				{
 					workId: "RJ54321",
-					reason: FAILURE_REASONS.API_ERROR as const,
+					reason: FAILURE_REASONS.API_ERROR,
 					errorDetails: "404 Not Found",
 				},
 			];
@@ -204,7 +203,7 @@ describe("failure-tracker", () => {
 		it("バッチコミットでエラーが発生した場合は例外を投げる", async () => {
 			mockBatch.commit.mockRejectedValue(new Error("Batch commit failed"));
 
-			const failures = [{ workId: "RJ12345", reason: FAILURE_REASONS.TIMEOUT as const }];
+			const failures = [{ workId: "RJ12345", reason: FAILURE_REASONS.TIMEOUT }];
 
 			await expect(trackMultipleFailedWorks(failures)).rejects.toThrow("Batch commit failed");
 		});

--- a/apps/functions/src/services/dlsite/__tests__/schema-drift.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/schema-drift.test.ts
@@ -73,7 +73,7 @@ describe("recordSchemaDriftForBatch", () => {
 	it("新フィールド出現で alert マーカー付き WARN を出す", () => {
 		recordSchemaDriftForBatch([{ workno: "RJ001", totally_new_field: 1 }], { batchSize: 1 });
 		expect(mockWarn).toHaveBeenCalledTimes(1);
-		const [, payload] = mockWarn.mock.calls[0];
+		const [, payload] = mockWarn.mock.calls[0]!;
 		expect(payload).toMatchObject({
 			alert: SCHEMA_DRIFT_ALERT,
 			newFields: ["totally_new_field"],

--- a/apps/functions/src/services/dlsite/__tests__/unified-data-processor.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/unified-data-processor.test.ts
@@ -247,9 +247,9 @@ describe("unified-data-processor", () => {
 
 			expect(results).toHaveLength(3);
 			expect(results.every((r) => r.success)).toBe(true);
-			expect(results[0].workId).toBe("RJ111111");
-			expect(results[1].workId).toBe("RJ222222");
-			expect(results[2].workId).toBe("RJ333333");
+			expect(results[0]!.workId).toBe("RJ111111");
+			expect(results[1]!.workId).toBe("RJ222222");
+			expect(results[2]!.workId).toBe("RJ333333");
 		});
 
 		it("大量のデータを適切なバッチサイズで処理する", async () => {
@@ -282,10 +282,10 @@ describe("unified-data-processor", () => {
 			const results = await processBatchUnifiedDLsiteData(apiDataList);
 
 			expect(results).toHaveLength(2);
-			expect(results[0].success).toBe(true);
-			expect(results[1].success).toBe(false);
-			expect(results[1].workId).toBe("RJ222222");
-			expect(results[1].errors[0]).toContain("統合処理エラー: Mapping error");
+			expect(results[0]!.success).toBe(true);
+			expect(results[1]!.success).toBe(false);
+			expect(results[1]!.workId).toBe("RJ222222");
+			expect(results[1]!.errors[0]).toContain("統合処理エラー: Mapping error");
 		});
 	});
 

--- a/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
@@ -3,7 +3,6 @@
  * プロトコル相対URLの正規化が正しく動作することを検証
  */
 
-import type { DLsiteApiResponse } from "@suzumina.click/shared-types";
 import { describe, expect, it } from "vitest";
 import { WorkMapper } from "../../mappers/work-mapper";
 
@@ -23,9 +22,7 @@ describe("URL正規化機能", () => {
 			site_id: "maniax",
 			author: "テスト声優",
 			price: 1000,
-			price_without_tax: 909,
 			official_price: 1000,
-			official_price_without_tax: 909,
 			discount_rate: 0,
 			is_discount_work: false,
 			rate_average: 4.5,
@@ -41,7 +38,7 @@ describe("URL正規化機能", () => {
 			],
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// メイン画像URLの正規化確認
 		expect(result.thumbnailUrl).toBe(
@@ -76,9 +73,7 @@ describe("URL正規化機能", () => {
 			site_id: "maniax",
 			author: "テスト声優",
 			price: 1000,
-			price_without_tax: 909,
 			official_price: 1000,
-			official_price_without_tax: 909,
 			discount_rate: 0,
 			is_discount_work: false,
 			rate_average: 4.5,
@@ -92,7 +87,7 @@ describe("URL正規化機能", () => {
 				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main.jpg",
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// 正しい形式のURLは変更されないことを確認
 		expect(result.thumbnailUrl).toBe(
@@ -118,9 +113,7 @@ describe("URL正規化機能", () => {
 			site_id: "maniax",
 			author: "テスト声優",
 			price: 1000,
-			price_without_tax: 909,
 			official_price: 1000,
-			official_price_without_tax: 909,
 			discount_rate: 0,
 			is_discount_work: false,
 			rate_average: 4.5,
@@ -132,7 +125,7 @@ describe("URL正規化機能", () => {
 				"//img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main.jpg 1x, //img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main_2x.jpg 2x",
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// srcsetから抽出した高解像度URLの正規化確認
 		expect(result.highResImageUrl).toBe(
@@ -155,9 +148,7 @@ describe("URL正規化機能", () => {
 			site_id: "maniax",
 			author: "テスト声優",
 			price: 1000,
-			price_without_tax: 909,
 			official_price: 1000,
-			official_price_without_tax: 909,
 			discount_rate: 0,
 			is_discount_work: false,
 			rate_average: 4.5,
@@ -169,7 +160,7 @@ describe("URL正規化機能", () => {
 			image_main: undefined,
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// デフォルトURLが設定されることを確認
 		expect(result.thumbnailUrl).toBe(
@@ -185,7 +176,7 @@ describe("URL正規化機能", () => {
 			// price 情報も欠損
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// フォールバック値が設定されることを確認
 		expect(result.id).toBe("RJ01037463");
@@ -209,7 +200,7 @@ describe("URL正規化機能", () => {
 			image_samples: [111, 222, 333] as any,
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// 数値が文字列に変換されて処理されることを確認
 		expect(result.thumbnailUrl).toBe("123456");
@@ -238,7 +229,7 @@ describe("URL正規化機能", () => {
 			] as any,
 		};
 
-		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
+		const result = WorkMapper.toWork(mockApiData);
 
 		// オブジェクトから適切なプロパティが抽出されて正規化されることを確認
 		expect(result.thumbnailUrl).toBe("https://img.dlsite.jp/test_thumb.jpg");

--- a/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
@@ -9,7 +9,7 @@ import { WorkMapper } from "../../mappers/work-mapper";
 
 describe("URL正規化機能", () => {
 	it("プロトコル相対URLを正しく正規化する", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			product_id: "RJ01037463",
 			work_name: "テスト作品",
@@ -41,7 +41,7 @@ describe("URL正規化機能", () => {
 			],
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// メイン画像URLの正規化確認
 		expect(result.thumbnailUrl).toBe(
@@ -53,16 +53,16 @@ describe("URL正規化機能", () => {
 
 		// サンプル画像URLの正規化確認
 		expect(result.sampleImages).toHaveLength(2);
-		expect(result.sampleImages[0].thumb).toBe(
+		expect(result.sampleImages[0]!.thumb).toBe(
 			"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_sample1.jpg",
 		);
-		expect(result.sampleImages[1].thumb).toBe(
+		expect(result.sampleImages[1]!.thumb).toBe(
 			"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_sample2.jpg",
 		);
 	});
 
 	it("既に正しい形式のURLはそのまま維持する", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			product_id: "RJ01037463",
 			work_name: "テスト作品",
@@ -92,7 +92,7 @@ describe("URL正規化機能", () => {
 				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main.jpg",
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// 正しい形式のURLは変更されないことを確認
 		expect(result.thumbnailUrl).toBe(
@@ -104,7 +104,7 @@ describe("URL正規化機能", () => {
 	});
 
 	it("srcsetから抽出した高解像度URLも正規化される", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			product_id: "RJ01037463",
 			work_name: "テスト作品",
@@ -132,7 +132,7 @@ describe("URL正規化機能", () => {
 				"//img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main.jpg 1x, //img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main_2x.jpg 2x",
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// srcsetから抽出した高解像度URLの正規化確認
 		expect(result.highResImageUrl).toBe(
@@ -141,7 +141,7 @@ describe("URL正規化機能", () => {
 	});
 
 	it("undefinedやnullのURLは適切に処理される", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			product_id: "RJ01037463",
 			work_name: "テスト作品",
@@ -169,7 +169,7 @@ describe("URL正規化機能", () => {
 			image_main: undefined,
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// デフォルトURLが設定されることを確認
 		expect(result.thumbnailUrl).toBe(
@@ -179,13 +179,13 @@ describe("URL正規化機能", () => {
 	});
 
 	it("必須フィールドが欠損していても処理される", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			// work_name と maker_name が欠損
 			// price 情報も欠損
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// フォールバック値が設定されることを確認
 		expect(result.id).toBe("RJ01037463");
@@ -196,7 +196,7 @@ describe("URL正規化機能", () => {
 	});
 
 	it("画像URLが数値型でも正しく処理される", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			work_name: "テスト作品",
 			maker_name: "テストサークル",
@@ -209,19 +209,19 @@ describe("URL正規化機能", () => {
 			image_samples: [111, 222, 333] as any,
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// 数値が文字列に変換されて処理されることを確認
 		expect(result.thumbnailUrl).toBe("123456");
 		expect(result.highResImageUrl).toBe("789012");
 		expect(result.sampleImages).toHaveLength(3);
-		expect(result.sampleImages[0].thumb).toBe("111");
-		expect(result.sampleImages[1].thumb).toBe("222");
-		expect(result.sampleImages[2].thumb).toBe("333");
+		expect(result.sampleImages[0]!.thumb).toBe("111");
+		expect(result.sampleImages[1]!.thumb).toBe("222");
+		expect(result.sampleImages[2]!.thumb).toBe("333");
 	});
 
 	it("画像URLがオブジェクト型でも正しく処理される", () => {
-		const mockApiData: DLsiteApiResponse = {
+		const mockApiData = {
 			workno: "RJ01037463",
 			work_name: "テスト作品",
 			maker_name: "テストサークル",
@@ -238,13 +238,13 @@ describe("URL正規化機能", () => {
 			] as any,
 		};
 
-		const result = WorkMapper.toWork(mockApiData);
+		const result = WorkMapper.toWork(mockApiData as DLsiteApiResponse);
 
 		// オブジェクトから適切なプロパティが抽出されて正規化されることを確認
 		expect(result.thumbnailUrl).toBe("https://img.dlsite.jp/test_thumb.jpg");
 		expect(result.highResImageUrl).toBe("https://img.dlsite.jp/test_main.jpg");
 		expect(result.sampleImages).toHaveLength(2); // 無効なオブジェクトはフィルタされる
-		expect(result.sampleImages[0].thumb).toBe("https://img.dlsite.jp/sample1.jpg");
-		expect(result.sampleImages[1].thumb).toBe("https://img.dlsite.jp/sample3.jpg");
+		expect(result.sampleImages[0]!.thumb).toBe("https://img.dlsite.jp/sample1.jpg");
+		expect(result.sampleImages[1]!.thumb).toBe("https://img.dlsite.jp/sample3.jpg");
 	});
 });

--- a/apps/functions/src/services/dlsite/__tests__/work-id-collector.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/work-id-collector.test.ts
@@ -102,21 +102,6 @@ const sampleAjaxResult = {
 	},
 };
 
-const _sampleAjaxResultWithFallbackPattern = {
-	search_result: `
-		<div class="work_item" data-list_item_product_id="RJ999999">
-			<a href="/maniax/work/=/product_id/RJ999999.html">作品</a>
-		</div>
-		<script type="application/json">{"product_id":"RJ888888","title":"作品データ"}</script>
-	`,
-	page_info: {
-		count: 2,
-		per_page: 30,
-		current_page: 1,
-		total_pages: 1,
-	},
-};
-
 describe("work-id-collector", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();

--- a/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
@@ -38,16 +38,16 @@ describe("WorkMapper", () => {
 		work_type_string: "音声作品",
 
 		genres: [
-			{ id: "1", name: "ASMR", search_val: "asmr" },
-			{ id: "2", name: "バイノーラル", search_val: "binaural" },
+			{ id: 1, name: "ASMR", search_val: "asmr", name_base: "asmr" },
+			{ id: 2, name: "バイノーラル", search_val: "binaural", name_base: "binaural" },
 		],
 
 		creaters: {
 			voice_by: [
-				{ id: "cv001", name: "声優A" },
-				{ id: "cv002", name: "声優B" },
+				{ id: "cv001", name: "声優A", type: "voice" },
+				{ id: "cv002", name: "声優B", type: "voice" },
 			],
-			scenario_by: [{ id: "sc001", name: "シナリオライター" }],
+			scenario_by: [{ id: "sc001", name: "シナリオライター", type: "scenario" }],
 		},
 
 		image_thum: "//img.dlsite.jp/modpub/images2/work/doujin/RJ12345678_img_thum.jpg",
@@ -184,15 +184,17 @@ describe("WorkMapper", () => {
 			const work = WorkMapper.toWork(mockRawApiData);
 
 			expect(work.creators?.voice_by).toEqual([
-				{ id: "cv001", name: "声優A" },
-				{ id: "cv002", name: "声優B" },
+				{ id: "cv001", name: "声優A", type: "voice" },
+				{ id: "cv002", name: "声優B", type: "voice" },
 			]);
 		});
 
 		it("シナリオライター情報を正しく抽出できる", () => {
 			const work = WorkMapper.toWork(mockRawApiData);
 
-			expect(work.creators?.scenario_by).toEqual([{ id: "sc001", name: "シナリオライター" }]);
+			expect(work.creators?.scenario_by).toEqual([
+				{ id: "sc001", name: "シナリオライター", type: "scenario" },
+			]);
 		});
 
 		it("creatersフィールドがない場合はundefinedを返す", () => {
@@ -220,9 +222,9 @@ describe("WorkMapper", () => {
 			const dataWithPromo: DLsiteApiResponse = {
 				...mockRawApiData,
 				genres: [
-					{ id: "1", name: "ASMR", search_val: "asmr" },
-					{ id: "2", name: "30%OFFキャンペーン", search_val: "campaign" },
-					{ id: "3", name: "新作ピックアップ", search_val: "pickup" },
+					{ id: 1, name: "ASMR", search_val: "asmr", name_base: "asmr" },
+					{ id: 2, name: "30%OFFキャンペーン", search_val: "campaign", name_base: "campaign" },
+					{ id: 3, name: "新作ピックアップ", search_val: "pickup", name_base: "pickup" },
 				],
 			};
 

--- a/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
@@ -1,7 +1,8 @@
+import type { youtube_v3 } from "googleapis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // quota monitor をモックして quota 充足/不足の両分岐を検証する
-const canExecuteOperation = vi.fn(() => true);
+const canExecuteOperation = vi.fn((..._a: unknown[]) => true);
 const recordQuotaUsage = vi.fn();
 const logQuotaUsage = vi.fn();
 const suggestOptimalOperations = vi.fn(() => ({ feasible: true, alternatives: [] as string[] }));
@@ -31,8 +32,7 @@ const makeClient = () => ({
 	playlists: { list: vi.fn() },
 	playlistItems: { list: vi.fn() },
 });
-// biome-ignore lint/suspicious/noExplicitAny: フェイククライアントを型に流し込む
-const asYoutube = (c: ReturnType<typeof makeClient>) => c as any;
+const asYoutube = (c: ReturnType<typeof makeClient>) => c as unknown as youtube_v3.Youtube;
 
 beforeEach(() => {
 	canExecuteOperation.mockReturnValue(true);

--- a/apps/functions/src/services/youtube/__tests__/youtube-api.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-api.test.ts
@@ -1,12 +1,5 @@
+import type { youtube_v3 } from "googleapis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-// googleapis型の独自定義（テスト用）
-// biome-ignore lint/correctness/noUnusedVariables: Interface used by test type definitions
-interface youtube_v3 {
-	Schema$SearchListResponse: any;
-	Schema$VideoListResponse: any;
-}
-
 import { SUZUKA_MINASE_CHANNEL_ID } from "../../../shared/common";
 import * as youtubeApi from "../youtube-api";
 
@@ -227,8 +220,8 @@ describe("youtube-api", () => {
 				maxResults: youtubeApi.MAX_VIDEOS_PER_BATCH,
 			});
 			expect(result).toHaveLength(2);
-			expect(result[0].id).toBe("video1");
-			expect(result[1].id).toBe("video2");
+			expect(result[0]!.id).toBe("video1");
+			expect(result[1]!.id).toBe("video2");
 		});
 
 		it("動画IDが多い場合はバッチ処理されること", async () => {
@@ -307,8 +300,8 @@ describe("youtube-api", () => {
 
 			// 検証（最初のバッチの結果だけが返されること）
 			expect(result).toHaveLength(2);
-			expect(result[0].id).toBe("video1");
-			expect(result[1].id).toBe("video2");
+			expect(result[0]!.id).toBe("video1");
+			expect(result[1]!.id).toBe("video2");
 		});
 
 		it("その他のエラーが発生した場合、エラーがスローされること", async () => {

--- a/apps/functions/src/shared/__tests__/array-utils.test.ts
+++ b/apps/functions/src/shared/__tests__/array-utils.test.ts
@@ -64,7 +64,7 @@ describe("Array Utils", () => {
 				const chunks = chunkArray(stringArray, 2);
 
 				// Type check: chunks should be string[][]
-				expect(typeof chunks[0][0]).toBe("string");
+				expect(typeof chunks[0]![0]).toBe("string");
 				expect(chunks).toEqual([
 					["a", "b"],
 					["c", "d"],

--- a/apps/functions/src/shared/__tests__/http-utils.test.ts
+++ b/apps/functions/src/shared/__tests__/http-utils.test.ts
@@ -175,9 +175,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockResolvedValue(mockResponse500);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 0 })).rejects.toThrow(
-				HttpRequestError,
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(HttpRequestError);
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
@@ -191,9 +189,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockResolvedValue(mockResponse429);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 0 })).rejects.toThrow(
-				HttpRequestError,
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(HttpRequestError);
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
@@ -207,9 +203,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockResolvedValue(mockResponse400);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 2 })).rejects.toThrow(
-				HttpRequestError,
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(HttpRequestError);
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
@@ -219,9 +213,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockRejectedValue(networkError);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 0 })).rejects.toThrow(
-				HttpRequestError,
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(HttpRequestError);
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
@@ -280,9 +272,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockRejectedValue(abortError);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 0 })).rejects.toThrow(
-				HttpRequestError,
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(HttpRequestError);
 
 			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
@@ -477,9 +467,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockResolvedValue(mockResponse);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 2 })).rejects.toThrow(
-				"HTTP 403 Forbidden",
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow("HTTP 403 Forbidden");
 		});
 
 		// リトライ機能のテストは複雑なため、基本機能のみテスト
@@ -494,7 +482,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockResolvedValue(mockResponse);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 0 })).rejects.toThrow(
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(
 				"HTTP 500 Internal Server Error",
 			);
 		});
@@ -536,9 +524,7 @@ describe("HTTP Utils", () => {
 
 			mockFetch.mockRejectedValue(abortError);
 
-			await expect(makeRequest("https://example.com", { maxRetries: 0 })).rejects.toThrow(
-				HttpRequestError,
-			);
+			await expect(makeRequest("https://example.com", {})).rejects.toThrow(HttpRequestError);
 		});
 
 		it("should handle non-Error thrown values", async () => {

--- a/apps/functions/src/shared/__tests__/logger.test.ts
+++ b/apps/functions/src/shared/__tests__/logger.test.ts
@@ -11,7 +11,7 @@ describe("logger", () => {
 		// console.logをモック
 		originalConsoleLog = console.log;
 		mockConsoleLog = vi.fn();
-		console.log = mockConsoleLog;
+		console.log = mockConsoleLog as typeof console.log;
 
 		// 環境変数をバックアップ
 		originalEnv = { ...process.env };
@@ -70,7 +70,7 @@ describe("logger", () => {
 			logger.info("test message");
 
 			expect(mockConsoleLog).toHaveBeenCalledTimes(1);
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 
 			// JSONパース可能であることを確認
 			const parsed = JSON.parse(logOutput);
@@ -85,7 +85,7 @@ describe("logger", () => {
 
 			logger.info("test message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed["logging.googleapis.com/labels"]).toEqual({
@@ -101,7 +101,7 @@ describe("logger", () => {
 
 			logger.info("test message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed["logging.googleapis.com/labels"]).toEqual({
@@ -112,7 +112,7 @@ describe("logger", () => {
 		it("should not include labels when K_SERVICE is not set", () => {
 			logger.info("test message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed["logging.googleapis.com/labels"]).toBeUndefined();
@@ -124,7 +124,7 @@ describe("logger", () => {
 
 			logger.error("test message", testError);
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.severity).toBe("ERROR");
@@ -145,7 +145,7 @@ describe("logger", () => {
 
 			logger.info("test message", options);
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.severity).toBe("INFO");
@@ -165,7 +165,7 @@ describe("logger", () => {
 			logger.info("test message");
 
 			expect(mockConsoleLog).toHaveBeenCalledTimes(1);
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 
 			// タイムスタンプ、アイコン、レベル、メッセージが含まれることを確認
 			expect(logOutput).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z ℹ️ INFO test message/);
@@ -177,7 +177,7 @@ describe("logger", () => {
 
 			logger.error("test message", testError);
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 
 			expect(logOutput).toContain("❌ ERROR test message");
 			expect(logOutput).toContain("Error: test error");
@@ -189,7 +189,7 @@ describe("logger", () => {
 
 			logger.info("test message", data);
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 
 			expect(logOutput).toContain("ℹ️ INFO test message");
 			expect(logOutput).toContain("Data:");
@@ -203,10 +203,10 @@ describe("logger", () => {
 			logger.warn("warn message");
 			logger.error("error message");
 
-			expect(mockConsoleLog.mock.calls[0][0]).toContain("🔍 DEBUG");
-			expect(mockConsoleLog.mock.calls[1][0]).toContain("ℹ️ INFO");
-			expect(mockConsoleLog.mock.calls[2][0]).toContain("⚠️ WARNING");
-			expect(mockConsoleLog.mock.calls[3][0]).toContain("❌ ERROR");
+			expect(mockConsoleLog.mock.calls[0]![0]).toContain("🔍 DEBUG");
+			expect(mockConsoleLog.mock.calls[1]![0]).toContain("ℹ️ INFO");
+			expect(mockConsoleLog.mock.calls[2]![0]).toContain("⚠️ WARNING");
+			expect(mockConsoleLog.mock.calls[3]![0]).toContain("❌ ERROR");
 		});
 	});
 
@@ -214,7 +214,7 @@ describe("logger", () => {
 		it("should output debug logs with correct severity", () => {
 			logger.debug("debug message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.severity).toBe("DEBUG");
@@ -224,7 +224,7 @@ describe("logger", () => {
 		it("should output info logs with correct severity", () => {
 			logger.info("info message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.severity).toBe("INFO");
@@ -234,7 +234,7 @@ describe("logger", () => {
 		it("should output warn logs with correct severity", () => {
 			logger.warn("warn message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.severity).toBe("WARNING");
@@ -244,7 +244,7 @@ describe("logger", () => {
 		it("should output error logs with correct severity", () => {
 			logger.error("error message");
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.severity).toBe("ERROR");
@@ -254,9 +254,9 @@ describe("logger", () => {
 
 	describe("Edge cases", () => {
 		it("should handle null options", () => {
-			expect(() => logger.info("test", null)).not.toThrow();
+			expect(() => logger.info("test", null as never)).not.toThrow();
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.message).toBe("test");
@@ -265,7 +265,7 @@ describe("logger", () => {
 		it("should handle undefined options", () => {
 			expect(() => logger.info("test", undefined)).not.toThrow();
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.message).toBe("test");
@@ -274,7 +274,7 @@ describe("logger", () => {
 		it("should handle empty object options", () => {
 			logger.info("test", {});
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.message).toBe("test");
@@ -286,7 +286,7 @@ describe("logger", () => {
 
 			logger.error("test message", testError);
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.error.message).toBe("test error");
@@ -311,7 +311,7 @@ describe("logger", () => {
 
 			logger.info("complex data", complexData);
 
-			const logOutput = mockConsoleLog.mock.calls[0][0];
+			const logOutput = mockConsoleLog.mock.calls[0]![0];
 			const parsed = JSON.parse(logOutput);
 
 			expect(parsed.user.id).toBe(123);

--- a/apps/functions/src/tools/core/__tests__/dlsite-dryrun-capture.test.ts
+++ b/apps/functions/src/tools/core/__tests__/dlsite-dryrun-capture.test.ts
@@ -107,8 +107,8 @@ describe("analyzeFields", () => {
 	it("presence は出現数の多い順に並ぶ", () => {
 		const responses = [{ workno: "1", price: 1 }, { workno: "2" }, { workno: "3" }];
 		const r = analyzeFields(responses, known);
-		expect(r.presence[0].field).toBe("workno");
-		expect(r.presence[0].count).toBe(3);
+		expect(r.presence[0]!.field).toBe("workno");
+		expect(r.presence[0]!.count).toBe(3);
 	});
 });
 

--- a/apps/functions/src/tools/firestore-local/__tests__/serialize.test.ts
+++ b/apps/functions/src/tools/firestore-local/__tests__/serialize.test.ts
@@ -83,8 +83,8 @@ describe("serialize: encodeValue/decodeValue round-trip", () => {
 		expect(result.liveStreamingDetails.actualStartTime.seconds).toBe(1700000000);
 		expect(result.liveStreamingDetails.scheduledStartTime.nanoseconds).toBe(500);
 		expect(result.tags).toEqual(["a", "b"]);
-		expect(result.snapshots[0].at).toBeInstanceOf(Timestamp);
-		expect(result.snapshots[0].value).toBe(10);
+		expect(result.snapshots[0]!.at).toBeInstanceOf(Timestamp);
+		expect(result.snapshots[0]!.value).toBe(10);
 	});
 
 	it("CollectionFixture 全体（複数ドキュメント）を往復しても整合する", () => {
@@ -98,7 +98,7 @@ describe("serialize: encodeValue/decodeValue round-trip", () => {
 		};
 
 		const encoded = JSON.parse(JSON.stringify(fixture)) as CollectionFixture;
-		const decodedFirst = decodeValue(encoded.docs[0].data, firestoreStub) as {
+		const decodedFirst = decodeValue(encoded.docs[0]!.data, firestoreStub) as {
 			publishedAt: Timestamp;
 			title: string;
 		};

--- a/apps/functions/tsconfig.json
+++ b/apps/functions/tsconfig.json
@@ -7,8 +7,14 @@
 		"rootDir": "./src",
 		"sourceMap": true,
 		"lib": ["ES2022"],
-		"allowSyntheticDefaultImports": true
+		"allowSyntheticDefaultImports": true,
+		// テストも typecheck 対象に含める（include の test 除外を撤去）。
+		// テストは vitest が ESM/Bundler 解決で実行し、本番ビルドは esbuild（scripts/build.mjs）なので
+		// tsc 専用にここで base の NodeNext を上書きする（NodeNext だとテストの top-level await import が
+		// CJS 扱いになり TS2835/TS1309 を量産するため）。
+		"module": "ESNext",
+		"moduleResolution": "Bundler"
 	},
 	"include": ["src"],
-	"exclude": ["src/**/*.test.ts", "src/development/**/*"]
+	"exclude": ["src/development/**/*"]
 }


### PR DESCRIPTION
## 背景（軸1: ガードの空洞化）

`apps/functions/tsconfig.json` が `src/**/*.test.ts` を exclude しており、`pnpm typecheck` が**テスト32ファイルを一切見ていなかった**。ui / shared-types はテストも typecheck 対象なのに functions / web だけ不揃い。本 PR は **SPR-193 の functions 分（PR1）**。web 分（約162件 + 死に `tsconfig.test.json` 撤去）は後続 PR2。

## 設定（config 起因の一括解消）

- `tsconfig.json` の test exclude を撤去し ui/shared-types と揃える。
- base の `NodeNext` を **tsc 専用に `ESNext`/`Bundler` へ上書き**（本番ビルドは esbuild = `scripts/build.mjs` なので影響なし）。NodeNext だとテストの top-level `await import` が CJS 扱いで **TS2835/TS1309 を量産**するため。→ これだけで config 起因 30件が消滅。

## 実エラー修正（機械的に黙らせず1件ずつ判断）

| 種別 | 対応 |
|---|---|
| 配列添字 `arr[N].x`（noUncheckedIndexedAccess） | `toHaveBeenCalled` 等で存在保証済みのため `!` |
| `youtube-api.test` の偽 `interface youtube_v3` | 本物の googleapis 名前空間 import に置換（型を namespace 参照していた誤り） |
| `work-mapper` genre/creater | 数値 `id`・`name_base`・creater `type` を補完（スキーマ追従） |
| `http-utils` の `maxRetries` | makeRequest は retry 未実装＝**stale option**。型は正しく省略済みなので除去（挙動不変） |
| `dlsite-firestore` の sampleWork | 旧フラット形（`voiceActors`/`scenario` 等）を現行 `creators` 前提へ修正、`customGenres` 補完 |
| `data-integrity` の Firestore mock | `vi.mocked` の厳格型を generic `Mock` に緩めて簡略モックを許容 |
| `creator-firestore` の readonly 代入 | `Object.assign` に |
| 死蔵 fixture / 未使用 local / realistic DLsite mock | 削除 / キャスト |

## 検証

`pnpm verify` green（functions typecheck がテスト込みで 0 件）/ functions build(esbuild) green / 対象テスト 93 件 pass（**挙動不変**）。

Closes（部分）SPR-193 ※完全クローズは web PR2 マージ後

🤖 Generated with [Claude Code](https://claude.com/claude-code)