### PR TITLE
test(web): creators page テストの stale mock 3キーを削除（SPR-174 監査残骸）

### DIFF
--- a/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
@@ -21,9 +21,6 @@ vi.mock("next/navigation", () => ({
 // Server Actions モック
 vi.mock("../actions", () => ({
 	getCreatorInfo: vi.fn(),
-	getCreatorWorks: vi.fn(),
-	getCreatorWithWorks: vi.fn(),
-	getCreatorWithWorksWithPagination: vi.fn(),
 	getCreatorWorksList: vi.fn(),
 }));
 


### PR DESCRIPTION
## 背景

SPR-174 エピック（29 issue）完了後の網羅監査で検出した唯一の実残骸。

`apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx` の `vi.mock("../actions")` に、実装に存在しない `getCreatorWorks` / `getCreatorWithWorks` / `getCreatorWithWorksWithPagination` の 3 キーが残っていた（SPR-183 等で実装側の死蔵 export を削除した際の取り残し）。テスト本文では未使用のため挙動影響なし。実装の export（`getCreatorInfo` / `getCreatorWorksList`）と mock を一致させる。

## 検証

対象テスト 6 件 pass / biome clean。テストファイルのみの変更（Two-Way Door）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)