### PR TITLE
docs(infra): firestore_indexes.tf の stale NOTES を是正（SPR-213 完了）

### DIFF
--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -195,18 +195,15 @@ resource "google_firestore_index" "audiobuttons_ispublic_createdat_desc" {
 # videos_livestreamingdetails_null_publishedat_asc: 削除完了
 
 # ===================================================================
-# ℹ️  NOTES - 自動作成・外部管理インデックス
+# ℹ️  NOTES - Firestore 自動作成（single-field）インデックス
 # ===================================================================
-# 
-# works コレクション:
-# - category×releaseDateISO: 既存インデックス使用 (Terraform外管理)
-# - price.current, rating.stars: Single-field自動作成
-# 
-# favorites コレクション:
-# - Single-fieldインデックス: Firestore自動作成
-
-# dlsite_timeseries_raw コレクション - 既存インデックス使用
-# date×workId×timestamp インデックスは外部で作成済み (Terraform外管理)
+#
+# - works: price.current / rating.stars / rating.count / releaseDateISO の単一フィールド
+#   orderBy は single-field index で自動対応（category との複合のみ上で明示定義）
+# - favorites（users/{uid}/favorites サブコレクション）: addedAt 等の単一フィールドは自動作成
+#
+# 旧 dlsite_timeseries_raw / dlsite_timeseries_daily コレクションと収集関数は統合アーキテクチャ移行で
+# 廃止済み（価格履歴の正本は works/{workId}/priceHistory）。残存していた孤立複合インデックスも SPR-213 で削除。
 
 # ===================================================================
 # 📈 PRICE HISTORY INDEXES - 価格履歴サブコレクション用


### PR DESCRIPTION
## 概要

[SPR-213](https://linear.app/nothink/issue/SPR-213) のインデックス棚卸し完了に伴い、`firestore_indexes.tf` の `ℹ️ NOTES` セクションに残っていた陳腐化コメントを是正します。**コメントのみの変更で `terraform plan` は no-op**（リソース定義は無変更）。

## 変更点

- **`dlsite_timeseries_raw` の「既存インデックス使用 / 外部で作成済み (Terraform外管理)」を削除**
  当該コレクションと収集関数は統合アーキテクチャ移行で**廃止済み**（`docs/reference/database-schema.md` / `infrastructure-architecture.md` にも明記）。残存していた孤立複合インデックスも **SPR-213 で gcloud 削除済み**（live コレクションは 0 ドキュメント）。
- **`works: category×releaseDateISO ... (Terraform外管理)` の誤記を撤去**
  `works_category_releasedateiso_desc/asc` は本ファイルで **managed リソースとして定義済み**のため「Terraform外管理」は矛盾（2025-08 のリソース追加前の記述が残存していた）。
- single-field 自動作成の補足のみ残し、価格履歴の正本（`works/{workId}/priceHistory` サブコレクション）への参照を追記。

## 背景（SPR-213 棚卸しの最終状態）

live 複合インデックス **44 → 14（query-backed のみ）** に収束:
- unmanaged-dead 16 を gcloud 削除
- managed-unused 13 を [#701](https://github.com/nothink-jp/suzumina.click/pull/701) で terraform 撤去 → apply
- 孤立の `dlsite_timeseries_raw` 1 を gcloud 削除（本 PR でコメントも是正）

post-cleanup の `FAILED_PRECONDITION` はゼロ。

## レビュー

`terraform/` だが**コメントのみ・plan no-op**。念のため plan で「No changes」を確認のうえ merge してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)