### PR TITLE
docs(reference): domain-model.md の死んだクラス Entity/VO コード例を撤去（SPR-174 監査）

### DIFF
--- a/docs/reference/domain-model.md
+++ b/docs/reference/domain-model.md
@@ -1,6 +1,6 @@
 # ドメインモデル設計（簡易版）
 
-**最終更新**: 2026-06-12  
+**最終更新**: 2026-06-13  
 **目的**: suzumina.clickプロジェクトのドメインモデルの簡潔な参照ドキュメント
 
 > **2026-06 (SPR-174 監査) 更新**: 各エンティティの「主要プロパティ」を shared-types の現行正本型
@@ -218,96 +218,26 @@ packages/shared-types/src/
 
 ## 設計原則
 
-1. **不変性**: 値オブジェクトは不変
-2. **カプセル化**: ビジネスロジックは適切なドメインオブジェクトに配置
-3. **Plain Object変換**: Next.js Server Componentsとの連携用
-4. **型安全性**: TypeScript strict modeで完全な型安全性
+1. **データ表現の一本化**: 各ドメインは PlainObject 型 + Zod スキーマで定義し、Firestore ⇄ 型の変換は
+   `transformers/` の純関数で行う（クラス Entity・クラス VO は持たない）
+2. **不変性**: PlainObject は読み取り専用の値として扱い、書き換えず新しい値を作る
+3. **RSC 境界の正本は PlainObject**: Server Component へ渡る正本は `*PlainObject`。
+   Firestore Document ⇄ PlainObject の変換層は RSC 境界の誤り訂正符号であり、新たな変換層を足さない
+4. **読み取り境界でのバリデーション**: Firestore 読み取りは Zod `safeParse` を通す
+   （例: `apps/web/src/app/works/utils/work-converters.ts` の `parseWorkDocument`、SPR-201）
+5. **型安全性**: TypeScript strict mode + `@suzumina.click/shared-types` の型を使う
 
-## Entity Implementation Patterns
+## 実装手順
 
-> **2026-06 (SPR-174 監査) 更新**: 以下のクラスベースのパターンは**歴史的な参考**。現行の shared-types は
-> エンティティクラスを持たず（クラス VO は SPR-181 で削除）、データは PlainObject + Zod スキーマ +
-> transformers で扱う。Entity / VO を新規に再導入する場合は CLAUDE.md の「Entity化のゲート」を先に通すこと。
+データ表現（PlainObject 型 + Zod スキーマ + `transformers/` の純関数）の具体的な実装手順
+— Firestore 読み取り境界での `safeParse`、`_computed` の付与、`fromFirestore` 変換の使い方など —
+は [entity-implementation-guide.md](./entity-implementation-guide.md) に一本化している。
+本ドキュメントはモデル（どの概念が存在し、どう関係するか）に専念し、how-to は重複再掲しない
+（CLAUDE.md §0「doc は少なく・濃く・近く」）。
 
-### Basic Entity Structure
-
-```typescript
-export class EntityName {
-  // Private readonly properties
-  constructor(
-    private readonly _id: EntityId,
-    private readonly _content: ContentValueObject,
-    private readonly _metadata: MetadataValueObject
-  ) {}
-
-  // Firestore restoration (required)
-  static fromFirestoreData(data: FirestoreData): EntityName | null {
-    try {
-      const id = new EntityId(data.id);
-      const content = ContentValueObject.fromData(data);
-      const metadata = MetadataValueObject.fromData(data);
-      
-      return new EntityName(id, content, metadata);
-    } catch (error) {
-      console.error('Failed to create entity:', error);
-      return null;
-    }
-  }
-
-  // Plain Object conversion (for Server Components)
-  toPlainObject(): EntityPlainObject {
-    return {
-      id: this._id.value,
-      content: this._content.toPlainObject(),
-      metadata: this._metadata.toPlainObject(),
-      _computed: {
-        displayName: this.getDisplayName(),
-        isValid: this.isValid(),
-      }
-    };
-  }
-}
-```
-
-### Value Object Structure
-
-> **2026-06 (SPR-181) 更新**: 以下はクラス VO の参考パターンだが、shared-types では**この層を廃止済み**。
-> 新規に値オブジェクトを再導入する場合は CLAUDE.md の「Entity化のゲート」を先に通すこと。
-
-```typescript
-export class ValueObjectName {
-  constructor(private readonly _value: string) {
-    this.validate();
-  }
-
-  private validate(): void {
-    if (!this._value || this._value.length === 0) {
-      throw new Error('Value cannot be empty');
-    }
-  }
-
-  get value(): string {
-    return this._value;
-  }
-
-  equals(other: ValueObjectName): boolean {
-    return this._value === other._value;
-  }
-
-  toPlainObject(): string {
-    return this._value;
-  }
-}
-```
-
-### Implementation Guidelines
-
-1. **Error Handling**: Use null returns instead of throwing errors
-2. **Validation**: Validate in constructors and factory methods
-3. **Immutability**: All properties should be readonly
-4. **Type Safety**: Use TypeScript strict mode
-5. **Server Components**: Always provide toPlainObject() method
+Entity / 値オブジェクトを新規に再導入する場合は、まず CLAUDE.md の「Entity化のゲート」を通すこと。
 
 ---
 
-最終更新: 2026-06-12（SPR-174 監査: 主要プロパティを shared-types の現行正本型に同期）
+最終更新: 2026-06-13（SPR-174 監査: 死んだクラス Entity / クラス VO のコード例を撤去し、実装手順は
+entity-implementation-guide.md へ集約。設計原則を関数型アーキテクチャに是正）


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
# domain-model.md の死んだクラス Entity / VO コード例を撤去（SPR-174 監査）

## 要件

SPR-174 ドキュメント監査の続き。`docs/reference/domain-model.md` に、関数型アーキテクチャ移行で全廃された**クラス Entity / クラス Value Object** のコード例が残っており、現存しない API を「実装パターン」として提示していた（＝嘘）。`entity-implementation-guide.md` は既に関数型へ全面改訂済み（v3.0）なので、how-to はそちらへ一本化し、本ドキュメントはモデル（どの概念が存在し、どう関係するか）に専念させる。

根拠（grep 0 件で確認済み）: `packages/shared-types` に `class Work/Video/AudioButton`・`extends BaseEntity`・`fromFirestoreData`・クラス VO は存在しない（`value-objects/` ディレクトリも不在）。データ表現は PlainObject 型 + Zod スキーマ + `transformers/` 純関数に一本化済み。

### 変更内容

- **Entity Implementation Patterns 節をまるごと撤去**: `class EntityName { static fromFirestoreData(): … | null; toPlainObject() }`・`class ValueObjectName`・「Use null returns instead of throwing errors」等の死んだコード例を削除し、「実装手順は [entity-implementation-guide.md](docs/reference/entity-implementation-guide.md) を参照」へ置換（CLAUDE.md §0「doc は少なく・濃く・近く」／how-to を重複再掲しない）。
- **設計原則を是正**: 「値オブジェクトは不変」「カプセル化: ビジネスロジックを適切なドメインオブジェクトに配置」という削除済みクラス前提の記述を、関数型アーキテクチャの事実（PlainObject + Zod + `transformers/` 純関数／読み取り境界の `safeParse`／RSC 境界正本は PlainObject）へ書き直し。
- **フッタ・冒頭日付を更新**（2026-06-13、SPR-174 監査注記）。

維持したもの: 冒頭 SPR-174 監査ノート、値オブジェクト一覧の SPR-181 注記、SPR-174 注記済みの実装状況節、各エンティティの主要プロパティ（commit 3d78827a で同期済み）。

diff: 1 file changed, 18 insertions(+), 88 deletions(-)。新規ドキュメントは作成していない（既存ファイルの更新のみ）。

## テスト項目

- [x] grep で残存マーカー 0 件を確認（`class EntityName` / `class ValueObjectName` / `fromFirestoreData` / `toPlainObject()` / `Use null returns` / `値オブジェクトは不変` 等）
- [x] リンク先 `docs/reference/entity-implementation-guide.md` の実在を確認
- [x] 本文の正本参照（`workTransformers.fromFirestore`・`parseWorkDocument` SPR-201）と shared-types 実体の整合を確認
- docs-only（markdown）のため `pnpm verify` 対象外（Biome は .md を lint せず、テストは Firestore をモック、ブラウザ観測対象なし）

<!-- I want to review in Japanese. -->