### PR TITLE
fix(seo): 詳細ページの canonical がトップを指す問題を是正

### DIFF
--- a/apps/web/src/app/circles/[circleId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/circles/[circleId]/__tests__/page.test.tsx
@@ -220,6 +220,9 @@ describe("CirclePage", () => {
 		expect(metadata).toEqual({
 			title: "テストサークル - suzumina.click",
 			description: "サークル「テストサークル」の作品一覧。総作品数: 10作品",
+			alternates: {
+				canonical: "/circles/RG12345",
+			},
 			openGraph: {
 				title: "テストサークル - suzumina.click",
 				description: "サークル「テストサークル」の作品一覧。総作品数: 10作品",

--- a/apps/web/src/app/circles/[circleId]/page.tsx
+++ b/apps/web/src/app/circles/[circleId]/page.tsx
@@ -23,6 +23,9 @@ export async function generateMetadata({ params }: { params: Promise<{ circleId:
 	return {
 		title: `${circle.name} - suzumina.click`,
 		description: `サークル「${circle.name}」の作品一覧。総作品数: ${circle.workCount}作品`,
+		alternates: {
+			canonical: `/circles/${circleId}`,
+		},
 		openGraph: {
 			title: `${circle.name} - suzumina.click`,
 			description: `サークル「${circle.name}」の作品一覧。総作品数: ${circle.workCount}作品`,

--- a/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/page.test.tsx
@@ -222,6 +222,9 @@ describe("CreatorPage", () => {
 			title: "テストクリエイター - suzumina.click",
 			description:
 				"クリエイター「テストクリエイター」（声優 / イラスト）の参加作品一覧。総作品数: 5作品",
+			alternates: {
+				canonical: "/creators/creator123",
+			},
 			openGraph: {
 				title: "テストクリエイター - suzumina.click",
 				description:

--- a/apps/web/src/app/creators/[creatorId]/page.tsx
+++ b/apps/web/src/app/creators/[creatorId]/page.tsx
@@ -26,6 +26,9 @@ export async function generateMetadata({ params }: { params: Promise<{ creatorId
 	return {
 		title: `${creator.name} - suzumina.click`,
 		description: `クリエイター「${creator.name}」（${typeLabel}）の参加作品一覧。総作品数: ${creator.workCount}作品`,
+		alternates: {
+			canonical: `/creators/${creatorId}`,
+		},
 		openGraph: {
 			title: `${creator.name} - suzumina.click`,
 			description: `クリエイター「${creator.name}」（${typeLabel}）の参加作品一覧。総作品数: ${creator.workCount}作品`,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -61,9 +61,6 @@ export const metadata: Metadata = {
 	authors: [{ name: "suzumina.click" }],
 	creator: "suzumina.click",
 	metadataBase: new URL("https://suzumina.click"),
-	alternates: {
-		canonical: "/",
-	},
 	openGraph: {
 		type: "website",
 		locale: "ja_JP",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import {
 	AudioButtonsSection,
@@ -9,6 +10,16 @@ import {
 import { HeroSection } from "@/components/home/hero-section";
 import { VideosSection } from "@/components/sections/videos-section";
 import { WorksSection } from "@/components/sections/works-section";
+
+// トップページの自己参照 canonical。
+// ルートレイアウトに canonical を置くと全ページが "/" を継承してしまう（Next.js は
+// pathname を自動付与しない）ため、ここでトップページ専用に明示する。詳細ページは
+// 各 generateMetadata で自身の URL を canonical に設定する。
+export const metadata: Metadata = {
+	alternates: {
+		canonical: "/",
+	},
+};
 
 // Cache Components モデル: HeroSection と CommunitySection は静的シェル、
 // 各データセクションはそれぞれ個別の <Suspense> 境界で並列ストリーミングされる。

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -28,6 +28,9 @@ export async function generateMetadata({ params }: UserProfilePageProps): Promis
 		return {
 			title: `${user.displayName}のプロフィール | すずみなくりっく！`,
 			description: `${user.displayName}さんの作成した音声ボタンをチェック。涼花みなせファンコミュニティ suzumina.click`,
+			alternates: {
+				canonical: `/users/${resolvedParams.userId}`,
+			},
 			openGraph: {
 				title: `${user.displayName}のプロフィール`,
 				description: `${user.displayName}さんのプロフィール`,

--- a/apps/web/src/app/videos/[videoId]/page.tsx
+++ b/apps/web/src/app/videos/[videoId]/page.tsx
@@ -68,5 +68,8 @@ export async function generateMetadata({ params }: VideoDetailPageProps) {
 	return {
 		title: `${video.title} | すずみなくりっく！`,
 		description: video.description || `涼花みなせさんの動画「${video.title}」の詳細ページです。`,
+		alternates: {
+			canonical: `/videos/${videoId}`,
+		},
 	};
 }

--- a/apps/web/src/app/works/[workId]/page.tsx
+++ b/apps/web/src/app/works/[workId]/page.tsx
@@ -48,5 +48,8 @@ export async function generateMetadata({ params }: WorkDetailPageProps) {
 		title: `${work.title} | すずみなくりっく！`,
 		description:
 			work.description || `涼花みなせさんが出演する音声作品「${work.title}」の詳細ページです。`,
+		alternates: {
+			canonical: `/works/${workId}`,
+		},
 	};
 }


### PR DESCRIPTION
## 要件

Google Search Console で詳細ページが正しくインデックスされない問題への対応。

- 「代替ページ（適切な canonical タグあり）」: `/works/RJ01613655`
- 「クロール済み - インデックス未登録」: `/videos/osAtF03MyLU`, `/works/RJ01544593` ほか

### 原因
ルートレイアウトの metadata に `alternates: { canonical: "/" }` をグローバル既定として置いていた（2025-07-06 から存在）。Next.js App Router の `alternates.canonical` は `title.template` と違い **パス名が自動付与されない単純な継承フィールド**のため、自前で canonical を上書きしない全ページが `<link rel="canonical" href="https://suzumina.click/">`（＝トップ）を出力していた。

結果、works / videos / circles / creators / users の各詳細ページが「自分はトップの複製」と Google に申告し、単独インデックスされていなかった。本番 live でも該当 URL が canonical→トップを出力していることを `curl` で確認済み。上記2バケットは確信度の差で振り分けが分かれているだけで、原因は同一。

`/buttons/[id]` と一覧ページ群は自前 canonical を持っていたため無傷。

### 変更内容
- `layout.tsx`: 誤ったグローバル既定 `canonical: "/"` を削除
- `page.tsx`（トップ）: 自己参照 `canonical: "/"` を明示（トップ本来の canonical を維持）
- `works/videos/circles/creators/users` 詳細: 既存の `buttons/[id]` パターンに揃え、自己参照 canonical を付与（`?utm_*` 等クエリ付き URL の重複集約にも有効）
- exact match だった circles/creators の metadata テストを更新

### レビュアー向けメモ
- `favicon.ico?...` の「インデックス未登録」は Next.js favicon 規約による静的アセットで、ページとしては元々インデックス対象外＝正常。本 PR の対象外。
- 「クロール済み - インデックス未登録」は本来 Google の品質/クロール予算判断も絡むが、今回は live で全対象が canonical→トップを出していたため本修正が主因への対処。再クロール後に残るページがあれば、残差はコンテンツ深度/内部リンク/ドメイン権威性の領域（コードではない）。
- デプロイ後に Search Console の両レポートで「修正を検証」を実施する想定。
- 認可/スキーマ/インフラには触れない web metadata のみの変更（Two-Way Door）。

## テスト項目

- [x] `pnpm --filter @suzumina.click/web typecheck`
- [x] `pnpm --filter @suzumina.click/web lint`（既存の無関係 warning 1件のみ）
- [x] `pnpm --filter @suzumina.click/web test`（890 passed / 1 skipped）
- [x] `pnpm lint:docs`
- [x] 本番 `curl` で現状の canonical→トップ出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)