### PR TITLE
feat(functions): dlsite creator 同期 reads を run-scoped 計測（SPR-225 Stage 0）

### DIFF
--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -12,6 +12,10 @@ import type {
 	WorkDocument,
 } from "@suzumina.click/shared-types";
 import firestore, { Timestamp } from "../infrastructure/database/firestore";
+import {
+	getCreatorSyncMetrics,
+	resetCreatorSyncMetrics,
+} from "../services/dlsite/creator-sync-metrics";
 import { getExistingWorksMap } from "../services/dlsite/dlsite-firestore";
 import { batchFetchIndividualInfo } from "../services/dlsite/individual-info-api-client";
 import {
@@ -532,6 +536,9 @@ async function prepareNewBatchProcessing(metadata: CollectionMetadata): Promise<
  * 統合データ収集処理の実行
  */
 async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
+	// SPR-225 Stage 0: creator 同期 reads の内訳をこの run の分だけ計測する（挙動は変えない）。
+	resetCreatorSyncMetrics();
+
 	try {
 		// メタデータから処理状態を確認
 		const metadata = await getOrCreateUnifiedMetadata();
@@ -618,6 +625,11 @@ async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 			basicDataUpdated: 0,
 			error: error instanceof Error ? error.message : "不明なエラー",
 		};
+	} finally {
+		// この run の creator 同期 reads 内訳を 1 行で出す（type=QUERY の主因を分解）。
+		// 完走・中断・例外いずれの経路でも必ず記録する。Cloud Monitoring の絞り込みキーにする
+		// ため、メッセージは Stage を含めない恒久キーにする（Stage 1 以降も同じキーに値が流れる）。
+		logger.info("creator同期reads計測", { ...getCreatorSyncMetrics() });
 	}
 }
 

--- a/apps/functions/src/services/dlsite/__tests__/creator-sync-metrics.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/creator-sync-metrics.test.ts
@@ -1,0 +1,76 @@
+/**
+ * creator 同期 reads 計測（SPR-225 Stage 0）のテスト
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	getCreatorSyncMetrics,
+	recordCreatorExistenceLookup,
+	recordExistingMappingQuery,
+	recordRecompute,
+	recordRelationDeletes,
+	recordRelationWrites,
+	resetCreatorSyncMetrics,
+} from "../creator-sync-metrics";
+
+describe("creator-sync-metrics", () => {
+	beforeEach(() => {
+		resetCreatorSyncMetrics();
+	});
+
+	it("初期状態は全カウンタ 0", () => {
+		expect(getCreatorSyncMetrics()).toEqual({
+			existingMappingQueries: 0,
+			existingMappingDocsRead: 0,
+			creatorExistenceLookups: 0,
+			recomputeCalls: 0,
+			recomputeDocsRead: 0,
+			relationWrites: 0,
+			relationDeletes: 0,
+		});
+	});
+
+	it("各 record が回数と docs 数を加算する", () => {
+		recordExistingMappingQuery(3);
+		recordExistingMappingQuery(2);
+		recordCreatorExistenceLookup();
+		recordRecompute(500);
+		recordRecompute(10);
+		recordRelationWrites(4);
+		recordRelationDeletes(1);
+
+		expect(getCreatorSyncMetrics()).toEqual({
+			existingMappingQueries: 2,
+			existingMappingDocsRead: 5,
+			creatorExistenceLookups: 1,
+			recomputeCalls: 2,
+			recomputeDocsRead: 510,
+			relationWrites: 4,
+			relationDeletes: 1,
+		});
+	});
+
+	it("reset で前 run の値をクリアする", () => {
+		recordRecompute(123);
+		recordRelationWrites(2);
+		resetCreatorSyncMetrics();
+
+		expect(getCreatorSyncMetrics()).toEqual({
+			existingMappingQueries: 0,
+			existingMappingDocsRead: 0,
+			creatorExistenceLookups: 0,
+			recomputeCalls: 0,
+			recomputeDocsRead: 0,
+			relationWrites: 0,
+			relationDeletes: 0,
+		});
+	});
+
+	it("snapshot は内部状態のコピーを返す（変更しても影響しない）", () => {
+		recordRecompute(5);
+		const snapshot = getCreatorSyncMetrics();
+		snapshot.recomputeDocsRead = 9999;
+
+		expect(getCreatorSyncMetrics().recomputeDocsRead).toBe(5);
+	});
+});

--- a/apps/functions/src/services/dlsite/creator-firestore.ts
+++ b/apps/functions/src/services/dlsite/creator-firestore.ts
@@ -14,6 +14,13 @@ import type {
 import { isValidCreatorId } from "@suzumina.click/shared-types";
 import firestore, { Timestamp } from "../../infrastructure/database/firestore";
 import * as logger from "../../shared/logger";
+import {
+	recordCreatorExistenceLookup,
+	recordExistingMappingQuery,
+	recordRecompute,
+	recordRelationDeletes,
+	recordRelationWrites,
+} from "./creator-sync-metrics";
 
 const CREATORS_COLLECTION = "creators";
 
@@ -171,6 +178,8 @@ async function getExistingCreatorMappings(
 			.where("workId", "==", workId)
 			.get();
 
+		recordExistingMappingQuery(worksSnapshot.docs.length);
+
 		worksSnapshot.docs.forEach((doc) => {
 			// 親ドキュメントのIDがクリエイターID
 			const creatorId = doc.ref.parent.parent?.id;
@@ -223,6 +232,7 @@ export async function updateCreatorWorkMapping(
 
 			// 新規作成の場合はcreatedAtも設定
 			const creatorDoc = await creatorRef.get();
+			recordCreatorExistenceLookup();
 			if (!creatorDoc.exists) {
 				creatorData.createdAt = Timestamp.now();
 			}
@@ -263,6 +273,11 @@ export async function updateCreatorWorkMapping(
 		const removedCount =
 			existingMappings.size -
 			Array.from(existingMappings.keys()).filter((id) => processedCreators.has(id)).length;
+
+		// 計測（実変更の代理値）は commit 成功後に確定値で記録する。
+		// batch に積んだ直後に数えると commit 失敗時に「書き込んだ」と誤計上するため。
+		recordRelationWrites(addedCount);
+		recordRelationDeletes(removedCount);
 
 		if (addedCount > 0 || removedCount > 0) {
 			logger.debug(`クリエイターマッピング更新完了: ${workId}`, {
@@ -372,6 +387,8 @@ export async function recomputeCreatorStats(creatorId: string): Promise<void> {
 		.doc(creatorId)
 		.collection("works")
 		.get();
+
+	recordRecompute(worksSnapshot.size);
 
 	if (worksSnapshot.empty) {
 		await firestore.collection(CREATORS_COLLECTION).doc(creatorId).update({

--- a/apps/functions/src/services/dlsite/creator-sync-metrics.ts
+++ b/apps/functions/src/services/dlsite/creator-sync-metrics.ts
@@ -1,0 +1,86 @@
+/**
+ * dlsite creator 同期の run-scoped 計測（SPR-225 Stage 0）
+ *
+ * 挙動は一切変えず、creator 同期パス（`updateCreatorWorkMapping` /
+ * `recomputeCreatorStats`）が 1 run で発生させる Firestore reads の内訳を可視化する。
+ * SPR-224 で「dlsite 1実行 = 6k〜60k QUERY」と判明した内訳（collectionGroup QUERY /
+ * creator 存在 LOOKUP / recompute 全スキャン）を分解し、後続 Stage の効果を測る基線にする。
+ *
+ * 正本: dlsite 関数はスケジュール起動（2h毎・単発）で並行実行が実質ゼロのため、
+ * run 単位の集計は module レベルのカウンタで足りる。run 開始で {@link resetCreatorSyncMetrics}、
+ * run 末尾で {@link getCreatorSyncMetrics} の snapshot を 1 行構造化ログに出す前提。
+ *
+ * 注意: `recomputeCreatorStats` は data-integrity-check / backfill ツールからも呼ばれるが、
+ * それらは reset/log しないため別 run としては観測されない（同 module を読み書きするだけで害はない）。
+ */
+
+/**
+ * 1 run で蓄積する creator 同期の reads/writes 内訳。
+ */
+export interface CreatorSyncMetricsSnapshot {
+	/** getExistingCreatorMappings の collectionGroup QUERY 回数（work あたり1） */
+	existingMappingQueries: number;
+	/** 上記 QUERY が返した relation ドキュメント総数（type=QUERY の read 量の代理値） */
+	existingMappingDocsRead: number;
+	/** creator doc の存在チェック get() 回数（type=LOOKUP） */
+	creatorExistenceLookups: number;
+	/** recomputeCreatorStats の呼び出し回数 */
+	recomputeCalls: number;
+	/** recompute の全スキャンが読んだ works サブコレクション ドキュメント総数（QUERY read 量の主因） */
+	recomputeDocsRead: number;
+	/** relation doc への書き込み回数（実変更の代理値） */
+	relationWrites: number;
+	/** relation doc の削除回数 */
+	relationDeletes: number;
+}
+
+function createEmptySnapshot(): CreatorSyncMetricsSnapshot {
+	return {
+		existingMappingQueries: 0,
+		existingMappingDocsRead: 0,
+		creatorExistenceLookups: 0,
+		recomputeCalls: 0,
+		recomputeDocsRead: 0,
+		relationWrites: 0,
+		relationDeletes: 0,
+	};
+}
+
+let metrics: CreatorSyncMetricsSnapshot = createEmptySnapshot();
+
+/** run 開始時に呼び、前 run の値をクリアする。 */
+export function resetCreatorSyncMetrics(): void {
+	metrics = createEmptySnapshot();
+}
+
+/** getExistingCreatorMappings の collectionGroup QUERY 1 回と、返った docs 数を記録する。 */
+export function recordExistingMappingQuery(docsRead: number): void {
+	metrics.existingMappingQueries += 1;
+	metrics.existingMappingDocsRead += docsRead;
+}
+
+/** creator doc 存在チェックの get()（LOOKUP）1 回を記録する。 */
+export function recordCreatorExistenceLookup(): void {
+	metrics.creatorExistenceLookups += 1;
+}
+
+/** recomputeCreatorStats 1 回と、その全スキャンが読んだ docs 数を記録する。 */
+export function recordRecompute(docsRead: number): void {
+	metrics.recomputeCalls += 1;
+	metrics.recomputeDocsRead += docsRead;
+}
+
+/** relation doc 書き込み回数を加算する。 */
+export function recordRelationWrites(count: number): void {
+	metrics.relationWrites += count;
+}
+
+/** relation doc 削除回数を加算する。 */
+export function recordRelationDeletes(count: number): void {
+	metrics.relationDeletes += count;
+}
+
+/** 現在の run の snapshot（コピー）を返す。ログ出力用。 */
+export function getCreatorSyncMetrics(): CreatorSyncMetricsSnapshot {
+	return { ...metrics };
+}


### PR DESCRIPTION
## 概要（SPR-225 Stage 0 / 計測・read-only・Two-Way Door）

親: [SPR-225](https://linear.app/nothink/issue/SPR-225/fetchdlsiteunifieddata) → [SPR-215](https://linear.app/nothink/issue/SPR-215) #3 Firestore reads。
[SPR-224](https://linear.app/nothink/issue/SPR-224) で判明した「dlsite 1実行 = 6k〜60k QUERY（type=QUERY が reads の96%・支配的源）」の**内訳を、挙動を一切変えずに可視化する基線**。各 Stage の reads 削減効果を実測で測れるようにする。

## 真因（接地済み）
`creator-firestore.ts` の `recomputeCreatorStats` が `updateCreatorWorkMapping` から **work ごと・dedup なし・影響 creator 全員（new ∪ existing）に対して全作品スキャン**で発火（`unified-data-processor.ts:106` 経由）。多作 creator（声優 N=数百〜千作）が処理対象 work に現れるたびフルスキャンが反復 → 60k QUERY の主因。

## 変更点
- **`creator-sync-metrics.ts`（新規）**: run-scoped カウンタ。`existingMappingQueries`/`existingMappingDocsRead`（collectionGroup QUERY）・`creatorExistenceLookups`（LOOKUP）・`recomputeCalls`/`recomputeDocsRead`（全スキャン docs＝QUERY read の主因）・`relationWrites`/`relationDeletes`。スケジュール単発実行前提で module 集計、run 開始 `reset`・run 末尾 `snapshot`。
- **`creator-firestore.ts`**: `getExistingCreatorMappings` / `recomputeCreatorStats` / 存在チェック `get()` を instrumentation（**読み取り量を記録するのみ・挙動不変**）。
- **`dlsite-individual-info-api.ts`**: `executeUnifiedDataCollection` 開始で `reset`、`finally` で 1 行構造化ログ（完走・中断・例外いずれの経路でも記録）。

## 検証
- `pnpm verify` green（lint:docs + lint:tokens + lint + typecheck + test、全パッケージ・カバレッジ閾値含む）。functions 376 passed。
- 計測 module の単体テスト追加（reset/record/snapshot コピー）。
- **デプロイ後**: Cloud Monitoring `document/read_count` type=QUERY を dlsite 実行時に5分粒度で観測し、本ログ（`recomputeDocsRead` 等）と突合して基線を確定。

## リスク
- 挙動変更なし（Two-Way Door）。`recomputeCreatorStats` は data-integrity-check / backfill からも呼ばれるが、それらは reset/log しないため別 run として観測されない（同 module を読み書きするだけで害なし）。

## 後続
Stage 1（recompute ゲート/dedup・★本丸の reads 削減）は別 PR。本 PR の計測でその前後比較を取る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)