### PR TITLE
fix(deps): broken lockfile（重複マッピングキー）を修復し main を復旧

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5829,13 +5829,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
   '@neoconfetti/react@1.0.0': {}
 
   '@next/bundle-analyzer@16.2.9':


### PR DESCRIPTION
## 概要
main の `pnpm-lock.yaml` が不正（YAML 重複マッピングキー）になり、`pnpm install --frozen-lockfile` を行う全 CI ジョブ（Security Scan / Container Scan / Parallel Quality 等）が `ERR_PNPM_BROKEN_LOCKFILE: duplicated mapping key (5832:3)` で失敗していたため、これを修復する。

## 原因
Dependabot dev 依存 PR（#659 / #661）の squash マージ時に、両者が `pnpm-lock.yaml` を変更しており、2件目のマージで lockfile が3-way自動マージされた。**テキスト衝突は発生しなかったが**、`'@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)'` のエントリが重複して挿入され、YAML として不正（同一キー2回）になった。

## 修正
完全に同一の重複ブロック1つ（7行）のみを除去。もう一方の同名エントリと `(@emnapi/core@1.9.2)` バリアントは保持。意味的変化はなく、`pnpm install --frozen-lockfile` がローカルで成功することを確認済み（main の package.json と整合）。

## 影響範囲
- `pnpm-lock.yaml` の 7 行削除のみ。依存バージョンの変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)