### PR TITLE
refactor(web): WorkDocument 読み取り境界に safeParse を導入（SPR-201）

### DIFF
--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -8,6 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vite
 
 // workTransformers, convertToCirclePlainObject のモック
 vi.mock("@suzumina.click/shared-types", () => ({
+	// parseWorkDocument 用の pass-through（検証は素通し）
+	WorkDocumentSchema: { safeParse: (data: unknown) => ({ success: true, data }) },
 	workTransformers: {
 		fromFirestore: vi.fn((data) => {
 			// Use the mock helper function to transform data

--- a/apps/web/src/app/circles/[circleId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/circles/[circleId]/__tests__/page.test.tsx
@@ -41,6 +41,8 @@ vi.mock("../components/circle-page-client", () => ({
 
 // shared-types モック
 vi.mock("@suzumina.click/shared-types", () => ({
+	// parseWorkDocument 用の pass-through（検証は素通し）
+	WorkDocumentSchema: { safeParse: (data: unknown) => ({ success: true, data }) },
 	convertToFrontendWork: vi.fn((work: any) => work), // パススルー変換
 }));
 

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // workTransformers のモック
 vi.mock("@suzumina.click/shared-types", () => ({
+	// parseWorkDocument 用の pass-through（検証は素通し）
+	WorkDocumentSchema: { safeParse: (data: unknown) => ({ success: true, data }) },
 	workTransformers: {
 		fromFirestore: vi.fn((data) => {
 			// Use the mock helper function to transform data

--- a/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
@@ -47,6 +47,8 @@ vi.mock("@/app/works/components/work-card", () => ({
 
 // shared-types モック
 vi.mock("@suzumina.click/shared-types", () => ({
+	// parseWorkDocument 用の pass-through（検証は素通し）
+	WorkDocumentSchema: { safeParse: (data: unknown) => ({ success: true, data }) },
 	getCreatorTypeLabel: vi.fn((types: string[]) => {
 		const labels: Record<string, string> = {
 			voice: "声優",

--- a/apps/web/src/app/works/[workId]/components/__tests__/age-rating-badge.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/age-rating-badge.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // checkAgeRating / getAgeRatingDisplayName の内部に依存せず分岐を検証
 const { mockCheck, mockDisplay } = vi.hoisted(() => ({ mockCheck: vi.fn(), mockDisplay: vi.fn() }));
 vi.mock("@suzumina.click/shared-types", () => ({
+	// parseWorkDocument 用の pass-through（検証は素通し）
+	WorkDocumentSchema: { safeParse: (data: unknown) => ({ success: true, data }) },
 	checkAgeRating: mockCheck,
 	getAgeRatingDisplayName: mockDisplay,
 }));

--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -11,7 +11,11 @@ import type { EnhancedSearchParams } from "./lib/work-filtering";
 import { filterWorksByUnifiedData, needsComplexFiltering } from "./lib/work-filtering";
 import { buildWorksQuery } from "./lib/work-query-builder";
 import { sortWorks } from "./lib/work-sorting";
-import { convertDocsToWorks, convertWorksToPlainObjects } from "./utils/work-converters";
+import {
+	convertDocsToWorks,
+	convertWorksToPlainObjects,
+	parseWorkDocument,
+} from "./utils/work-converters";
 
 /**
  * シンプルなクエリで作品を取得
@@ -198,7 +202,7 @@ export async function getWorkById(workId: string): Promise<WorkPlainObject | nul
 				return null;
 			}
 
-			const data = doc.data() as import("@suzumina.click/shared-types").WorkDocument;
+			const data = parseWorkDocument({ ...doc.data(), id: doc.id });
 
 			// データにIDが設定されていない場合、ドキュメントIDを使用
 			if (!data.id) {

--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -202,12 +202,8 @@ export async function getWorkById(workId: string): Promise<WorkPlainObject | nul
 				return null;
 			}
 
+			// raw に id: doc.id を常に含めるため、data.id は設定済み
 			const data = parseWorkDocument({ ...doc.data(), id: doc.id });
-
-			// データにIDが設定されていない場合、ドキュメントIDを使用
-			if (!data.id) {
-				data.id = doc.id;
-			}
 
 			// フロントエンド形式に変換
 			return workTransformers.fromFirestore(data);

--- a/apps/web/src/app/works/utils/__tests__/work-converters.test.ts
+++ b/apps/web/src/app/works/utils/__tests__/work-converters.test.ts
@@ -1,8 +1,29 @@
 import type { WorkDocument } from "@suzumina.click/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { convertDocsToWorks, convertWorksToPlainObjects } from "../work-converters";
+import * as logger from "@/lib/logger";
+import {
+	convertDocsToWorks,
+	convertWorksToPlainObjects,
+	parseWorkDocument,
+} from "../work-converters";
 
 vi.mock("@/lib/logger", () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }));
+
+// WorkDocumentSchema の必須フィールドを満たす最小の有効データ（genres 等の default 検証用に省略）
+const validRaw = {
+	id: "RJ001",
+	productId: "RJ001",
+	title: "作品1",
+	circle: "サークル1",
+	description: "説明",
+	category: "SOU",
+	workUrl: "https://www.dlsite.com/maniax/work/=/product_id/RJ001.html",
+	thumbnailUrl: "https://img.dlsite.jp/RJ001.jpg",
+	price: { current: 1000, currency: "JPY" },
+	lastFetchedAt: "2024-01-01T00:00:00.000Z",
+	createdAt: "2024-01-01T00:00:00.000Z",
+	updatedAt: "2024-01-01T00:00:00.000Z",
+};
 
 const workData = (over: Record<string, unknown> = {}): WorkDocument =>
 	({
@@ -15,11 +36,29 @@ const workData = (over: Record<string, unknown> = {}): WorkDocument =>
 		releaseDateISO: "2024-01-01",
 		language: "ja",
 		...over,
-		// biome-ignore lint/suspicious/noExplicitAny: テスト用の最小 WorkDocument
-	}) as any;
+	}) as unknown as WorkDocument;
 
 beforeEach(() => {
 	vi.clearAllMocks();
+});
+
+describe("parseWorkDocument", () => {
+	it("検証成功時に schema の default を実効化する（genres 等が欠けていても [] になる）", () => {
+		const result = parseWorkDocument(validRaw);
+		expect(result.genres).toEqual([]);
+		expect(result.customGenres).toEqual([]);
+		expect(result.sampleImages).toEqual([]);
+		// id 等スキーマ非定義の付帯フィールドも温存される
+		expect(result.id).toBe("RJ001");
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("検証失敗時は warn して raw を非破壊で返す（落とさない）", () => {
+		const raw = { productId: "RJ999", title: "必須欠落" };
+		const result = parseWorkDocument(raw);
+		expect(result).toBe(raw); // cast フォールバック（同一参照で継続）
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("convertDocsToWorks", () => {

--- a/apps/web/src/app/works/utils/work-converters.ts
+++ b/apps/web/src/app/works/utils/work-converters.ts
@@ -1,6 +1,34 @@
 import type { WorkDocument, WorkPlainObject } from "@suzumina.click/shared-types";
-import { workTransformers } from "@suzumina.click/shared-types";
+import { WorkDocumentSchema, workTransformers } from "@suzumina.click/shared-types";
 import * as logger from "@/lib/logger";
+
+/**
+ * Firestore の生データを WorkDocument として検証する（読み取り境界の漏斗）。
+ *
+ * `WorkDocumentSchema` の `.default([])`（genres / customGenres / sampleImages 等）は **parse 時のみ効く**ため、
+ * 従来の blind cast では「required のはずのフィールドが実行時に欠ける」静かな型嘘が残っていた（SPR-201）。
+ * ここで safeParse を通して default を実効化する。
+ *
+ * 検証失敗時は **非破壊フォールバック**（cast で継続）+ warn でスキーマドリフトを観測する。
+ * 本番データとスキーマの整合が未確認のため「落とさず観測」を選ぶ — warn が常態化したら schema を実態へ寄せ、
+ * 収束を確認できたら parse 失敗を skip に倒す余地がある。
+ */
+export function parseWorkDocument(raw: unknown): WorkDocument {
+	const parsed = WorkDocumentSchema.safeParse(raw);
+	if (parsed.success) {
+		// parse 済み（default 適用）を基準に、スキーマ外フィールドは raw から温存する
+		// （id 等スキーマ非定義の付帯フィールドを落とさないため）。
+		return { ...(raw as Record<string, unknown>), ...parsed.data } as WorkDocument;
+	}
+	logger.warn("WorkDocument スキーマ検証に失敗（cast で継続）", {
+		workId:
+			(raw as { productId?: string })?.productId ?? (raw as { id?: string })?.id ?? "(unknown)",
+		issues: parsed.error.issues
+			.slice(0, 5)
+			.map((i) => `${i.path.join(".") || "(root)"}: ${i.code}`),
+	});
+	return raw as WorkDocument;
+}
 
 /**
  * Firestoreドキュメントを作品オブジェクトに変換
@@ -11,7 +39,7 @@ export async function convertDocsToWorks(
 	const works: WorkPlainObject[] = [];
 	for (const doc of docs) {
 		try {
-			const data = { ...doc.data(), id: doc.id } as WorkDocument;
+			const data = parseWorkDocument({ ...doc.data(), id: doc.id });
 			if (!data.id) {
 				data.id = data.productId;
 			}
@@ -33,8 +61,9 @@ export async function convertDocsToWorks(
  */
 export function convertWorksToPlainObjects(paginatedWorks: WorkDocument[]): WorkPlainObject[] {
 	const works: WorkPlainObject[] = [];
-	for (const data of paginatedWorks) {
+	for (const rawData of paginatedWorks) {
 		try {
+			const data = parseWorkDocument(rawData);
 			if (!data.id) {
 				data.id = data.productId;
 			}
@@ -43,7 +72,7 @@ export function convertWorksToPlainObjects(paginatedWorks: WorkDocument[]): Work
 		} catch (error) {
 			// エラーがあっても他のデータの処理は続行
 			logger.warn("作品データ変換エラー", {
-				workId: data.id || data.productId,
+				workId: rawData.id || rawData.productId,
 				error: error instanceof Error ? error.message : String(error),
 			});
 		}

--- a/apps/web/src/app/works/utils/work-converters.ts
+++ b/apps/web/src/app/works/utils/work-converters.ts
@@ -16,8 +16,7 @@ import * as logger from "@/lib/logger";
 export function parseWorkDocument(raw: unknown): WorkDocument {
 	const parsed = WorkDocumentSchema.safeParse(raw);
 	if (parsed.success) {
-		// parse 済み（default 適用）を基準に、スキーマ外フィールドは raw から温存する
-		// （id 等スキーマ非定義の付帯フィールドを落とさないため）。
+		// parse 済み（default 適用）を基準に、スキーマが strip する未定義フィールドは raw から温存する。
 		return { ...(raw as Record<string, unknown>), ...parsed.data } as WorkDocument;
 	}
 	logger.warn("WorkDocument スキーマ検証に失敗（cast で継続）", {
@@ -39,10 +38,8 @@ export async function convertDocsToWorks(
 	const works: WorkPlainObject[] = [];
 	for (const doc of docs) {
 		try {
+			// raw に id: doc.id を常に含めるため、data.id は成功/フォールバックいずれでも設定済み
 			const data = parseWorkDocument({ ...doc.data(), id: doc.id });
-			if (!data.id) {
-				data.id = data.productId;
-			}
 			const converted = workTransformers.fromFirestore(data);
 			works.push(converted);
 		} catch (error) {


### PR DESCRIPTION
## 背景（軸3: スキーマという約束が実行時に効いていない）

366行の `WorkDocumentSchema` は `z.infer` の型取得のみに使われ、**本番経路での parse はゼロ**。読み取りは全て blind cast だった。スキーマの `.default([])`（genres / customGenres / sampleImages 等）は **parse 時のみ効く**ため、cast 経由では「required のはずのフィールドが実行時に欠ける」**静かな型嘘**が残っていた。

## 方針 (a): 読み取り漏斗で safeParse

新しい変換層は作らず、web の読み取り漏斗（`work-converters`）に `parseWorkDocument` を導入:

- **検証成功** → `.default` 適用済みを採用。スキーマ外フィールド（`id` 等）は raw からマージで温存
- **検証失敗** → **`warn` + 非破壊フォールバック（cast で継続）**。works を落とさない

**「落とさず観測」を選んだ理由**: 本番データとスキーマの整合が未確認のため。この設計なら**実装そのものが検証手段**になり、`warn` の発生率で「スキーマが実態に合っているか」を安全に観測できる。収束を確認したら schema を実態へ寄せる / parse 失敗を skip へ倒す余地を残す。

| 経路 | 対応 |
|---|---|
| `convertDocsToWorks` / `convertWorksToPlainObjects` / `getWorkById` | parseWorkDocument 経由に |
| `fetchPopularGenres` | 全件 get + `Array.isArray(genres)` ガード済みで堅牢 → 対象外（一覧 N 件 parse の負荷も回避） |
| functions 側 blind cast 5箇所 | 書き込み直後の読み戻しが多く優先度低 → 別途（issue の指示どおり web を先に） |

`parseWorkDocument` のテスト追加（default 実効化 / warn+fallback の非破壊）。shared-types を全モックするテスト群に pass-through の `WorkDocumentSchema` を追加。

## 検証

`pnpm verify` green（既存の変換テストは非破壊で全 pass・挙動不変）。Two-Way Door。**SPR-174 エピックの最後の子 issue**。

Closes SPR-201

🤖 Generated with [Claude Code](https://claude.com/claude-code)