### PR TITLE
fix(web): ログアウトをclient signOutにしリロード無しでヘッダー更新

### DIFF
--- a/apps/web/src/app/auth/__tests__/actions.test.ts
+++ b/apps/web/src/app/auth/__tests__/actions.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { signInAction, signOutAction } from "../actions";
+import { signInAction } from "../actions";
 
 vi.mock("@/lib/auth/server");
 vi.mock("@/lib/logger", () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }));
 
-const { signInWithDiscord, signOutCurrent } = vi.mocked(await import("@/lib/auth/server"));
+const { signInWithDiscord } = vi.mocked(await import("@/lib/auth/server"));
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -20,18 +20,5 @@ describe("signInAction", () => {
 	it("エラーは再 throw する", async () => {
 		signInWithDiscord.mockRejectedValue(new Error("auth fail"));
 		await expect(signInAction()).rejects.toThrow("auth fail");
-	});
-});
-
-describe("signOutAction", () => {
-	it("signOutCurrent を呼ぶ", async () => {
-		signOutCurrent.mockResolvedValue(undefined);
-		await signOutAction();
-		expect(signOutCurrent).toHaveBeenCalledWith("/");
-	});
-
-	it("エラーは再 throw する", async () => {
-		signOutCurrent.mockRejectedValue(new Error("signout fail"));
-		await expect(signOutAction()).rejects.toThrow("signout fail");
 	});
 });

--- a/apps/web/src/app/auth/actions.ts
+++ b/apps/web/src/app/auth/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { signInWithDiscord, signOutCurrent } from "@/lib/auth/server";
+import { signInWithDiscord } from "@/lib/auth/server";
 import * as logger from "@/lib/logger";
 
 export async function signInAction() {
@@ -12,22 +12,6 @@ export async function signInAction() {
 	} catch (error) {
 		logger.error("Discordサインインでエラーが発生", {
 			action: "signInAction",
-			error: error instanceof Error ? error.message : String(error),
-			stack: error instanceof Error ? error.stack : undefined,
-		});
-		throw error;
-	}
-}
-
-export async function signOutAction() {
-	logger.info("サインアウト開始", { action: "signOutAction" });
-
-	try {
-		await signOutCurrent("/");
-		logger.info("サインアウト成功", { action: "signOutAction" });
-	} catch (error) {
-		logger.error("サインアウトでエラーが発生", {
-			action: "signOutAction",
 			error: error instanceof Error ? error.message : String(error),
 			stack: error instanceof Error ? error.stack : undefined,
 		});

--- a/apps/web/src/components/user/__tests__/user-menu.test.tsx
+++ b/apps/web/src/components/user/__tests__/user-menu.test.tsx
@@ -1,7 +1,7 @@
 import type { UserSession } from "@suzumina.click/shared-types";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import UserMenu from "../user-menu";
 
 // UserAvatarコンポーネントのモック
@@ -32,6 +32,9 @@ vi.mock("next/navigation", () => ({
 	useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }));
 
+// logger のモック（エラーパス検証用）
+vi.mock("@/lib/logger", () => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() }));
+
 // Next.js Linkコンポーネントのモック
 vi.mock("next/link", () => ({
 	default: ({ children, href }: { children: React.ReactNode; href: string }) => (
@@ -52,6 +55,10 @@ describe("UserMenu", () => {
 		},
 		isActive: true,
 	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
 	it("ユーザー情報を正しく表示する", () => {
 		render(<UserMenu user={mockUser} />);
@@ -102,6 +109,18 @@ describe("UserMenu", () => {
 
 		// client ストアをクリアする signOut が呼ばれ、その後ホームへ戻し refresh する
 		expect(mockSignOut).toHaveBeenCalledOnce();
+		await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/"));
+		expect(mockRefresh).toHaveBeenCalledOnce();
+	});
+
+	it("signOut 失敗時もホーム遷移 + refresh で実セッション状態へ再同期する", async () => {
+		mockSignOut.mockRejectedValueOnce(new Error("network error"));
+		const user = userEvent.setup();
+		render(<UserMenu user={mockUser} />);
+
+		await user.click(screen.getByRole("button", { name: "ユーザーメニューを開く" }));
+		await user.click(screen.getByText("ログアウト"));
+
 		await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/"));
 		expect(mockRefresh).toHaveBeenCalledOnce();
 	});

--- a/apps/web/src/components/user/__tests__/user-menu.test.tsx
+++ b/apps/web/src/components/user/__tests__/user-menu.test.tsx
@@ -1,5 +1,5 @@
 import type { UserSession } from "@suzumina.click/shared-types";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import UserMenu from "../user-menu";
@@ -19,9 +19,17 @@ vi.mock("../user-avatar", () => ({
 	),
 }));
 
-// Server Actionsのモック
-vi.mock("@/app/auth/actions", () => ({
-	signOutAction: vi.fn(),
+// client 認証抽象のモック（signOut）
+const mockSignOut = vi.fn(async () => {});
+vi.mock("@/lib/auth/client", () => ({
+	signOut: () => mockSignOut(),
+}));
+
+// next/navigation のモック（router.push / refresh）
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
 }));
 
 // Next.js Linkコンポーネントのモック
@@ -81,7 +89,7 @@ describe("UserMenu", () => {
 		expect(myPageLink).toHaveAttribute("href", "/users/me");
 	});
 
-	it("ログアウトボタンがサブミットボタンとして正しく設定されている", async () => {
+	it("ログアウト押下で client signOut → ホーム遷移 + refresh する", async () => {
 		const user = userEvent.setup();
 		render(<UserMenu user={mockUser} />);
 
@@ -89,9 +97,13 @@ describe("UserMenu", () => {
 		const triggerButton = screen.getByRole("button", { name: "ユーザーメニューを開く" });
 		await user.click(triggerButton);
 
-		// ログアウトボタンを確認
-		const logoutButton = screen.getByRole("button", { name: /ログアウト/i });
-		expect(logoutButton).toHaveAttribute("type", "submit");
+		// ログアウト項目（menuitem）を押下
+		await user.click(screen.getByText("ログアウト"));
+
+		// client ストアをクリアする signOut が呼ばれ、その後ホームへ戻し refresh する
+		expect(mockSignOut).toHaveBeenCalledOnce();
+		await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/"));
+		expect(mockRefresh).toHaveBeenCalledOnce();
 	});
 
 	it("アクセシビリティ属性が正しく設定されている", () => {

--- a/apps/web/src/components/user/user-menu.tsx
+++ b/apps/web/src/components/user/user-menu.tsx
@@ -14,6 +14,7 @@ import { Heart, LogOut, Settings, User } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { signOut } from "@/lib/auth/client";
+import * as logger from "@/lib/logger";
 import UserAvatar from "./user-avatar";
 
 interface UserMenuProps {
@@ -25,8 +26,17 @@ export default function UserMenu({ user }: UserMenuProps) {
 
 	// client 側 signOut で session ストアを反応的にクリアし、ヘッダー表示をリロード無しで更新する。
 	// その後ホームへ戻し、サーバーコンポーネント側の per-user 表示も再取得させる。
+	// signOut 失敗時（ネットワーク等）もログのみで遷移は続行する: 続く refresh が
+	// 実セッション状態に再同期するため、見た目だけログアウトする不整合を避けられる。
 	const handleSignOut = async () => {
-		await signOut();
+		try {
+			await signOut();
+		} catch (error) {
+			logger.error("ログアウトに失敗しました", {
+				action: "signOut",
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 		router.push("/");
 		router.refresh();
 	};

--- a/apps/web/src/components/user/user-menu.tsx
+++ b/apps/web/src/components/user/user-menu.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { UserSession } from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import {
@@ -10,7 +12,8 @@ import {
 } from "@suzumina.click/ui/components/ui/dropdown-menu";
 import { Heart, LogOut, Settings, User } from "lucide-react";
 import Link from "next/link";
-import { signOutAction } from "@/app/auth/actions";
+import { useRouter } from "next/navigation";
+import { signOut } from "@/lib/auth/client";
 import UserAvatar from "./user-avatar";
 
 interface UserMenuProps {
@@ -18,6 +21,16 @@ interface UserMenuProps {
 }
 
 export default function UserMenu({ user }: UserMenuProps) {
+	const router = useRouter();
+
+	// client 側 signOut で session ストアを反応的にクリアし、ヘッダー表示をリロード無しで更新する。
+	// その後ホームへ戻し、サーバーコンポーネント側の per-user 表示も再取得させる。
+	const handleSignOut = async () => {
+		await signOut();
+		router.push("/");
+		router.refresh();
+	};
+
 	return (
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
@@ -64,13 +77,13 @@ export default function UserMenu({ user }: UserMenuProps) {
 					</Link>
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
-				<DropdownMenuItem asChild>
-					<form action={signOutAction} className="w-full">
-						<button type="submit" className="flex items-center gap-2 w-full text-left">
-							<LogOut className="h-4 w-4" />
-							<span>ログアウト</span>
-						</button>
-					</form>
+				<DropdownMenuItem
+					// asChild を使わず DropdownMenuItem 自体を押下対象にする（選択でメニューは閉じる）。
+					onSelect={() => void handleSignOut()}
+					className="flex items-center gap-2 cursor-pointer"
+				>
+					<LogOut className="h-4 w-4" />
+					<span>ログアウト</span>
 				</DropdownMenuItem>
 			</DropdownMenuContent>
 		</DropdownMenu>

--- a/apps/web/src/lib/auth/__mocks__/server.ts
+++ b/apps/web/src/lib/auth/__mocks__/server.ts
@@ -9,4 +9,3 @@ import { vi } from "vitest";
 
 export const getCurrentUser = vi.fn(async () => null);
 export const signInWithDiscord = vi.fn(async () => {});
-export const signOutCurrent = vi.fn(async () => {});

--- a/apps/web/src/lib/auth/better-auth-client.ts
+++ b/apps/web/src/lib/auth/better-auth-client.ts
@@ -38,3 +38,13 @@ export function useBetterAuthSessionState(): {
 export function useBetterAuthAppUser(): UserSession | null {
 	return useBetterAuthSessionState().user;
 }
+
+/**
+ * クライアント側サインアウト。better-auth の sign-out エンドポイントを叩いて
+ * サーバーのセッション cookie を失効させると同時に、**client セッションストアもクリア**する。
+ * これにより useSession() が反応的に null へ更新され、ヘッダー等の表示がリロード無しで切り替わる
+ * （サーバーアクションでの signOut は client ストアを無効化できずリロードまで古い状態が残っていた）。
+ */
+export async function signOutClient(): Promise<void> {
+	await authClient.signOut();
+}

--- a/apps/web/src/lib/auth/client.ts
+++ b/apps/web/src/lib/auth/client.ts
@@ -7,7 +7,11 @@
 "use client";
 
 import type { UserSession } from "@suzumina.click/shared-types";
-import { useBetterAuthAppUser, useBetterAuthSessionState } from "./better-auth-client";
+import {
+	signOutClient,
+	useBetterAuthAppUser,
+	useBetterAuthSessionState,
+} from "./better-auth-client";
 
 export function useSession(): UserSession | null {
 	return useBetterAuthAppUser();
@@ -19,4 +23,12 @@ export function useSession(): UserSession | null {
  */
 export function useSessionState(): { user: UserSession | null; isPending: boolean } {
 	return useBetterAuthSessionState();
+}
+
+/**
+ * クライアント側サインアウト。サーバーのセッション cookie 失効に加えて client セッションストアも
+ * クリアするため、useSession() を参照する表示（ヘッダー等）がリロード無しで更新される。
+ */
+export async function signOut(): Promise<void> {
+	return signOutClient();
 }

--- a/apps/web/src/lib/auth/server.ts
+++ b/apps/web/src/lib/auth/server.ts
@@ -37,16 +37,3 @@ export async function signInWithDiscord(callbackURL = "/"): Promise<void> {
 	}
 	redirect(res.url);
 }
-
-/**
- * 現在のセッションからサインアウトし、callbackURL へリダイレクトする。
- */
-export async function signOutCurrent(callbackURL = "/"): Promise<void> {
-	const [{ auth }, { headers }, { redirect }] = await Promise.all([
-		import("@/lib/better-auth/auth"),
-		import("next/headers"),
-		import("next/navigation"),
-	]);
-	await auth.api.signOut({ headers: await headers() });
-	redirect(callbackURL);
-}


### PR DESCRIPTION
## 背景
#729 でヘッダーを client island 化（`authClient.useSession()` 参照）した副作用。メニューからログアウトしても**リロードするまでヘッダーがログイン状態のまま**残る、という報告への対応。

## 原因
ログアウトはサーバーアクション（`signOutAction` → `auth.api.signOut()` + `redirect("/")`）だった。これは**サーバーのセッション cookie は失効させるが、client 側の `authClient` セッションストアを無効化しない**。redirect も soft navigation のため、ヘッダーの `useSession()` はメモリ上の古いセッションを保持し続け、ハードリロードで `/api/auth/get-session` を引き直すまで表示が更新されなかった。

## 対応（idiomatic な単一 signout 経路へ統一）
- client の **`authClient.signOut()`** を使う。sign-out エンドポイントでサーバー cookie を失効させると同時に **client ストアを反応的にクリア**するため、`useSession()` が即 `null` になりリロード不要でヘッダーが切り替わる
- `UserMenu` を client component 化し、ログアウトは `onSelect` で `signOut()` → `router.push("/")` + `router.refresh()`
- 未使用化した `signOutAction` / `signOutCurrent`（+ mock・テスト）を撤去。`signIn` は外部 OAuth への redirect が必要なためサーバーアクションのまま据え置き
- `UserMenu` / `auth/actions` のテストを新経路に更新

## 検証
- `pnpm verify` 通過（lint:docs / lint:tokens / lint / typecheck / test・カバレッジ閾値）
- **残**: ログイン状態→ログアウトの反応的更新の目視は Discord OAuth が必要でローカル Emulator では再現不可。本番/ステージングで「ログアウト押下 → リロード無しで即ログアウト表示」を確認のこと

> [!NOTE]
> 認証 = **One-Way Door**。最終レビューは人間（@nothink-jp）で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)