### PR TITLE
fix(ui): dark の warning-foreground を hue 38 に揃える

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -149,7 +149,7 @@
 		--success: 150 60% 52%;
 		--success-foreground: 150 70% 10%;
 		--warning: 38 95% 60%;
-		--warning-foreground: 32 90% 12%;
+		--warning-foreground: 38 90% 12%;
 
 		--border: 326 10% 16%;
 		--input: 326 10% 16%;


### PR DESCRIPTION
## 背景
[#686](https://github.com/nothink-jp/suzumina.click/pull/686)（status 色相調整）の AI レビューで指摘された pre-existing nit。マージ後に取り残したため、独立 PR として整合させる。

## 変更
`.dark` の `--warning-foreground` が hue 32 のままで、同ブロックの `--warning`(38) と追加コメント「warning 38 に整合」と食い違っていた点を解消。

```diff
- --warning-foreground: 32 90% 12%;
+ --warning-foreground: 38 90% 12%;
```

L12% の near-black のため**見た目は不変**。純粋にコメントと値を一致させる一貫性修正（1 file・1 行）。

## 検証
- `pnpm verify` **exit 0**（lint / typecheck / 全 test pass）

## Door 区分
**Two-Way Door**（UI/表示・戻せる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)