### PR TITLE
feat(ui): 桜霞の状態色を提案 hue に寄せ AA 準拠で調整（success/warning/info）

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -58,12 +58,14 @@
 		--destructive-foreground: 60 9% 98%;
 
 		/* 状態色（情報=青 / 成功=緑 / 注意=琥珀）— 素の blue/green/amber 直書きの置換先（点3）。
-		 * いずれも text-on-white と white-on-bg の相互で WCAG AA 4.5:1 を満たすよう darken。危険=destructive を流用。 */
-		--info: 214 84% 44%; /* ≈ #1267ca */
+		 * 色相は Claude Design の桜霞提案（info 210 / success 150 / warning 38）に寄せつつ、
+		 * text-on-white・white-on-bg・text on bg-{status}/10 の3用途で WCAG AA 4.5:1 を満たすよう L を darken。
+		 * 危険=destructive を流用。 */
+		--info: 210 70% 42%; /* 青（提案 hue 210）。3用途とも ≈5.1:1↑ ✓ */
 		--info-foreground: 0 0% 100%;
-		--success: 142 70% 29%; /* ≈ #15803d (green-700) */
+		--success: 150 50% 30%; /* 緑（提案 hue 150）。3用途とも ≈5.4:1↑ ✓ */
 		--success-foreground: 0 0% 100%;
-		--warning: 30 92% 32%; /* ≈ #9c4f0a (amber-700/800)。琥珀は明色のため darken: text-warning on bg-warning/10 も 4.5:1（点3 で実測） */
+		--warning: 38 85% 32%; /* 琥珀（提案 hue 38。明色のため darken）。text on bg-warning/10 も ≈4.7:1 ✓ */
 		--warning-foreground: 0 0% 100%;
 
 		--border: 330 20% 91%; /* 桜霞: faint rose-grey */
@@ -141,11 +143,11 @@
 		--destructive: 0 62.8% 30.6%;
 		--destructive-foreground: 60 9% 98%;
 
-		/* 状態色 ダーク: text-* がダーク面で読めるよう明るめ。bg-* 用に foreground は暗色 */
-		--info: 214 90% 66%;
-		--info-foreground: 214 84% 14%;
-		--success: 142 60% 52%;
-		--success-foreground: 142 70% 10%;
+		/* 状態色 ダーク: text-* がダーク面で読めるよう明るめ。bg-* 用に foreground は暗色（hue は light と整合: info 210 / success 150 / warning 38） */
+		--info: 210 90% 66%;
+		--info-foreground: 210 84% 14%;
+		--success: 150 60% 52%;
+		--success-foreground: 150 70% 10%;
 		--warning: 38 95% 60%;
 		--warning-foreground: 32 90% 12%;
 


### PR DESCRIPTION
## 背景
[#685](https://github.com/nothink-jp/suzumina.click/pull/685) で導入した桜霞パレットに続く調整。状態色（success/warning/info）の **色相を Claude Design の提案に寄せる**。ただし提案値は L が高く WCAG AA を満たさないため、**色相だけ採用し L を darken して AA を確保**した。

## 変更（status トークンの色相を提案へ・明度は AA 準拠）
| トークン | 旧 | 新 | 提案 hue |
|---|---|---|---|
| `info` | `214 84% 44%` | `210 70% 42%` | 210 |
| `success` | `142 70% 29%` | `150 50% 30%` | 150 |
| `warning` | `30 92% 32%` | `38 85% 32%` | 38 |
| `destructive` | `0 72% 45%` | 据え置き | — |

`.dark` の hue も light と整合（info 210 / success 150）。

## AA（手計算・3用途）
status は `text-{status}`（白地・`bg-{status}/10` 上）と `bg-{status} text-{status}-foreground`（白文字）の両方で使われる。各色を3用途すべてで 4.5:1 以上に:
- info `210 70% 42%`: ≈5.1–5.5:1
- success `150 50% 30%`: ≈5.4–6.1:1
- warning `38 85% 32%`: ≈4.7–4.95:1（琥珀は明色のため最もタイト）

提案の元値（success L45% / warning L58% / info L58%）は白文字・白地テキストで 2.0–3.2:1 と未達のため**不採用**。

## destructive を据え置く理由
赤(0°)を維持し、新 primary（くすみローズ 340°）と色相を分離 → 危険と主役色の混同を避ける。

## 検証
- `pnpm verify` **exit 0**（lint:docs / lint:tokens / lint / typecheck / 全 test pass）
- 差分は `globals.css` の status トークンのみ（1 file）

## Door 区分
**Two-Way Door**（UI/表示・戻せる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)