### PR TITLE
chore: worktree 複製対象に apps/functions/.env を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -3,3 +3,4 @@
 # 詳細: ADR-008 / https://code.claude.com/docs/en/worktrees
 apps/web/.env
 apps/web/.env.local
+apps/functions/.env


### PR DESCRIPTION
## 背景

ADR-008 の worktree 自動複製（SessionStart フック `worktree-bootstrap.sh` + `.worktreeinclude`）の複製対象が `apps/web` の env のみで、`apps/functions/.env` が抜けていた。

このため、新規 worktree で functions 側の ADC 直結ツール（例: SPR-232 の region 等価性計測 `check:region-equivalence`）を動かすたびに、main から `apps/functions/.env` を手動コピーする必要があった。

実際 SPR-232 第2回計測でこの抜けに当たったため、対象リストに1行追加する。

## 変更

`.worktreeinclude` に `apps/functions/.env` を追加（gitignore 済みファイルのみコピーする仕組みなので条件は満たす）。

## 効く範囲

- 次回以降に **main から作成される worktree** から有効（既存セッションには影響なし）。
- `apps/functions/.env.local` は実体が無いため追加していない。

## 確認

- `pnpm verify` 不要レベルの設定ファイル1行追加（lint/typecheck/test 対象外）。
- pre-commit（secretlint）通過済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)