### PR TITLE
perf(web): Firestore reads 削減 — 集計の全件スキャン TTL 延長（SPR-218）

### DIFF
--- a/apps/web/src/app/__tests__/sitemap.test.ts
+++ b/apps/web/src/app/__tests__/sitemap.test.ts
@@ -381,12 +381,12 @@ describe("sitemap", () => {
 		expect(urls).toContain("https://suzumina.click/buttons/create");
 	});
 
-	// 動的部分は unstable_cache で 1h キャッシュされる前提 (#416)。
+	// 動的部分は unstable_cache で 24h キャッシュされる前提 (#416 / SPR-218 で 1h→24h)。
 	// キャッシュキー / revalidate / tags が意図せず変わったら検知する。
-	it("回帰検知: unstable_cache が固定キー・revalidate=3600・tag=sitemap で登録される", () => {
+	it("回帰検知: unstable_cache が固定キー・revalidate=86400・tag=sitemap で登録される", () => {
 		expect(unstableCacheCalls).toContainEqual({
 			keys: ["sitemap-dynamic-pages"],
-			options: expect.objectContaining({ revalidate: 3600, tags: ["sitemap"] }),
+			options: expect.objectContaining({ revalidate: 86400, tags: ["sitemap"] }),
 		});
 	});
 });

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -5,11 +5,14 @@ import { getFirestore } from "@/lib/firestore";
 import { warn as logWarn } from "@/lib/logger";
 
 // build 時の Firestore アクセスを避け、リクエスト時に Cloud Run の SA credentials で生成する (SPR-60)
-// Firestore 取得部分は unstable_cache で 1 時間キャッシュし、毎リクエストでクエリが走らないようにする
+// Firestore 取得部分は unstable_cache でキャッシュし、毎リクエストでクエリが走らないようにする
 // cacheComponents 有効下では route segment config `dynamic` が使えないため、
 // `await connection()` でリクエストスコープに入り build-time prerender を回避する
-
-const SITEMAP_REVALIDATE_SECONDS = 3600;
+//
+// SPR-218: works+videos+buttons の全件スキャンが Firestore QUERY reads の一因（reads の96%がQUERY）。
+// sitemap に時間単位の鮮度は不要（クローラの再取得は低頻度・新規コンテンツは数時間〜1日内で十分）なため、
+// TTL を 1h→24h に延長して全件 read 頻度を 24分の1 に抑える。
+const SITEMAP_REVALIDATE_SECONDS = 86400;
 
 const getDynamicSitemapPages = unstable_cache(
 	async (baseUrl: string): Promise<MetadataRoute.Sitemap> => {

--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -262,10 +262,12 @@ async function fetchPopularGenres(limit: number): Promise<PopularGenre[]> {
 	).then((result) => (result.success ? result.data : []));
 }
 
-// 全 works を読むためコスト大。ジャンルは works 追加（2h DLsite 同期）時のみ変化する低頻度データのため
-// 10 分キャッシュで /works 表示ごとの全件 read を抑える（SPR-161）。
+// 全 works(約2069件)を読むためコスト大。ジャンルは works 追加（2h DLsite 同期）時のみ変化する低頻度データ。
+// SPR-218: reads 実測で、この全件スキャンが Firestore QUERY reads（全体の96%がQUERY）の主因の一つと判明。
+// ジャンルは低頻度変化で 6h 鮮度で十分なため TTL を 10分→6h に延長し全件 read 頻度を ~36分の1 に抑える
+// （SPR-161 の 10 分は短すぎた）。即時反映が要る場合は works 更新時に revalidateTag("works-list") で対応。
 const getPopularGenresCached = unstable_cache(fetchPopularGenres, ["popular-genres"], {
-	revalidate: 600,
+	revalidate: 21600,
 	tags: ["works-list"],
 });
 


### PR DESCRIPTION
親: SPR-215 / **SPR-218**（#3 Firestore reads 削減）

## 背景・実測による源の切り分け
Firestore reads = **24.4M/月**（Billing 上 App Engine ¥1,452/月）。実測で type 別内訳は **QUERY 96% / LOOKUP 4% / NOT_FOUND 0.2%** ＝ reads の大半は**コレクションスキャン**。源を切り分け:
- youtube 関数は `batch.set(merge)` の**書き込み専用**（read 源でない）
- リスト一覧（/works 等）は `limit(12)`+offset で **paginated＝主因ではない**（当初推定の訂正）
- 真因は **web の全件スキャン集計**: `getPopularGenres`（works 2069全件・10分cache）と `sitemap`（works+videos+buttons 全件・1h cache）
- dlsite `collectionGroup("works")` が2時間毎に ~2M/月の二次寄与

## 変更
- `app/works/actions.ts` `getPopularGenres` の `unstable_cache` TTL: **600s(10分) → 21600s(6h)**
- `app/sitemap.ts` `SITEMAP_REVALIDATE_SECONDS`: **3600s(1h) → 86400s(24h)**

全件スキャンの頻度を **getPopularGenres ~36×・sitemap ~24×** 下げる。鮮度トレードオフは軽微（ジャンルは2h DLsite 同期でのみ変化・sitemap は時間単位の鮮度不要）。即時反映が要る場合は `revalidateTag("works-list")` で対応可。

## リスク
- Two-Way Door（app code・revert で即戻る）。挙動は不変で、変わるのはキャッシュ更新間隔のみ
- typecheck 通過

## 検証（マージ後）
- Firestore QUERY reads が Monitoring（`firestore.googleapis.com/document/read_count` type=QUERY）で減少することを実測（measure-by-changing-one-variable）
- 残れば次段: 複雑フィルタ検索（works 全件・uncached）のキャッシュ化を検討

関連: SPR-221（エッジキャッシュ）/ SPR-220（実額観測窓）

🤖 Generated with [Claude Code](https://claude.com/claude-code)