### PR TITLE
refactor(ui): stories の status 色を semantic トークンに置換（点5 F-1・選択的）

### DIFF
--- a/packages/ui/src/components/ui/alert-dialog.stories.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.stories.tsx
@@ -87,7 +87,7 @@ export const DeleteConfirmation: Story = {
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
-						<AlertTriangleIcon className="h-5 w-5 text-red-500" />
+						<AlertTriangleIcon className="h-5 w-5 text-destructive" />
 						項目の削除
 					</AlertDialogTitle>
 					<AlertDialogDescription>
@@ -97,7 +97,7 @@ export const DeleteConfirmation: Story = {
 				</AlertDialogHeader>
 				<AlertDialogFooter>
 					<AlertDialogCancel>キャンセル</AlertDialogCancel>
-					<AlertDialogAction className="bg-red-600 hover:bg-red-700">削除する</AlertDialogAction>
+					<AlertDialogAction variant="destructive">削除する</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>
 		</AlertDialog>
@@ -135,7 +135,7 @@ export const SaveChanges: Story = {
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
-						<InfoIcon className="h-5 w-5 text-blue-500" />
+						<InfoIcon className="h-5 w-5 text-info" />
 						変更を保存
 					</AlertDialogTitle>
 					<AlertDialogDescription>
@@ -161,7 +161,7 @@ export const PublishContent: Story = {
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
-						<CheckCircleIcon className="h-5 w-5 text-green-500" />
+						<CheckCircleIcon className="h-5 w-5 text-success" />
 						記事の公開
 					</AlertDialogTitle>
 					<AlertDialogDescription>
@@ -171,7 +171,7 @@ export const PublishContent: Story = {
 				</AlertDialogHeader>
 				<AlertDialogFooter>
 					<AlertDialogCancel>下書きのまま</AlertDialogCancel>
-					<AlertDialogAction className="bg-green-600 hover:bg-green-700">
+					<AlertDialogAction className="bg-success text-success-foreground hover:bg-success/90">
 						公開する
 					</AlertDialogAction>
 				</AlertDialogFooter>
@@ -188,7 +188,7 @@ export const AccountDeletion: Story = {
 			</AlertDialogTrigger>
 			<AlertDialogContent className="max-w-md">
 				<AlertDialogHeader>
-					<AlertDialogTitle className="flex items-center gap-2 text-red-600">
+					<AlertDialogTitle className="flex items-center gap-2 text-destructive">
 						<AlertTriangleIcon className="h-5 w-5" />
 						アカウントの削除
 					</AlertDialogTitle>
@@ -201,12 +201,12 @@ export const AccountDeletion: Story = {
 							<li>メッセージ履歴</li>
 							<li>購入履歴</li>
 						</ul>
-						<p className="font-medium text-red-600">この操作は取り消すことができません。</p>
+						<p className="font-medium text-destructive">この操作は取り消すことができません。</p>
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
 					<AlertDialogCancel>キャンセル</AlertDialogCancel>
-					<AlertDialogAction className="bg-red-600 hover:bg-red-700">削除する</AlertDialogAction>
+					<AlertDialogAction variant="destructive">削除する</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>
 		</AlertDialog>
@@ -259,6 +259,8 @@ export const ResetSettings: Story = {
 	),
 };
 
+// NOTE: 任意の Tailwind クラスで自由にテーマ付けできることの実演。
+// 生の blue/purple は status 意味ではなく装飾の意図的な指定（semantic トークン化しない）。
 export const CustomStyling: Story = {
 	render: () => (
 		<AlertDialog>

--- a/packages/ui/src/components/ui/switch.stories.tsx
+++ b/packages/ui/src/components/ui/switch.stories.tsx
@@ -174,9 +174,9 @@ export const AgeRatingFilter: Story = {
 						</div>
 					</div>
 				) : (
-					<div className="flex items-center gap-3 px-3 py-2 border border-blue-200 rounded-md bg-blue-50">
-						<Shield className="h-4 w-4 text-blue-600" />
-						<span className="text-sm text-blue-700 font-medium">全年齢対象作品のみ表示中</span>
+					<div className="flex items-center gap-3 px-3 py-2 border border-success/30 rounded-md bg-success/10">
+						<Shield className="h-4 w-4 text-success" />
+						<span className="text-sm text-success font-medium">全年齢対象作品のみ表示中</span>
 					</div>
 				)}
 


### PR DESCRIPTION
## 概要

Claude Design「DS Review — Phase 5」spec の **F-1（stories の生 Tailwind 色）** のうち、**status の意味を持つ箇所だけ**を Phase 2-4 の semantic トークンへ寄せる選択的修正。stories はコピペ見本になるため、shipped 済みの Do/Don't（生色を使わない）と矛盾しない状態にする。

## 変更

- **alert-dialog.stories**: 削除系 → `text-destructive` / 削除ボタン → `variant="destructive"`（className override より prop が正道）。情報 → `text-info`、成功 → `text-success`、公開ボタン → `bg-success text-success-foreground hover:bg-success/90`（success の Button variant が無いためトークン直指定）。
- **switch.stories**: 「全年齢のみ」バッジを本番 `age-rating-badge` と同じ `border-success/30 text-success bg-success/10` に（spec の指示どおり info ではなく success）。
- **CustomStyling story** の blue/purple は「任意テーマの実演＝意図的」とコメント明記して**残置**（status ではなく装飾）。

装飾色（価格・アイコン背景・highlight 例）は status 意味を持たないため対象外。

## spec のうち「やらない」と判断した分

実コードと照合した結果、Phase 5 spec は問題を過大評価していた（既知パターン）。

- **F-2（spec が「重大」）**: `_adherence.oxlintrc.json` も oxlint も**リポジトリに存在しない**幻覚。トークン lint は既に `pnpm lint:tokens`。対応不要。
- **B/C（size・命名規約）**: `.design-sync/conventions.md` に明文化済み。
- **D（custom/ 物理分割）/ E（SimpleList）**: 高 churn・コスメティック / 不要な新規抽象のため見送り。
- **A-1/A-2（破壊的改名）**: 配色は既に semantic、語彙だけの差で価値が薄く見送り。

## 検証

- `pnpm --filter @suzumina.click/ui lint`（exit 0）/ `typecheck`（exit 0）
- diff は stories のみ（className + 1 prop）＝ **Two-Way Door**

🤖 Generated with [Claude Code](https://claude.com/claude-code)