### PR TITLE
fix(web): autocomplete タイトル補完を正しいフィールド名に修正（SPR-214）

### DIFF
--- a/apps/web/src/actions/__tests__/autocomplete.test.ts
+++ b/apps/web/src/actions/__tests__/autocomplete.test.ts
@@ -45,7 +45,14 @@ describe("getAutocompleteSuggestions", () => {
 				audioButtons: [
 					{
 						id: "b1",
-						data: { isPublic: true, tags: ["ゲーム", "実況"], title: "ゲーム配信", playCount: 50 },
+						// 実スキーマのフィールド名で mock する（buttonText / stats.playCount）。
+						// 旧 title / playCount は存在せず、タイトル候補が常に空になっていた（SPR-214）。
+						data: {
+							isPublic: true,
+							tags: ["ゲーム", "実況"],
+							buttonText: "ゲーム配信",
+							stats: { playCount: 50 },
+						},
 					},
 				],
 				videos: [{ id: "v1", data: { title: "ゲーム実況動画" } }],

--- a/apps/web/src/actions/autocomplete.ts
+++ b/apps/web/src/actions/autocomplete.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { getFirestore } from "@/lib/firestore";
+import * as logger from "@/lib/logger";
 
 const AutocompleteQuerySchema = z.object({
 	q: z.string().min(1).max(100),
@@ -98,7 +99,11 @@ async function getTagSuggestions(
 		);
 
 		return uniqueSuggestions.slice(0, limit);
-	} catch (_error) {
+	} catch (error) {
+		// index 欠落/フィールド drift を silent に握りつぶさない（CLAUDE.md / SPR-213 Tier3 監視に効かせる）
+		logger.error("autocomplete: タグ候補の取得に失敗", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return [];
 	}
 }
@@ -113,7 +118,7 @@ async function getTitleSuggestions(
 		const audioButtonsRef = firestore.collection("audioButtons");
 		const audioButtonsSnapshot = await audioButtonsRef
 			.where("isPublic", "==", true)
-			.orderBy("playCount", "desc")
+			.orderBy("stats.playCount", "desc")
 			.limit(200)
 			.get();
 
@@ -121,12 +126,14 @@ async function getTitleSuggestions(
 
 		audioButtonsSnapshot.docs.forEach((doc) => {
 			const data = doc.data();
-			if (data.title?.toLowerCase().includes(query.toLowerCase())) {
+			// audioButtons の表示テキストは buttonText（title フィールドは存在しない）。
+			// 再生数は stats.playCount（旧 playCount から移行済み）。
+			if (data.buttonText?.toLowerCase().includes(query.toLowerCase())) {
 				titleSuggestions.push({
 					id: `audio-title-${doc.id}`,
-					text: data.title,
+					text: data.buttonText,
 					type: "title",
-					count: data.playCount || 0,
+					count: data.stats?.playCount || 0,
 				});
 			}
 		});
@@ -135,7 +142,10 @@ async function getTitleSuggestions(
 		return titleSuggestions
 			.sort((a, b) => (b.count || 0) - (a.count || 0))
 			.slice(0, Math.floor(limit / 2));
-	} catch (_error) {
+	} catch (error) {
+		logger.error("autocomplete: タイトル候補の取得に失敗", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return [];
 	}
 }
@@ -164,7 +174,10 @@ async function getVideoSuggestions(
 		});
 
 		return videoSuggestions.slice(0, Math.floor(limit / 4));
-	} catch (_error) {
+	} catch (error) {
+		logger.error("autocomplete: 動画候補の取得に失敗", {
+			error: error instanceof Error ? error.message : String(error),
+		});
 		return [];
 	}
 }


### PR DESCRIPTION
## 概要

[SPR-214](https://linear.app/nothink/issue/SPR-214)。`apps/web/src/actions/autocomplete.ts` の `getTitleSuggestions` が**旧フィールド名でクエリ・参照**しており、**タイトル補完候補が常に空**（silent fail）になっていた不具合の修正。SPR-213 の index 棚卸し中に発見。

## 修正

| 箇所 | 旧（バグ） | 新 |
|---|---|---|
| orderBy | `playCount` | `stats.playCount`（対応 index `audiobuttons_ispublic_stats_playcount_desc` は managed/live に存在） |
| テキスト一致/表示 | `data.title` | `data.buttonText`（audioButtons に `title` は無い。正本 `shared-types/audio-button.ts`） |
| count | `data.playCount` | `data.stats?.playCount` |

旧コードでは `orderBy("playCount")` が `isPublic + playCount` の index を要求して `FAILED_PRECONDITION` になり、`catch { return [] }` で**ログにも出ず**空配列を返していた（仮にクエリが通っても `data.title` が undefined で候補ゼロ）。

## 併せて（SPR-213 連動・再発防止）

`getTagSuggestions` / `getTitleSuggestions` / `getVideoSuggestions` の **3つの silent catch に `logger.error` を追加**。index 欠落・フィールド drift を握りつぶさず、SPR-213 Tier3 の監視アラート（`requires an index`）に効かせる（CLAUDE.md の新ルール「`FAILED_PRECONDITION` を catch で握りつぶさない」に整合）。

## テスト

`autocomplete.test.ts` の mock を**実スキーマ（`buttonText` / `stats.playCount`）に修正**。旧 mock は `title` / `playCount` を渡すことで buggy 経路を pass させていた（＝テストもバグを追認していた）。

- autocomplete test **5 passed** / web typecheck green

## レビュー

UI ロジック（Server Action）の Two-Way Door。`stats.playCount` の index は本番に存在し、`buttonText` はスキーマ正本どおり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)