### PR TITLE
fix(security): security-scan を PR でも実行し対象 path に Dockerfile/workspace を追加

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,12 +7,23 @@ on:
   push:
     branches:
       - main
-    paths:
+    # 依存解決・イメージ構成に影響するファイル。pnpm-workspace.yaml(overrides の正本) と
+    # apps/web/Dockerfile を含める(以前は欠落し、Dockerfile/ベースイメージ単独の変更では
+    # コンテナスキャンが走らず退行を見逃していた)
+    paths: &scan-paths
       - 'package.json'
       - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
       - 'apps/*/package.json'
       - 'packages/*/package.json'
+      - 'apps/web/Dockerfile'
       - '.github/workflows/security-scan.yml'
+  # マージ前にイメージ/依存スキャンを走らせる(以前は push 後の main でしか走らず、
+  # PR 時点で脆弱性を検出できなかった)。paths は push と同一(アンカーで同期しドリフト再発を防ぐ)
+  pull_request:
+    branches:
+      - main
+    paths: *scan-paths
 
 permissions:
   contents: read


### PR DESCRIPTION
## 背景

[#657](https://github.com/nothink-jp/suzumina.click/pull/657) の脆弱性対応中に、`security-scan.yml`（Trivy コンテナスキャン等）のトリガに2つの穴を発見した。いずれも「スキャンが走るべき時に走らない」種類の欠落。

1. **PR で走らない** — `pull_request` トリガが無く、push 後の `main` でしか走らなかった。実際 #657 もマージ後に初めて Trivy で 0 件を確認できた＝**マージ前にコンテナ脆弱性を検出できない**状態だった（CodeQL は PR で走るのに対し非対称）。
2. **path フィルタが Dockerfile を含まない** — `apps/web/Dockerfile` も `pnpm-workspace.yaml`（overrides の正本）も無く、**Dockerfile/ベースイメージ単独の変更ではコンテナスキャンが走らない**＝base image 退行を見逃す。#657 は偶然 `pnpm-lock.yaml` も触ったので発火した。

## 変更内容

`.github/workflows/security-scan.yml` の `on:` のみ変更：

- **`pull_request`（→ main）トリガを追加**。これで `container-scan`（Docker build → Trivy → SARIF）が PR でも走り、新規脆弱性が PR チェックに出る。
- **paths に `pnpm-workspace.yaml` と `apps/web/Dockerfile` を追加**（push / pull_request 双方）。
- **push と pull_request の paths を YAML アンカー（`&scan-paths` / `*scan-paths`）で同期**。今回のような2リスト間のドリフト再発を構造的に防ぐ。

ジョブ本体・権限（`security-events: write`）・スケジュール（週次）は不変。

## レビュー観点（One-Way Door: CI/CD 変更）

- **fork からの PR**では `GITHUB_TOKEN` が read-only になり SARIF アップロードが失敗し得るが、当該ステップは既に `continue-on-error: true`。本リポはソロ運用で PR は同一リポのブランチ由来のため実害なし。
- PR が上記 paths に触れると Docker build を含む `container-scan` が走るため、該当 PR の CI 時間が増える（依存/Dockerfile 変更時のみ・doc/ソースのみの PR では発火しない）。
- 全3ジョブ（dependency-scan / container-scan / secret-scan）が PR でも走る。意図通り（マージ前カバレッジ拡大）。

## 関連クリーンアップ（本PR外・対応済み）

- 旧 Trivy カテゴリ `...:image-scan` のゴースト解析36件を削除（ジョブ名 `image-scan`→`container-scan` リネームの置き土産）。
- CodeQL default setup に `javascript-typescript` を追加（従来 `actions` のみだった）。

いずれも GitHub 側設定の操作でコード変更ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)