### PR TITLE
feat(web): /buttons/[id] を純公開 shell + client island に再設計し public キャッシュへ復帰（SPR-223）

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -287,22 +287,50 @@ const nextConfig = {
 					},
 				],
 			},
-			// 公開コンテンツの「詳細」ページ（:path+ ＝ 1 セグメント以上）は private, no-store。
-			// 3 詳細とも per-user 状態を SSR に焼く設計のため、public だと共有キャッシュ漏洩になる:
-			//   - /buttons/[id]: お気に入り/高低評価を SSR に焼く（SPR-222）。/edit・/create は認証必須
-			//   - /works/[id]:   作品評価（星/10選）を getWorkEvaluation で SSR に焼く
-			//   - /videos/[id]:  関連音声ボタンのお気に入り/高低評価を SSR に焼く（RelatedAudioButtonsServer）
-			// いずれも leaf の client が実状態を取り直さない（自己補正しない）ため、
-			// 共有キャッシュに乗ると User A の状態が User B に配信されうる。
-			// :path+ は一覧（/buttons・/videos・/works）に一致しないため public ルールと競合しない。
-			// これは stopgap で SPR-221 の詳細ページキャッシュを一時的に諦める取引。
-			// 恒久解は per-user を client island へ隔離して public に戻す（SPR-223 系）。
+			// videos/works の「詳細」は per-user 状態を SSR に焼くため private, no-store（SPR-226 stopgap）:
+			//   - /works/[id]:  作品評価（星/10選）を getWorkEvaluation で SSR に焼く
+			//   - /videos/[id]: 関連音声ボタンのお気に入り/高低評価を SSR に焼く（RelatedAudioButtonsServer）
+			// leaf の client が実状態を取り直さないため、public だと User A の状態が User B に漏れる。
+			// 恒久解（per-user を client island へ隔離して public に戻す）は SPR-226 の恒久解節。
 			{
-				source: "/(buttons|videos|works)/:path+",
+				source: "/(videos|works)/:path+",
 				headers: [
 					{
 						key: "Cache-Control",
 						value: "private, no-store",
+					},
+				],
+			},
+			// buttons の認証必須ページは CDN エッジでキャッシュさせない:
+			//   - /buttons/create:   音声ボタン作成（ProtectedRoute）
+			//   - /buttons/[id]/edit: 音声ボタン編集（認証必須）
+			{
+				source: "/buttons/create",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "private, no-store",
+					},
+				],
+			},
+			{
+				source: "/buttons/:id/edit",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "private, no-store",
+					},
+				],
+			},
+			// buttons の「詳細」は SPR-223 で純公開 shell + client island 化し session を SSR で読まなくなったため
+			// public へ復帰（SPR-222 stopgap を解除し SPR-221 のエッジキャッシュ効果を回復）。
+			// :id((?!create$)[^/]+) ＝ 1 セグメント詳細から create を除外し、create-private と二重一致させない。
+			{
+				source: "/buttons/:id((?!create$)[^/]+)",
+				headers: [
+					{
+						key: "Cache-Control",
+						value: "public, s-maxage=120, stale-while-revalidate=300",
 					},
 				],
 			},

--- a/apps/web/src/app/buttons/[id]/page.tsx
+++ b/apps/web/src/app/buttons/[id]/page.tsx
@@ -3,7 +3,6 @@ import { Eye } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
-import { getFavoritesStatusAction } from "@/actions/favorites";
 import { getAudioButtonById } from "@/app/buttons/actions";
 import {
 	AudioButtonDetailHeader,
@@ -11,7 +10,6 @@ import {
 	AudioButtonDetailSidebar,
 	RelatedAudioButtons,
 } from "@/components/audio-button-detail";
-import { getCurrentUser } from "@/lib/auth/server";
 
 interface AudioButtonDetailPageProps {
 	params: Promise<{
@@ -101,40 +99,9 @@ export default async function AudioButtonDetailPage({ params }: AudioButtonDetai
 
 	const audioButton = result.data;
 
-	// ユーザーのセッションを取得
-	const user = await getCurrentUser();
-	const isAuthenticated = !!user;
-
-	// お気に入り状態を取得（認証済みの場合のみ）
-	let isFavorited = false;
-	let isLiked = false;
-	let isDisliked = false;
-
-	if (isAuthenticated && user?.discordId) {
-		try {
-			const favoritesStatusMap = await getFavoritesStatusAction([audioButton.id]);
-			isFavorited = favoritesStatusMap.get(audioButton.id) || false;
-		} catch (_error) {
-			// お気に入り状態の取得に失敗した場合はfalse
-			isFavorited = false;
-		}
-
-		// 高評価・低評価状態を取得
-		try {
-			const { getLikeDislikeStatusAction } = await import("@/actions/dislikes");
-			const likeDislikeStatusMap = await getLikeDislikeStatusAction([audioButton.id]);
-			const status = likeDislikeStatusMap.get(audioButton.id) || {
-				isLiked: false,
-				isDisliked: false,
-			};
-			isLiked = status.isLiked;
-			isDisliked = status.isDisliked;
-		} catch (_error) {
-			// 高評価・低評価状態の取得に失敗した場合はfalse
-			isLiked = false;
-			isDisliked = false;
-		}
-	}
+	// per-user 状態（お気に入り/高低評価/編集権限）はここで取得しない。
+	// 純公開 shell として session を読まず、各 client island が自分の状態を解決する（SPR-223）。
+	// これにより詳細ページを共有キャッシュ可（public）へ戻せる（SPR-222/226 の per-user SSR 漏洩を解消）。
 
 	return (
 		<div className="min-h-screen">
@@ -145,14 +112,7 @@ export default async function AudioButtonDetailPage({ params }: AudioButtonDetai
 				{/* メインコンテンツ: グリッドレイアウト */}
 				<div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-8">
 					{/* 左側: 音声ボタン詳細 */}
-					<AudioButtonDetailMainContent
-						audioButton={audioButton}
-						user={user}
-						isAuthenticated={isAuthenticated}
-						isFavorited={isFavorited}
-						isLiked={isLiked}
-						isDisliked={isDisliked}
-					/>
+					<AudioButtonDetailMainContent audioButton={audioButton} />
 
 					{/* 右側: 動画カード + ユーザーカード */}
 					<AudioButtonDetailSidebar

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-actions.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-actions.tsx
@@ -3,43 +3,33 @@ import { LikeDislikeButtons } from "@/components/audio/like-dislike-buttons";
 
 interface AudioButtonDetailActionsProps {
 	audioButtonId: string;
-	isFavorited: boolean;
 	favoriteCount: number;
 	likeCount: number;
-	isLiked: boolean;
-	isDisliked: boolean;
-	isAuthenticated: boolean;
 }
 
 export function AudioButtonDetailActions({
 	audioButtonId,
-	isFavorited,
 	favoriteCount,
 	likeCount,
-	isLiked,
-	isDisliked,
-	isAuthenticated,
 }: AudioButtonDetailActionsProps) {
+	// per-user 状態（お気に入り/高低評価）は SSR に焼かず、各 leaf が client で自己解決する
+	// （純公開 shell・SPR-223）。ここで渡すのは公開データ（件数）のみ。
 	return (
 		<div className="mb-6">
 			<div className="flex gap-2 flex-wrap">
 				{/* お気に入りボタン */}
 				<FavoriteButton
 					audioButtonId={audioButtonId}
-					isFavorited={isFavorited}
 					favoriteCount={favoriteCount}
 					showCount={false}
 					size="sm"
 					className="flex items-center gap-1"
-					isAuthenticated={isAuthenticated}
 				/>
 
 				{/* 高評価・低評価ボタングループ */}
 				<LikeDislikeButtons
 					audioButtonId={audioButtonId}
 					initialLikeCount={likeCount}
-					initialIsLiked={isLiked}
-					initialIsDisliked={isDisliked}
 					variant="outline"
 					size="sm"
 				/>

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
@@ -1,11 +1,11 @@
-import type { AudioButtonPlainObject, UserSession } from "@suzumina.click/shared-types";
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
 import { TimeDisplay } from "@suzumina.click/ui/components/custom/time-display";
 import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent } from "@suzumina.click/ui/components/ui/card";
-import { Calendar, Clock, Pencil } from "lucide-react";
-import Link from "next/link";
+import { Calendar, Clock } from "lucide-react";
 import { AudioButtonDeleteButton } from "@/components/audio/audio-button-delete-button";
+import { AudioButtonEditButton } from "@/components/audio/audio-button-edit-button";
 import { AudioButtonTagEditorDetail } from "@/components/audio/audio-button-tag-editor-detail";
 import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
 import { AudioButtonDetailActions } from "./audio-button-detail-actions";
@@ -36,21 +36,9 @@ function formatRelativeTime(dateString: string): string {
 
 interface AudioButtonDetailMainContentProps {
 	audioButton: AudioButtonPlainObject;
-	user: UserSession | null;
-	isAuthenticated: boolean;
-	isFavorited: boolean;
-	isLiked: boolean;
-	isDisliked: boolean;
 }
 
-export function AudioButtonDetailMainContent({
-	audioButton,
-	user,
-	isAuthenticated,
-	isFavorited,
-	isLiked,
-	isDisliked,
-}: AudioButtonDetailMainContentProps) {
+export function AudioButtonDetailMainContent({ audioButton }: AudioButtonDetailMainContentProps) {
 	return (
 		<div className="lg:col-span-2">
 			<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">
@@ -77,15 +65,11 @@ export function AudioButtonDetailMainContent({
 						</div>
 						{/* 編集・削除ボタン */}
 						<div className="flex items-center gap-2">
-							{/* 編集ボタン */}
-							{user && audioButton.creatorId === user.discordId && (
-								<Button variant="outline" size="sm" asChild className="flex items-center gap-1">
-									<Link href={`/buttons/${audioButton.id}/edit`}>
-										<Pencil className="h-4 w-4" />
-										編集
-									</Link>
-								</Button>
-							)}
+							{/* 編集ボタン（作成者のみ・client island で session 解決） */}
+							<AudioButtonEditButton
+								audioButtonId={audioButton.id}
+								createdBy={audioButton.creatorId}
+							/>
 							{/* 削除ボタン */}
 							<AudioButtonDeleteButton
 								audioButtonId={audioButton.id}
@@ -121,7 +105,6 @@ export function AudioButtonDetailMainContent({
 						<AudioButtonTagEditorDetail
 							audioButtonId={audioButton.id}
 							tags={audioButton.tags || []}
-							currentUserId={user?.discordId}
 						/>
 					</div>
 
@@ -138,12 +121,8 @@ export function AudioButtonDetailMainContent({
 					{/* アクションボタン */}
 					<AudioButtonDetailActions
 						audioButtonId={audioButton.id}
-						isFavorited={isFavorited}
 						favoriteCount={audioButton.stats.favoriteCount || 0}
 						likeCount={audioButton.stats.likeCount}
-						isLiked={isLiked}
-						isDisliked={isDisliked}
-						isAuthenticated={isAuthenticated}
 					/>
 
 					{/* YouTube動画情報 */}

--- a/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
@@ -35,36 +35,28 @@ describe("AudioButtonTagEditorDetail", () => {
 			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.queryByText("編集")).not.toBeInTheDocument();
-			expect(
-				screen.getByText("※ タグを編集するには、ボタンの作成者としてログインする必要があります"),
-			).toBeInTheDocument();
+			expect(screen.getByText("※ タグを編集するにはログインが必要です")).toBeInTheDocument();
 		});
 
 		it("作成者には編集権限がある", () => {
 			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
-			expect(
-				screen.queryByText("※ タグを編集するには、ボタンの作成者としてログインする必要があります"),
-			).not.toBeInTheDocument();
+			expect(screen.queryByText("※ タグを編集するにはログインが必要です")).not.toBeInTheDocument();
 		});
 
 		it("管理者には編集権限がある", () => {
 			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
-			expect(
-				screen.queryByText("※ タグを編集するには、ボタンの作成者としてログインする必要があります"),
-			).not.toBeInTheDocument();
+			expect(screen.queryByText("※ タグを編集するにはログインが必要です")).not.toBeInTheDocument();
 		});
 
 		it("ログインユーザーなら誰でも編集権限がある", () => {
 			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
-			expect(
-				screen.queryByText("※ タグを編集するには、ボタンの作成者としてログインする必要があります"),
-			).not.toBeInTheDocument();
+			expect(screen.queryByText("※ タグを編集するにはログインが必要です")).not.toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-tag-editor-detail.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { useSession } from "@/lib/auth/client";
 import { AudioButtonTagEditorDetail } from "../audio-button-tag-editor-detail";
 
 // モック
@@ -8,21 +9,29 @@ vi.mock("@/app/buttons/actions", () => ({
 	updateAudioButtonTags: vi.fn(),
 }));
 
+// 認証は client session で解決（SPR-223）。ログインユーザーなら誰でもタグ編集可。
+vi.mock("@/lib/auth/client", () => ({
+	useSession: vi.fn(),
+}));
+const mockUseSession = vi.mocked(useSession);
+
 // useRouter is mocked in vitest.setup.ts
 
 describe("AudioButtonTagEditorDetail", () => {
 	const defaultProps = {
 		audioButtonId: "test-button-id",
 		tags: [],
-		currentUserId: undefined,
 	};
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// 既定はログイン済み（編集可）。未認証ケースは個別に null を設定する。
+		mockUseSession.mockReturnValue({ discordId: "creator-id" } as never);
 	});
 
 	describe("権限チェック", () => {
 		it("未認証ユーザーには編集権限がない", () => {
+			mockUseSession.mockReturnValue(null);
 			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.queryByText("編集")).not.toBeInTheDocument();
@@ -32,7 +41,7 @@ describe("AudioButtonTagEditorDetail", () => {
 		});
 
 		it("作成者には編集権限がある", () => {
-			render(<AudioButtonTagEditorDetail {...defaultProps} currentUserId="creator-id" />);
+			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
 			expect(
@@ -41,7 +50,7 @@ describe("AudioButtonTagEditorDetail", () => {
 		});
 
 		it("管理者には編集権限がある", () => {
-			render(<AudioButtonTagEditorDetail {...defaultProps} currentUserId="admin-id" />);
+			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
 			expect(
@@ -50,7 +59,7 @@ describe("AudioButtonTagEditorDetail", () => {
 		});
 
 		it("ログインユーザーなら誰でも編集権限がある", () => {
-			render(<AudioButtonTagEditorDetail {...defaultProps} currentUserId="other-user-id" />);
+			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("編集")).toBeInTheDocument();
 			expect(
@@ -61,7 +70,7 @@ describe("AudioButtonTagEditorDetail", () => {
 
 	describe("タグ表示", () => {
 		it("タグが存在しない場合の表示", () => {
-			render(<AudioButtonTagEditorDetail {...defaultProps} currentUserId="creator-id" />);
+			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(
 				screen.getByText("タグを追加して音声ボタンを見つけやすくしましょう"),
@@ -70,6 +79,7 @@ describe("AudioButtonTagEditorDetail", () => {
 		});
 
 		it("タグが存在しない場合の未認証ユーザー表示", () => {
+			mockUseSession.mockReturnValue(null);
 			render(<AudioButtonTagEditorDetail {...defaultProps} />);
 
 			expect(screen.getByText("タグはまだ設定されていません")).toBeInTheDocument();
@@ -81,7 +91,6 @@ describe("AudioButtonTagEditorDetail", () => {
 				<AudioButtonTagEditorDetail
 					{...defaultProps}
 					tags={["React", "TypeScript", "音声ボタン"]}
-					currentUserId="creator-id"
 				/>,
 			);
 
@@ -95,13 +104,7 @@ describe("AudioButtonTagEditorDetail", () => {
 	describe("編集機能", () => {
 		it("編集モードに入ることができる", async () => {
 			const user = userEvent.setup();
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					tags={["既存タグ"]}
-					currentUserId="creator-id"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={["既存タグ"]} />);
 
 			const editButton = screen.getByText("編集");
 			await user.click(editButton);
@@ -116,13 +119,7 @@ describe("AudioButtonTagEditorDetail", () => {
 
 		it("編集をキャンセルできる", async () => {
 			const user = userEvent.setup();
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					tags={["既存タグ"]}
-					currentUserId="creator-id"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={["既存タグ"]} />);
 
 			// 編集モードに入る
 			const editButton = screen.getByText("編集");
@@ -151,13 +148,7 @@ describe("AudioButtonTagEditorDetail", () => {
 				success: true,
 			});
 
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					tags={["既存タグ"]}
-					currentUserId="creator-id"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={["既存タグ"]} />);
 
 			// 編集モードに入る
 			const editButton = screen.getByText("編集");
@@ -194,7 +185,7 @@ describe("AudioButtonTagEditorDetail", () => {
 				error: "保存に失敗しました",
 			});
 
-			render(<AudioButtonTagEditorDetail {...defaultProps} tags={[]} currentUserId="creator-id" />);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={[]} />);
 
 			// 編集モードに入る
 			const editButton = screen.getByText("タグを追加");
@@ -229,7 +220,7 @@ describe("AudioButtonTagEditorDetail", () => {
 			});
 			vi.mocked(updateAudioButtonTags).mockReturnValue(promise);
 
-			render(<AudioButtonTagEditorDetail {...defaultProps} tags={[]} currentUserId="creator-id" />);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={[]} />);
 
 			// 編集モードに入る
 			const editButton = screen.getByText("タグを追加");
@@ -258,25 +249,13 @@ describe("AudioButtonTagEditorDetail", () => {
 
 	describe("アクセシビリティ", () => {
 		it("適切なセクション構造を持つ", () => {
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					tags={["テストタグ"]}
-					currentUserId="creator-id"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={["テストタグ"]} />);
 
 			expect(screen.getByText("タグ")).toBeInTheDocument();
 		});
 
 		it("編集ボタンが適切にラベル付けされている", () => {
-			render(
-				<AudioButtonTagEditorDetail
-					{...defaultProps}
-					tags={["テストタグ"]}
-					currentUserId="creator-id"
-				/>,
-			);
+			render(<AudioButtonTagEditorDetail {...defaultProps} tags={["テストタグ"]} />);
 
 			const editButton = screen.getByText("編集");
 			expect(editButton).toBeInTheDocument();

--- a/apps/web/src/components/audio/__tests__/favorite-button.test.tsx
+++ b/apps/web/src/components/audio/__tests__/favorite-button.test.tsx
@@ -26,6 +26,13 @@ vi.mock("sonner", () => ({
 // Server actions mock
 vi.mock("@/actions/favorites", () => ({
 	toggleFavoriteAction: vi.fn().mockResolvedValue({ success: true, isFavorited: true }),
+	getFavoritesStatusAction: vi.fn().mockResolvedValue(new Map()),
+}));
+
+// 認証は client session で解決する（SPR-223）。未認証なら self-fetch effect は発火せず、
+// isFavorited prop 駆動の描画が保たれる。
+vi.mock("@/lib/auth/client", () => ({
+	useSession: () => null,
 }));
 
 describe("FavoriteButton - Touch Optimization", () => {
@@ -40,12 +47,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 
 			sizes.forEach((size) => {
 				const { container } = render(
-					<FavoriteButton
-						audioButtonId="test"
-						isFavorited={false}
-						size={size}
-						isAuthenticated={true}
-					/>,
+					<FavoriteButton audioButtonId="test" isFavorited={false} size={size} />,
 				);
 
 				const button = container.querySelector("button");
@@ -73,28 +75,14 @@ describe("FavoriteButton - Touch Optimization", () => {
 		it("should have minimum 44px touch target on mobile", () => {
 			mockViewport(375, 667); // Mobile viewport
 
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="sm"
-					isAuthenticated={true}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={false} size="sm" />);
 
 			const button = screen.getByLabelText("お気に入りに追加");
 			expect(button).toHaveClass("h-11"); // 44px minimum on mobile
 		});
 
 		it("should maintain touch target size when favorited", () => {
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={true}
-					size="default"
-					isAuthenticated={true}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={true} size="default" />);
 
 			const button = screen.getByLabelText("お気に入りから削除");
 			validateResponsiveClasses(button, {
@@ -105,14 +93,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 
 	describe("Responsive Behavior", () => {
 		testAcrossViewports("should maintain proper sizing", (viewport) => {
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="default"
-					isAuthenticated={true}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={false} size="default" />);
 
 			const button = screen.getByLabelText("お気に入りに追加");
 
@@ -129,14 +110,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 			const sizes = ["sm", "default", "lg"] as const;
 
 			sizes.forEach((size) => {
-				render(
-					<FavoriteButton
-						audioButtonId="test"
-						isFavorited={false}
-						size={size}
-						isAuthenticated={true}
-					/>,
-				);
+				render(<FavoriteButton audioButtonId="test" isFavorited={false} size={size} />);
 
 				const icon = document.querySelector("svg");
 				expect(icon).toBeInTheDocument();
@@ -153,14 +127,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 
 	describe("Touch Interaction", () => {
 		it("should be accessible for touch interaction", async () => {
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="default"
-					isAuthenticated={true}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={false} size="default" />);
 
 			const button = screen.getByLabelText("お気に入りに追加");
 
@@ -181,14 +148,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 		it("should handle mobile touch interactions correctly", () => {
 			mockViewport(375, 667); // Mobile
 
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="sm"
-					isAuthenticated={true}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={false} size="sm" />);
 
 			const button = screen.getByLabelText("お気に入りに追加");
 
@@ -209,12 +169,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 		it("should show different visual states for favorited/unfavorited", () => {
 			// Unfavorited state
 			const { rerender } = render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="default"
-					isAuthenticated={true}
-				/>,
+				<FavoriteButton audioButtonId="test" isFavorited={false} size="default" />,
 			);
 
 			let button = screen.getByLabelText("お気に入りに追加");
@@ -222,14 +177,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 			expect(button).toHaveClass("border", "bg-background");
 
 			// Favorited state
-			rerender(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={true}
-					size="default"
-					isAuthenticated={true}
-				/>,
-			);
+			rerender(<FavoriteButton audioButtonId="test" isFavorited={true} size="default" />);
 
 			button = screen.getByLabelText("お気に入りから削除");
 			// heart は status と同型の semantic role（生スケール直書きを避ける）。お気に入り active の面色
@@ -241,12 +189,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 
 			sizes.forEach((size) => {
 				const { container } = render(
-					<FavoriteButton
-						audioButtonId="test"
-						isFavorited={true}
-						size={size}
-						isAuthenticated={true}
-					/>,
+					<FavoriteButton audioButtonId="test" isFavorited={true} size={size} />,
 				);
 
 				const buttons = screen.getAllByLabelText("お気に入りから削除");
@@ -261,39 +204,20 @@ describe("FavoriteButton - Touch Optimization", () => {
 	describe("Accessibility", () => {
 		it("should have proper ARIA labels", () => {
 			const { rerender } = render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="default"
-					isAuthenticated={true}
-				/>,
+				<FavoriteButton audioButtonId="test" isFavorited={false} size="default" />,
 			);
 
 			// Unfavorited state
 			expect(screen.getByLabelText("お気に入りに追加")).toBeInTheDocument();
 
 			// Favorited state
-			rerender(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={true}
-					size="default"
-					isAuthenticated={true}
-				/>,
-			);
+			rerender(<FavoriteButton audioButtonId="test" isFavorited={true} size="default" />);
 
 			expect(screen.getByLabelText("お気に入りから削除")).toBeInTheDocument();
 		});
 
 		it("should be keyboard navigable", () => {
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="default"
-					isAuthenticated={true}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={false} size="default" />);
 
 			const button = screen.getByLabelText("お気に入りに追加");
 
@@ -308,14 +232,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 		});
 
 		it("should handle unauthenticated state properly", () => {
-			render(
-				<FavoriteButton
-					audioButtonId="test"
-					isFavorited={false}
-					size="default"
-					isAuthenticated={false}
-				/>,
-			);
+			render(<FavoriteButton audioButtonId="test" isFavorited={false} size="default" />);
 
 			// ログインが必要な状態でも適切なサイズを保持
 			const button = screen.getByLabelText("お気に入りに追加");
@@ -329,14 +246,7 @@ describe("FavoriteButton - Touch Optimization", () => {
 
 			const TestWrapper = ({ isFavorited }: { isFavorited: boolean }) => {
 				renderSpy();
-				return (
-					<FavoriteButton
-						audioButtonId="test"
-						isFavorited={isFavorited}
-						size="default"
-						isAuthenticated={true}
-					/>
-				);
+				return <FavoriteButton audioButtonId="test" isFavorited={isFavorited} size="default" />;
 			};
 
 			const { rerender } = render(<TestWrapper isFavorited={false} />);

--- a/apps/web/src/components/audio/audio-button-edit-button.tsx
+++ b/apps/web/src/components/audio/audio-button-edit-button.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { Pencil } from "lucide-react";
+import Link from "next/link";
+import { useSession } from "@/lib/auth/client";
+
+interface AudioButtonEditButtonProps {
+	/** 音声ボタンID */
+	audioButtonId: string;
+	/** 作成者の Discord ID（公開データ） */
+	createdBy: string;
+}
+
+/**
+ * 音声ボタン編集ボタン（作成者のみ表示）。
+ * 作成者判定は client の session で行い、per-user 状態を SSR に焼かない（純公開 shell・SPR-223）。
+ * 実際の編集権限は編集ページ/Server Action 側の認可で担保する（ここは表示ゲートのみ）。
+ */
+export function AudioButtonEditButton({ audioButtonId, createdBy }: AudioButtonEditButtonProps) {
+	const user = useSession();
+	const canEdit = user?.discordId && user.discordId === createdBy;
+
+	if (!canEdit) {
+		return null;
+	}
+
+	return (
+		<Button variant="outline" size="sm" asChild className="flex items-center gap-1">
+			<Link href={`/buttons/${audioButtonId}/edit`}>
+				<Pencil className="h-4 w-4" />
+				編集
+			</Link>
+		</Button>
+	);
+}

--- a/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
+++ b/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
@@ -14,14 +14,13 @@ import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { type AutocompleteSuggestion, getAutocompleteSuggestions } from "@/actions/autocomplete";
 import { updateAudioButtonTags } from "@/app/buttons/actions";
+import { useSession } from "@/lib/auth/client";
 
 export interface AudioButtonTagEditorDetailProps {
 	/** 音声ボタンID */
 	audioButtonId: string;
 	/** 現在のタグ配列 */
 	tags: string[];
-	/** 現在のユーザーのDiscord ID */
-	currentUserId?: string;
 	/** 追加のクラス名 */
 	className?: string;
 }
@@ -29,17 +28,18 @@ export interface AudioButtonTagEditorDetailProps {
 export function AudioButtonTagEditorDetail({
 	audioButtonId,
 	tags,
-	currentUserId,
 	className,
 }: AudioButtonTagEditorDetailProps) {
 	const router = useRouter();
+	// 認証状態は client の session から解決し、per-user 状態を SSR に焼かない（純公開 shell・SPR-223）
+	const user = useSession();
 	const [isEditing, setIsEditing] = useState(false);
 	const [editingTags, setEditingTags] = useState<string[]>(tags);
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 
 	// 編集権限チェック（ログインユーザーなら誰でも編集可能）
-	const canEdit = !!currentUserId;
+	const canEdit = !!user?.discordId;
 
 	/**
 	 * AutocompleteSuggestion を TagSuggestion に変換

--- a/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
+++ b/apps/web/src/components/audio/audio-button-tag-editor-detail.tsx
@@ -224,7 +224,7 @@ export function AudioButtonTagEditorDetail({
 
 				{!canEdit && !isEditing && (
 					<p className="text-xs text-muted-foreground mt-2 pt-2 border-t">
-						※ タグを編集するには、ボタンの作成者としてログインする必要があります
+						※ タグを編集するにはログインが必要です
 					</p>
 				)}
 			</CardContent>

--- a/apps/web/src/components/audio/favorite-button.tsx
+++ b/apps/web/src/components/audio/favorite-button.tsx
@@ -6,28 +6,30 @@ import { Heart } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
-import { toggleFavoriteAction } from "@/actions/favorites";
+import { getFavoritesStatusAction, toggleFavoriteAction } from "@/actions/favorites";
+import { useSession } from "@/lib/auth/client";
 
 interface FavoriteButtonProps {
 	audioButtonId: string;
-	isFavorited: boolean;
+	isFavorited?: boolean;
 	favoriteCount?: number;
 	showCount?: boolean;
 	size?: "sm" | "default" | "lg";
 	className?: string;
-	isAuthenticated?: boolean;
 }
 
 export function FavoriteButton({
 	audioButtonId,
-	isFavorited: initialIsFavorited,
+	isFavorited: initialIsFavorited = false,
 	favoriteCount = 0,
 	showCount = true,
 	size = "default",
 	className,
-	isAuthenticated = false,
 }: FavoriteButtonProps) {
 	const router = useRouter();
+	// 認証状態は client の session から解決（per-user 状態を SSR に焼かない・SPR-223）
+	const user = useSession();
+	const isAuthenticated = !!user;
 	const [isPending, startTransition] = useTransition();
 	const [isFavorited, setIsFavorited] = useState(initialIsFavorited);
 
@@ -35,6 +37,19 @@ export function FavoriteButton({
 	useEffect(() => {
 		setIsFavorited(initialIsFavorited);
 	}, [initialIsFavorited]);
+
+	// お気に入り状態は SSR に焼かず、認証済みなら client で自分の状態を取得する（純公開 shell・SPR-223）。
+	// これにより詳細ページを共有キャッシュ可（public）に戻しても A の状態が B に漏れない。
+	useEffect(() => {
+		if (!isAuthenticated) return;
+		let cancelled = false;
+		void getFavoritesStatusAction([audioButtonId]).then((statusMap) => {
+			if (!cancelled) setIsFavorited(statusMap.get(audioButtonId) ?? false);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [audioButtonId, isAuthenticated]);
 
 	const handleToggle = () => {
 		if (!isAuthenticated) {


### PR DESCRIPTION
## 背景（SPR-223 / 親: SPR-215・SPR-222 の恒久解）

[SPR-222](https://linear.app/nothink/issue/SPR-222)（#710 stopgap）の恒久解。`/buttons/[id]` は `page.tsx` トップで `getCurrentUser` + favorites/likes を **server 取得**し、per-user 状態（お気に入り/高低評価/編集権限）を server コンポーネント連鎖で **SSR に焼いて**いた。leaf の client が実状態を取り直さないため SSR 値が固定され、これが共有キャッシュ漏洩 footgun の根本原因だった。

`/videos/[id]` の shell 方式（server で session を読まず、per-user は client island の `useSession()` で解決）に倣い、per-user をすべて client island へ隔離する。

## 変更

| ファイル | 内容 |
|---|---|
| `app/buttons/[id]/page.tsx` | `getCurrentUser`/favorites/likes の **server 取得を全撤去** → 純公開 shell |
| `audio-button-detail-main-content.tsx` | per-user prop 撤去。編集ボタンを client island 化・タグ editor の `currentUserId` prop 依存を解消 |
| `audio-button-detail-actions.tsx` | per-user prop 撤去し公開データ（件数）のみ渡す |
| `favorite-button.tsx` | `useSession()` + mount 後 self-fetch（SSR に焼かない） |
| `audio-button-tag-editor-detail.tsx` | `currentUserId` prop → `useSession()` 内部解決 |
| **新規** `audio-button-edit-button.tsx` | 作成者限定の編集リンクを client island 化（削除ボタンが既に同パターン） |
| `next.config.mjs` | `/buttons/[id]` を **public 復帰**。create/edit は private 維持 |
| テスト2件 | `useSession` モックへ移行（29 tests pass） |

### 認可は後退しない
表示ゲートを client（`useSession()`）へ移すだけで、**認可の正本は各 Server Action の `getCurrentUser` null チェックのまま**（編集/削除/お気に入り/タグ更新の実行は引き続き server で認可）。client ゲートは UI 表示のみ。

### next.config のキャッシュ復帰
- `/buttons/[id]`（詳細）→ **public, s-maxage=120, swr=300**（SPR-222 stopgap 解除・SPR-221 のエッジキャッシュ効果を回復）
- `/buttons/create`・`/buttons/[id]/edit` → 認証必須のため **private, no-store** 維持
- 負の先読み `/buttons/:id((?!create$)[^/]+)` で `create` を詳細公開ルールから除外し二重一致を回避
- `/works/[id]`・`/videos/[id]` は **SPR-226 stopgap のまま private 継続**（恒久解は別途・SPR-226 恒久解節）

## 検証

- **path matching**: Next の compiled path-to-regexp で全代表パスを検証。各パスが厳密に1ルールのみ一致（list→public / detail→public / create・edit→private / works・videos detail→private / settings→private）。Cache-Control 競合なし。
- **`pnpm verify`**: EXIT=0（lint:docs + lint:tokens + lint + typecheck + test・カバレッジ閾値含む）。
- **デプロイ後の本番確認（必須）**: 
  1. `curl -I https://suzumina.click/buttons/<id>` が `public, s-maxage=120` を返す
  2. ログイン中の User B が、別ユーザー A が直前に見た詳細ページで A のお気に入り/評価を見ない（per-user が SSR に残っていない）
  3. 自分のお気に入り/高低評価/編集ボタンが client でハイドレーション後に正しく表示される

## スコープ

- Two-Way Door（web レンダリング・auth ロジックの認可ゲートは不変）。
- works/videos の public 復帰は SPR-226 の恒久解として横展開予定（同じ island テンプレ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)