### PR TITLE
fix(web): 音声ボタン作成後の詳細遷移で作成フォームのちらつきを解消

### DIFF
--- a/apps/web/src/app/buttons/[id]/loading.tsx
+++ b/apps/web/src/app/buttons/[id]/loading.tsx
@@ -1,0 +1,56 @@
+import { Card, CardContent, CardHeader } from "@suzumina.click/ui/components/ui/card";
+import { Skeleton } from "@suzumina.click/ui/components/ui/skeleton";
+
+/**
+ * 詳細ページの遷移フォールバック。
+ * 作成成功直後に `/buttons/[id]` へ遷移する際、新規ドキュメントの read-after-write で
+ * RSC 取得に時間がかかる。loading が無いと遷移元（作成フォーム）が表示されたままになり、
+ * 「作成画面に戻った」ように見えるため、即座にスケルトンへ差し替える。
+ */
+export default function AudioButtonDetailLoading() {
+	return (
+		<div className="min-h-screen">
+			<div className="container mx-auto px-4 pt-6 pb-4 max-w-7xl">
+				<Skeleton className="h-5 w-64" />
+			</div>
+
+			<div className="container mx-auto px-4 pb-8 max-w-7xl">
+				<div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-8">
+					<div className="lg:col-span-2 space-y-4">
+						<Card>
+							<CardHeader>
+								<Skeleton className="h-7 w-3/4" />
+							</CardHeader>
+							<CardContent className="space-y-4">
+								<Skeleton className="h-24 w-full rounded-lg" />
+								<div className="space-y-2">
+									<Skeleton className="h-4 w-full" />
+									<Skeleton className="h-4 w-5/6" />
+								</div>
+								<div className="flex gap-2">
+									<Skeleton className="h-6 w-16 rounded-full" />
+									<Skeleton className="h-6 w-20 rounded-full" />
+								</div>
+							</CardContent>
+						</Card>
+					</div>
+
+					<div className="space-y-4">
+						<Card>
+							<CardContent className="p-4 space-y-3">
+								<Skeleton className="aspect-video w-full rounded-lg" />
+								<Skeleton className="h-4 w-4/5" />
+							</CardContent>
+						</Card>
+						<Card>
+							<CardContent className="p-4 flex items-center gap-3">
+								<Skeleton className="h-10 w-10 rounded-full" />
+								<Skeleton className="h-4 w-32" />
+							</CardContent>
+						</Card>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -154,7 +154,12 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 
 	return (
 		<ProtectedRoute>
+			{/*
+			 * key で動画/開始時刻ごとに remount。App Router は同一 /buttons/create セグメントの
+			 * 再訪で page instance を使い回すため、別動画で来たときに前回のフォーム値が残るのを防ぐ。
+			 */}
 			<AudioButtonCreator
+				key={`${videoId}:${startTime}`}
 				videoId={videoId}
 				videoTitle={videoResult.title}
 				videoDuration={videoDuration}

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -388,16 +388,17 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 		});
 	});
 
-	describe("フォーム残留対策（再訪時のリセット）", () => {
-		// App Router は同一セグメント再訪で page instance を使い回すため、create フローを
-		// 抜けるたびに key で内部フォームを作り直し、次に作成を始めたときまっさらにする。
-		it("作成成功後にフォームが初期状態へ作り直される", async () => {
+	describe("作成完了・キャンセルの遷移", () => {
+		// 成功・キャンセルはいずれも create セグメント外へ遷移し instance が unmount されるため、
+		// 遷移先が描画されるまでフォームを空白化せず「作成中…」を維持する（ちらつき防止）。
+		// 同一セグメント別動画の値残留は page 側の key（videoId+startTime）で remount して防ぐ。
+		it("作成成功で詳細ページへ遷移し、遷移中はフォームを空白化せず作成中表示を維持する", async () => {
 			const user = userEvent.setup();
 			render(<AudioButtonCreator {...defaultProps} />);
 
-			// タイトルと有効な時間範囲を入力（前回作成したボタンの入力を再現）
+			// タイトルと有効な時間範囲を入力
 			const titleInput = screen.getByPlaceholderText("例: おはようございます");
-			await user.type(titleInput, "前回のタイトル");
+			await user.type(titleInput, "作成するタイトル");
 
 			const timeInputs = screen.getAllByPlaceholderText("0:00.0");
 			await user.clear(timeInputs[1]!);
@@ -408,16 +409,17 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			await waitFor(() => expect(createButton).toBeEnabled());
 			await user.click(createButton);
 
-			// 詳細ページへ遷移しつつ、保持された instance はリセットされる
+			// 詳細ページへ遷移する
 			await waitFor(() => {
 				expect(mockPush).toHaveBeenCalledWith("/buttons/new-audio-button-id");
 			});
-			await waitFor(() => {
-				expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
-			});
+
+			// 遷移完了まで「作成中…」を維持し、フォームは空白化しない（ちらつき防止）
+			expect(screen.getByRole("button", { name: /作成中/ })).toBeInTheDocument();
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("作成するタイトル");
 		});
 
-		it("キャンセル後にフォームが初期状態へ作り直される", async () => {
+		it("キャンセルで前のページへ戻る", async () => {
 			const user = userEvent.setup();
 			render(<AudioButtonCreator {...defaultProps} />);
 
@@ -427,9 +429,20 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			await user.click(screen.getByRole("button", { name: "キャンセル" }));
 
 			expect(mockBack).toHaveBeenCalled();
-			await waitFor(() => {
-				expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
-			});
+		});
+
+		it("別動画で再訪（key 変更）するとフォームが初期状態へ作り直される", async () => {
+			const user = userEvent.setup();
+			const { rerender } = render(<AudioButtonCreator key="video-a" {...defaultProps} />);
+
+			const titleInput = screen.getByPlaceholderText("例: おはようございます");
+			await user.type(titleInput, "前回のタイトル");
+			expect(titleInput).toHaveValue("前回のタイトル");
+
+			// page 側の key 変更（別動画への遷移）を模した remount
+			rerender(<AudioButtonCreator key="video-b" {...defaultProps} videoId="other-video" />);
+
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
 		});
 	});
 

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -5,7 +5,7 @@ import { YouTubePlayer } from "@suzumina.click/ui/components/custom/youtube-play
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Loader2, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
 import { useSession } from "@/lib/auth/client";
@@ -22,32 +22,19 @@ interface AudioButtonCreatorProps {
 }
 
 /**
- * フォーム残留対策のラッパー。
- * /buttons/create は `private, no-store`（bfcache 非対象）だが、App Router は同一
- * ページセグメントを再訪したとき page コンポーネントの instance を使い回すため、
- * 純粋 useState で持つフォーム値（タイトル/説明/タグ/開始・終了時刻）が前回作成した
- * ボタンのまま残ることがある。作成完了・キャンセルで create フローを抜けるたびに key を
- * 更新して内部フォームを丸ごと作り直し、次に作成を始めたときは必ずまっさらにする。
+ * 音声ボタン作成フォーム。
+ * フォーム値（タイトル/説明/タグ/開始・終了時刻）は useState で保持する。
+ * 作成成功・キャンセルはいずれも create セグメント外（詳細ページ / 戻り先）へ遷移するため
+ * この instance は unmount され、次に作成画面へ来たときは必ずまっさらに mount される。
+ * 同一セグメントを別動画で再訪したときの値残留は page 側の `key`（videoId+startTime）で
+ * remount して防ぐ（apps/web/src/app/buttons/create/page.tsx）。
  */
-export function AudioButtonCreator(props: AudioButtonCreatorProps) {
-	const [formKey, setFormKey] = useState(0);
-	const resetForm = useCallback(() => setFormKey((key) => key + 1), []);
-
-	return <AudioButtonCreatorInner key={formKey} onLeave={resetForm} {...props} />;
-}
-
-interface AudioButtonCreatorInnerProps extends AudioButtonCreatorProps {
-	/** create フローを抜ける直前に呼び、保持された instance の入力値をリセットする */
-	onLeave: () => void;
-}
-
-function AudioButtonCreatorInner({
+export function AudioButtonCreator({
 	videoId,
 	videoTitle,
 	videoDuration = 600,
 	initialStartTime = 0,
-	onLeave,
-}: AudioButtonCreatorInnerProps) {
+}: AudioButtonCreatorProps) {
 	const router = useRouter();
 	const user = useSession();
 
@@ -91,14 +78,18 @@ function AudioButtonCreatorInner({
 			const result = await createAudioButton(input);
 
 			if (result.success) {
+				// 詳細ページへ遷移。create セグメントを離れるためこの instance は破棄される。
+				// 遷移完了まで「作成中…」を維持し、フォームを空白化しない（ちらつき防止）。
+				// 既知の制約: router.push に完了コールバックが無いため、遷移が完了しない異常時
+				// （ネットワーク断・SSR エラー等）は「作成中…」のまま固着しうる。ちらつき防止を優先。
 				router.push(`/buttons/${result.data.id}`);
-				onLeave();
-			} else {
-				setError(result.error || "作成に失敗しました");
+				return;
 			}
+
+			setError(result.error || "作成に失敗しました");
+			setIsCreating(false);
 		} catch (_error) {
 			setError("予期しないエラーが発生しました");
-		} finally {
 			setIsCreating(false);
 		}
 	}, [
@@ -112,7 +103,6 @@ function AudioButtonCreatorInner({
 		setIsCreating,
 		setError,
 		videoTitle,
-		onLeave,
 	]);
 
 	// 時間調整用のハンドラーは共通フックから取得
@@ -196,7 +186,6 @@ function AudioButtonCreatorInner({
 									variant="outline"
 									onClick={() => {
 										router.back();
-										onLeave();
 									}}
 									disabled={isCreating}
 									className="w-full sm:w-auto min-h-[44px] order-2 sm:order-1"


### PR DESCRIPTION
## 背景

新規で音声ボタンを作成した直後、詳細ページではなく「空の作成画面に戻った」ように見える、という UX 報告。

コード上は作成成功時に `router.push('/buttons/[id]')` で詳細ページへ遷移する設計（＝期待どおり）だが、その直前に同期で `onLeave()` がフォームを空白化していた。`/buttons/[id]` には `loading.tsx` が無く、新規ドキュメントの read-after-write 取得待ち中は遷移元（＝今空白化した作成フォーム）が表示されたままになるため、「作成画面に戻った」誤認が生じていた。

## 変更内容

### (A) 成功時の in-place リセットを撤去 → リセットをマウント時へ移管
- `AudioButtonCreator` の `onLeave`/`formKey` ラッパーを撤去。作成成功・キャンセルはいずれも create セグメント外（詳細 / 戻り先）へ遷移して instance が unmount されるため、その場でのフォームリセットは不要。
- 成功時は `setIsCreating(false)` せず「作成中…」を遷移完了まで維持（遷移元を空白化しない）。
- 同一セグメントを別動画で再訪したときの値残留（#717 の本来の対象）は、page 側の `key={\`${videoId}:${startTime}\`}` で remount して解消。

### (B) 詳細ページに `loading.tsx`
- `apps/web/src/app/buttons/[id]/loading.tsx` を追加。`router.push` 直後にスケルトンへ即差し替わり、取得待ち中も作成フォームが見えない。

## 検証
- `typecheck` ✅ / `biome check` ✅
- 該当テストを新アーキテクチャに合わせて更新（成功=詳細遷移＋作成中維持＋非空白化 / キャンセル=戻る / 別動画 key 変更=リセット）→ 3 件 pass
- ブラウザ検証は見送り: このちらつきは read-after-write 遅延起因で、Emulator では遅延が出ず再現しないため

## 補足
- 同ファイルの既存テスト「現在時間設定ボタンが動作する」はファイル単独フル実行で flaky に落ちる（YouTube プレイヤーモックの `setTimeout` がテスト間に漏れる既存問題、本変更とは無関係。元コードでも再現）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)