### PR TITLE
fix(web): /buttons/create を再訪時にフォーム初期化して前回作成値の残留を防ぐ

### DIFF
--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -388,6 +388,51 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 		});
 	});
 
+	describe("フォーム残留対策（再訪時のリセット）", () => {
+		// App Router は同一セグメント再訪で page instance を使い回すため、create フローを
+		// 抜けるたびに key で内部フォームを作り直し、次に作成を始めたときまっさらにする。
+		it("作成成功後にフォームが初期状態へ作り直される", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			// タイトルと有効な時間範囲を入力（前回作成したボタンの入力を再現）
+			const titleInput = screen.getByPlaceholderText("例: おはようございます");
+			await user.type(titleInput, "前回のタイトル");
+
+			const timeInputs = screen.getAllByPlaceholderText("0:00.0");
+			await user.clear(timeInputs[1]!);
+			await user.type(timeInputs[1]!, "0:05.0");
+			await user.tab();
+
+			const createButton = screen.getByRole("button", { name: /音声ボタンを作成/ });
+			await waitFor(() => expect(createButton).toBeEnabled());
+			await user.click(createButton);
+
+			// 詳細ページへ遷移しつつ、保持された instance はリセットされる
+			await waitFor(() => {
+				expect(mockPush).toHaveBeenCalledWith("/buttons/new-audio-button-id");
+			});
+			await waitFor(() => {
+				expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
+			});
+		});
+
+		it("キャンセル後にフォームが初期状態へ作り直される", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			const titleInput = screen.getByPlaceholderText("例: おはようございます");
+			await user.type(titleInput, "入力途中のタイトル");
+
+			await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+			expect(mockBack).toHaveBeenCalled();
+			await waitFor(() => {
+				expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
+			});
+		});
+	});
+
 	describe("Accessibility", () => {
 		it("キーボードナビゲーションが機能する", async () => {
 			const user = userEvent.setup();

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -5,7 +5,7 @@ import { YouTubePlayer } from "@suzumina.click/ui/components/custom/youtube-play
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Loader2, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
 import { useSession } from "@/lib/auth/client";
@@ -21,12 +21,33 @@ interface AudioButtonCreatorProps {
 	initialStartTime?: number;
 }
 
-export function AudioButtonCreator({
+/**
+ * フォーム残留対策のラッパー。
+ * /buttons/create は `private, no-store`（bfcache 非対象）だが、App Router は同一
+ * ページセグメントを再訪したとき page コンポーネントの instance を使い回すため、
+ * 純粋 useState で持つフォーム値（タイトル/説明/タグ/開始・終了時刻）が前回作成した
+ * ボタンのまま残ることがある。作成完了・キャンセルで create フローを抜けるたびに key を
+ * 更新して内部フォームを丸ごと作り直し、次に作成を始めたときは必ずまっさらにする。
+ */
+export function AudioButtonCreator(props: AudioButtonCreatorProps) {
+	const [formKey, setFormKey] = useState(0);
+	const resetForm = useCallback(() => setFormKey((key) => key + 1), []);
+
+	return <AudioButtonCreatorInner key={formKey} onLeave={resetForm} {...props} />;
+}
+
+interface AudioButtonCreatorInnerProps extends AudioButtonCreatorProps {
+	/** create フローを抜ける直前に呼び、保持された instance の入力値をリセットする */
+	onLeave: () => void;
+}
+
+function AudioButtonCreatorInner({
 	videoId,
 	videoTitle,
 	videoDuration = 600,
 	initialStartTime = 0,
-}: AudioButtonCreatorProps) {
+	onLeave,
+}: AudioButtonCreatorInnerProps) {
 	const router = useRouter();
 	const user = useSession();
 
@@ -71,6 +92,7 @@ export function AudioButtonCreator({
 
 			if (result.success) {
 				router.push(`/buttons/${result.data.id}`);
+				onLeave();
 			} else {
 				setError(result.error || "作成に失敗しました");
 			}
@@ -90,6 +112,7 @@ export function AudioButtonCreator({
 		setIsCreating,
 		setError,
 		videoTitle,
+		onLeave,
 	]);
 
 	// 時間調整用のハンドラーは共通フックから取得
@@ -171,7 +194,10 @@ export function AudioButtonCreator({
 							<div className="flex flex-col sm:flex-row gap-3 w-full lg:justify-end">
 								<Button
 									variant="outline"
-									onClick={() => router.back()}
+									onClick={() => {
+										router.back();
+										onLeave();
+									}}
 									disabled={isCreating}
 									className="w-full sm:w-auto min-h-[44px] order-2 sm:order-1"
 								>


### PR DESCRIPTION
## 背景 / 症状

`/buttons/create?video_id=...` で、直前に同じ video_id でボタンを作った後に新規作成を始めると、**前回作成したボタンの入力値（タイトル・説明・タグ・開始/終了時刻）が新規フォームに残る**。ユーザー報告では**ページ内リンク経由（SPA 遷移）で再現**。

## 原因（当初の bfcache 診断は誤り → 訂正）

- フォームの全入力値は `useAudioButtonEditor` 配下の純粋な `useState` のみで保持（永続化なし）。
- `/buttons/create` は `next.config.mjs` で **`Cache-Control: private, no-store`**（[next.config.mjs:310-316](apps/web/next.config.mjs:310)）＝ **bfcache 非対象**。よって bfcache は原因ではない。
- 真因は **App Router が同一ページセグメント（`/buttons/create`）を再訪したとき、page コンポーネントの instance を使い回し、`useState` を保持する**挙動。
- 作成系リンク（[video-detail.tsx:810](apps/web/src/app/videos/[videoId]/components/video-detail.tsx:810) 他）は全て `/buttons/create?video_id=X` と**同一 URL**のため、URL / searchParams を `key` にしても解消しない。

## 修正

`AudioButtonCreator` をラッパー化し、フォーム本体を `AudioButtonCreatorForm`（`key={formKey}`）に分離。**作成完了・キャンセルで create フローを抜けるたびに `formKey` を更新**して内部フォームを丸ごと作り直す。

- 保持された instance も、次に作成を始めたときには必ず初期状態になる（全 useState・時間サブフックまで漏れなくリセット）。
- 通常の入力・タブ切替等では再マウントしない。
- 影響範囲は create フローのみ（編集フローは別コンポーネントで未変更）。

## テスト

`audio-button-creator.test.tsx` に2件追加:
- 作成成功後にフォームが初期状態へ作り直される（`/buttons/[id]` 遷移＋入力クリア）
- キャンセル後にフォームが初期状態へ作り直される

## 検証

- ✅ typecheck（web）/ Biome lint（clean）/ 追加2件を含むテスト pass。
- ⚠️ 既知: 同ファイルの既存テスト `現在時間設定ボタンが動作する` がこのローカル環境で timing 依存により失敗するが、**origin/main でも同様に失敗する pre-existing flaky**（YouTube プレイヤー mock の `setTimeout(10ms)` + debounce が waitFor 既定 1秒に間に合わない）であり、本変更とは無関係。本 PR で新たな失敗は導入していない。
- ⚠️ 未実施: 本番同等のブラウザ手動再現（ログイン＋YouTube 埋め込み＋実 SPA 遷移が必要）。修正は「作成/キャンセルで抜けるたびに instance をリセット」する設計で、報告された「前回作成したボタンの値が残る」経路を確実に断つ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)