### PR TITLE
fix(web): ヘッダー認証表示を client island 化しCDN焼き付きを解消

### DIFF
--- a/apps/web/src/components/layout/__tests__/session-aware-controls.test.tsx
+++ b/apps/web/src/components/layout/__tests__/session-aware-controls.test.tsx
@@ -1,0 +1,52 @@
+import type { UserSession } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSessionState } from "@/lib/auth/client";
+import { SessionAwareControls } from "../session-aware-controls";
+
+// 認証抽象だけを mock（プロバイダは触らない）。useSessionState は bare auto-mock で vi.fn 化される。
+vi.mock("@/lib/auth/client");
+
+// 子は表示責務のみ。ここでは island の分岐ロジック（isPending / user 有無）に絞って検証する。
+vi.mock("../../user/auth-button", () => ({
+	default: ({ user }: { user?: UserSession | null }) => (
+		<div data-testid="auth-button">{user ? user.displayName : "ログイン"}</div>
+	),
+}));
+vi.mock("../mobile-menu", () => ({
+	default: ({ user }: { user?: UserSession | null }) => (
+		<div data-testid="mobile-menu">{user ? "認証済み" : "未認証"}</div>
+	),
+}));
+
+const mockUser = { discordId: "123", displayName: "テストユーザー" } as UserSession;
+
+function setSessionState(state: { user: UserSession | null; isPending: boolean }) {
+	vi.mocked(useSessionState).mockReturnValue(state);
+}
+
+describe("SessionAwareControls", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("セッション解決前（isPending）は何も描画しない（SSR に per-user を出さずちらつきも防ぐ）", () => {
+		setSessionState({ user: null, isPending: true });
+		const { container } = render(<SessionAwareControls />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("未ログイン（解決済み・user=null）はログインボタンと未認証メニューを描画", () => {
+		setSessionState({ user: null, isPending: false });
+		render(<SessionAwareControls />);
+		expect(screen.getByTestId("auth-button")).toHaveTextContent("ログイン");
+		expect(screen.getByTestId("mobile-menu")).toHaveTextContent("未認証");
+	});
+
+	it("ログイン済みはユーザー情報を子へ渡す", () => {
+		setSessionState({ user: mockUser, isPending: false });
+		render(<SessionAwareControls />);
+		expect(screen.getByTestId("auth-button")).toHaveTextContent("テストユーザー");
+		expect(screen.getByTestId("mobile-menu")).toHaveTextContent("認証済み");
+	});
+});

--- a/apps/web/src/components/layout/session-aware-controls.tsx
+++ b/apps/web/src/components/layout/session-aware-controls.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useSessionState } from "@/lib/auth/client";
+import AuthButton from "../user/auth-button";
+import MobileMenu from "./mobile-menu";
+
+/**
+ * ヘッダーの認証表示（ログインボタン / ユーザーメニュー / モバイルメニュー）を client 島として描画する。
+ *
+ * session を SSR で読まないのが要点。これにより public ページ（`/`・一覧）の SSR 出力から per-user が
+ * 消え、Cloudflare のエッジキャッシュ（next.config の `public, s-maxage`）に表示名・アバターが
+ * 焼き付かなくなる。旧実装は SiteHeader 内の async server component が `getCurrentUser()` を呼んでおり、
+ * 解決済みヘッダーごと CDN にキャッシュされ、ログアウト後も古いログイン状態が残っていた
+ * （かつ別ユーザーへ表示名が配信されうるクロスユーザー漏洩クラス）。詳細ページの SPR-226 と同じ
+ * client island 化の方針に揃える。
+ */
+export function SessionAwareControls() {
+	const { user, isPending } = useSessionState();
+
+	// セッション解決前は描画しない。ヘッダーの min-h で枠は確保済みなので CLS=0。
+	// fallback を null にすることで、ログイン済みユーザーに一瞬「ログイン」ボタンが出るちらつきを防ぐ。
+	if (isPending) {
+		return null;
+	}
+
+	return (
+		<>
+			{/* 認証ボタン（デスクトップ） */}
+			<div className="hidden md:flex">
+				<AuthButton user={user} />
+			</div>
+
+			{/* モバイルメニュー */}
+			<MobileMenu user={user} />
+		</>
+	);
+}

--- a/apps/web/src/components/layout/site-header.tsx
+++ b/apps/web/src/components/layout/site-header.tsx
@@ -1,9 +1,6 @@
 import Link from "next/link";
-import { Suspense } from "react";
-import { getCurrentUser } from "@/lib/auth/server";
-import AuthButton from "../user/auth-button";
 import { DesktopNav } from "./desktop-nav";
-import MobileMenu from "./mobile-menu";
+import { SessionAwareControls } from "./session-aware-controls";
 
 export default function SiteHeader() {
 	return (
@@ -30,31 +27,14 @@ export default function SiteHeader() {
 
 						{/* 認証関連: wrapper の min-h で UserMenu (desktop ~52px) と
 							MobileMenu (mobile 44px) と同じ高さを常に確保する。これにより
-							Suspense リゾルブ前後でヘッダー全体の高さは変動せず CLS=0 を保てる。
-							fallback は枠確保不要なので null で十分。 */}
+							client island のセッション解決前後でヘッダー全体の高さは変動せず CLS=0 を保てる。
+							SessionAwareControls は session を client 自己取得し SSR に焼かない（CDN 漏洩防止）。 */}
 						<div className="flex items-center space-x-4 min-h-[44px] md:min-h-[52px]">
-							<Suspense fallback={null}>
-								<SessionAwareControls />
-							</Suspense>
+							<SessionAwareControls />
 						</div>
 					</div>
 				</div>
 			</header>
-		</>
-	);
-}
-
-async function SessionAwareControls() {
-	const user = await getCurrentUser();
-	return (
-		<>
-			{/* 認証ボタン */}
-			<div className="hidden md:flex">
-				<AuthButton user={user} />
-			</div>
-
-			{/* モバイルメニュー */}
-			<MobileMenu user={user} />
 		</>
 	);
 }

--- a/apps/web/src/lib/auth/__mocks__/client.ts
+++ b/apps/web/src/lib/auth/__mocks__/client.ts
@@ -7,3 +7,6 @@
 import { vi } from "vitest";
 
 export const useSession = vi.fn(() => null);
+
+// 既定は「解決済み・未ログイン」。isPending を見る呼び出し側（ヘッダー island 等）向け。
+export const useSessionState = vi.fn(() => ({ user: null, isPending: false }));

--- a/apps/web/src/lib/auth/better-auth-client.ts
+++ b/apps/web/src/lib/auth/better-auth-client.ts
@@ -20,15 +20,6 @@ const authClient = createAuthClient({
 });
 
 /**
- * 現在のセッションの appUser（アプリ UserSession）を返す client フック。未認証は null。
- * customSession の戻り（{ user, session, appUser }）から appUser を取り出す。
- */
-export function useBetterAuthAppUser(): UserSession | null {
-	const { data } = authClient.useSession();
-	return data?.appUser ?? null;
-}
-
-/**
  * セッションの appUser に加えて解決中フラグ（isPending）も返す client フック。
  * 初回ロード時の「未解決 = null」と「未認証 = null」を区別したい呼び出し側（ヘッダー等）が使う。
  */
@@ -38,4 +29,12 @@ export function useBetterAuthSessionState(): {
 } {
 	const { data, isPending } = authClient.useSession();
 	return { user: data?.appUser ?? null, isPending };
+}
+
+/**
+ * 現在のセッションの appUser（アプリ UserSession）を返す client フック。未認証は null。
+ * isPending を見ない呼び出し側向けの薄いラッパー。
+ */
+export function useBetterAuthAppUser(): UserSession | null {
+	return useBetterAuthSessionState().user;
 }

--- a/apps/web/src/lib/auth/better-auth-client.ts
+++ b/apps/web/src/lib/auth/better-auth-client.ts
@@ -27,3 +27,15 @@ export function useBetterAuthAppUser(): UserSession | null {
 	const { data } = authClient.useSession();
 	return data?.appUser ?? null;
 }
+
+/**
+ * セッションの appUser に加えて解決中フラグ（isPending）も返す client フック。
+ * 初回ロード時の「未解決 = null」と「未認証 = null」を区別したい呼び出し側（ヘッダー等）が使う。
+ */
+export function useBetterAuthSessionState(): {
+	user: UserSession | null;
+	isPending: boolean;
+} {
+	const { data, isPending } = authClient.useSession();
+	return { user: data?.appUser ?? null, isPending };
+}

--- a/apps/web/src/lib/auth/client.ts
+++ b/apps/web/src/lib/auth/client.ts
@@ -7,8 +7,16 @@
 "use client";
 
 import type { UserSession } from "@suzumina.click/shared-types";
-import { useBetterAuthAppUser } from "./better-auth-client";
+import { useBetterAuthAppUser, useBetterAuthSessionState } from "./better-auth-client";
 
 export function useSession(): UserSession | null {
 	return useBetterAuthAppUser();
+}
+
+/**
+ * `useSession()` に解決中フラグを足した版。セッション解決前（isPending）と未認証（user=null）を
+ * 区別したい呼び出し側で使う。
+ */
+export function useSessionState(): { user: UserSession | null; isPending: boolean } {
+	return useBetterAuthSessionState();
 }


### PR DESCRIPTION
## 背景・症状
ログアウト直後でも上部メニュー（ヘッダー）が見た目上ログイン状態のまま残ることがある（「時々」再現）。

## 原因
ヘッダー `SiteHeader → SessionAwareControls` が `getCurrentUser()` で session を **SSR に焼き込んで**いた。一方で `next.config.mjs` は `/`・一覧（`/buttons|videos|works` 等）に `public, s-maxage` を付与し、Cloudflare の `respect_origin`（`terraform/cloudflare.tf` rule#5）でエッジキャッシュしている。

その結果、**解決済みヘッダー（ログイン中ユーザーの表示名・アバター込み）ごと CDN にキャッシュ**されていた。cache key に Cookie を含まないため：
- ログアウト後（cookie 削除済み）でも、CDN HIT で「ログイン中に生成された HTML」が返り、ログイン状態が残る
- さらに別ユーザー・未ログイン訪問者へ表示名が配信されうる **クロスユーザー漏洩クラス**
- CDN の HIT/MISS 次第なので「時々」という症状になる

詳細ページ（works/videos/buttons）は SPR-223/226 で per-user を client island に逃がして対処済みだったが、**グローバルヘッダーの認証表示だけが最後の SSR per-user として残っていた**。

## 対応
SPR-226 と同じく、session を SSR で読まず **client 自己取得する island** に切り出す。これで public ページの SSR 出力から per-user が消え、CDN がキャッシュできる内容に認証情報が含まれなくなる。

- **新規** `session-aware-controls.tsx`（`"use client"`）: `useSessionState()` で取得。`isPending` 中は `null`（ヘッダーの `min-h` で枠確保済み・CLS=0）
- `site-header.tsx`: async server の `getCurrentUser()` 呼び出しと `Suspense` を撤去し island に差し替え
- `better-auth-client.ts` / `client.ts`: loading 区別用に `useSessionState()`（`{ user, isPending }`）を追加（既存 `useSession` は据え置き）

## 検証
- `pnpm verify` 通過（lint:docs / lint:tokens / lint / typecheck / test・カバレッジ閾値）
- ローカル（Emulator）:
  - 生 SSR HTML に認証UI（`Discordログイン`／`ユーザーメニューを開く`／モバイルメニューボタン）が **0 件** → CDN がキャッシュする出力に per-user が無い
  - client island がマウントし `GET /api/auth/get-session` を発行（新挙動）
  - hydration エラー/警告なし

## 残作業（要・本番実測）
本番 CDN 挙動はローカル再現不可。デプロイ後に `curl -I https://suzumina.click/` の `cf-cache-status: HIT` 状態で本文へ表示名が混入しないこと・ログアウト直後に即切り替わることを実測する。

> [!NOTE]
> 認証 × キャッシュ＝**One-Way Door**。セルフマージ・ポリシー上、AIレビュー任せにせず最終レビューは人間（@nothink-jp）で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)