### PR TITLE
feat(infra): 公開コンテンツページを Cloudflare エッジキャッシュ化（respect_origin・SPR-221）

### DIFF
--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -77,14 +77,17 @@ resource "cloudflare_ruleset" "cache_rules" {
   }
 
   # 1b. 個人化/認証ページ: キャッシュ完全無効（多重防御 / SPR-221）
-  #   下の #5 公開コンテンツ rule は respect_origin で origin の no-store を尊重するため
-  #   個人化ページは本来キャッシュされないが、念のため個人化セクションを明示バイパスする。
+  #   #5 公開コンテンツ rule は respect_origin で origin の no-store を尊重するため個人化ページは
+  #   本来キャッシュされない（Cloudflare は HTML をデフォルトでキャッシュしないことも実測で確認）が、
+  #   念のため明示バイパスする。/buttons/ を含めるのは /buttons/[id] が per-user 状態を SSR に焼くのに
+  #   public を返す footgun（SPR-222）のため＝origin ヘッダを信用せず CDN 側で明示除外（多重防御）。
+  #   /buttons 一覧は末尾スラッシュ無しなのでここに一致せず #5 でキャッシュされる。
   rules {
     action = "set_cache_settings"
     action_parameters {
       cache = false
     }
-    expression  = "(starts_with(http.request.uri.path, \"/settings\") or starts_with(http.request.uri.path, \"/favorites\") or starts_with(http.request.uri.path, \"/users\") or starts_with(http.request.uri.path, \"/auth\"))"
+    expression  = "(starts_with(http.request.uri.path, \"/settings\") or starts_with(http.request.uri.path, \"/favorites\") or starts_with(http.request.uri.path, \"/users\") or starts_with(http.request.uri.path, \"/auth\") or starts_with(http.request.uri.path, \"/buttons/\"))"
     description = "個人化/認証: キャッシュ無効"
     enabled     = true
   }
@@ -189,7 +192,8 @@ resource "cloudflare_ruleset" "cache_rules" {
         mode = "respect_origin"
       }
     }
-    expression  = "(starts_with(http.request.uri.path, \"/works\") or starts_with(http.request.uri.path, \"/videos\") or starts_with(http.request.uri.path, \"/circles\") or starts_with(http.request.uri.path, \"/creators\") or http.request.uri.path eq \"/buttons\")"
+    # 前方一致を「ちょうど一致 or サブパス」に厳密化し、将来 /workspace 等が誤マッチするのを防ぐ（minor）
+    expression  = "(http.request.uri.path eq \"/works\" or starts_with(http.request.uri.path, \"/works/\") or http.request.uri.path eq \"/videos\" or starts_with(http.request.uri.path, \"/videos/\") or http.request.uri.path eq \"/circles\" or starts_with(http.request.uri.path, \"/circles/\") or http.request.uri.path eq \"/creators\" or starts_with(http.request.uri.path, \"/creators/\") or http.request.uri.path eq \"/buttons\")"
     description = "公開コンテンツ: origin Cache-Control 尊重でエッジキャッシュ（/buttons は一覧のみ）"
     enabled     = true
   }

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -76,6 +76,19 @@ resource "cloudflare_ruleset" "cache_rules" {
     enabled     = true
   }
 
+  # 1b. 個人化/認証ページ: キャッシュ完全無効（多重防御 / SPR-221）
+  #   下の #5 公開コンテンツ rule は respect_origin で origin の no-store を尊重するため
+  #   個人化ページは本来キャッシュされないが、念のため個人化セクションを明示バイパスする。
+  rules {
+    action = "set_cache_settings"
+    action_parameters {
+      cache = false
+    }
+    expression  = "(starts_with(http.request.uri.path, \"/settings\") or starts_with(http.request.uri.path, \"/favorites\") or starts_with(http.request.uri.path, \"/users\") or starts_with(http.request.uri.path, \"/auth\"))"
+    description = "個人化/認証: キャッシュ無効"
+    enabled     = true
+  }
+
   # 2. Next.js 静的アセット: 1年キャッシュ（ビルドハッシュで immutable）
   rules {
     action = "set_cache_settings"
@@ -147,6 +160,37 @@ resource "cloudflare_ruleset" "cache_rules" {
     }
     expression  = "(http.request.uri.path eq \"/\")"
     description = "ホームページ: PPR 動的鮮度確保のため 60 秒キャッシュ"
+    enabled     = true
+  }
+
+  # 5. 公開コンテンツページ: origin の Cache-Control を尊重してエッジキャッシュ（SPR-221）
+  #
+  #   prerender 済み・公開のコンテンツ一覧/詳細をエッジ配信し、min_instances=0 時の
+  #   オリジン cold start をユーザーから不可視にする。origin が出す stale-while-revalidate=300 を
+  #   respect_origin で尊重 → 再検証はバックグラウンドで行われ、ユーザーは常に即座にキャッシュ応答を得る
+  #   （ホームページ #4 が override_origin=60 なのは min=1 前提で鮮度を固定する設計。こちらは min=0 を
+  #   狙うため swr を活かす respect_origin を採用する点が異なる）。
+  #
+  #   安全性: respect_origin は origin の Cache-Control を尊重するため、private/no-store を返す
+  #   個人化ページは自動でキャッシュされない。ただし origin が誤って public を返す例外
+  #   （/buttons/[id] = per-user 状態を SSR に焼くのに public; SPR-222）があるため、
+  #   /buttons は一覧（path eq "/buttons"）のみ対象とし /buttons/* 詳細は含めない。
+  #   SPR-223 で /buttons/[id] を純公開化したら starts_with("/buttons") へ拡張可能。
+  #
+  #   RSC ナビゲーションは Next.js が ?_rsc= クエリを付けるため cache key で自然に分離される。
+  rules {
+    action = "set_cache_settings"
+    action_parameters {
+      cache = true
+      edge_ttl {
+        mode = "respect_origin"
+      }
+      browser_ttl {
+        mode = "respect_origin"
+      }
+    }
+    expression  = "(starts_with(http.request.uri.path, \"/works\") or starts_with(http.request.uri.path, \"/videos\") or starts_with(http.request.uri.path, \"/circles\") or starts_with(http.request.uri.path, \"/creators\") or http.request.uri.path eq \"/buttons\")"
+    description = "公開コンテンツ: origin Cache-Control 尊重でエッジキャッシュ（/buttons は一覧のみ）"
     enabled     = true
   }
 }


### PR DESCRIPTION
親: SPR-215 / **SPR-221**（#2 min-instances=0 と #3 Firestore reads を一手で解く keystone）

## 背景
運用コスト見直しで、コンテンツページ（/works,/buttons 等）が `cf-cache-status: DYNAMIC`＝毎回オリジン直と判明。これらは **prerender 済み・公開で origin が `public, s-maxage` を出している**のに、現 cache rule が `/`・`/_next/*` しか対象にしていないため素通りしていた。エッジキャッシュ化すると **min=0 時の cold start を不可視化**でき、オリジン到達減で **Firestore reads も削減**できる。

## 変更（`terraform/cloudflare.tf`）
2つの cache rule を追加:
1. **個人化/認証バイパス**（多重防御）: `/settings`,`/favorites`,`/users`,`/auth` を `cache=false`
2. **公開コンテンツキャッシュ**: `/works`,`/videos`,`/circles`,`/creators`（starts_with）+ `/buttons`（一覧のみ・eq）を `cache=true` + `edge_ttl=respect_origin`

## 設計・安全性
- **respect_origin** は origin の `Cache-Control` を尊重 → `private/no-store` の個人化ページは**自動でキャッシュされない**（force-cache の `override_origin` は使わない）
- ホームページ #4 が `override_origin=60` なのは min=1 前提の鮮度固定。本ルールは **min=0 を狙うため swr を活かす respect_origin**（`stale-while-revalidate=300` で再検証をバックグラウンド化＝ユーザーは cold start を待たない）
- **/buttons/[id] は除外**: per-user 状態を SSR に焼くのに `public` を返す例外（**SPR-222** footgun）のため。`/buttons` 一覧のみキャッシュ。**SPR-223** で純公開化後に `starts_with("/buttons")` へ拡張可能
- RSC ナビは Next.js の `?_rsc=` クエリで cache key が自然分離（ホームページで実証済み）
- `terraform fmt` / `terraform validate` 通過

## 検証計画（本番 apply 後・ステージング不可）
- [ ] 公開ページ（/works,/videos,/circles,/creators,/buttons）が `cf-cache-status: HIT` になる
- [ ] **個人化ページ（/favorites,/settings,/buttons/[id]）が依然キャッシュされない**（最重要・漏洩チェック）
- [ ] **ログイン/未ログインで応答が同一か diff**（ヘッダだけ信用しない。SPR-222 の教訓）
- [ ] クライアントサイドナビ（RSC）が壊れない
- [ ] PPR 動的部分の鮮度が許容内（swr 窓 = s-maxage + 300s）
- [ ] Firestore reads の減少を Monitoring で確認（#3 効果）
- 上記 OK 後に別途 **min-instances=0**（SPR-217）へ

## リスク / ロールバック
- One-Way Door（Cloudflare/Terraform・本番キャッシュ）。**ステージング不可＝apply 後にライブ検証**する前提
- 最大リスク = 個人化ページの誤キャッシュ（漏洩）。respect_origin + 明示バイパス + /buttons詳細除外 + apply 後の login/logout diff で多重防御
- 問題時は本PRを revert すれば即座に従来挙動へ

関連: SPR-217(#2) / SPR-218(#3) / SPR-222(footgun) / SPR-223(/buttons/[id] 再設計)

🤖 Generated with [Claude Code](https://claude.com/claude-code)