### PR TITLE
fix(web): /buttons/[id] の origin Cache-Control を private, no-store 化（共有キャッシュ漏洩 footgun・SPR-222）

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -267,8 +267,24 @@ const nextConfig = {
 					},
 				],
 			},
+			// videos/works は詳細も session を読まない純公開 shell なので一覧・詳細とも public。
 			{
-				source: "/(buttons|videos|works)/:path*",
+				source: "/(videos|works)/:path*",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "public, s-maxage=120, stale-while-revalidate=300",
+					},
+				],
+			},
+			// buttons は一覧のみ public。/buttons/[id] は per-user 状態（お気に入り/高低評価）を
+			// SSR に焼くため、また /buttons/[id]/edit・/buttons/create は認証必須のため、
+			// 配下を public にすると共有キャッシュ漏洩になる（SPR-222 footgun）。
+			// CDN 側（terraform/cloudflare.tf）の設計（一覧のみキャッシュ・/buttons/* はバイパス）に
+			// origin の Cache-Control も揃え、CF 設定ドリフトや別プロキシ前段でも構造的に漏れないようにする。
+			// 恒久解（/buttons/[id] を純公開 shell + client island 化）は SPR-223。それが入れば public に戻せる。
+			{
+				source: "/buttons",
 				headers: [
 					{
 						key: "Cache-Control",
@@ -277,8 +293,18 @@ const nextConfig = {
 				],
 			},
 			// 認証必須・セッション依存ページは CDN エッジでキャッシュさせない
+			// （/buttons/:path+ は /buttons 一覧に一致せず詳細・編集・作成のみを対象にする）
 			{
 				source: "/(admin|settings|favorites|users)/:path*",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "private, no-store",
+					},
+				],
+			},
+			{
+				source: "/buttons/:path+",
 				headers: [
 					{
 						key: "Cache-Control",


### PR DESCRIPTION
## 背景（SPR-222 / 親: SPR-215 GCPコスト見直し）

`/buttons/[id]`（音声ボタン詳細）は per-user 状態（お気に入り/高評価/低評価）を SSR に焼き込みつつ、`next.config.mjs` の `/(buttons|videos|works)/:path*` 一括マッチャによって `cache-control: public, s-maxage=120, stale-while-revalidate=300` を出していた。共有キャッシュ（CDN/中間プロキシ）に乗ると **User A の状態が User B に配信される**漏洩になる dormant な footgun（SPR-221 のエッジキャッシュ化調査中に発見）。

同マッチャは per-user の `/buttons/[id]` だけでなく、認証必須の `/buttons/[id]/edit`・`/buttons/create` にも public を付けていた。

## CDN 側は既に正しい（変更不要）

`terraform/cloudflare.tf`（SPR-221）は rule #5（公開コンテンツ）を `/buttons` 一覧（`path eq "/buttons"`）のみ対象とし、別 bypass rule が `/buttons/` 配下を明示除外済み。残る穴は **origin（next.config.mjs）が public を出し続けていた点**で、CF 設定ドリフトや別プロキシ前段で踏む地雷だった。Terraform/CI/auth は一切触っていない。

## 変更

`apps/web/next.config.mjs` の Cache-Control マッチャを CDN 設計に揃えて分離:

| ルート | 変更前 | 変更後 |
|---|---|---|
| `/buttons`（一覧・public-safe） | public, s-maxage=120, swr=300 | 据え置き |
| `/buttons/[id]`（per-user） | public, s-maxage=120, swr=300 | **private, no-store** |
| `/buttons/[id]/edit`・`/buttons/create`（認証必須） | public, s-maxage=120, swr=300 | **private, no-store** |
| `/videos/*`・`/works/*`（純公開 shell） | public, s-maxage=120, swr=300 | 据え置き（`/(videos\|works)/:path*` に分離） |

`/buttons/:path+`（`+`＝1セグメント以上）が `/buttons` 一覧に一致しないため、public と private の二重一致＝Cache-Control 競合は発生しない。

## 検証

- **path matching**: Next 自身が `headers()` で使う compiled path-to-regexp で全代表パスを検証。`/buttons`→public のみ / `/buttons/abc`・`/buttons/abc/edit`・`/buttons/create`→private のみ / `/works/*`・`/videos/*`→public のみ。二重一致なし。
- **`pnpm verify`**: EXIT=0（lint:docs + lint:tokens + lint + typecheck + test 一括・カバレッジ閾値含む）。
- 実レスポンスヘッダは respect_origin の性質上デプロイ後に本番 curl で確認するのが筋（dev モードは HMR 用に no-store を被せるため検証に不向き）。

## スコープ

- next.config の cache header は **Two-Way Door**（戻せる）。
- これは **stopgap**。恒久解（`/buttons/[id]` を純公開 shell + client island 化して public に戻す）は **SPR-223**。

## 完了条件（SPR-222）

✅ `/buttons/[id]` が origin で共有キャッシュ不可（private, no-store）を出し、CF 設定ドリフトや別プロキシ前段でも構造的に誤キャッシュが起きない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)