### PR TITLE
refactor(ui): ConfigurableList の props を汎用/特化で型分離しフィルタ UI を抽出

### DIFF
--- a/packages/ui/src/components/custom/configurable-list.tsx
+++ b/packages/ui/src/components/custom/configurable-list.tsx
@@ -1,22 +1,20 @@
 /**
  * ConfigurableList - カスタマイズ可能なリストコンポーネント
  * フィルター、ソート、URL同期、サーバーサイドデータ取得機能を提供
+ *
+ * props は責務で 2 つに分かれる（型は ConfigurableListProps = 合成）:
+ * - 汎用表示・ページング・状態: ListDisplayProps（items/renderItem/layout/loading 等）
+ * - 用途特化クエリ・サーバー連携: ListQueryProps（filters/sorts/search/urlSync/fetchFn 等）
+ * フィルター UI ウィジェットは configurable-list-filters（FilterControl）に分離。
  */
 
 "use client";
 
-import { ChevronDown } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Checkbox } from "../ui/checkbox";
-import { Input } from "../ui/input";
-import { Label } from "../ui/label";
-import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Skeleton } from "../ui/skeleton";
-import { Slider } from "../ui/slider";
 import { ConfigurableListControls } from "./configurable-list/configurable-list-controls";
+import { FilterControl } from "./configurable-list/configurable-list-filters";
 import { ConfigurableListFooter } from "./configurable-list/configurable-list-footer";
 import { ConfigurableListHeader } from "./configurable-list/configurable-list-header";
 import { ConfigurableListItems } from "./configurable-list/configurable-list-items";
@@ -31,339 +29,10 @@ import type {
 } from "./configurable-list/types";
 import { calculatePagination } from "./configurable-list/utils/data-adapter";
 import {
-	generateOptions,
 	getDefaultFilterValues,
 	hasActiveFilters,
 	normalizeOptions,
 } from "./configurable-list/utils/filter-helpers";
-
-// Filter component helpers to reduce complexity
-function SelectFilter({
-	value,
-	config,
-	onChange,
-}: {
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	const options = generateOptions(config);
-	return (
-		<Select value={value?.toString() || ""} onValueChange={onChange}>
-			<SelectTrigger className="w-[180px]" aria-label={config.label || "絞り込み"}>
-				<SelectValue placeholder={config.placeholder || `${config.label}を選択`} />
-			</SelectTrigger>
-			<SelectContent>
-				{options.map((opt) => (
-					<SelectItem key={opt.value} value={opt.value}>
-						{opt.label}
-					</SelectItem>
-				))}
-			</SelectContent>
-		</Select>
-	);
-}
-
-function BooleanFilter({
-	keyName,
-	value,
-	config,
-	onChange,
-}: {
-	keyName: string;
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	return (
-		<Button variant={value ? "default" : "outline"} size="sm" onClick={() => onChange(!value)}>
-			{config.label || keyName}
-		</Button>
-	);
-}
-
-function MultiselectFilter({
-	keyName,
-	value,
-	config,
-	onChange,
-}: {
-	keyName: string;
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	const options = generateOptions(config);
-	const selectedValues = Array.isArray(value) ? value : [];
-
-	return (
-		<div className="space-y-2">
-			<Label>{config.label}</Label>
-			<div className="space-y-1 max-h-48 overflow-y-auto border rounded-md p-2">
-				{options.map((opt) => (
-					<div key={opt.value} className="flex items-center space-x-2">
-						<Checkbox
-							id={`${keyName}-${opt.value}`}
-							checked={selectedValues.includes(opt.value)}
-							onCheckedChange={(checked) => {
-								const newValues = checked
-									? [...selectedValues, opt.value]
-									: selectedValues.filter((v) => v !== opt.value);
-								onChange(newValues.length > 0 ? newValues : undefined);
-							}}
-						/>
-						<Label
-							htmlFor={`${keyName}-${opt.value}`}
-							className="text-sm font-normal cursor-pointer"
-						>
-							{opt.label}
-						</Label>
-					</div>
-				))}
-			</div>
-		</div>
-	);
-}
-
-function RangeFilter({
-	value,
-	config,
-	onChange,
-}: {
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	const min = config.min ?? 0;
-	const max = config.max ?? 100;
-	const step = config.step ?? 1;
-	const rangeValue = value as { min?: number; max?: number } | undefined;
-	const currentMin = rangeValue?.min ?? min;
-	const currentMax = rangeValue?.max ?? max;
-
-	return (
-		<div className="space-y-2">
-			<Label>{config.label}</Label>
-			<div className="flex items-center space-x-2">
-				<Input
-					type="number"
-					value={currentMin}
-					min={min}
-					max={max}
-					step={step}
-					className="w-20"
-					onChange={(e) => {
-						const newMin = Number(e.target.value);
-						onChange({ min: newMin, max: currentMax });
-					}}
-				/>
-				<span className="text-sm text-muted-foreground">〜</span>
-				<Input
-					type="number"
-					value={currentMax}
-					min={min}
-					max={max}
-					step={step}
-					className="w-20"
-					onChange={(e) => {
-						const newMax = Number(e.target.value);
-						onChange({ min: currentMin, max: newMax });
-					}}
-				/>
-			</div>
-			<Slider
-				value={[currentMin, currentMax]}
-				min={min}
-				max={max}
-				step={step}
-				onValueChange={([newMin, newMax]) => {
-					onChange({ min: newMin, max: newMax });
-				}}
-				className="mt-2"
-			/>
-		</div>
-	);
-}
-
-function DateFilter({
-	keyName,
-	value,
-	config,
-	onChange,
-}: {
-	keyName: string;
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	return (
-		<div className="space-y-2">
-			<Label>{config.label || keyName}</Label>
-			<Input
-				type="date"
-				value={value?.toString() || ""}
-				onChange={(e) => onChange(e.target.value || undefined)}
-				className="w-[180px]"
-			/>
-		</div>
-	);
-}
-
-function DateRangeFilter({
-	keyName,
-	value,
-	config,
-	onChange,
-}: {
-	keyName: string;
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	const dateValue = value as { start?: string; end?: string } | undefined;
-	return (
-		<div className="space-y-2">
-			<Label>{config.label || keyName}</Label>
-			<div className="flex items-center space-x-2">
-				<Input
-					type="date"
-					value={dateValue?.start || ""}
-					min={config.minDate}
-					max={config.maxDate}
-					onChange={(e) => {
-						onChange({
-							start: e.target.value || undefined,
-							end: dateValue?.end,
-						});
-					}}
-					className="w-[140px]"
-				/>
-				<span className="text-sm text-muted-foreground">〜</span>
-				<Input
-					type="date"
-					value={dateValue?.end || ""}
-					min={config.minDate}
-					max={config.maxDate}
-					onChange={(e) => {
-						onChange({
-							start: dateValue?.start,
-							end: e.target.value || undefined,
-						});
-					}}
-					className="w-[140px]"
-				/>
-			</div>
-		</div>
-	);
-}
-
-function TagsFilter({
-	keyName,
-	value,
-	config,
-	onChange,
-}: {
-	keyName: string;
-	value: unknown;
-	config: FilterConfig;
-	onChange: (value: unknown) => void;
-}) {
-	const options = generateOptions(config);
-	const selectedValues = Array.isArray(value) ? value : [];
-	const isLoading = options === undefined || options === null;
-	const hasNoData = !isLoading && options.length === 0;
-
-	return (
-		<Popover>
-			<PopoverTrigger asChild>
-				<Button
-					variant="outline"
-					size="sm"
-					className="h-9 border-dashed"
-					disabled={isLoading || hasNoData}
-				>
-					{config.label || keyName}
-					{selectedValues.length > 0 && (
-						<>
-							<div className="mx-1 h-4 w-[1px] bg-border" />
-							<Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
-								{selectedValues.length}
-							</Badge>
-							<div className="hidden space-x-1 lg:flex">
-								{selectedValues.length > 2 ? (
-									<Badge variant="secondary" className="rounded-sm px-1 font-normal">
-										{selectedValues.length}件選択中
-									</Badge>
-								) : (
-									options
-										.filter((option) => selectedValues.includes(option.value))
-										.map((option) => (
-											<Badge
-												key={option.value}
-												variant="secondary"
-												className="rounded-sm px-1 font-normal"
-											>
-												{option.label}
-											</Badge>
-										))
-								)}
-							</div>
-						</>
-					)}
-					<ChevronDown className="ml-2 h-4 w-4" />
-				</Button>
-			</PopoverTrigger>
-			<PopoverContent className="w-[300px] p-0" align="start">
-				<div className="p-4">
-					<div className="mb-2 text-sm font-medium">{config.label || keyName}</div>
-					{isLoading ? (
-						<div className="flex items-center justify-center py-8">
-							<div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-							<span className="ml-2 text-sm text-muted-foreground">読み込み中...</span>
-						</div>
-					) : options.length === 0 ? (
-						<div className="text-center py-4 text-sm text-muted-foreground">データがありません</div>
-					) : (
-						<>
-							<div className="grid gap-2 max-h-[300px] overflow-y-auto">
-								{options.map((option) => (
-									<div key={option.value} className="flex items-center space-x-2">
-										<Checkbox
-											id={`tag-${option.value}`}
-											checked={selectedValues.includes(option.value)}
-											onCheckedChange={(checked) => {
-												const newValues = checked
-													? [...selectedValues, option.value]
-													: selectedValues.filter((v) => v !== option.value);
-												onChange(newValues.length > 0 ? newValues : undefined);
-											}}
-										/>
-										<Label
-											htmlFor={`tag-${option.value}`}
-											className="text-sm font-normal cursor-pointer flex-1"
-										>
-											{option.label}
-										</Label>
-									</div>
-								))}
-							</div>
-							{selectedValues.length > 0 && (
-								<Button
-									variant="ghost"
-									size="sm"
-									className="mt-2 w-full"
-									onClick={() => onChange(undefined)}
-								>
-									クリア
-								</Button>
-							)}
-						</>
-					)}
-				</div>
-			</PopoverContent>
-		</Popover>
-	);
-}
 
 export function ConfigurableList<T>({
 	items: initialItems,
@@ -476,35 +145,16 @@ export function ConfigurableList<T>({
 		onSearch: handleSearch,
 	});
 
-	// フィルターコンポーネントのレンダリング
+	// フィルターUIの描画（type 振り分けは configurable-list-filters の FilterControl に委譲）
 	const renderFilter = useCallback(
-		(key: string, config: FilterConfig) => {
-			const value = fetchParams.filters[key];
-			const onChange = (v: unknown) => handleFilterChange(key, v);
-
-			switch (config.type) {
-				case "select":
-					return <SelectFilter value={value} config={config} onChange={onChange} />;
-				case "boolean":
-					return <BooleanFilter keyName={key} value={value} config={config} onChange={onChange} />;
-				case "multiselect":
-					return (
-						<MultiselectFilter keyName={key} value={value} config={config} onChange={onChange} />
-					);
-				case "range":
-					return <RangeFilter value={value} config={config} onChange={onChange} />;
-				case "date":
-					return <DateFilter keyName={key} value={value} config={config} onChange={onChange} />;
-				case "dateRange":
-					return (
-						<DateRangeFilter keyName={key} value={value} config={config} onChange={onChange} />
-					);
-				case "tags":
-					return <TagsFilter keyName={key} value={value} config={config} onChange={onChange} />;
-				default:
-					return null;
-			}
-		},
+		(key: string, config: FilterConfig) => (
+			<FilterControl
+				keyName={key}
+				value={fetchParams.filters[key]}
+				config={config}
+				onChange={(v) => handleFilterChange(key, v)}
+			/>
+		),
 		[fetchParams.filters, handleFilterChange],
 	);
 

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-filters.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-filters.tsx
@@ -249,20 +249,15 @@ function TagsFilter({
 	config: FilterConfig;
 	onChange: (value: unknown) => void;
 }) {
+	// generateOptions は常に配列を返す（nullish にならない）ため、判定は「空かどうか」だけで足りる
 	const options = generateOptions(config);
 	const selectedValues = Array.isArray(value) ? value : [];
-	const isLoading = options === undefined || options === null;
-	const hasNoData = !isLoading && options.length === 0;
+	const hasOptions = options.length > 0;
 
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<Button
-					variant="outline"
-					size="sm"
-					className="h-9 border-dashed"
-					disabled={isLoading || hasNoData}
-				>
+				<Button variant="outline" size="sm" className="h-9 border-dashed" disabled={!hasOptions}>
 					{config.label || keyName}
 					{selectedValues.length > 0 && (
 						<>
@@ -297,14 +292,7 @@ function TagsFilter({
 			<PopoverContent className="w-[300px] p-0" align="start">
 				<div className="p-4">
 					<div className="mb-2 text-sm font-medium">{config.label || keyName}</div>
-					{isLoading ? (
-						<div className="flex items-center justify-center py-8">
-							<div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-							<span className="ml-2 text-sm text-muted-foreground">読み込み中...</span>
-						</div>
-					) : options.length === 0 ? (
-						<div className="text-center py-4 text-sm text-muted-foreground">データがありません</div>
-					) : (
+					{hasOptions ? (
 						<>
 							<div className="grid gap-2 max-h-[300px] overflow-y-auto">
 								{options.map((option) => (
@@ -339,6 +327,8 @@ function TagsFilter({
 								</Button>
 							)}
 						</>
+					) : (
+						<div className="text-center py-4 text-sm text-muted-foreground">データがありません</div>
 					)}
 				</div>
 			</PopoverContent>

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-filters.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-filters.tsx
@@ -1,0 +1,386 @@
+/**
+ * ConfigurableList のフィルター UI ウィジェット群と、type による振り分け。
+ *
+ * ここは「用途特化（クエリの絞り込み UI）」の責務。リスト本体のオーケストレーション
+ * （ConfigurableList）からは分離し、FilterControl 経由でのみ依存させる。
+ */
+
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { Badge } from "../../ui/badge";
+import { Button } from "../../ui/button";
+import { Checkbox } from "../../ui/checkbox";
+import { Input } from "../../ui/input";
+import { Label } from "../../ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "../../ui/popover";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../ui/select";
+import { Slider } from "../../ui/slider";
+import type { FilterConfig } from "./types";
+import { generateOptions } from "./utils/filter-helpers";
+
+function SelectFilter({
+	value,
+	config,
+	onChange,
+}: {
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	const options = generateOptions(config);
+	return (
+		<Select value={value?.toString() || ""} onValueChange={onChange}>
+			<SelectTrigger className="w-[180px]" aria-label={config.label || "絞り込み"}>
+				<SelectValue placeholder={config.placeholder || `${config.label}を選択`} />
+			</SelectTrigger>
+			<SelectContent>
+				{options.map((opt) => (
+					<SelectItem key={opt.value} value={opt.value}>
+						{opt.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function BooleanFilter({
+	keyName,
+	value,
+	config,
+	onChange,
+}: {
+	keyName: string;
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	return (
+		<Button variant={value ? "default" : "outline"} size="sm" onClick={() => onChange(!value)}>
+			{config.label || keyName}
+		</Button>
+	);
+}
+
+function MultiselectFilter({
+	keyName,
+	value,
+	config,
+	onChange,
+}: {
+	keyName: string;
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	const options = generateOptions(config);
+	const selectedValues = Array.isArray(value) ? value : [];
+
+	return (
+		<div className="space-y-2">
+			<Label>{config.label}</Label>
+			<div className="space-y-1 max-h-48 overflow-y-auto border rounded-md p-2">
+				{options.map((opt) => (
+					<div key={opt.value} className="flex items-center space-x-2">
+						<Checkbox
+							id={`${keyName}-${opt.value}`}
+							checked={selectedValues.includes(opt.value)}
+							onCheckedChange={(checked) => {
+								const newValues = checked
+									? [...selectedValues, opt.value]
+									: selectedValues.filter((v) => v !== opt.value);
+								onChange(newValues.length > 0 ? newValues : undefined);
+							}}
+						/>
+						<Label
+							htmlFor={`${keyName}-${opt.value}`}
+							className="text-sm font-normal cursor-pointer"
+						>
+							{opt.label}
+						</Label>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function RangeFilter({
+	value,
+	config,
+	onChange,
+}: {
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	const min = config.min ?? 0;
+	const max = config.max ?? 100;
+	const step = config.step ?? 1;
+	const rangeValue = value as { min?: number; max?: number } | undefined;
+	const currentMin = rangeValue?.min ?? min;
+	const currentMax = rangeValue?.max ?? max;
+
+	return (
+		<div className="space-y-2">
+			<Label>{config.label}</Label>
+			<div className="flex items-center space-x-2">
+				<Input
+					type="number"
+					value={currentMin}
+					min={min}
+					max={max}
+					step={step}
+					className="w-20"
+					onChange={(e) => {
+						const newMin = Number(e.target.value);
+						onChange({ min: newMin, max: currentMax });
+					}}
+				/>
+				<span className="text-sm text-muted-foreground">〜</span>
+				<Input
+					type="number"
+					value={currentMax}
+					min={min}
+					max={max}
+					step={step}
+					className="w-20"
+					onChange={(e) => {
+						const newMax = Number(e.target.value);
+						onChange({ min: currentMin, max: newMax });
+					}}
+				/>
+			</div>
+			<Slider
+				value={[currentMin, currentMax]}
+				min={min}
+				max={max}
+				step={step}
+				onValueChange={([newMin, newMax]) => {
+					onChange({ min: newMin, max: newMax });
+				}}
+				className="mt-2"
+			/>
+		</div>
+	);
+}
+
+function DateFilter({
+	keyName,
+	value,
+	config,
+	onChange,
+}: {
+	keyName: string;
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	return (
+		<div className="space-y-2">
+			<Label>{config.label || keyName}</Label>
+			<Input
+				type="date"
+				value={value?.toString() || ""}
+				onChange={(e) => onChange(e.target.value || undefined)}
+				className="w-[180px]"
+			/>
+		</div>
+	);
+}
+
+function DateRangeFilter({
+	keyName,
+	value,
+	config,
+	onChange,
+}: {
+	keyName: string;
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	const dateValue = value as { start?: string; end?: string } | undefined;
+	return (
+		<div className="space-y-2">
+			<Label>{config.label || keyName}</Label>
+			<div className="flex items-center space-x-2">
+				<Input
+					type="date"
+					value={dateValue?.start || ""}
+					min={config.minDate}
+					max={config.maxDate}
+					onChange={(e) => {
+						onChange({
+							start: e.target.value || undefined,
+							end: dateValue?.end,
+						});
+					}}
+					className="w-[140px]"
+				/>
+				<span className="text-sm text-muted-foreground">〜</span>
+				<Input
+					type="date"
+					value={dateValue?.end || ""}
+					min={config.minDate}
+					max={config.maxDate}
+					onChange={(e) => {
+						onChange({
+							start: dateValue?.start,
+							end: e.target.value || undefined,
+						});
+					}}
+					className="w-[140px]"
+				/>
+			</div>
+		</div>
+	);
+}
+
+function TagsFilter({
+	keyName,
+	value,
+	config,
+	onChange,
+}: {
+	keyName: string;
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	const options = generateOptions(config);
+	const selectedValues = Array.isArray(value) ? value : [];
+	const isLoading = options === undefined || options === null;
+	const hasNoData = !isLoading && options.length === 0;
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button
+					variant="outline"
+					size="sm"
+					className="h-9 border-dashed"
+					disabled={isLoading || hasNoData}
+				>
+					{config.label || keyName}
+					{selectedValues.length > 0 && (
+						<>
+							<div className="mx-1 h-4 w-[1px] bg-border" />
+							<Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
+								{selectedValues.length}
+							</Badge>
+							<div className="hidden space-x-1 lg:flex">
+								{selectedValues.length > 2 ? (
+									<Badge variant="secondary" className="rounded-sm px-1 font-normal">
+										{selectedValues.length}件選択中
+									</Badge>
+								) : (
+									options
+										.filter((option) => selectedValues.includes(option.value))
+										.map((option) => (
+											<Badge
+												key={option.value}
+												variant="secondary"
+												className="rounded-sm px-1 font-normal"
+											>
+												{option.label}
+											</Badge>
+										))
+								)}
+							</div>
+						</>
+					)}
+					<ChevronDown className="ml-2 h-4 w-4" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-[300px] p-0" align="start">
+				<div className="p-4">
+					<div className="mb-2 text-sm font-medium">{config.label || keyName}</div>
+					{isLoading ? (
+						<div className="flex items-center justify-center py-8">
+							<div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+							<span className="ml-2 text-sm text-muted-foreground">読み込み中...</span>
+						</div>
+					) : options.length === 0 ? (
+						<div className="text-center py-4 text-sm text-muted-foreground">データがありません</div>
+					) : (
+						<>
+							<div className="grid gap-2 max-h-[300px] overflow-y-auto">
+								{options.map((option) => (
+									<div key={option.value} className="flex items-center space-x-2">
+										<Checkbox
+											id={`tag-${option.value}`}
+											checked={selectedValues.includes(option.value)}
+											onCheckedChange={(checked) => {
+												const newValues = checked
+													? [...selectedValues, option.value]
+													: selectedValues.filter((v) => v !== option.value);
+												onChange(newValues.length > 0 ? newValues : undefined);
+											}}
+										/>
+										<Label
+											htmlFor={`tag-${option.value}`}
+											className="text-sm font-normal cursor-pointer flex-1"
+										>
+											{option.label}
+										</Label>
+									</div>
+								))}
+							</div>
+							{selectedValues.length > 0 && (
+								<Button
+									variant="ghost"
+									size="sm"
+									className="mt-2 w-full"
+									onClick={() => onChange(undefined)}
+								>
+									クリア
+								</Button>
+							)}
+						</>
+					)}
+				</div>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+/**
+ * FilterConfig.type に応じて対応するフィルター UI を描画する振り分け。
+ * value / onChange はオーケストレータ側のクエリ状態から束縛して渡す。
+ */
+export function FilterControl({
+	keyName,
+	value,
+	config,
+	onChange,
+}: {
+	keyName: string;
+	value: unknown;
+	config: FilterConfig;
+	onChange: (value: unknown) => void;
+}) {
+	switch (config.type) {
+		case "select":
+			return <SelectFilter value={value} config={config} onChange={onChange} />;
+		case "boolean":
+			return <BooleanFilter keyName={keyName} value={value} config={config} onChange={onChange} />;
+		case "multiselect":
+			return (
+				<MultiselectFilter keyName={keyName} value={value} config={config} onChange={onChange} />
+			);
+		case "range":
+			return <RangeFilter value={value} config={config} onChange={onChange} />;
+		case "date":
+			return <DateFilter keyName={keyName} value={value} config={config} onChange={onChange} />;
+		case "dateRange":
+			return (
+				<DateRangeFilter keyName={keyName} value={value} config={config} onChange={onChange} />
+			);
+		case "tags":
+			return <TagsFilter keyName={keyName} value={value} config={config} onChange={onChange} />;
+		default:
+			return null;
+	}
+}

--- a/packages/ui/src/components/custom/configurable-list/types.ts
+++ b/packages/ui/src/components/custom/configurable-list/types.ts
@@ -102,15 +102,48 @@ export interface ListError {
 }
 
 /**
- * ConfigurableList用のプロパティ
+ * 汎用リスト表示・ページング・状態の props（責務: 「ページ分割されたリストをどう描画するか」）。
+ * どのリストでも使う関心事のみ。フィルタ/ソート/検索/取得などの用途特化は ListQueryProps 側に置く。
  */
-export interface ConfigurableListProps<T> {
+export interface ListDisplayProps<T> {
 	items: T[];
 	renderItem: (item: T, index: number) => React.ReactNode;
-	itemsPerPage?: number;
+	className?: string;
+	emptyMessage?: string;
+	loadingComponent?: React.ReactNode;
+
+	// リスト本体の見出し（スクリーンリーダー向け）。
+	// ページ h1 と各カードの見出し（h3）の間を埋める中間 h2 として sr-only で描画し、
+	// 見出しレベルの skip を防ぐ。指定時のみ描画。
+	listHeading?: string;
+
+	// レイアウト設定
+	layout?: "list" | "grid" | "flex";
+	gridColumns?: {
+		default?: number;
+		sm?: number;
+		md?: number;
+		lg?: number;
+		xl?: number;
+	};
+
+	// 状態（外部から注入する loading / error）
 	loading?: boolean;
 	error?: ListError;
-	className?: string;
+
+	// ページング設定
+	itemsPerPage?: number;
+	itemsPerPageOptions?: number[];
+
+	// 初期総数（サーバーサイドレンダリング時）
+	initialTotal?: number;
+}
+
+/**
+ * 用途特化のクエリ（フィルタ/ソート/検索/URL同期）とサーバー連携の props
+ * （責務: 「リストをどう絞り込み・並べ替え・取得するか」）。設定値は画面ごとに異なる。
+ */
+export interface ListQueryProps<T> {
 	// フィルター設定
 	filters?: Record<string, FilterConfig>;
 
@@ -129,32 +162,16 @@ export interface ConfigurableListProps<T> {
 	dataAdapter?: DataAdapter<T>;
 	fetchFn: (params: unknown) => Promise<unknown>;
 
-	// カスタマイズ
+	// 取得エラーのコールバック
 	onError?: (error: Error) => void;
-	emptyMessage?: string;
-	loadingComponent?: React.ReactNode;
-
-	// レイアウト設定
-	layout?: "list" | "grid" | "flex";
-	gridColumns?: {
-		default?: number;
-		sm?: number;
-		md?: number;
-		lg?: number;
-		xl?: number;
-	};
-
-	// ページサイズ設定
-	itemsPerPageOptions?: number[];
-
-	// 初期総数（サーバーサイドレンダリング時）
-	initialTotal?: number;
-
-	// リスト本体の見出し（スクリーンリーダー向け）。
-	// ページ h1 と各カードの見出し（h3）の間を埋める中間 h2 として sr-only で描画し、
-	// 見出しレベルの skip を防ぐ。指定時のみ描画。
-	listHeading?: string;
 }
+
+/**
+ * ConfigurableList 用のプロパティ。
+ * 汎用表示（ListDisplayProps）と用途特化クエリ（ListQueryProps）の合成。
+ * どちらの責務に属する prop かは各インターフェイス定義を参照。
+ */
+export type ConfigurableListProps<T> = ListDisplayProps<T> & ListQueryProps<T>;
 
 /**
  * AdvancedList用のコントローラー

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -10,7 +10,9 @@ export type {
 	FilterConfig,
 	ListController,
 	ListDataSource,
+	ListDisplayProps,
 	ListError,
+	ListQueryProps,
 	SortConfig,
 	StandardListParams,
 } from "./configurable-list/types";


### PR DESCRIPTION
## 背景

DS Phase 0 監査 **点5「高レベル抽象の肥大化」**。`configurable-list.tsx`（620行）に、汎用リスト機能と用途特化機能が1コンポーネントに混在していた。

## やったこと

### 1. props を責務で型分離（型合成・非破壊）

実体は 22 props（"46" は古い design-sync スナップショット由来の過大評価）。型を責務で合成に分割：

- **`ListDisplayProps<T>`（汎用13）** — 「ページ分割リストをどう描画するか」: `items` / `renderItem` / `className` / `emptyMessage` / `loadingComponent` / `listHeading` / `layout` / `gridColumns` / `loading` / `error` / `itemsPerPage` / `itemsPerPageOptions` / `initialTotal`
- **`ListQueryProps<T>`（特化9）** — 「どう絞り込み・並べ替え・取得するか」: `filters` / `sorts` / `defaultSort` / `searchable` / `searchPlaceholder` / `urlSync` / `fetchFn` / `dataAdapter` / `onError`
- **`ConfigurableListProps<T> = ListDisplayProps<T> & ListQueryProps<T>`**（合成）

`ConfigurableListProps` の名前・shape は不変のため **呼び出し側は1行も変更なし**（apps/web の7リストページすべて無変更）。deprecate エイリアスは不要だった。

### 2. フィルタ UI ウィジェットを抽出

7種のフィルタ UI ウィジェット（`SelectFilter`…`TagsFilter`）+ type 振り分けを `configurable-list-filters.tsx`（`FilterControl`）へ分離。オーケストレータ本体は **620 → 270 行**に縮小。

## 設計判断（CLAUDE.md 軸2 の言語化）

混在の実体は **props 数ではなくファイルレベル**だった。620行中327行が「用途特化のフィルタ UI」でオーケストレーションと同居していた。

**コンポーネント自体の2分割（汎用 `<List>` + `<QueryList>`）は採らなかった**：7画面すべてが fetch + urlSync + sort のフル機構を使い「素の汎用リスト」の消費者がゼロ。誰も使わない汎用コンポーネント新設は CLAUDE.md が禁じる過剰一般化のため。新しい変換層・ラッパー抽象は足していない（型合成は runtime 変換なし・shape 不変）。

## 検証

`pnpm verify` 全パッケージ green（lint:docs / lint:tokens / lint / typecheck / test + coverage 閾値）。ui 349 / web 890 テスト pass。runtime 挙動・呼び出し側 API ともに変化なし。

## レビュー区分

非破壊（呼び出し側・runtime 変化なし、テスト全 green）＝ Two-Way Door 寄り。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
