### PR TITLE
chore(repo): knip.json の誤検出を解消しレポートを信頼できる状態に

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/knip@6/schema.json",
-	"ignore": ["terraform/**"],
+	"ignore": ["terraform/**", ".design-sync/**"],
 	"ignoreDependencies": [
 		"@secretlint/secretlint-formatter-sarif",
 		"@secretlint/secretlint-rule-pattern",
@@ -11,10 +11,15 @@
 			"entry": ["src/endpoints/index.ts"]
 		},
 		"apps/web": {
-			"ignore": ["vitest-mocks/**", "vitest.d.ts"]
+			"ignore": ["vitest-mocks/**"],
+			"ignoreBinaries": ["tsx"]
 		},
 		"packages/ui": {
-			"ignore": [".storybook/mocks/**"]
+			"ignore": [".storybook/mocks/**", "ds-entry.tsx"],
+			"ignoreDependencies": ["postcss-load-config"]
+		},
+		"packages/typescript-config": {
+			"ignoreDependencies": ["next"]
 		}
 	}
 }


### PR DESCRIPTION
## 概要

knip CI は**非ブロッキング**な棚卸しレポート（[knip.yml](.github/workflows/knip.yml) / SPR-117）で、削除判断を人/LLM が1件ずつ行う前提。レポートに設定由来の偽陽性が混じると信頼性が落ちるため、**config 起因のノイズだけを解消**し「残るのは真の dead 候補のみ」という状態にする。挙動変化なし・`knip.json` のみの変更。

## 変更内容（`knip.json` のみ）

| 偽陽性 / ノイズ | 原因 | 対処 |
|---|---|---|
| Unused files: `ds-entry.tsx`, `.design-sync/shims/next-link.tsx` | design-sync ツーリングの entry/shim（`config.json` の `entry`・`sync.tsconfig.json` の `paths` が参照）。import グラフ外なので knip が未使用判定 | `.design-sync/**` を root `ignore` に追加 + `ds-entry.tsx` を `packages/ui` の `ignore` に追加 |
| Unlisted dependency: `postcss-load-config` | `packages/ui/postcss.config.mjs` の JSDoc 型注釈（`@type {import('postcss-load-config').Config}`）のみの参照 | `packages/ui.ignoreDependencies` に追加 |
| Unresolved import: `next` | `packages/typescript-config/nextjs.json` の `plugins:[{name:"next"}]`＝共有 tsconfig の意図的 plugin 参照 | `packages/typescript-config.ignoreDependencies` に追加 |
| Unlisted binary: `tsx` | `apps/web` の `migrate:audiobuttons:*` scripts で使用。`tsx` は `apps/functions` の devDep として hoist 済み | `apps/web.ignoreBinaries` に追加 |
| Configuration hint: `vitest.d.ts` | knip の "Remove from ignore"＝この ignore はもう不要 | `apps/web.ignore` から除去（再 run で再フラグされないことを確認） |

### `ds-entry.tsx` を `entry` ではなく `ignore` にした理由

`ds-entry.tsx` は `export *` のみの design-sync bundle 専用 barrel。`entry` に登録すると、そこから到達する **ui の全 export が「使用済み」扱いになり、真の未使用 export を隠す**。`ignore` なら当該ファイルの未使用報告だけを止め、downstream の実使用解析は変えない。実際、再 run 後も ui の未使用 export（`SortOption` 型・`NotImplementedOverlay`/`TagInput`/`YouTubePlayer` の重複等）は引き続き検出されており、マスクしていないことを確認済み。

## 結果（再 run 後の knip レポート）

偽陽性（unlisted dep/binary・unresolved import・config hint・design-sync files）が消え、**残るのは真の候補のみ**：

- Unused files: `apps/functions/src/tools/test-price-history-date.ts`（未配線の dead な debug ツール）/ `apps/functions/scripts/reset-batch-lock.js`（バッチロック手動リセットの意図的 break-glass ops スクリプト）
- Unused exports / types / duplicate exports: 過剰 export・冗長な再エクスポート（別タスクで個別判断）

knip は真の候補が残るため exit 1 のままだが、CI 非ブロッキング・「報告のみ」の設計どおり。

## 補足

`tsx` は `apps/web` の devDep として宣言する代替（依存の明示・drift 防止）もあるが、本 PR は knip config 衛生化に範囲を限定し package.json/lockfile は触っていない。

## 検証

`pnpm verify`（lint:docs + lint:tokens + lint + typecheck + test）→ EXIT=0。

## レビュー区分

戻せる **Two-Way Door**（ツーリング設定・CI 非ブロッキング）。AI レビューのみで自己マージ可の範囲。

🤖 Generated with [Claude Code](https://claude.com/claude-code)