### PR TITLE
fix(web): /works/[id]・/videos/[id] 詳細を private, no-store 化（per-user SSR 漏洩 stopgap・SPR-226）

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -267,24 +267,9 @@ const nextConfig = {
 					},
 				],
 			},
-			// videos/works は詳細も session を読まない純公開 shell なので一覧・詳細とも public。
+			// 公開コンテンツの「一覧」ページはエッジキャッシュ可（SPR-221）。
 			{
-				source: "/(videos|works)/:path*",
-				headers: [
-					{
-						key: "Cache-Control",
-						value: "public, s-maxage=120, stale-while-revalidate=300",
-					},
-				],
-			},
-			// buttons は一覧のみ public。/buttons/[id] は per-user 状態（お気に入り/高低評価）を
-			// SSR に焼くため、また /buttons/[id]/edit・/buttons/create は認証必須のため、
-			// 配下を public にすると共有キャッシュ漏洩になる（SPR-222 footgun）。
-			// CDN 側（terraform/cloudflare.tf）の設計（一覧のみキャッシュ・/buttons/* はバイパス）に
-			// origin の Cache-Control も揃え、CF 設定ドリフトや別プロキシ前段でも構造的に漏れないようにする。
-			// 恒久解（/buttons/[id] を純公開 shell + client island 化）は SPR-223。それが入れば public に戻せる。
-			{
-				source: "/buttons",
+				source: "/(buttons|videos|works)",
 				headers: [
 					{
 						key: "Cache-Control",
@@ -293,7 +278,6 @@ const nextConfig = {
 				],
 			},
 			// 認証必須・セッション依存ページは CDN エッジでキャッシュさせない
-			// （/buttons/:path+ は /buttons 一覧に一致せず詳細・編集・作成のみを対象にする）
 			{
 				source: "/(admin|settings|favorites|users)/:path*",
 				headers: [
@@ -303,8 +287,18 @@ const nextConfig = {
 					},
 				],
 			},
+			// 公開コンテンツの「詳細」ページ（:path+ ＝ 1 セグメント以上）は private, no-store。
+			// 3 詳細とも per-user 状態を SSR に焼く設計のため、public だと共有キャッシュ漏洩になる:
+			//   - /buttons/[id]: お気に入り/高低評価を SSR に焼く（SPR-222）。/edit・/create は認証必須
+			//   - /works/[id]:   作品評価（星/10選）を getWorkEvaluation で SSR に焼く
+			//   - /videos/[id]:  関連音声ボタンのお気に入り/高低評価を SSR に焼く（RelatedAudioButtonsServer）
+			// いずれも leaf の client が実状態を取り直さない（自己補正しない）ため、
+			// 共有キャッシュに乗ると User A の状態が User B に配信されうる。
+			// :path+ は一覧（/buttons・/videos・/works）に一致しないため public ルールと競合しない。
+			// これは stopgap で SPR-221 の詳細ページキャッシュを一時的に諦める取引。
+			// 恒久解は per-user を client island へ隔離して public に戻す（SPR-223 系）。
 			{
-				source: "/buttons/:path+",
+				source: "/(buttons|videos|works)/:path+",
 				headers: [
 					{
 						key: "Cache-Control",


### PR DESCRIPTION
## 背景（SPR-226 / 親: SPR-215・SPR-222 と同型）

[SPR-223](https://linear.app/nothink/issue/SPR-223)（/buttons/[id] 再設計）の調査中に、**SPR-222 と同型の per-user SSR 漏洩 footgun が /works/[id]・/videos/[id] にも存在**することが判明。buttons は SPR-222（#710）で private 化済み（dormant だった）のに対し、**works/videos 詳細は SPR-221（#707）後に origin が public を出し Cloudflare が実際にエッジキャッシュする経路が生きている**ため深刻度が高い。

### 漏洩機序
詳細ページが per-user 状態を **SSR に焼き込みつつ** `public, s-maxage=120, swr=300` を出す。leaf の client が実状態を取り直さない（自己補正しない）ため、共有キャッシュに乗ると **ログイン中の User B が User A の状態が焼かれたキャッシュを踏み、A の状態が B に配信される**。

| ページ | per-user の出所 | client 自己補正 |
|---|---|---|
| `/works/[id]` | `page.tsx:23` の `getWorkEvaluation()`（作品評価・星/10選）を SSR に焼く | `work-evaluation.tsx:20` `useState(initialEvaluation)` のみ＝**しない** |
| `/videos/[id]` | `related-audio-buttons-server.tsx:23` が関連ボタンのお気に入り/高低評価を SSR に焼く | 初期値 defined で client 再取得が発火せず＝**しない**（軽度・サイドバー6件） |

`curl -I https://suzumina.click/works/<id>` は `public, s-maxage=120` / `cf-cache-status: MISS`（respect_origin で次回キャッシュ）。`vary` に Cookie 無し＝共有キャッシュはユーザー非依存 → 漏洩経路が開いている。

## 変更

`apps/web/next.config.mjs` の Cache-Control を 3 詳細ページで統一整理（一覧は public 維持）:

| ルート | 変更後 |
|---|---|
| `/(buttons\|videos\|works)`（一覧） | public, s-maxage=120, swr=300 |
| `/(buttons\|videos\|works)/:path+`（詳細/編集/作成） | **private, no-store** |

`:path+`（1セグメント以上）は一覧に一致しないため public ルールと競合しない。

## ⚠️ トレードオフ

これは **SPR-221（#707）の「詳細ページ」エッジキャッシュを一時的に巻き戻す**（一覧は維持）。min=0 下で詳細が cold start を食う＝コスト/LCP の一時後退。SPR-222 で buttons がキャッシュを諦めたのと同じ取引で、**恒久解（per-user を client island へ隔離して public に戻す・SPR-223 系）までの stopgap**。

## 検証

- **path matching**: Next の compiled path-to-regexp で全代表パス検証。一覧→public のみ / 詳細→private のみ / settings 等→private-auth / circles・creators は既存 public ルールで別処理。二重一致なし。
- **`pnpm verify`**: EXIT=0（lint:docs + lint:tokens + lint + typecheck + test 一括）。初回 run の `audio-button-creator` テスト失敗は flaky（現在時刻依存・単独実行 20/20 passed・本変更と無関係）で再実行 EXIT=0。
- respect_origin の CF が origin の private を尊重するため terraform 変更は不要。実ヘッダはデプロイ後に本番 curl で確認するのが筋。

## スコープ
- next.config の cache header = **Two-Way Door**（戻せる）。terraform/auth/CI 不変。
- 恒久解は別 Issue（works/videos = SPR-226 恒久解節 / buttons = SPR-223）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)