### PR TITLE
feat(functions): creator recompute を per-work から run 末尾の dedup drain へ（SPR-225 Stage 1）

### DIFF
--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -12,6 +12,11 @@ import type {
 	WorkDocument,
 } from "@suzumina.click/shared-types";
 import firestore, { Timestamp } from "../infrastructure/database/firestore";
+import { recomputeCreatorStats } from "../services/dlsite/creator-firestore";
+import {
+	resetCreatorRecomputeQueue,
+	takeQueuedCreators,
+} from "../services/dlsite/creator-recompute-queue";
 import {
 	getCreatorSyncMetrics,
 	resetCreatorSyncMetrics,
@@ -533,11 +538,42 @@ async function prepareNewBatchProcessing(metadata: CollectionMetadata): Promise<
 }
 
 /**
+ * SPR-225 Stage 1: この run で stat 変化のあった creator を 1 回ずつ recompute する。
+ *
+ * `updateCreatorWorkMapping` が per-work で積んだ変更 creator を run 末尾で dedup 取り出しし、
+ * creator ごと 1 回だけ `recomputeCreatorStats`（全作品スキャン）を実行する。完走・中断・例外の
+ * いずれの経路でも呼ばれる前提（finally）。recompute 失敗は集計の denormalize ズレに留まり、
+ * 週次 `checkDataIntegrity` でも修復されるためログのみで握る。
+ */
+async function recomputeQueuedCreators(): Promise<void> {
+	const creatorIds = takeQueuedCreators();
+	if (creatorIds.length === 0) {
+		return;
+	}
+
+	const results = await Promise.allSettled(
+		creatorIds.map((creatorId) => recomputeCreatorStats(creatorId)),
+	);
+	// 失敗時はどの creator が denormalize ズレのまま残ったかを ID で残す
+	// （デプロイ直後の観測で追えるように。週次 cron で最終的に修復される）。
+	const failedIds = results
+		.map((r, i) => (r.status === "rejected" ? creatorIds[i] : undefined))
+		.filter((id): id is string => id !== undefined);
+	logger.info("creator集計recompute(SPR-225 Stage1・dedup後)", {
+		対象creator数: creatorIds.length,
+		失敗: failedIds.length,
+		...(failedIds.length > 0 && { 失敗creatorIds: failedIds }),
+	});
+}
+
+/**
  * 統合データ収集処理の実行
  */
 async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 	// SPR-225 Stage 0: creator 同期 reads の内訳をこの run の分だけ計測する（挙動は変えない）。
 	resetCreatorSyncMetrics();
+	// SPR-225 Stage 1: 変更 creator の recompute キューを run 開始でクリアする。
+	resetCreatorRecomputeQueue();
 
 	try {
 		// メタデータから処理状態を確認
@@ -626,9 +662,12 @@ async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 			error: error instanceof Error ? error.message : "不明なエラー",
 		};
 	} finally {
-		// この run の creator 同期 reads 内訳を 1 行で出す（type=QUERY の主因を分解）。
-		// 完走・中断・例外いずれの経路でも必ず記録する。Cloud Monitoring の絞り込みキーにする
-		// ため、メッセージは Stage を含めない恒久キーにする（Stage 1 以降も同じキーに値が流れる）。
+		// SPR-225 Stage 1: 変更のあった creator を run 末尾で creator ごと 1 回だけ recompute。
+		// 中断/例外時も、それまでに処理済みのバッチ分は recompute される（次 run へ持ち越さない）。
+		await recomputeQueuedCreators();
+		// この run の creator 同期 reads 内訳を 1 行で出す（type=QUERY の主因を分解）。recompute(drain)
+		// の読み取りも計上するため recompute の後に出す。Cloud Monitoring の絞り込みキーにするため、
+		// メッセージは Stage を含めない恒久キーにする（Stage 1 以降も同じキーに値が流れる）。
 		logger.info("creator同期reads計測", { ...getCreatorSyncMetrics() });
 	}
 }

--- a/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/creator-firestore.test.ts
@@ -12,6 +12,7 @@ import {
 	removeCreatorMappings,
 	updateCreatorWorkMapping,
 } from "../creator-firestore";
+import { resetCreatorRecomputeQueue, takeQueuedCreators } from "../creator-recompute-queue";
 
 // Firestoreモジュールのモック（モック定義より先に記述）
 vi.mock("../../../infrastructure/database/firestore", () => {
@@ -118,6 +119,9 @@ describe("creator-firestore", () => {
 
 		// コミット成功
 		mockCommit.mockResolvedValue(undefined);
+
+		// SPR-225 Stage 1: 各テストを独立させるため recompute キューをクリア
+		resetCreatorRecomputeQueue();
 	});
 
 	afterEach(() => {
@@ -271,6 +275,119 @@ describe("creator-firestore", () => {
 			expect(result.success).toBe(false);
 			expect(result.error).toBe("Commit failed");
 			expect(logger.error).toHaveBeenCalled();
+		});
+	});
+
+	describe("updateCreatorWorkMapping recompute キュー連携 (SPR-225 Stage 1)", () => {
+		// 既存マッピングなしを返す collectionGroup query モック
+		const mockNoExistingMappings = () => {
+			mockCollectionGroup.mockReturnValueOnce({ where: mockWhere });
+			mockWhere.mockReturnValueOnce({ get: mockGet });
+			mockGet.mockResolvedValueOnce({ docs: [] });
+		};
+
+		// 既存マッピングを返す collectionGroup query モック
+		const mockExistingMappings = (
+			entries: { creatorId: string; roles: string[]; circleId?: string }[],
+		) => {
+			mockCollectionGroup.mockReturnValueOnce({ where: mockWhere });
+			mockWhere.mockReturnValueOnce({ get: mockGet });
+			mockGet.mockResolvedValueOnce({
+				docs: entries.map((e) => ({
+					ref: { parent: { parent: { id: e.creatorId } } },
+					data: () => ({ workId: "RJ1", roles: e.roles, circleId: e.circleId ?? "RG1" }),
+				})),
+			});
+		};
+
+		it("新規 creator は全員キューに積まれ、inline recompute（update）は走らない", async () => {
+			mockNoExistingMappings();
+			mockGet.mockResolvedValue({ exists: false, data: () => null });
+
+			const result = await updateCreatorWorkMapping(
+				{
+					workno: "RJ1",
+					maker_id: "RG1",
+					creaters: {
+						voice_by: [
+							{ id: "VA001", name: "声優A" },
+							{ id: "VA002", name: "声優B" },
+						],
+					},
+				} as any,
+				"RJ1",
+			);
+
+			expect(result.success).toBe(true);
+			expect(new Set(takeQueuedCreators())).toEqual(new Set(["VA001", "VA002"]));
+			// per-work の inline recompute は廃止 → creator doc の update は呼ばれない
+			expect(mockUpdate).not.toHaveBeenCalled();
+		});
+
+		it("roles 不変（name のみ変更）はキューに積まない", async () => {
+			mockExistingMappings([{ creatorId: "VA001", roles: ["voice"] }]);
+			mockGet.mockResolvedValueOnce({
+				exists: true,
+				data: () => ({ creatorId: "VA001", name: "声優A" }),
+			});
+
+			const result = await updateCreatorWorkMapping(
+				{
+					workno: "RJ1",
+					maker_id: "RG1",
+					creaters: { voice_by: [{ id: "VA001", name: "声優A更新" }] },
+				} as any,
+				"RJ1",
+			);
+
+			expect(result.success).toBe(true);
+			expect(takeQueuedCreators()).toEqual([]);
+		});
+
+		it("roles が変わった creator はキューに積む", async () => {
+			mockExistingMappings([{ creatorId: "VA001", roles: ["voice"] }]);
+			mockGet.mockResolvedValue({
+				exists: true,
+				data: () => ({ creatorId: "VA001", name: "声優A" }),
+			});
+
+			const result = await updateCreatorWorkMapping(
+				{
+					workno: "RJ1",
+					maker_id: "RG1",
+					creaters: {
+						voice_by: [{ id: "VA001", name: "声優A" }],
+						scenario_by: [{ id: "VA001", name: "声優A" }],
+					},
+				} as any,
+				"RJ1",
+			);
+
+			expect(result.success).toBe(true);
+			expect(takeQueuedCreators()).toEqual(["VA001"]);
+		});
+
+		it("API から消えた creator（関連削除）はキューに積む。roles 不変の継続 creator は積まない", async () => {
+			mockExistingMappings([
+				{ creatorId: "VA001", roles: ["voice"] },
+				{ creatorId: "VA002", roles: ["illustration"] },
+			]);
+			mockGet.mockResolvedValue({
+				exists: true,
+				data: () => ({ creatorId: "VA001", name: "声優A" }),
+			});
+
+			const result = await updateCreatorWorkMapping(
+				{
+					workno: "RJ1",
+					maker_id: "RG1",
+					creaters: { voice_by: [{ id: "VA001", name: "声優A" }] },
+				} as any,
+				"RJ1",
+			);
+
+			expect(result.success).toBe(true);
+			expect(takeQueuedCreators()).toEqual(["VA002"]);
 		});
 	});
 

--- a/apps/functions/src/services/dlsite/__tests__/creator-recompute-queue.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/creator-recompute-queue.test.ts
@@ -1,0 +1,51 @@
+/**
+ * creator 再計算キュー（SPR-225 Stage 1）のテスト
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	enqueueChangedCreators,
+	queuedCreatorCount,
+	resetCreatorRecomputeQueue,
+	takeQueuedCreators,
+} from "../creator-recompute-queue";
+
+describe("creator-recompute-queue", () => {
+	beforeEach(() => {
+		resetCreatorRecomputeQueue();
+	});
+
+	it("初期状態は空", () => {
+		expect(queuedCreatorCount()).toBe(0);
+		expect(takeQueuedCreators()).toEqual([]);
+	});
+
+	it("enqueue した creator を重複排除して保持する", () => {
+		enqueueChangedCreators(["VA001", "VA002"]);
+		enqueueChangedCreators(["VA002", "VA003"]);
+
+		expect(queuedCreatorCount()).toBe(3);
+		expect(new Set(takeQueuedCreators())).toEqual(new Set(["VA001", "VA002", "VA003"]));
+	});
+
+	it("take はキューを空にする（2回目は空配列）", () => {
+		enqueueChangedCreators(["VA001"]);
+
+		expect(takeQueuedCreators()).toEqual(["VA001"]);
+		expect(takeQueuedCreators()).toEqual([]);
+		expect(queuedCreatorCount()).toBe(0);
+	});
+
+	it("reset で積んだ creator をクリアする", () => {
+		enqueueChangedCreators(["VA001", "VA002"]);
+		resetCreatorRecomputeQueue();
+
+		expect(queuedCreatorCount()).toBe(0);
+	});
+
+	it("Set など任意の Iterable を受け付ける", () => {
+		enqueueChangedCreators(new Set(["VA001", "VA001", "VA002"]));
+
+		expect(queuedCreatorCount()).toBe(2);
+	});
+});

--- a/apps/functions/src/services/dlsite/creator-firestore.ts
+++ b/apps/functions/src/services/dlsite/creator-firestore.ts
@@ -14,6 +14,7 @@ import type {
 import { isValidCreatorId } from "@suzumina.click/shared-types";
 import firestore, { Timestamp } from "../../infrastructure/database/firestore";
 import * as logger from "../../shared/logger";
+import { enqueueChangedCreators } from "./creator-recompute-queue";
 import {
 	recordCreatorExistenceLookup,
 	recordExistingMappingQuery,
@@ -198,7 +199,119 @@ async function getExistingCreatorMappings(
 }
 
 /**
+ * 2 つの役割集合が（順不同で）同一かを判定する。
+ *
+ * roles は重複なし（{@link addOrUpdateCreatorMapping} で集約済み）の前提なので、
+ * 長さ一致 + 片側包含で集合一致を判定できる。
+ */
+function isSameRoleSet(a: CreatorType[], b: CreatorType[]): boolean {
+	if (a.length !== b.length) {
+		return false;
+	}
+	const setA = new Set(a);
+	return b.every((role) => setA.has(role));
+}
+
+type WorkBatch = ReturnType<typeof firestore.batch>;
+
+/**
+ * API 由来の新マッピングを batch に書き込み、stat 影響変化のあった creator を集める。
+ *
+ * 副作用: `processedCreators` に処理済み creatorId を、`changedCreators` に stat 影響変化
+ * （新規関連 or roles 変化）のあった creatorId を追加する。
+ */
+async function applyNewCreatorMappings(
+	batch: WorkBatch,
+	workId: string,
+	circleId: string,
+	newMappings: Map<string, ExtractedCreator>,
+	existingMappings: Map<string, CreatorWorkRelation>,
+	processedCreators: Set<string>,
+	changedCreators: Set<string>,
+): Promise<void> {
+	for (const [creatorId, mapping] of newMappings) {
+		const creatorRef = firestore.collection(CREATORS_COLLECTION).doc(creatorId);
+		const mappingRef = creatorRef.collection("works").doc(workId);
+
+		// クリエイター基本情報の更新（merge: true で部分更新）
+		const creatorData: Partial<CreatorDocument> = {
+			creatorId,
+			name: mapping.name,
+			updatedAt: Timestamp.now(),
+		};
+
+		// 新規作成の場合はcreatedAtも設定
+		const creatorDoc = await creatorRef.get();
+		recordCreatorExistenceLookup();
+		if (!creatorDoc.exists) {
+			creatorData.createdAt = Timestamp.now();
+		}
+
+		batch.set(creatorRef, creatorData, { merge: true });
+
+		// 作品との関連情報を設定
+		const relationData: CreatorWorkRelation = {
+			workId,
+			roles: mapping.roles,
+			circleId,
+			updatedAt: Timestamp.now(),
+		};
+
+		batch.set(mappingRef, relationData);
+
+		// stat 影響変化の検出: 新規関連 or roles が変わったときのみ recompute 対象。
+		// circleId/name のみの変更は workCount/types/primaryRole に影響しないため対象外。
+		const existing = existingMappings.get(creatorId);
+		if (!existing || !isSameRoleSet(existing.roles, mapping.roles)) {
+			changedCreators.add(creatorId);
+		}
+
+		processedCreators.add(creatorId);
+	}
+}
+
+/**
+ * API から消えた creator の関連を batch から削除し、stat 影響変化として集める。
+ *
+ * @returns 削除した関連の件数（計測は commit 成功後に呼び出し側で記録する）
+ */
+function deleteStaleCreatorMappings(
+	batch: WorkBatch,
+	workId: string,
+	existingMappings: Map<string, CreatorWorkRelation>,
+	processedCreators: Set<string>,
+	changedCreators: Set<string>,
+): number {
+	let deleted = 0;
+	for (const [creatorId] of existingMappings) {
+		if (processedCreators.has(creatorId)) {
+			continue;
+		}
+		const mappingRef = firestore
+			.collection(CREATORS_COLLECTION)
+			.doc(creatorId)
+			.collection("works")
+			.doc(workId);
+
+		batch.delete(mappingRef);
+		// 関連削除は workCount/types を変えるため recompute 対象。
+		changedCreators.add(creatorId);
+		deleted += 1;
+
+		logger.debug(`クリエイターマッピング削除: ${creatorId} - ${workId}`);
+	}
+	return deleted;
+}
+
+/**
  * クリエイターと作品のマッピングを更新（差分更新）
+ *
+ * SPR-225 Stage 1: relation の書き込みは従来どおり行うが、**creator 集計（workCount/types/
+ * primaryRole）の再計算はこの関数では行わない**。stat に影響する mapping 変化（relation の
+ * 追加/削除/roles 変化）のあった creator だけを run-scoped キューへ enqueue し、エンドポイントが
+ * run 末尾で creator ごと 1 回だけ recompute する（per-work・dedup なしの全スキャン反復＝
+ * SPR-224 の 6k〜60k QUERY を解消）。name のみの変更は relation/creator doc を書き直すが
+ * stat には影響しないため enqueue しない。
  *
  * @param apiData DLsite APIレスポンス
  * @param workId 作品ID
@@ -211,94 +324,47 @@ export async function updateCreatorWorkMapping(
 	try {
 		const batch = firestore.batch();
 		const processedCreators = new Set<string>();
+		// stat（workCount/types/primaryRole）に影響する mapping 変化のあった creator。
+		// run 末尾で 1 回ずつ recompute するためにキューへ積む（per-work recompute は廃止）。
+		const changedCreators = new Set<string>();
 
 		// 現在のマッピングを取得
 		const existingMappings = await getExistingCreatorMappings(workId);
 
 		// APIデータから新しいマッピングを構築
 		const newMappings = extractCreatorMappings(apiData);
+		const circleId = apiData.maker_id || "UNKNOWN";
 
-		// 追加・更新
-		for (const [creatorId, mapping] of newMappings) {
-			const creatorRef = firestore.collection(CREATORS_COLLECTION).doc(creatorId);
-			const mappingRef = creatorRef.collection("works").doc(workId);
-
-			// クリエイター基本情報の更新（merge: true で部分更新）
-			const creatorData: Partial<CreatorDocument> = {
-				creatorId,
-				name: mapping.name,
-				updatedAt: Timestamp.now(),
-			};
-
-			// 新規作成の場合はcreatedAtも設定
-			const creatorDoc = await creatorRef.get();
-			recordCreatorExistenceLookup();
-			if (!creatorDoc.exists) {
-				creatorData.createdAt = Timestamp.now();
-			}
-
-			batch.set(creatorRef, creatorData, { merge: true });
-
-			// 作品との関連情報を設定
-			const relationData: CreatorWorkRelation = {
-				workId,
-				roles: mapping.roles,
-				circleId: apiData.maker_id || "UNKNOWN",
-				updatedAt: Timestamp.now(),
-			};
-
-			batch.set(mappingRef, relationData);
-
-			processedCreators.add(creatorId);
-		}
-
-		// 削除（APIデータに存在しないマッピング）
-		for (const [creatorId] of existingMappings) {
-			if (!processedCreators.has(creatorId)) {
-				const mappingRef = firestore
-					.collection(CREATORS_COLLECTION)
-					.doc(creatorId)
-					.collection("works")
-					.doc(workId);
-
-				batch.delete(mappingRef);
-
-				logger.debug(`クリエイターマッピング削除: ${creatorId} - ${workId}`);
-			}
-		}
+		// 追加・更新 → 削除（APIデータに存在しないマッピング）
+		await applyNewCreatorMappings(
+			batch,
+			workId,
+			circleId,
+			newMappings,
+			existingMappings,
+			processedCreators,
+			changedCreators,
+		);
+		const removedCount = deleteStaleCreatorMappings(
+			batch,
+			workId,
+			existingMappings,
+			processedCreators,
+			changedCreators,
+		);
 
 		await batch.commit();
 
-		const addedCount = processedCreators.size;
-		const removedCount =
-			existingMappings.size -
-			Array.from(existingMappings.keys()).filter((id) => processedCreators.has(id)).length;
-
 		// 計測（実変更の代理値）は commit 成功後に確定値で記録する。
 		// batch に積んだ直後に数えると commit 失敗時に「書き込んだ」と誤計上するため。
-		recordRelationWrites(addedCount);
+		recordRelationWrites(processedCreators.size);
 		recordRelationDeletes(removedCount);
 
-		if (addedCount > 0 || removedCount > 0) {
-			logger.debug(`クリエイターマッピング更新完了: ${workId}`, {
-				added: addedCount,
-				removed: removedCount,
-			});
-		}
-
-		// SPR-74 Phase B: 影響を受けたクリエイターの workCount/types/primaryRole を再計算。
-		// マッピングの batch.commit は成功しているので、失敗しても処理結果は success のまま。
-		const affectedCreators = new Set<string>([
-			...processedCreators,
-			...Array.from(existingMappings.keys()),
-		]);
-		const results = await Promise.allSettled(
-			Array.from(affectedCreators).map((creatorId) => recomputeCreatorStats(creatorId)),
-		);
-		const failed = results.filter((r) => r.status === "rejected").length;
-		if (failed > 0) {
-			logger.warn(`クリエイター集計再計算で ${failed} 件失敗`, { workId });
-		}
+		// SPR-225 Stage 1: 影響を受けた creator の workCount/types/primaryRole 再計算は
+		// ここでは行わず（per-work・dedup なしの全スキャン反復が SPR-224 の reads 主因だった）、
+		// stat 影響変化のあった creator だけを run-scoped キューへ積む。エンドポイントが run 末尾で
+		// creator ごと 1 回だけ recompute する（SPR-74 Phase B の denormalize 同期はそこで担保）。
+		enqueueChangedCreators(changedCreators);
 
 		return { success: true };
 	} catch (error) {

--- a/apps/functions/src/services/dlsite/creator-recompute-queue.ts
+++ b/apps/functions/src/services/dlsite/creator-recompute-queue.ts
@@ -1,0 +1,54 @@
+/**
+ * dlsite creator 同期の run-scoped 再計算キュー（SPR-225 Stage 1）
+ *
+ * 旧設計は `updateCreatorWorkMapping` が **work ごと・dedup なし**で、影響 creator 全員
+ * （new ∪ existing）に `recomputeCreatorStats`（全作品スキャン）を発火していた。多作 creator
+ * （声優 N=数百〜千作）が処理対象 work に現れるたびフルスキャンが反復し、SPR-224 の
+ * 「1実行 6k〜60k QUERY」の主因になっていた。
+ *
+ * 新設計: `updateCreatorWorkMapping` は recompute せず、**stat に影響する mapping 変化**
+ * （relation の追加/削除/roles 変化）のあった creator だけをここに enqueue する。
+ * エンドポイントが batch loop 後（run 末尾）に {@link takeQueuedCreators} で取り出し、
+ * **creator ごと 1 回だけ** recompute する。これで全スキャンは「実際に変わった少数 creator ×1」
+ * に限定され、reads の主因を解消する。
+ *
+ * 正本: dlsite 関数はスケジュール起動（2h毎・単発）で並行実行が実質ゼロのため、run 単位の
+ * 集約は module レベルの Set で足りる。run 開始で {@link resetCreatorRecomputeQueue}、
+ * run 末尾（完走・中断・例外いずれの経路でも）に drain する前提。
+ *
+ * この「単発実行」前提はデプロイ設定 `max-instances=1`（`terraform/function_dlsite_individual_info_api.tf`
+ * のヘッダに明記・関数本体は out-of-band 管理）で担保される。将来 concurrency > 1 へ移行する場合は、
+ * 別 run が互いのキューを `resetCreatorRecomputeQueue()` で潰しうるため、module-level の Set でなく
+ * run-scoped state を引数で引き回す設計へ作り替えること。
+ */
+
+const queued = new Set<string>();
+
+/**
+ * stat 影響変化のあった creator を再計算対象として登録する（重複は Set で吸収）。
+ */
+export function enqueueChangedCreators(creatorIds: Iterable<string>): void {
+	for (const id of creatorIds) {
+		queued.add(id);
+	}
+}
+
+/**
+ * 登録済みの creator を重複排除した配列で取り出し、キューを空にする。
+ * run 末尾で 1 回だけ呼び、各 creator を 1 回ずつ recompute する。
+ */
+export function takeQueuedCreators(): string[] {
+	const ids = Array.from(queued);
+	queued.clear();
+	return ids;
+}
+
+/** 現在キューに積まれた creator 数（ログ/テスト用）。 */
+export function queuedCreatorCount(): number {
+	return queued.size;
+}
+
+/** run 開始時に呼び、前 run の残骸をクリアする。 */
+export function resetCreatorRecomputeQueue(): void {
+	queued.clear();
+}


### PR DESCRIPTION
## 概要（SPR-225 Stage 1 / recompute ゲート・dedup ★reads 削減の本丸）

親: [SPR-225](https://linear.app/nothink/issue/SPR-225) → [SPR-215](https://linear.app/nothink/issue/SPR-215) #3 Firestore reads。
[SPR-224](https://linear.app/nothink/issue/SPR-224) の「dlsite 1実行 = 6k〜60k QUERY（reads の96%が type=QUERY）」の**主因を解消**する。

> ⚠️ **Stacked PR**: base は Stage 0（[#715](https://github.com/nothink-jp/suzumina.click/pull/715)）。**#715 をマージ後に base を `main` に切り替え**てマージしてください。
> ⚠️ **One-Way Door 寄り**（本番データ同期パイプライン）。セルフマージ・ポリシーに従い **AI 任せにせず自分でレビュー**してからマージ。

## 主因（接地済み）
`updateCreatorWorkMapping` が **work ごと・dedup なし**で、影響 creator 全員（new ∪ existing）に `recomputeCreatorStats`（creator の全作品スキャン）を発火。多作 creator（声優 N=数百〜千作）が処理対象 work に現れるたびフルスキャンが反復 → 60k QUERY。`forceUpdate:false` は work doc 書き込みのみゲートで recompute は未変更でも走っていた。

## 変更点
- **`updateCreatorWorkMapping`**: per-work の inline recompute を**撤去**。stat に影響する mapping 変化（relation の**追加/削除/roles 変化**）のあった creator だけを run-scoped キューへ enqueue。relation/creator doc の**書き込みは従来どおり**（name 伝播・既存 write 挙動を維持）。`name`/`circleId` のみの変更は workCount/types/primaryRole に影響しないため enqueue しない。
- **`creator-recompute-queue.ts`（新規）**: run-scoped な変更 creator キュー（Set で dedup）。
- **`dlsite-individual-info-api.ts`**: run 開始でキュー reset、batch loop 後（`finally`）に **creator ごと 1 回だけ** recompute して drain。完走・中断・例外いずれの経路でも drain（処理済みバッチ分は次 run へ持ち越さない）。
- 複雑度を抑えるため新マッピング適用 / 古マッピング削除を**ヘルパー関数に抽出**（cognitive complexity 17→閾値内）。

## 設計判断（R1・レビューで確定）
変化のあった**少数 creator はフル recompute（workCount/types/primaryRole）を run 末尾で 1 回だけ**実行。**整合性 cron（`checkDataIntegrity`）は変更せず**、creator 集計の正しさを hot-path で保ったまま reads を激減させる。

- 別案 R2（hot-path は `.count()` で workCount のみ更新し types/primaryRole 権威計算を週次 cron へ委譲）は、**事後修復への依存を増やす**（軸1）ため不採用。
- ゲート＋dedup で recompute 自体が稀になるため、R1 の追加 read（変化した少数 creator のフルスキャン ×1）は小さく有界。「実際に変わった少数 creator ×1回」に限定され 60k storm を解消。

## 検証
- `pnpm verify` green（lint:docs + lint:tokens + lint + typecheck + test、全パッケージ・カバレッジ閾値含む）。functions 385 passed（+9: キュー/enqueue 挙動テスト）。
- enqueue 挙動: 新規=全員 enqueue・inline recompute（update）なし / roles 不変（name のみ）=enqueue しない / roles 変化=enqueue / 関連削除=enqueue を網羅。
- **デプロイ後**: Cloud Monitoring `document/read_count` type=QUERY を dlsite 実行時に5分粒度で観測し、Stage 0 の計測ログ（`recomputeCalls`/`recomputeDocsRead`）の前後比較で reads 減を実測。

## リスク・ロールバック
- creator denormalize（workCount/types/primaryRole）は run 末尾 drain で同期。プロセスが drain 前に落ちると一部 creator の集計が次変更/週次 cron まで遅延し得る（relation 本体は commit 済み・有界な eventual）。
- 戻せる単位（recompute を per-work へ戻すだけ）。整合性 cron は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)