### PR TITLE
fix(ui): エラーページ CTA の gradient を suzuka 系へ寄せ白文字 AA を回復

### DIFF
--- a/apps/web/src/app/buttons/error.tsx
+++ b/apps/web/src/app/buttons/error.tsx
@@ -48,7 +48,7 @@ export default function ButtonsError({
 					<div className="space-y-3">
 						<Button
 							onClick={reset}
-							className="w-full sm:w-auto bg-gradient-to-r from-suzuka-500 to-minase-700 hover:from-suzuka-600 hover:to-minase-800 text-white group"
+							className="w-full sm:w-auto bg-gradient-to-r from-suzuka-500 to-suzuka-700 hover:from-suzuka-600 hover:to-suzuka-800 text-white group"
 						>
 							<RefreshCw className="mr-2 h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
 							再読み込み

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -49,7 +49,7 @@ export default function GlobalError({
 							<div className="space-y-3">
 								<Button
 									onClick={reset}
-									className="w-full bg-gradient-to-r from-suzuka-500 to-minase-700 hover:from-suzuka-600 hover:to-minase-800 text-white flex items-center gap-2 group"
+									className="w-full bg-gradient-to-r from-suzuka-500 to-suzuka-700 hover:from-suzuka-600 hover:to-suzuka-800 text-white flex items-center gap-2 group"
 								>
 									<RefreshCw className="h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
 									再試行する

--- a/apps/web/src/app/videos/error.tsx
+++ b/apps/web/src/app/videos/error.tsx
@@ -44,7 +44,7 @@ export default function VideosError({
 					<div className="space-y-3">
 						<Button
 							onClick={reset}
-							className="w-full sm:w-auto bg-gradient-to-r from-suzuka-500 to-minase-700 hover:from-suzuka-600 hover:to-minase-800 text-white group"
+							className="w-full sm:w-auto bg-gradient-to-r from-suzuka-500 to-suzuka-700 hover:from-suzuka-600 hover:to-suzuka-800 text-white group"
 						>
 							<RefreshCw className="mr-2 h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
 							再読み込み

--- a/apps/web/src/app/works/error.tsx
+++ b/apps/web/src/app/works/error.tsx
@@ -46,7 +46,7 @@ export default function WorksError({
 					<div className="space-y-3">
 						<Button
 							onClick={reset}
-							className="w-full sm:w-auto bg-gradient-to-r from-suzuka-500 to-minase-700 hover:from-suzuka-600 hover:to-minase-800 text-white group"
+							className="w-full sm:w-auto bg-gradient-to-r from-suzuka-500 to-suzuka-700 hover:from-suzuka-600 hover:to-suzuka-800 text-white group"
 						>
 							<RefreshCw className="mr-2 h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
 							再読み込み


### PR DESCRIPTION
## 背景

桜霞パレット導入（minase のミルクティー化, #685〜）後、エラーページの CTA ボタンが使う gradient `from-suzuka-500 to-minase-700 ... text-white`（hover `to-minase-800`）の **minase 端で白文字コントラストが不足**していた。AudioButton / text-secondary 誤用を直した「桜霞パレット不整合の修正」の際に見つけた、同根のスコープ外の取りこぼし。

WCAG 実測（globals.css の現行 HSL で計算）:
- suzuka-500 端 + 白 = **5.71**（合格）
- minase-700 端 + 白 = **4.22**（通常テキスト 4.5:1 未満 ✗）

## 対応

gradient 端を **suzuka 系へ寄せる**（minase を深めるのではなく）。

| | before | after |
|---|---|---|
| 通常 | `from-suzuka-500 to-minase-700` | `from-suzuka-500 to-suzuka-700` |
| hover | `hover:from-suzuka-600 hover:to-minase-800` | `hover:from-suzuka-600 hover:to-suzuka-800` |

### suzuka 系を選んだ理由（桜霞の設計意図準拠）
- これらは各エラーページの **primary action**（再試行 / 再読み込み）。primary action → primary color、そして `--primary` は suzuka-500。CTA をローズ gradient にするのが意味的に正しい。
- 桜霞では **minase = 明るいミルクティーの secondary・限定使用**。白文字のために minase を最暗の `-800/-900`（ダーク / 最も濃いミルクティー）へ押し下げるのは、ミルクティーの性格に反し、サブ色を重 CTA に徴用することになる。suzuka へ寄せれば minase は本来のレーンに留まる。
- amber への再彩度化はしない（conventions.md / packages/ui/README.md）。

### コントラスト（修正後・light）
- suzuka-500 + 白 = 5.71 / suzuka-700 + 白 ≈ **8.4** / hover の suzuka-600・-800 はさらに濃く、gradient 全域・hover とも AA 余裕で合格。

## 変更ファイル（CTA の gradient 文字列のみ）
- `apps/web/src/app/global-error.tsx`
- `apps/web/src/app/buttons/error.tsx`
- `apps/web/src/app/videos/error.tsx`
- `apps/web/src/app/works/error.tsx`

## スコープ確認
白文字 gradient CTA はこの 4 ページのみ。他の `from-suzuka-500 to-minase-*` は `minase-500` 止まりの装飾（テキスト gradient / アバター / separator）でコントラスト問題なし。

## 既知の別件（本 PR の対象外）
これらの CTA は raw scale を `dark:` 変種なし + `text-white` 固定で使っており、ダークモードでは scale 反転で gradient 端が明色化し白文字が破綻する（suzuka でも同様）。既存挙動で、本 PR のライト時 AA 修正で悪化はしていない。必要なら別 PR で扱う。

## 検証
- `pnpm verify` パス（lint:docs + lint:tokens + lint + typecheck + test、カバレッジ閾値含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)