### PR TITLE
chore(design-sync): トークン抽出を authored token に限定する申し送り（[TOKEN_SCOPE]）

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -48,6 +48,37 @@ claude.ai/design への同期に関する、リポジトリ固有の前提と落
 - CSS は Tailwind v4（`@import "tailwindcss"`）。converter は sb-reference から
   コンパイル済み CSS を scrape する（[CSS_FROM_STORYBOOK]）想定。
 
+## トークン抽出スコープ（[TOKEN_SCOPE]・要遵守 / Claude Design 指示 2026-06-18）
+
+converter は sb-reference の**コンパイル済み CSS** を scrape する（上記 [CSS_FROM_STORYBOOK]）。
+放置すると Tailwind v4 が生成した内部変数・ユーティリティ定義まで「トークン」として拾い、
+component-style 配下／未分類が大量に出る（報告値: 89 件 component-style 配下・141 件 未分類）。
+**トークン抽出はオーサリングされた実トークンに限定する**こと。
+
+- **含める（design token）**: `packages/ui/src/styles/globals.css` の `:root` / `.dark` / `@theme`
+  配下で宣言された、色・角丸・ブランドスケール・モーションの実トークン:
+  `--background, --foreground, --card*, --popover*, --primary*, --secondary*, --muted*, --accent*,
+  --destructive*, --border, --input, --ring, --focus-ring*, --radius*, --suzuka-{50..950},
+  --minase-{50..950}, --animate-*`（`--chart-*` / `--font-size-a11y-*` は #670 で削除済み）。
+- **除外する**:
+  - Tailwind 内部変数 `--tw-*` 全般。
+  - ユーティリティセレクタ配下で宣言される変数（`:where(.space-y-*…)` / `.translate-x-*` 等の
+    クラススコープで宣言される変数）。
+  - フレームワーク設定変数（`:root` にあるが design token ではない）:
+    `--color-scheme, --container-center, --container-padding, --container-screens-2xl,
+    --default-border-radius`。layout config を design pane に出したい場合のみ Claude Design 判断で含める。
+- **`@theme` の `--color-*` は `:root` 実トークンの別形（重複させない）**: `@theme` は `:root`/`.dark` を
+  Tailwind 用に再エクスポートする層で、`--color-primary: hsl(var(--primary))` のように `:root --primary`
+  を hsl ラップしただけ。`--color-X`（@theme）と `--X`（:root）は**同一の論理トークン**なので、コンパイル済み
+  CSS から両方拾っても**別トークンとして二重に出さない**（論理トークン単位で 1 回。どちらの form を key に
+  するかは converter の選択 — `:root` form は生値 `340 75% 48%`、`@theme --color-*` form は utility 名
+  `bg-primary` 等に対応）。`@theme` 固有の純粋な追加は `--radius-xl`（radius スケール補完・`:root` 未定義）のみ。
+- 正本は globals.css の `:root`/`.dark`/`@theme`。`@kind` 注釈をコンパイル済みバンドルに手書き
+  しても再同期で消えるため不可 → **抽出段でこのスコープ規則を適用する**。
+- 補助: root の `pnpm lint:tokens`（`scripts/lint-css-tokens.mjs`）が `:root` 実トークンの
+  「定義あり・参照なし」を別途守る。母集合はこの `:root` 実トークン（フレームワーク設定変数を除く）
+  ＋ `@theme` 固有分（`--radius-xl`）。
+
 ## solo phase の知見（[GENERAL] 含む）
 
 - **[GENERAL] next.js が IIFE 初期化時に "process is not defined" で全バンドルを落とす**:


### PR DESCRIPTION
## 背景

`/design-sync` の converter は `sb-reference`（Storybook build）の**コンパイル済み CSS** を scrape してトークンを抽出する。そのため Tailwind v4 が生成した内部変数（`--tw-*`）やユーティリティセレクタ配下の宣言（`:where(.space-y-*…)` / `.translate-x-*` 等）まで「トークン」として拾い、**component-style 配下 89 件・未分類 141 件**のノイズが出ていた（Claude Design 報告・2026-06-18）。

`@kind` 注釈をコンパイル済みバンドルに手書きしても**再同期で消える**ため、durable な申し送りが必要。

## 変更

`.design-sync/NOTES.md` に `## トークン抽出スコープ（[TOKEN_SCOPE]・要遵守）` を追加。次回 `/design-sync` が**抽出段で**適用すべきスコープを明文化した：

- **含める**: `packages/ui/src/styles/globals.css` の `:root` / `.dark` / `@theme` 配下の実トークンのみ（`--background`/`--primary*`/`--suzuka-*`/`--minase-*`/`--radius*` 等）
- **除外する**: `--tw-*` 全般、ユーティリティセレクタ配下で宣言される変数

## 検証

- globals.css の custom property 宣言は `:root`(66) / `.dark`(44) / `@theme`(45) のみ・既知 family だけで、コンポーネント/ユーティリティセレクタ配下の authored 宣言は **0 件**。→ 「89/141 件」はコンパイル済み CSS 由来で確定、指示は技術的に正しい。
- 母集合は root の `pnpm lint:tokens`（`scripts/lint-css-tokens.mjs`・#670）が守る `:root` 実トークン＋`@theme` 露出分と対応。

## 補足

NOTES.md は実行時のみ参照されるドキュメント（CI のリンク/型チェック対象外）。コード挙動・ビルドには影響しない。マージ後に terminal から `/design-sync` を走らせると本スコープが効く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)