### PR TITLE
fix(web): 音声ボタン詳細ページの RSC エラーを修正（server shell の関数 prop を client island へ隔離）

### DIFF
--- a/apps/web/src/app/videos/components/video-card-tags.tsx
+++ b/apps/web/src/app/videos/components/video-card-tags.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { VideoTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
+import { buildTagSearchHref } from "@/lib/tag-search";
+
+interface VideoCardTagsProps {
+	playlistTags: string[];
+	userTags: string[];
+	categoryId?: string;
+	categoryName?: string;
+	searchQuery?: string;
+}
+
+/**
+ * VideoCard のタグ表示 island（client）。
+ * 純関数 {@link buildTagSearchHref} を VideoTagDisplay（client）へ渡す DI は client 境界内でのみ成立する。
+ * server shell の VideoCard から直接関数を渡すと RSC で
+ * "Functions cannot be passed directly to Client Components" になるため、ここに隔離する。
+ */
+export function VideoCardTags({
+	playlistTags,
+	userTags,
+	categoryId,
+	categoryName,
+	searchQuery,
+}: VideoCardTagsProps) {
+	return (
+		<VideoTagDisplay
+			playlistTags={playlistTags}
+			userTags={userTags}
+			categoryId={categoryId}
+			categoryName={categoryName}
+			size="sm"
+			maxTagsPerLayer={5}
+			showEmptyLayers={false}
+			showCategory={true}
+			compact={true}
+			tagHref={buildTagSearchHref}
+			searchQuery={searchQuery}
+		/>
+	);
+}

--- a/apps/web/src/app/videos/components/video-card-tags.tsx
+++ b/apps/web/src/app/videos/components/video-card-tags.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { VideoTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
+import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
 import { buildTagSearchHref } from "@/lib/tag-search";
 
 interface VideoCardTagsProps {
 	playlistTags: string[];
 	userTags: string[];
 	categoryId?: string;
-	categoryName?: string;
 	searchQuery?: string;
 }
 
@@ -16,14 +16,15 @@ interface VideoCardTagsProps {
  * 純関数 {@link buildTagSearchHref} を VideoTagDisplay（client）へ渡す DI は client 境界内でのみ成立する。
  * server shell の VideoCard から直接関数を渡すと RSC で
  * "Functions cannot be passed directly to Client Components" になるため、ここに隔離する。
+ * categoryName も純関数 getYouTubeCategoryName で算出できるため island 内で完結させ、prop を増やさない。
  */
 export function VideoCardTags({
 	playlistTags,
 	userTags,
 	categoryId,
-	categoryName,
 	searchQuery,
 }: VideoCardTagsProps) {
+	const categoryName = getYouTubeCategoryName(categoryId) || undefined;
 	return (
 		<VideoTagDisplay
 			playlistTags={playlistTags}

--- a/apps/web/src/app/videos/components/video-card.tsx
+++ b/apps/web/src/app/videos/components/video-card.tsx
@@ -1,6 +1,5 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { HighlightText } from "@suzumina.click/ui/components/custom/highlight-text";
-import { VideoTagDisplay } from "@suzumina.click/ui/components/custom/three-layer-tag-display";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
 import { Calendar, Lock } from "lucide-react";
@@ -8,8 +7,8 @@ import Link from "next/link";
 import React from "react";
 import ThumbnailImage from "@/components/ui/thumbnail-image";
 import { getVideoBadgeInfo } from "@/components/video/video-badge";
-import { buildTagSearchHref } from "@/lib/tag-search";
 import VideoCardActions from "./video-card-actions";
+import { VideoCardTags } from "./video-card-tags";
 
 // 表示日付（純関数）: ライブ配信は配信開始時間を優先し、無効なら公開時間にフォールバック
 function getDisplayDate(video: VideoPlainObject) {
@@ -160,19 +159,13 @@ function VideoCard({ video, variant = "grid", priority = false, searchQuery }: V
 						</time>
 					</div>
 
-					{/* タグ表示（一列・コンパクト） */}
+					{/* タグ表示（一列・コンパクト）。tagHref(関数)注入は client island に隔離する */}
 					<div className="mb-4">
-						<VideoTagDisplay
+						<VideoCardTags
 							playlistTags={video.tags?.playlistTags || []}
 							userTags={video.tags?.userTags || []}
 							categoryId={video.categoryId}
 							categoryName={categoryName || undefined}
-							size="sm"
-							maxTagsPerLayer={5}
-							showEmptyLayers={false}
-							showCategory={true}
-							compact={true}
-							tagHref={buildTagSearchHref}
 							searchQuery={searchQuery}
 						/>
 					</div>

--- a/apps/web/src/app/videos/components/video-card.tsx
+++ b/apps/web/src/app/videos/components/video-card.tsx
@@ -1,7 +1,6 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { HighlightText } from "@suzumina.click/ui/components/custom/highlight-text";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
-import { getYouTubeCategoryName } from "@suzumina.click/ui/lib/youtube-category-utils";
 import { Calendar, Lock } from "lucide-react";
 import Link from "next/link";
 import React from "react";
@@ -64,7 +63,6 @@ interface VideoCardProps {
 function VideoCard({ video, variant = "grid", priority = false, searchQuery }: VideoCardProps) {
 	const actualButtonCount = video.audioButtonCount ?? 0;
 	const { formattedDate, displayLabel, dateTimeValue } = getDisplayDate(video);
-	const categoryName = getYouTubeCategoryName(video.categoryId);
 	const videoBadgeInfo = getVideoBadgeInfo(video);
 
 	return (
@@ -165,7 +163,6 @@ function VideoCard({ video, variant = "grid", priority = false, searchQuery }: V
 							playlistTags={video.tags?.playlistTags || []}
 							userTags={video.tags?.userTags || []}
 							categoryId={video.categoryId}
-							categoryName={categoryName || undefined}
 							searchQuery={searchQuery}
 						/>
 					</div>


### PR DESCRIPTION
## 問題
音声ボタン詳細ページ `/buttons/[id]` で Server Components render エラーが発生していた。

本番ログ（Cloud Run `suzumina-click-web`, digest `3643344376`）で実体を特定:
> Error: Functions cannot be passed directly to Client Components unless you explicitly expose it by marking it with "use server".

## 原因
`apps/web/src/app/videos/components/video-card.tsx` が **Client Component** の `VideoTagDisplay`（`packages/ui` の three-layer-tag-display）に**純関数** `buildTagSearchHref` を `tagHref` prop で渡していた。Server→Client 境界は関数を越えられないため、`VideoCard` が **server 描画される文脈でだけ** RSC エラーになる。

なぜ詳細ページ限定か:
- 動画一覧 `video-list.tsx` とホームのカルーセル `videos-section.tsx` は**両方 `"use client"`** → VideoCard が client ツリーで描画され関数 prop が通る＝壊れない
- 詳細 sidebar の `video-card-wrapper.tsx` **だけが真の Server Component** → ここでのみ落ちていた

DS Phase 2 (#673) より前のログにも出ており既存バグ。

## 修正
`VideoCard` の "server shell" 設計を維持しつつ、関数注入を薄い **client island**（既存 `VideoCardActions` と同型）に隔離:
- 新規 `video-card-tags.tsx`（`"use client"`）が `buildTagSearchHref` を `VideoTagDisplay` に渡す
- `VideoCard` からはシリアライズ可能なデータだけ渡す

## 検証
- `pnpm verify` 通過（全パッケージの typecheck / lint / lint:docs / lint:tokens / test）
- Emulator のシードは audioButton と video の id が一致せず詳細 sidebar の VideoCard 経路を踏めないため、検証時のみ 1 件を一時リンクして再現 → 詳細ページが **200 で完全描画**、sidebar の元動画カードが **server 描画で正常表示**、server/console エラーともゼロを確認（一時改変は revert 済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)