### PR TITLE
fix(web): better-auth 1.6.22 対応 — discordId を server 側 provisioning に移行

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,7 @@
 		"@hookform/resolvers": "^5.4.0",
 		"@suzumina.click/shared-types": "workspace:*",
 		"@suzumina.click/ui": "workspace:*",
-		"better-auth": "^1.6.19",
+		"better-auth": "^1.6.22",
 		"lucide-react": "^1.21.0",
 		"next": "^16.2.9",
 		"react": "^19.2.7",

--- a/apps/web/src/lib/better-auth/__tests__/provision-discord-id.test.ts
+++ b/apps/web/src/lib/better-auth/__tests__/provision-discord-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { provisionDiscordIdOnAuthUser } from "../on-first-signup";
+
+/**
+ * better-auth 1.6.21+ の破壊的変更（input:false フィールドは OAuth profile sync で無視される）への
+ * 回帰ガード。account.create フックが better-auth user の discordId を server 側で充填することを固定する。
+ * これが欠けると enrich-session が appUser を null にし、新規ユーザーが認証不能になる。
+ */
+describe("provisionDiscordIdOnAuthUser", () => {
+	const account = { providerId: "discord", accountId: "discord-123", userId: "ba-user-1" };
+
+	it("ba_user.discordId を accountId（Discord user id）で update する", async () => {
+		const update = vi.fn().mockResolvedValue(null);
+		await provisionDiscordIdOnAuthUser(account, { update });
+		expect(update).toHaveBeenCalledWith({
+			model: "user",
+			where: [{ field: "id", value: "ba-user-1", operator: "eq", connector: "AND" }],
+			update: { discordId: "discord-123" },
+		});
+	});
+
+	it("discord 以外のプロバイダでは何もしない", async () => {
+		const update = vi.fn();
+		await provisionDiscordIdOnAuthUser({ ...account, providerId: "github" }, { update });
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("accountId / userId が欠けていれば何もしない", async () => {
+		const update = vi.fn();
+		await provisionDiscordIdOnAuthUser({ ...account, accountId: "" }, { update });
+		await provisionDiscordIdOnAuthUser({ ...account, userId: "" }, { update });
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("update 失敗でも throw せずサインアップを止めない（best-effort）", async () => {
+		const update = vi.fn().mockRejectedValue(new Error("firestore down"));
+		await expect(provisionDiscordIdOnAuthUser(account, { update })).resolves.toBeUndefined();
+	});
+});

--- a/apps/web/src/lib/better-auth/__tests__/provision-discord-id.test.ts
+++ b/apps/web/src/lib/better-auth/__tests__/provision-discord-id.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import * as logger from "@/lib/logger";
 import { provisionDiscordIdOnAuthUser } from "../on-first-signup";
 
 /**
@@ -32,8 +33,15 @@ describe("provisionDiscordIdOnAuthUser", () => {
 		expect(update).not.toHaveBeenCalled();
 	});
 
-	it("update 失敗でも throw せずサインアップを止めない（best-effort）", async () => {
+	it("update 失敗でも throw せず、本番でも観測できるよう常にエラーログを残す（best-effort）", async () => {
 		const update = vi.fn().mockRejectedValue(new Error("firestore down"));
+		const logError = vi.spyOn(logger, "error").mockImplementation(() => {});
 		await expect(provisionDiscordIdOnAuthUser(account, { update })).resolves.toBeUndefined();
+		// 認証クリティカルな失敗は isDev ガード無しで必ずログする（サイレント握り潰し防止）。
+		expect(logError).toHaveBeenCalledWith(
+			"better-auth: discordId provisioning 失敗",
+			expect.objectContaining({ discordId: "discord-123" }),
+		);
+		logError.mockRestore();
 	});
 });

--- a/apps/web/src/lib/better-auth/auth.ts
+++ b/apps/web/src/lib/better-auth/auth.ts
@@ -12,7 +12,7 @@ import { nextCookies } from "better-auth/next-js";
 import { customSession } from "better-auth/plugins";
 import { buildAppUserForSession } from "./enrich-session";
 import { firestoreAdapter } from "./firestore-adapter";
-import { createAppUserOnFirstSignup } from "./on-first-signup";
+import { createAppUserOnFirstSignup, provisionDiscordIdOnAuthUser } from "./on-first-signup";
 
 export const auth = betterAuth({
 	appName: "suzumina.click",
@@ -25,7 +25,9 @@ export const auth = betterAuth({
 
 	user: {
 		additionalFields: {
-			// Discord ユーザー ID（アプリ `users` ドキュメント ID と一致）。API 入力では設定不可。
+			// Discord ユーザー ID（アプリ `users` ドキュメント ID と一致）。API 入力では設定不可（input:false）。
+			// better-auth 1.6.21+ は input:false フィールドへの OAuth profile 値を無視するため、
+			// 値の充填は account.create フックの provisionDiscordIdOnAuthUser で server 側から行う。
 			discordId: { type: "string", required: false, input: false },
 		},
 	},
@@ -41,15 +43,16 @@ export const auth = betterAuth({
 			clientId: process.env.DISCORD_CLIENT_ID || "",
 			clientSecret: process.env.DISCORD_CLIENT_SECRET || "",
 			scope: ["identify", "email", "guilds"],
-			mapProfileToUser: (profile) => ({ discordId: profile.id }),
 		},
 	},
 
 	databaseHooks: {
 		account: {
 			create: {
-				// 初回 Discord 連携時にアプリ users/{discordId} を自動作成する（詳細は on-first-signup.ts）。
 				after: async (account) => {
+					// better-auth user の discordId を server 側で充填（input:false のため mapProfileToUser は不可）。
+					await provisionDiscordIdOnAuthUser(account);
+					// 初回 Discord 連携時にアプリ users/{discordId} を自動作成する（詳細は on-first-signup.ts）。
 					await createAppUserOnFirstSignup(account);
 				},
 			},

--- a/apps/web/src/lib/better-auth/on-first-signup.ts
+++ b/apps/web/src/lib/better-auth/on-first-signup.ts
@@ -11,8 +11,6 @@ import { createUser, userExists } from "@/lib/user-firestore";
 import { extractAvatarHash, fetchDiscordGuildMembership } from "./discord-guild";
 import { type FirestoreOps, firestoreOps } from "./firestore-adapter";
 
-const isDev = process.env.NODE_ENV !== "production";
-
 // better-auth 標準モデル(user 等)へのアクセスはアダプタ境界(firestoreOps)を共有する。
 const ops = firestoreOps();
 
@@ -44,8 +42,9 @@ export async function provisionDiscordIdOnAuthUser(
 			update: { discordId: account.accountId },
 		});
 	} catch (err) {
-		if (isDev)
-			logError("better-auth: discordId provisioning 失敗", { discordId: account.accountId, err });
+		// 認証クリティカル: 失敗すると enrich-session が appUser を null にし新規ユーザーが認証不能になる。
+		// best-effort でサインアップは止めないが、本番でも観測可能にするため常にエラーログを残す。
+		logError("better-auth: discordId provisioning 失敗", { discordId: account.accountId, err });
 	}
 }
 
@@ -81,6 +80,8 @@ export async function createAppUserOnFirstSignup(account: FirstSignupAccount): P
 			guildMembership,
 		});
 	} catch (err) {
-		if (isDev) logError("better-auth: app user 作成失敗", { discordId, err });
+		// discordId provisioning と同じく認証クリティカル（users/{discordId} 不在も appUser を null にする）。
+		// 本番でも検知できるよう常にエラーログを残す。
+		logError("better-auth: app user 作成失敗", { discordId, err });
 	}
 }

--- a/apps/web/src/lib/better-auth/on-first-signup.ts
+++ b/apps/web/src/lib/better-auth/on-first-signup.ts
@@ -9,7 +9,7 @@ import { SUZUMINA_GUILD_ID } from "@suzumina.click/shared-types";
 import { error as logError } from "@/lib/logger";
 import { createUser, userExists } from "@/lib/user-firestore";
 import { extractAvatarHash, fetchDiscordGuildMembership } from "./discord-guild";
-import { firestoreOps } from "./firestore-adapter";
+import { type FirestoreOps, firestoreOps } from "./firestore-adapter";
 
 const isDev = process.env.NODE_ENV !== "production";
 
@@ -22,6 +22,31 @@ interface FirstSignupAccount {
 	accessToken?: string | null;
 	accountId: string;
 	userId: string;
+}
+
+/**
+ * better-auth user の `discordId`（additionalField / input:false）を server 側で充填する。
+ *
+ * better-auth 1.6.21+ は OAuth profile sync で input:false のフィールドへの provider 値を無視するため、
+ * `mapProfileToUser` では埋められない。account.create フックで account.accountId（= Discord user id）から
+ * 明示セットする。これが無いと enrich-session が discordId 無しで appUser を null にし、新規ユーザーが認証不能になる。
+ * best-effort（失敗してもサインアップ自体は止めない）。テスト用に ops を注入可能。
+ */
+export async function provisionDiscordIdOnAuthUser(
+	account: Pick<FirstSignupAccount, "providerId" | "accountId" | "userId">,
+	opsImpl: Pick<FirestoreOps, "update"> = ops,
+): Promise<void> {
+	if (account.providerId !== "discord" || !account.accountId || !account.userId) return;
+	try {
+		await opsImpl.update({
+			model: "user",
+			where: [{ field: "id", value: account.userId, operator: "eq", connector: "AND" }],
+			update: { discordId: account.accountId },
+		});
+	} catch (err) {
+		if (isDev)
+			logError("better-auth: discordId provisioning 失敗", { discordId: account.accountId, err });
+	}
 }
 
 export async function createAppUserOnFirstSignup(account: FirstSignupAccount): Promise<void> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       better-auth:
-        specifier: ^1.6.19
-        version: 1.6.20(@opentelemetry/api@1.9.0)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
+        specifier: ^1.6.22
+        version: 1.6.22(@opentelemetry/api@1.9.0)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9)
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
@@ -453,14 +453,14 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@better-auth/core@1.6.20':
-    resolution: {integrity: sha512-y73I1xNXuNYiHBFduWGRcJ2ro2rNuVDEYkgVMJtIaRXtbosdXHs9gfyQrHecgeHMHKx1SYSBT/CExak0vVMTng==}
+  '@better-auth/core@1.6.22':
+    resolution: {integrity: sha512-aFH/5nzmR501jAJPKjJfiVg4BrkcjVCqq9WS9JnhTruE/2PIWopv1QGMiRIRqxXaPbHczri7cqRdhep3Lg5PMw==}
     peerDependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@cloudflare/workers-types': '>=4'
       '@opentelemetry/api': ^1.9.0
-      better-call: 1.3.6
+      better-call: 1.3.7
       jose: ^6.1.0
       kysely: 0.28.17
       nanostores: ^1.0.1
@@ -470,46 +470,46 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.20':
-    resolution: {integrity: sha512-hJHfCdAiZrC7EmZAt3NAiGgcNo9Y5Qz3PLL+a9rODXaAJGCMvzUJniqef9wHuJBwU0SWW+2f4wXe8xQmaC/IKQ==}
+  '@better-auth/drizzle-adapter@1.6.22':
+    resolution: {integrity: sha512-uNa9qH53CfxBmuKP8kbLWxY90oIRwUPn5BcHhO+szK05e2yh6EYwSNNivDSqV3YG5HPfjtPHulklInjq1wtm3w==}
     peerDependencies:
-      '@better-auth/core': ^1.6.20
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       drizzle-orm: ^0.45.2
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.20':
-    resolution: {integrity: sha512-Uvpmgbx5y8JqXroVanNzDdKzOl3HojoTz+/X6MR6zOUr25IzlYz660mjnu0rxKiIF55kD3CroqFsDzjNUw7ERw==}
+  '@better-auth/kysely-adapter@1.6.22':
+    resolution: {integrity: sha512-4k/07lPRizlQi+B+uOE5CwTfH3w+Lq8ZDX1nDN1+e+glRVKAIfHoLvC9cfAVcCbio3DDrl0RTbwjLwjEhG0LxA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.20
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       kysely: 0.28.17
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.20':
-    resolution: {integrity: sha512-J5Ni0LlFijbzXlwu2rFHaD8zEFocmajyzWkRnHsq8LhV/Dk4iWQwwnqzLrPoDQEj8roECAUF03hrIeMzqWRqJQ==}
+  '@better-auth/memory-adapter@1.6.22':
+    resolution: {integrity: sha512-rbepe/gHhWs0aF4fAu6+l+wNPJxT9XN4U+Hqa1Y/5HhjtT9y5evo3INrSWlkIOymsMaQ0cBPrSL5pm9Z195hcA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.20
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.20':
-    resolution: {integrity: sha512-ClDBJf6h4g85WJswxwQwxLaiyRU67Gmz/uaIf19tY1gqlLJDykSGjmqRNSBMG5rWABNzcNqbO4KG31rYUldbIw==}
+  '@better-auth/mongo-adapter@1.6.22':
+    resolution: {integrity: sha512-OYnfySHlVkIx7y6XNBsCHjKhl6IYGprRkFwifc/TAuPBVjoRKhLKRAXuzMdWTQYFt4FYb6holbhjNUrXxPIWcw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.20
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/prisma-adapter@1.6.20':
-    resolution: {integrity: sha512-WhYdhSGuVSfu1peCSf2snmmVzfWjRaEvbSrsNCusiwGE9l94HlES4mjSPM48fed24hL7yg4j1dYK/yjEt87FpQ==}
+  '@better-auth/prisma-adapter@1.6.22':
+    resolution: {integrity: sha512-I6lWQwLva732V600u5dLM2kRcQ94pRZOVVfZ87+Ow9RBxMUnV+I+YQ5h2yggdN2tmsmITacZTy1DSZbDxGu0LQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.20
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -519,21 +519,15 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.20':
-    resolution: {integrity: sha512-3BhbY3naQDERvdJvJ7fGszVY6rpsVfc6c9uyBVZlC1coVEF/rkM0rIcjtMVI1GUH7vWy1wjR6qF5vQnMun3XNQ==}
+  '@better-auth/telemetry@1.6.22':
+    resolution: {integrity: sha512-glq/oEk9qP+zGh9k/WUH5+pwvBCMolNNhaAVBCtYQrkADFee2gP3VoPs1YeO9coNuOmBhc+AYSIHs+fL9DoJnw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.20
+      '@better-auth/core': ^1.6.22
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
-  '@better-auth/utils@0.4.1':
-    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
-
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
-
-  '@better-fetch/fetch@1.3.0':
-    resolution: {integrity: sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A==}
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
@@ -2976,8 +2970,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  better-auth@1.6.20:
-    resolution: {integrity: sha512-fSpGHGRKiGRiYVd3QTQtuVZ8oxpiSe/7ip0Rpvt/Sy8zQbEbVKUPMOhE0gLXg+FjqTUsIo7582hxUYxtEcqUpA==}
+  better-auth@1.6.22:
+    resolution: {integrity: sha512-B5s6+lPsDWp8rGLRnvNyr5h9tftG9zLRjNrlkEJdYRhcuhPhJiw9b8o6ibgxEFpSAdUqoDaP5/FLqfu8QsXIVg==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -3038,8 +3032,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.6:
-    resolution: {integrity: sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA==}
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -5394,13 +5388,13 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.6(zod@4.4.3)
+      better-call: 1.3.7(zod@4.4.3)
       jose: 6.2.1
       kysely: 0.28.17
       nanostores: 1.3.0
@@ -5408,48 +5402,42 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
 
-  '@better-auth/drizzle-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/mongo-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/prisma-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-
-  '@better-auth/utils@0.4.1':
-    dependencies:
-      '@noble/hashes': 2.2.0
 
   '@better-auth/utils@0.4.2':
     dependencies:
       '@noble/hashes': 2.2.0
-
-  '@better-fetch/fetch@1.3.0': {}
 
   '@better-fetch/fetch@1.3.1': {}
 
@@ -7656,20 +7644,20 @@ snapshots:
 
   baseline-browser-mapping@2.10.37: {}
 
-  better-auth@1.6.20(@opentelemetry/api@1.9.0)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
+  better-auth@1.6.22(@opentelemetry/api@1.9.0)(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.9):
     dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/prisma-adapter': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.6(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.22(@better-auth/core@1.6.22(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.6(zod@4.4.3)
+      better-call: 1.3.7(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.1
       kysely: 0.28.17
@@ -7684,10 +7672,10 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.6(zod@4.4.3):
+  better-call@1.3.7(zod@4.4.3):
     dependencies:
-      '@better-auth/utils': 0.4.1
-      '@better-fetch/fetch': 1.3.0
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.1.0
     optionalDependencies:


### PR DESCRIPTION
## 背景（One-Way Door / 認証）
#726 で意図的に除外した better-auth 1.6.22 を、破壊的変更へ対応した上で取り込む。

better-auth 1.6.21 の changelog:
> OAuth sign-up / account-link の profile sync は `input: false` の user フィールドへの provider 値を**無視する**ようになった。`mapProfileToUser` で `input: false` フィールドを埋めていたアプリは server 側 provisioning で設定せよ。

本リポジトリは `auth.ts` で `discordId` を `input: false` かつ `mapProfileToUser: (profile) => ({ discordId: profile.id })` で埋めていた。素のアップグレードでは:
- **新規 Discord サインアップで better-auth user の `discordId` が埋まらない**
- → `enrich-session.ts` が `discordId` 無しで `appUser` を `null` にする
- → 新規ユーザーが全認証アクション不能（既存ユーザーは ba_user に保存済みのため無事）
- CI は新規 OAuth サインアップを通すテストが無いため緑のまま素通りする

## 変更
- `mapProfileToUser`（1.6.21+ で discordId に対して no-op）を廃止
- `provisionDiscordIdOnAuthUser` を追加し、`account.create.after` フックで `account.accountId`（= Discord user id）から better-auth user の `discordId` を server 側で明示セット（best-effort、失敗してもサインアップは止めない）
- 回帰ガードの unit test を追加（`__tests__/provision-discord-id.test.ts`）
- `better-auth` `^1.6.19` → `^1.6.22`（lockfile 1.6.22）。X-Forwarded-For スプーフによる per-IP rate limit バイパス対策の security fix も同梱

## 検証
- `pnpm verify` 緑（EXIT=0）。apps/web 888 passed（新規テスト含む）、カバレッジ閾値も通過
- provisioning は `account.accountId` 由来で profile mapping に依存しないため、`enrich-session.ts` が読む `user.discordId` はサインアップ時点で確実に永続化される

## レビュー観点（認証 = 自己レビュー必須）
- フック発火順: better-auth は user → account 作成 → `account.create.after`。フック時点で ba_user は存在し `ops.update(model:"user", id=account.userId)` が当たる
- 既存ユーザーへの影響なし（discordId は作成済み doc に保持）。本対応は新規サインアップ／アカウント連携時の充填のみ

#726 マージ後に rebase 不要（依存定義が別ファイル行のため衝突しない見込み。lockfile は衝突時 better-auth 側を優先で再 install）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)