### PR TITLE
fix(infra): Firestore index alert に resource.type 制約を追加（#703 apply 400 修正）

### DIFF
--- a/terraform/monitoring_firestore_index.tf
+++ b/terraform/monitoring_firestore_index.tf
@@ -32,13 +32,32 @@ resource "google_monitoring_alert_policy" "firestore_missing_index" {
   project      = var.gcp_project_id
   combiner     = "OR"
 
+  # log-based metric は web(cloud_run_revision) と functions(cloud_function) の両ログから時系列を生成する。
+  # monitoring の alert filter は単一 resource.type の制約が必須（OR 不可）なため resource.type ごとに
+  # condition を分け、combiner=OR でいずれかが発火したら通知する。
+  # metric type は .name（メトリクス名のみ）で参照する（.id は provider 差でフルパス化し得るため・#703 レビュー）。
   conditions {
-    display_name = "Firestore で index 要求エラー（FAILED_PRECONDITION）検出"
+    display_name = "Firestore index 要求エラー（Cloud Run / web）"
 
     condition_threshold {
-      # .name（メトリクス名のみ）を使う。.id は provider バージョンで projects/.../metrics/ の
-      # フルパスになり得て無効 metric type になるため、曖昧さのない .name に揃える（#703 レビュー）。
-      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.firestore_missing_index.name}\""
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.firestore_missing_index.name}\" resource.type=\"cloud_run_revision\""
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+
+  conditions {
+    display_name = "Firestore index 要求エラー（Cloud Functions）"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.firestore_missing_index.name}\" resource.type=\"cloud_function\""
 
       aggregations {
         alignment_period   = "300s"


### PR DESCRIPTION
## 概要

[#703](https://github.com/nothink-jp/suzumina.click/pull/703) merge 後の `terraform apply` が **alert policy 作成で 400 エラー**になりました（plan は通過、apply で失敗）。

```
Error 400: Field alert_policy.conditions[0].condition_threshold.filter had an invalid value
... must specify a restriction on "resource.type" in the filter
```

## 原因

monitoring の alert filter は **`resource.type` の制約が必須**ですが、condition の filter が `metric.type` のみで `resource.type` を欠いていました（稼働中の `monitoring_dlsite.tf` は `resource.type="cloud_function"` を付与しており、こちらが正）。

## 修正

log-based metric は web(`cloud_run_revision`)と functions(`cloud_function`)の両ログから時系列を生成するため、**`resource.type` ごとに condition を分割**し `combiner=OR` でいずれか発火させます。各 condition は稼働中の dlsite alert と同形（`metric.type` + `resource.type`）。

## 状態（重要）

- 失敗した apply で **`google_logging_metric.firestore_missing_index` は作成済み**（terraform state にあり）。
- 本 PR を merge → apply すると **alert policy のみ create**（metric は no-op）。
- `.name` 参照（#703 レビュー対応）は反映済み。apply 400 はあくまで `resource.type` 欠落が原因で、`.name` 化自体は正しく動作（エラーログの filter が `logging.googleapis.com/user/firestore_missing_index_errors` で `projects/` プレフィックス無し＝正）。

## レビュー / apply

`terraform/` のみ。plan で「alert policy 1件の create のみ（metric は変更なし）」を確認のうえ apply してください。apply 後、ログに `requires an index` を一度流して通知到達を確認すると確実です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)