### PR TITLE
feat(ui): DS Phase 4 — Alert に状態色 variant 追加 + API 語彙/境界を明文化（点5）

### DIFF
--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -53,6 +53,16 @@ white text on orange (it fails AA at 2.3:1; use dark or `minase-50` text).
 
 **Radius:** `rounded-sm | rounded-md | rounded-lg | rounded-xl | rounded-full` (from the `--radius` token, 0.5rem).
 
+## Component API conventions
+
+- **variant / size vocabulary** — `Button` is the base set; other components use a consistent subset:
+  - `variant`: `default | secondary | destructive | outline | ghost | link` (Button, Badge).
+  - `Alert` variant: `default | destructive | info | success | warning` (status colors).
+  - `Toggle` variant: `default | outline`.
+  - `size`: `default | sm | lg | icon` (+ `xs` / `icon-*` on Button). Don't invent new variant/size names — pick from these unions (each component's `VariantProps` is the contract).
+- **prop naming** — state booleans `is*` (`isFavorite`, `isAuthenticated`), event handlers `on*` (`onFavoriteToggle`, `onTagClick`), display toggles `show*` (`showDetailLink`, `showIcon`). Plain config booleans (`disabled`, `compact`, `animated`) stay unprefixed, matching React idiom.
+- **primitive vs domain** — `components/ui/*` are reusable shadcn-derived primitives (Button, Badge, Alert, …); `components/custom/*` are app-specific compositions (AudioButton, TagList, ConfigurableList, …). Both are re-exported from the package root.
+
 ## Where the truth lives
 
 - The bound **`styles.css`** (and its `@import` closure) is the authoritative source of tokens and

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -22,7 +22,7 @@ system has its own vocabulary; use the names below.
 **Variants are props, not classes.** Examples (check each component's `<Name>.d.ts` for the exact union):
 - `<Button variant="default | secondary | destructive | outline | ghost | link" size="default | sm | lg | icon">`
 - `<Badge variant="default | secondary | destructive | outline">`
-- `<Alert variant="default | destructive">`
+- `<Alert variant="default | destructive | info | success | warning">`
 
 **Semantic color utilities** (pair a `bg-*` surface with its matching `*-foreground` text):
 

--- a/packages/ui/src/components/ui/alert.stories.tsx
+++ b/packages/ui/src/components/ui/alert.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { AlertCircle, Terminal } from "lucide-react";
+import { AlertCircle, AlertTriangle, CheckCircle, Info as InfoIcon, Terminal } from "lucide-react";
 
 import { Alert, AlertDescription, AlertTitle } from "./alert";
 
@@ -13,7 +13,7 @@ const meta = {
 	argTypes: {
 		variant: {
 			control: { type: "select" },
-			options: ["default", "destructive"],
+			options: ["default", "destructive", "info", "success", "warning"],
 		},
 	},
 	decorators: [
@@ -44,6 +44,36 @@ export const Destructive: Story = {
 			<AlertCircle className="h-4 w-4" />
 			<AlertTitle>Error</AlertTitle>
 			<AlertDescription>Your session has expired. Please log in again.</AlertDescription>
+		</Alert>
+	),
+};
+
+export const Info: Story = {
+	render: () => (
+		<Alert variant="info">
+			<InfoIcon className="h-4 w-4" />
+			<AlertTitle>お知らせ</AlertTitle>
+			<AlertDescription>一般公開を開始しました。閲覧は誰でもご利用いただけます。</AlertDescription>
+		</Alert>
+	),
+};
+
+export const Success: Story = {
+	render: () => (
+		<Alert variant="success">
+			<CheckCircle className="h-4 w-4" />
+			<AlertTitle>保存しました</AlertTitle>
+			<AlertDescription>設定が正常に保存されました。</AlertDescription>
+		</Alert>
+	),
+};
+
+export const Warning: Story = {
+	render: () => (
+		<Alert variant="warning">
+			<AlertTriangle className="h-4 w-4" />
+			<AlertTitle>注意</AlertTitle>
+			<AlertDescription>この操作は取り消せません。続行する前にご確認ください。</AlertDescription>
 		</Alert>
 	),
 };

--- a/packages/ui/src/components/ui/alert.tsx
+++ b/packages/ui/src/components/ui/alert.tsx
@@ -10,6 +10,11 @@ const alertVariants = cva(
 				default: "bg-card text-card-foreground",
 				destructive:
 					"bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+				info: "bg-card text-info *:data-[slot=alert-description]:text-info [&>svg]:text-current",
+				success:
+					"bg-card text-success *:data-[slot=alert-description]:text-success [&>svg]:text-current",
+				warning:
+					"bg-card text-warning *:data-[slot=alert-description]:text-warning [&>svg]:text-current",
 			},
 		},
 		defaultVariants: {


### PR DESCRIPTION
## 概要

Claude Design Phase 0 監査 spec の **Phase 4（論点 5: コンポーネント API 一貫性）**。Phase 0 監査の最終フェーズ。

## 調査結果: 点5 は大半が既に整合

| 観点 | 実態 |
|---|---|
| variant/size 語彙 | **整合済み**（Button が superset、Badge も同6種、Alert/Toggle は妥当な subset。drift なし） |
| prop 命名（is*/on*/show*） | **概ね遵守**（`disabled`/`compact`/`animated` 等の形容詞 bool は React idiom で問題なし） |
| ListPageLayout | Header/Content/Grid/Stats/EmptyState に**良く分解済み**＝健全 |

→ spec が懸念した「不整合・肥大化」の大半は存在せず。**破壊的な改名・リファクタは行わない**（CLAUDE.md「新しい抽象を足すな・過剰一般化禁止」）。additive な改善＋明文化に絞る保守的スコープ（ユーザー合意）。

## 変更

- **Alert に `info` / `success` / `warning` variant を追加**（点3 の状態色トークンの締め・additive・非破壊）。
  - description は full `text-{status}`（当初 `/90` 透過は success が AA 4.26 で割れたため除去）。
  - **Storybook a11y テストで AA 確認**（Info/Success/Warning ストーリー追加）。
- **`conventions.md` に "Component API conventions" 節**を追加: variant/size 語彙（Button が base）、`is*`/`on*`/`show*` 命名規約、primitive(`ui/`) vs domain(`custom/`) 境界。

## 別タスク化（このPR外）

`ConfigurableList`（46 props）の「汎用 / 用途特化」分割は破壊的で **One-Way 寄り**のため、DS 掃除 PR と分離し独立タスクに（後方互換 deprecate エイリアスで段階移行）。

## 検証

- `pnpm verify` 緑（lint:docs/lint:tokens/lint/typecheck/test 全 pass・**ui 349 / web 890**）。
- **Storybook a11y 333 pass**（Alert 新 variant 含む・axe 実測 contrast）。

## レビュー区分

Two-Way Door（Alert variant 追加・doc）。AI レビューで可。

---

これで **Phase 0 監査（論点 1〜7）の改修フェーズ 1〜4 が完了**します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)