### PR TITLE
fix(terraform): works.workId の COLLECTION_GROUP single-field index を追加 (SPR-204)

### DIFF
--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -413,23 +413,55 @@ resource "google_firestore_index" "circles_name_workcount_desc" {
 }
 
 # creators サブコレクション works - Collection Group Query用
-# 注意: 単一フィールドのCollection Group QueryはFirestoreが自動的にインデックスを作成するため、
-# 複合インデックスのみを定義する必要があります。
+#
+# 重要: COLLECTION_GROUP スコープの「単一フィールド」index は Firestore の自動生成対象外。
+# 自動生成されるのは COLLECTION スコープの単一フィールド index のみで、
+# collectionGroup("works").where("workId", "==", ...) のような CG 横断クエリには
+# 明示的な single-field index 設定（exemption）が必須。無いと実行時に
+# `9 FAILED_PRECONDITION: The query requires a COLLECTION_GROUP_ASC index ...` になる。
+# 参照: apps/functions/src/services/dlsite/creator-firestore.ts getExistingCreatorMappings() / SPR-204
+#
+# 複合 index 専用の google_firestore_index ではなく、単一フィールド index 設定を扱う
+# google_firestore_field で定義する。index_config は当該フィールドの index 構成を
+# 「全置換」するため、既定の COLLECTION ASC/DESC を残したうえで COLLECTION_GROUP ASC を追加する。
+resource "google_firestore_field" "works_workid_collection_group" {
+  project    = var.gcp_project_id
+  database   = "(default)"
+  collection = "works"
+  field      = "workId"
 
-# 複合インデックスの例: 役割と作品IDの組み合わせ検索用
-# 現在のクエリでは不要だが、将来的に必要になる可能性がある
+  index_config {
+    # 既定（自動生成）の単一フィールド index を維持（明示しないと削除される）
+    indexes {
+      query_scope = "COLLECTION"
+      order       = "ASCENDING"
+    }
+    indexes {
+      query_scope = "COLLECTION"
+      order       = "DESCENDING"
+    }
+    # 本対応で追加する Collection Group index（getExistingCreatorMappings 用）
+    indexes {
+      query_scope = "COLLECTION_GROUP"
+      order       = "ASCENDING"
+    }
+  }
+}
+
+# （将来用・複合インデックスの例）役割と作品IDの組み合わせ検索用。
+# 現在のクエリでは不要。必要になったら有効化する。
 # resource "google_firestore_index" "creators_works_collection_group_roles_workid" {
 #   project    = var.gcp_project_id
 #   collection = "works"
 #   database   = "(default)"
-#   
+#
 #   query_scope = "COLLECTION_GROUP"
-#   
+#
 #   fields {
 #     field_path   = "roles"
 #     array_config = "CONTAINS"
 #   }
-#   
+#
 #   fields {
 #     field_path = "workId"
 #     order      = "ASCENDING"

--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -380,8 +380,10 @@ resource "google_firestore_index" "contacts_priority_createdat_desc" {
 # 
 # ⚠️ 注意: dateフィールドのみのインデックスは不要
 # Firestoreの自動single-fieldインデックスで十分対応可能
-# - date ASC/DESC: Single-field indexで自動作成
-# - Collection Group クエリ: 自動インデックスで対応
+# - date ASC/DESC: Single-field index（COLLECTION スコープ）で自動作成
+# - Collection Group クエリ: 現在 collectionGroup("priceHistory") は未使用のため不要。
+#   使う場合は google_firestore_field で COLLECTION_GROUP index を明示定義すること
+#   （COLLECTION_GROUP スコープの単一フィールド index は自動生成されない。SPR-204 参照）
 # 
 # 以下のクエリパターンが自動インデックスで実行可能:
 # - orderBy('date', 'desc').limit(90)


### PR DESCRIPTION
## 概要

`fetchDLsiteUnifiedData`（Cloud Functions 2nd gen・2時間おき）の定期実行で多発していた
`既存クリエイターマッピング取得エラー: RJxxxxx` の根本原因を修正する。

Fixes SPR-204 — https://linear.app/nothink/issue/SPR-204

## 根本原因

`apps/functions/src/services/dlsite/creator-firestore.ts` の `getExistingCreatorMappings()` が使う

```ts
firestore.collectionGroup("works").where("workId", "==", workId).get()
```

には `works` コレクショングループに対する **COLLECTION_GROUP スコープの `workId` 単一フィールド index** が必須。
これが未定義のため、実行のたびに全件 `9 FAILED_PRECONDITION: The query requires a COLLECTION_GROUP_ASC index ...` で失敗していた。

真因は Terraform 側のコメントの誤り（「単一フィールドの CG クエリは Firestore が自動 index 化される」）。
実際に自動生成されるのは **COLLECTION スコープ**の単一フィールド index のみで、**COLLECTION_GROUP スコープは対象外**。
このため `workId` の CG index だけが恒久的に欠落していた。

- ログ retention 窓の最古 **2026-05-13** から継続する慢性障害（新規回帰ではない）。
- 普段は処理対象作品が少なく埋もれていたが、**2026-06-11 に処理量急増で 1,438 件/日**まで顕在化。

## 影響範囲

- ✅ 作品データ（価格・メタデータ）の保存は正常（バッチは `50/50件成功`、エラーは握りつぶされ継続）。
- ❌ クリエイター⇄作品マッピングの**差分削除が機能しない**（`getExistingCreatorMappings` が常に空を返すため、
  クレジットから外れたクリエイターの `creators/{id}/works/{workId}` が孤立して残る）。追加・更新は正常。
- 整合性 cron `checkDataIntegrity`（孤立 Creator マッピング修復）が事後修復で覆い隠していた状態。
  本来 index で設計上守るべき不変条件（CLAUDE.md 軸1）。

## 変更内容

`terraform/firestore_indexes.tf`

1. `google_firestore_field.works_workid_collection_group` を追加し、`works.workId` に
   **COLLECTION_GROUP ASC** index を定義。
   - `index_config` はフィールドの index 構成を**全置換**するため、既定の **COLLECTION ASC/DESC** も明示し非破壊にした。
   - 単一フィールド index 設定は `google_firestore_index`（複合専用）ではなく `google_firestore_field` で定義する。
2. 誤ったコメントを訂正（CG スコープ単一フィールド index は自動生成されない旨を明記）。

## 検証

- `terraform fmt -check -recursive` → クリーン
- `terraform validate`（provider hashicorp/google 7.33.0）→ `Success! The configuration is valid.`
- ※ 本 PR には apply は含まない（下記手順参照）。

## 適用手順（マージ後 / One-Way Door）

本番 state は **production workspace**。full apply は live を巻き戻すため `-target` 限定で適用する。

```bash
cd terraform
terraform workspace select production
terraform plan  -target=google_firestore_field.works_workid_collection_group
terraform apply -target=google_firestore_field.works_workid_collection_group
```

`plan` が「当該 index 追加のみ」かつ既定の COLLECTION ASC/DESC を削除しないことを必ず確認すること。

## 適用後の確認

1. `gcloud firestore indexes fields list --collection-group=works` で `workId` の COLLECTION_GROUP ASC が `READY`。
2. 次回 `fetchDLsiteUnifiedData` 実行後、Cloud Logging で `既存クリエイターマッピング取得エラー` が **0 件**になること。

## 補足

- これは Terraform / GCP インフラ変更（**One-Way Door**）。CLAUDE.md のセルフマージ・ポリシー上、AI レビュー任せにせず
  `terraform plan` を自分で確認してからマージ・適用すること。
- ログ粒度の見直し（任意）と `collectionGroup("works")` がトップレベル `works` も拾う点（実害なし・防御済み）は
  SPR-204 に記載のとおりスコープ外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
