### PR TITLE
chore(functions): SPR-232 region 等価性チェックツール追加 + tools 整理整頓

### DIFF
--- a/apps/functions/biome.json
+++ b/apps/functions/biome.json
@@ -56,6 +56,16 @@
 			}
 		},
 		{
+			"includes": ["**/src/tools/**"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noConsole": "off"
+					}
+				}
+			}
+		},
+		{
 			"includes": ["**/src/development/**"],
 			"linter": {
 				"rules": {

--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -20,6 +20,7 @@
 		"collect:work-ids": "dotenv -e .env -- tsx src/tools/core/collect-work-ids.ts",
 		"collect:complete-local": "dotenv -e .env -- tsx src/tools/core/local-complete-collector.ts",
 		"detect:region-restrictions": "dotenv -e .env -- tsx src/tools/core/region-restriction-detector.ts",
+		"check:region-equivalence": "dotenv -e .env -- tsx src/tools/core/region-equivalence-check.ts",
 		"tools:capture": "dotenv -e .env -- tsx src/tools/core/dlsite-dryrun-capture.ts",
 		"tools:stats": "dotenv -e .env -- tsx src/tools/run-tools.ts stats",
 		"tools:report": "dotenv -e .env -- tsx src/tools/run-tools.ts report",

--- a/apps/functions/src/tools/core/local-complete-collector.ts
+++ b/apps/functions/src/tools/core/local-complete-collector.ts
@@ -1,10 +1,11 @@
 /**
  * DLsite完全データローカル収集ツール
  *
- * ローカル環境（日本）で全1,488作品の完全データ収集を実行し
+ * ローカル環境（日本）で全作品の完全データ収集を実行し
  * リージョン制限作品を含む全作品情報をCloud Firestoreに安全に投入する
  *
- * 設計: docs/DLSITE_REGION_RESTRICTION_DESIGN.md Phase 2
+ * 背景: asset(`dlsite-work-ids.json`)との region 突合に依存。asset 削除の可否は SPR-232 で評価中。
+ *       region 等価性の確認は check:region-equivalence（旧 docs/DLSITE_REGION_RESTRICTION_DESIGN.md は不在）。
  */
 
 import { readFileSync } from "node:fs";

--- a/apps/functions/src/tools/core/region-equivalence-check.ts
+++ b/apps/functions/src/tools/core/region-equivalence-check.ts
@@ -1,0 +1,72 @@
+/**
+ * DLsite work-id の region 等価性チェック（read-only・SPR-232）
+ *
+ * ローカル(日本)スクレイプ L と 本番 Firestore `works` の doc ID F を突合し、
+ * asia-northeast1（本番 region）が日本可視作品を取りこぼしていないかを確認する。
+ * - L \ F = 日本可視・本番未保持 ＝ region 制限候補（★主シグナル。0 なら実害なし）
+ * - F \ L = 本番保持・今回 scrape 外 ＝ 削除/delist/ページング差
+ * asset(`dlsite-work-ids.json`)も参考突合する。書き込みは一切しない。
+ *
+ * 用途: SPR-232（asset 削除の可否を運用後の複数 run で判断）の反復計測。
+ * 実行: pnpm --filter @suzumina.click/functions check:region-equivalence
+ *       （ADC 必須＝本番 Firestore 直結。Emulator では F が空になり無意味）
+ */
+
+import workIdsAsset from "../../assets/dlsite-work-ids.json";
+import firestore from "../../infrastructure/database/firestore";
+import { collectAllWorkIds } from "../../services/dlsite/work-id-collector";
+
+function preview(ids: string[], n = 25): string {
+	if (ids.length === 0) return "(なし)";
+	return ids.slice(0, n).join(", ") + (ids.length > n ? ` …(+${ids.length - n}件)` : "");
+}
+
+async function main(): Promise<void> {
+	const startedAt = Date.now();
+
+	console.log("▶ [1/2] ローカル(日本)スクレイプ開始 …（requestDelay 由来で数分かかる）");
+	const local = await collectAllWorkIds({ maxPages: 100 });
+	const L = new Set(local.workIds);
+	console.log(
+		`  ローカル取得 L=${L.size}件 / DLsite報告総数(totalCount)=${local.totalCount} / pages=${local.totalPages}`,
+	);
+
+	console.log("▶ [2/2] 本番 Firestore `works` の doc ID 取得 …");
+	const refs = await firestore.collection("works").listDocuments();
+	const F = new Set(refs.map((r) => r.id));
+	console.log(`  Firestore works F=${F.size}件`);
+
+	const A = new Set((workIdsAsset as { workIds: string[] }).workIds);
+
+	const intersection = [...L].filter((id) => F.has(id)).length;
+	const LminusF = [...L].filter((id) => !F.has(id)).sort();
+	const FminusL = [...F].filter((id) => !L.has(id)).sort();
+	const LminusA = [...L].filter((id) => !A.has(id)).sort();
+	const AminusL = [...A].filter((id) => !L.has(id)).sort();
+
+	console.log("\n==== SPR-232 region 等価性計測 ====");
+	console.log(`L = ローカル日本スクレイプ      : ${L.size}`);
+	console.log(`F = 本番 Firestore works        : ${F.size}`);
+	console.log(`A = asset(dlsite-work-ids.json) : ${A.size}`);
+	console.log(`L ∩ F                           : ${intersection}`);
+	console.log("");
+	console.log(`★ L \\ F (日本可視・本番未保持=region制限候補): ${LminusF.length}`);
+	console.log(`    ${preview(LminusF)}`);
+	console.log(`  F \\ L (本番保持・今回scrape外=削除/delist/ページング差): ${FminusL.length}`);
+	console.log(`    ${preview(FminusL)}`);
+	console.log(`  L \\ A (asset 未収載＝asset が古い側の証拠): ${LminusA.length}`);
+	console.log(`    ${preview(LminusA)}`);
+	console.log(`  A \\ L (asset 固有＝asset にだけ在る古い ID): ${AminusL.length}`);
+	console.log(`    ${preview(AminusL)}`);
+	console.log(
+		"\n判定の目安: L \\ F = 0 なら「日本から見える作品はすべて本番が保持」＝region 制限の実害なし。",
+	);
+	console.log(`(elapsed ${((Date.now() - startedAt) / 1000).toFixed(1)}s)`);
+}
+
+main()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error("計測エラー:", error);
+		process.exit(1);
+	});

--- a/apps/functions/src/tools/core/region-equivalence-check.ts
+++ b/apps/functions/src/tools/core/region-equivalence-check.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
 	const F = new Set(refs.map((r) => r.id));
 	console.log(`  Firestore works F=${F.size}件`);
 
-	const A = new Set((workIdsAsset as { workIds: string[] }).workIds);
+	const A = new Set(workIdsAsset.workIds);
 
 	const intersection = [...L].filter((id) => F.has(id)).length;
 	const LminusF = [...L].filter((id) => !F.has(id)).sort();

--- a/apps/functions/src/tools/core/region-restriction-detector.ts
+++ b/apps/functions/src/tools/core/region-restriction-detector.ts
@@ -356,6 +356,9 @@ class RegionRestrictionDetector {
 async function main(): Promise<void> {
 	try {
 		logger.info("🚀 DLsite リージョン制限検出ツール開始");
+		logger.warn(
+			"⚠️ 判定基準は asset(dlsite-work-ids.json) との差分です。asset が stale だと誤った regionRestricted フラグを本番 works に書き込みます。実行前に check:region-equivalence で鮮度を確認してください（SPR-232）",
+		);
 
 		const detector = new RegionRestrictionDetector();
 

--- a/apps/functions/src/tools/core/region-restriction-detector.ts
+++ b/apps/functions/src/tools/core/region-restriction-detector.ts
@@ -4,7 +4,10 @@
  * 現在のリージョンで取得できない作品を検出し、
  * リージョン制限フラグを設定してFirestoreに記録する
  *
- * 設計: docs/DLSITE_REGION_RESTRICTION_DESIGN.md Phase 1
+ * 注意: 判定基準は asset(`dlsite-work-ids.json`)との差分。asset が stale だと誤検出して
+ *       Firestore に誤った regionRestricted フラグを書き込むため、実行前に
+ *       check:region-equivalence で asset の鮮度と region 等価性を確認すること（SPR-232）。
+ *       （旧 docs/DLSITE_REGION_RESTRICTION_DESIGN.md は不在）
  */
 
 import { readFileSync } from "node:fs";

--- a/apps/functions/src/tools/firestore-local/dump.ts
+++ b/apps/functions/src/tools/firestore-local/dump.ts
@@ -72,18 +72,15 @@ async function main(): Promise<void> {
 		const fixture = await dumpCollection(firestore, name, limit);
 		const file = join(FIXTURES_DIR, `${name}.json`);
 		await writeFile(file, `${JSON.stringify(fixture, null, 2)}\n`, "utf-8");
-		// biome-ignore lint/suspicious/noConsole: 開発ツールの進捗表示
 		console.log(`[dump] ${name}: ${fixture.docs.length} 件 -> ${file}`);
 	}
 
-	// biome-ignore lint/suspicious/noConsole: 開発ツールの進捗表示
 	console.log(
 		"[dump] 完了。サブコレクション(priceHistory 等)とユーザー系は対象外です。フィクスチャをコミットしてください。",
 	);
 }
 
 main().catch((err) => {
-	// biome-ignore lint/suspicious/noConsole: 開発ツールのエラー表示
 	console.error("[dump] 失敗:", err);
 	process.exit(1);
 });

--- a/apps/functions/src/tools/firestore-local/seed.ts
+++ b/apps/functions/src/tools/firestore-local/seed.ts
@@ -55,26 +55,21 @@ async function main(): Promise<void> {
 
 	const fixtures = await loadFixtureFiles();
 	if (fixtures.length === 0) {
-		// biome-ignore lint/suspicious/noConsole: 開発ツールの進捗表示
 		console.log(
 			`[seed] フィクスチャがありません (${FIXTURES_DIR})。seed:dump で本番から取得するか、JSON を追加してください。`,
 		);
 		return;
 	}
 
-	// biome-ignore lint/suspicious/noConsole: 開発ツールの進捗表示
 	console.log(`[seed] Emulator ${process.env.FIRESTORE_EMULATOR_HOST} へ投入します`);
 	for (const fixture of fixtures) {
 		await seedCollection(firestore, fixture);
-		// biome-ignore lint/suspicious/noConsole: 開発ツールの進捗表示
 		console.log(`[seed] ${fixture.collection}: ${fixture.docs.length} 件`);
 	}
-	// biome-ignore lint/suspicious/noConsole: 開発ツールの進捗表示
 	console.log("[seed] 完了");
 }
 
 main().catch((err) => {
-	// biome-ignore lint/suspicious/noConsole: 開発ツールのエラー表示
 	console.error("[seed] 失敗:", err);
 	process.exit(1);
 });


### PR DESCRIPTION
## 概要

[SPR-232](https://linear.app/nothink/issue/SPR-232)（asset `dlsite-work-ids.json` 削除可否を運用後の複数 run で判断）の**反復計測を再現可能にする**ためのツール追加と、ついでに `apps/functions/src/tools/` の軽い整理整頓。挙動不変（dev-only ツールのみ・本番ランタイムは無変更）。

## 変更点

### 1. 計測ツール追加（read-only）
- `tools/core/region-equivalence-check.ts` を追加。ローカル(日本)スクレイプ **L** と 本番 Firestore `works` の doc ID **F** を突合し、`L\F`（日本可視・本番未保持＝**region 制限候補**）を主シグナルに出力。asset **A** も参考突合。書き込みは一切なし。
- `pnpm --filter @suzumina.click/functions check:region-equivalence` で実行（ADC 必須）。
- **第1回計測（2026-06-28）**: `L=2071`（DLsite 報告 totalCount=2071・完全取得）/ `F=2076` / **`L\F=0`** ＝ region 等価・実害なし。asset は stale（A=1681・新 391 件未収載）も確認。詳細は SPR-232 コメント。

### 2. tools の整理整頓
- **stale doc 参照の是正**（軸1: doc drift = 負債）: `region-restriction-detector` / `local-complete-collector` が指す `docs/DLSITE_REGION_RESTRICTION_DESIGN.md` は**不在** → 正確なポインタに置換。
  - `region-restriction-detector` に注意書きを追加: 判定基準が **stale asset との差分**のため、stale だと**誤った `regionRestricted` フラグを本番に書き込む**実害がある（今日 asset は stale）。実行前に `check:region-equivalence` で鮮度確認すること。
  - `local-complete-collector` のハードコード件数「1,488作品」を一般化。
- **dev-only tools の console を許容**: `src/tools/**` に `noConsole: off` の biome override を追加（既存の `src/development/**` override と同型）。これに伴い `dump`/`seed` の冗長な inline `biome-ignore noConsole`（計8件・override で unused 化）を撤去。`tools/` 配下の biome 警告は **0** に。

## 非対象（意図的に残置）
- 既存の asset 連動ツール（`collect:work-ids` / `collect:complete-local` / `detect:region-restrictions`）の**削除はしない**。asset 自体の削除可否は SPR-232 が運用データで判断する領域のため、本 PR は触らない（stale 警告のみ追記）。

## 検証
- `pnpm verify` green（lint:docs + lint:tokens + lint + typecheck + test・カバレッジ閾値含む）。新ツールはテストにロードされないためカバレッジ不変。
- 第1回計測を実機（ADC 直結・本番 Firestore read-only）で実行済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)