### PR TITLE
chore(infra): 未使用 Firestore 複合インデックス13件を terraform から撤去（SPR-213）

### DIFF
--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -11,47 +11,8 @@
 # 既存のFirestoreインデックス管理について
 # 注意: google_firestore_indexesデータソースは存在しないため、
 # 既存インデックスの管理は手動インポートまたはスクリプトで行う
-# 詳細: terraform/firestore_index_mapping.md を参照
-
-# ===================================================================
-# ✅ ACTIVE INDEXES - 使用中 (動画フィルター機能で実装済み)
-# ===================================================================
-# 
-# 以下のインデックスは詳細調査により実際に使用中と判明
-# videos/actions.ts で動画種別・カテゴリフィルターに使用
-#
-# videos コレクションのインデックス - liveBroadcastContent（昇順）と publishedAt（降順）
-# ✅ 使用中 - 動画種別フィルター（配信アーカイブ、プレミア公開、通常動画）
-resource "google_firestore_index" "videos_liveBroadcast_publishedAt_desc" {
-  project    = var.gcp_project_id
-  collection = "videos"
-
-  fields {
-    field_path = "liveBroadcastContent"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "publishedAt"
-    order      = "DESCENDING"
-  }
-}
-
-# ✅ 使用中 - 動画種別フィルター（古い順ソート）
-resource "google_firestore_index" "videos_liveBroadcast_publishedAt_asc" {
-  project    = var.gcp_project_id
-  collection = "videos"
-
-  fields {
-    field_path = "liveBroadcastContent"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "publishedAt"
-    order      = "ASCENDING"
-  }
-}
+# クエリ→インデックス対応表・棚卸し記録: Linear SPR-213 を参照
+# （定義の正本は本ファイル + firestore_indexes_audiobuttons_update.tf + live。旧 firestore_index_mapping.md は不在）
 
 # ===================================================================
 # 🔴 DELETED INDEX - videoType機能未実装により削除済み
@@ -181,27 +142,6 @@ resource "google_firestore_index" "audiobuttons_ispublic_createdat_desc" {
 #   }
 # }
 
-# audioButtons コレクションのインデックス - tags（配列）、isPublic（昇順）、createdAt（降順）
-resource "google_firestore_index" "audiobuttons_tags_ispublic_createdat_desc" {
-  project    = var.gcp_project_id
-  collection = "audioButtons"
-
-  fields {
-    field_path   = "tags"
-    array_config = "CONTAINS"
-  }
-
-  fields {
-    field_path = "isPublic"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "createdAt"
-    order      = "DESCENDING"
-  }
-}
-
 # audioButtons コレクションのインデックス - createdBy（昇順）、createdAt（降順）
 # 🔄 MIGRATED TO NEW FIELD NAMES - Use audiobuttons_creatorid_createdat_desc instead
 # resource "google_firestore_index" "audiobuttons_createdby_createdat_desc" {
@@ -224,22 +164,6 @@ resource "google_firestore_index" "audiobuttons_tags_ispublic_createdat_desc" {
 # 🟡 FUTURE FEATURE - レート制限機能用
 # audiobuttons_createdby_createdat_asc: レート制限機能復活時に追加
 
-# users コレクションのインデックス - isPublicProfile（昇順）、createdAt（降順）
-resource "google_firestore_index" "users_ispublicprofile_createdat_desc" {
-  project    = var.gcp_project_id
-  collection = "users"
-
-  fields {
-    field_path = "isPublicProfile"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "createdAt"
-    order      = "DESCENDING"
-  }
-}
-
 # ===================================================================
 # 🔶 FALLBACK INDEXES - フォールバック機能で利用 (無効化中)
 # ===================================================================
@@ -256,39 +180,6 @@ resource "google_firestore_index" "users_ispublicprofile_createdat_desc" {
 
 # Note: Single-field index for releaseDateISO is automatically created by Firestore
 # Removed dlsiteworks_releasedateiso_asc - use single field index controls instead
-
-# ✅ IMPORT REQUIRED - カテゴリフィルター機能で使用中
-# videos_categoryid_publishedat_desc: 既存インデックス（要インポート）
-resource "google_firestore_index" "videos_categoryid_publishedat_desc" {
-  project    = var.gcp_project_id
-  collection = "videos"
-
-  fields {
-    field_path = "categoryId"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "publishedAt"
-    order      = "DESCENDING"
-  }
-}
-
-# ✅ IMPORT REQUIRED - カテゴリフィルター機能（古い順ソート）
-resource "google_firestore_index" "videos_categoryid_publishedat_asc" {
-  project    = var.gcp_project_id
-  collection = "videos"
-
-  fields {
-    field_path = "categoryId"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "publishedAt"
-    order      = "ASCENDING"
-  }
-}
 
 # ===================================================================
 # 🔴 DELETED INDEXES - 配信詳細フィルター機能未実装により削除済み
@@ -318,60 +209,6 @@ resource "google_firestore_index" "videos_categoryid_publishedat_asc" {
 # date×workId×timestamp インデックスは外部で作成済み (Terraform外管理)
 
 # ===================================================================
-# 🔴 CRITICAL MISSING INDEXES - 即座に実装必要
-# ===================================================================
-
-# ✅ IMPORT REQUIRED - 管理者お問い合わせ管理機能で使用中
-# contacts_status_createdat_desc: 既存インデックス（要インポート）
-resource "google_firestore_index" "contacts_status_createdat_desc" {
-  project    = var.gcp_project_id
-  collection = "contacts"
-
-  fields {
-    field_path = "status"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "createdAt"
-    order      = "DESCENDING"
-  }
-
-  fields {
-    field_path = "__name__"
-    order      = "DESCENDING"
-  }
-}
-
-# ✅ IMPORT REQUIRED - 優先度別お問い合わせフィルター用
-resource "google_firestore_index" "contacts_priority_createdat_desc" {
-  project    = var.gcp_project_id
-  collection = "contacts"
-
-  fields {
-    field_path = "priority"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "createdAt"
-    order      = "DESCENDING"
-  }
-
-  fields {
-    field_path = "__name__"
-    order      = "DESCENDING"
-  }
-}
-
-# ===================================================================
-# 🟡 PLANNED INDEXES - 将来機能強化用
-# ===================================================================
-
-# 🟡 FUTURE FEATURE - Collection Group favorites (将来拡張用)
-# favorites_collection_group_audiobuttonid_createdat: 将来実装時に管理者用インデックスとして追加
-
-# ===================================================================
 # 📈 PRICE HISTORY INDEXES - 価格履歴サブコレクション用
 # ===================================================================
 
@@ -396,23 +233,6 @@ resource "google_firestore_index" "contacts_priority_createdat_desc" {
 # ===================================================================
 # 🆕 CIRCLE & CREATOR INDEXES - サークル・クリエイター機能用 (2025-07-21追加)
 # ===================================================================
-
-# circles コレクション - サークル一覧ページ用（将来実装）
-# 名前順、作品数順でのソート用
-resource "google_firestore_index" "circles_name_workcount_desc" {
-  project    = var.gcp_project_id
-  collection = "circles"
-
-  fields {
-    field_path = "name"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "workCount"
-    order      = "DESCENDING"
-  }
-}
 
 # creators サブコレクション works - Collection Group Query用
 #
@@ -470,63 +290,9 @@ resource "google_firestore_field" "works_workid_collection_group" {
 #   }
 # }
 
-# creators サブコレクション works - サークル別クリエイター検索用（複合インデックス）
-# 特定のサークルで活動するクリエイターを更新日時順で検索
-# このインデックスは複合クエリで必要
-resource "google_firestore_index" "creators_works_collection_group_circleid" {
-  project    = var.gcp_project_id
-  collection = "works"
-  database   = "(default)"
-
-  query_scope = "COLLECTION_GROUP"
-
-  fields {
-    field_path = "circleId"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "updatedAt"
-    order      = "DESCENDING"
-  }
-}
-
-# works コレクション - サークル別作品一覧用
-# サークルIDと登録日の複合インデックス
-resource "google_firestore_index" "works_circleid_registdate_desc" {
-  project    = var.gcp_project_id
-  collection = "works"
-
-  fields {
-    field_path = "circleId"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "registDate"
-    order      = "DESCENDING"
-  }
-}
-
 # ===================================================================
 # 🆕 WORKS COLLECTION OPTIMIZATION INDEXES - パフォーマンス最適化用 (2025-08-01追加)
 # ===================================================================
-
-# works コレクション - R18フィルタ + 最新順
-resource "google_firestore_index" "works_isr18_releasedateiso_desc" {
-  project    = var.gcp_project_id
-  collection = "works"
-
-  fields {
-    field_path = "isR18"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "releaseDateISO"
-    order      = "DESCENDING"
-  }
-}
 
 # works コレクション - カテゴリ + 最新順
 resource "google_firestore_index" "works_category_releasedateiso_desc" {
@@ -535,27 +301,6 @@ resource "google_firestore_index" "works_category_releasedateiso_desc" {
 
   fields {
     field_path = "category"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "releaseDateISO"
-    order      = "DESCENDING"
-  }
-}
-
-# works コレクション - カテゴリ + R18フィルタ + 最新順
-resource "google_firestore_index" "works_category_isr18_releasedateiso_desc" {
-  project    = var.gcp_project_id
-  collection = "works"
-
-  fields {
-    field_path = "category"
-    order      = "ASCENDING"
-  }
-
-  fields {
-    field_path = "isR18"
     order      = "ASCENDING"
   }
 
@@ -686,29 +431,26 @@ resource "google_firestore_index" "works_category_popular_desc" {
 # }
 
 # ===================================================================
-# 📊 SUMMARY - Terraform管理インデックス状況 (2025-08-04更新 - worksソート用インデックス追加)
+# 📊 SUMMARY - Terraform 管理インデックス（2026-06-24 SPR-213 で棚卸し）
 # ===================================================================
-# 
-# 【現在の構成】
-# ✅ 実装済み (使用中):          30個 (audioButtons: 8, users: 2, contacts: 2, favorites: 1, circles: 1, creatorMappings: 2, works: 14, videos: 2追加)
-# 🔴 削除推奨 (未使用):          10個 (videos関連、audioButtons startTime 1個)
-# 🆕 新規追加 (最適化):          15個 (works: 13, videos: 2)
-# 🔶 無効化中 (フォールバック):   4個 (createdBy関連、マイページ用)
-# ℹ️ 自動インデックス対応:        priceHistory (single-fieldで十分)
-# 
-# 【コスト影響】
-# - 削除による削減: 月額 -$20 (年間 -$240)
-# - 新規追加コスト: 月額 +$10 (年間 +$120) ※contacts/favorites/circles/creators追加
-# - 純削減効果:     月額 -$10 (年間 -$120)
-# 
-# 【実装アクション】
-# 1. 即座実装: terraform apply (contacts, favorites, circles, creators インデックス)
-# 2. 削除実行: terraform destroy -target (videos 未使用10個)
-# 3. priceHistory: Firestore自動インデックスで対応済み
-# 4. 監視継続: 新機能実装時のインデックス要件チェック
-# 
+#
+# 本ファイルが管理する複合インデックスは「実クエリで使われるもの」に限定する。
+# クエリ→インデックス対応の全体像・live との突合・削除記録は Linear SPR-213 を参照。
+#
+# 【管理対象（query-backed）】
+# - works_category_*（6）: /works のカテゴリ閲覧（work-query-builder.ts。category 単独は simple path で
+#   Firestore where(category)+orderBy を実行）
+# - audiobuttons_ispublic_createdat_desc（1）: 音声ボタン一覧 newest / autocomplete tags
+# - works.workId COLLECTION_GROUP（google_firestore_field・SPR-204）: creator-firestore.ts
+# - ※ audioButtons の creatorId / stats.* / videoId 系は firestore_indexes_audiobuttons_update.tf が管理
+#
+# 【SPR-213 で本ファイルから撤去した managed-unused（13）】
+# videos categoryId/liveBroadcast（×4）, works isR18 系（×2）, users isPublicProfile,
+# audioButtons tags, contacts status/priority（×2）, circles name+workCount,
+# works circleId+registDate, creators CG circleId+updatedAt
+# → いずれもアプリが「全件取得 + in-memory フィルタ」のため where() 0 hit（SPR-88/161）
+#
 # 【管理方針】
-# - 全複合インデックスをTerraformで一元管理
-# - 実装前にクエリパターン分析実施
-# - 未使用インデックスの定期的削除
-# - フォールバック戦略による障害耐性確保
+# - 「terraform に定義がある＝使用中」ではない。追加時は実クエリの where+orderBy 形を必ず確認する
+# - Emulator は複合インデックスを強制しないため、新規 where+orderBy は live/ADC 直結で要検証
+# - live にあり config に無い未管理インデックスの削除は gcloud で実施（SPR-213 で別途）


### PR DESCRIPTION
## 概要

[SPR-213](https://linear.app/nothink/issue/SPR-213) のクエリ→インデックス対応表（apps の全 Firestore クエリを12ファイル精読）で **「実クエリに使われていない」と確定した managed 複合インデックス13件**を terraform から撤去します。このアプリは works/videos/circles 一覧を**全件取得 + in-memory フィルタ**で実装している（SPR-88/161、database-schema.md にも明記）ため、これらの `where()`/`orderBy` は Firestore クエリとして発行されません。

`live44 のうち query-backed は14のみ`という調査結果のうち、本 PR は **terraform 管理下の未使用13件**を扱います（live のみの非管理16件は gcloud で別途）。

## 撤去する13件（`where()` 0 hit を確認済み）

| index | 理由（コード根拠） |
|---|---|
| `videos_categoryid_publishedat_desc` / `_asc` | videos は `orderBy(publishedAt)` 単独取得 + **全フィルタ in-memory**（`videos/actions.ts`）。`where("categoryId")` 0 hit |
| `videos_liveBroadcast_publishedAt_desc` / `_asc` | 同上。`where("liveBroadcastContent")` 0 hit。動画種別フィルタも in-memory（`_computed.videoType`）|
| `works_isr18_releasedateiso_desc` | R18 フィルタは `showR18` で in-memory。`where("isR18")` 0 hit |
| `works_category_isr18_releasedateiso_desc` | 同上 |
| `users_ispublicprofile_createdat_desc` | `where("isPublicProfile")` 0 hit |
| `audiobuttons_tags_ispublic_createdat_desc` | タグ絞り込みは `filterByTags` で in-memory。array-contains 0 hit |
| `contacts_status_createdat_desc` / `contacts_priority_createdat_desc` | contacts は `.add()`（書込）のみ。admin 一覧は **SPR-164 で撤去済** |
| `circles_name_workcount_desc` | circles は全件 `.get()` + in-memory sort |
| `works_circleid_registdate_desc` | サークル作品は全件 `.get()` + in-memory filter（`circles/[circleId]/actions.ts`）|
| `creators_works_collection_group_circleid` | CG クエリは `workId` のみ（`creator-firestore.ts`）。`circleId+updatedAt` の CG クエリは存在しない |

## 維持（query-backed・触らない）

- `works_category_*`（6）— /works カテゴリ閲覧（category 単独は simple path で `where(category)+orderBy` 実行）
- `audiobuttons_ispublic_createdat_desc` — 音声ボタン一覧 newest / autocomplete tags
- `works.workId` COLLECTION_GROUP field（`google_firestore_field`・SPR-204）
- audioButtons の `creatorId`/`stats.*`/`videoId` 系は **`firestore_indexes_audiobuttons_update.tf` が管理**（本 PR 対象外）

あわせて、陳腐化していた SUMMARY を実態に是正し、不在ファイル `firestore_index_mapping.md` への参照を SPR-213 へ修正。

## ⚠️ apply 時の影響 / レビュー観点（One-Way Door）

- `terraform apply` で **live の該当13インデックスが destroy** されます（plan に `13 to destroy`。※#700 未 apply の場合は budget topic destroy も混ざる点に注意）。
- 複合インデックス削除は本番クエリを壊しうる（`FAILED_PRECONDITION`）。本表は**静的解析**ベースのため、**apply 後に `/works`・`/videos`・`/buttons`・お問い合わせ・サークルページの表示/絞り込み/ソートが正常か確認**してください。
- `terraform/` 変更につき SPR-37 上、ご自身レビュー + apply 必須。plan が「13インデックスの destroy のみ（他リソースに change/destroy が無い）」であることを確認のうえ apply してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)