### PR TITLE
fix(functions): dlsite schema drift ベースラインに is_sound_playable を追加

### DIFF
--- a/apps/functions/src/services/dlsite/__tests__/schema-drift.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/schema-drift.test.ts
@@ -32,6 +32,8 @@ describe("KNOWN_FIELDS", () => {
 		// ベースライン由来（未モデルだが観測実績あり）
 		expect(KNOWN_FIELDS.has("workno")).toBe(true);
 		expect(KNOWN_FIELDS.has("genres")).toBe(true);
+		// 2026-06-24 から本番で観測された恒常追加フィールド（alert 沈静化の回帰ガード）
+		expect(KNOWN_FIELDS.has("is_sound_playable")).toBe(true);
 		// 254 + Zod キーの union なので相応に大きい
 		expect(KNOWN_FIELDS.size).toBeGreaterThan(200);
 	});

--- a/apps/functions/src/services/dlsite/dlsite-known-api-fields.ts
+++ b/apps/functions/src/services/dlsite/dlsite-known-api-fields.ts
@@ -10,6 +10,7 @@
  *   → tmp/dlsite-capture/report.json の fieldUsage(presence+unknownFields) の和集合
  *
  * 最終生成: 2026-06-04 / サンプル150件で観測した 254 フィールド
+ * 手動追記: 2026-07-04 is_sound_playable（本番 drift alert 観測による）
  */
 export const KNOWN_DLSITE_API_FIELDS: readonly string[] = [
 	"age_category",
@@ -131,6 +132,8 @@ export const KNOWN_DLSITE_API_FIELDS: readonly string[] = [
 	"is_show_campaign_end_date",
 	"is_show_rate",
 	"is_smartphone_work",
+	// 音声再生可能フラグ（推測）。2026-06-24 から本番 drift alert で全バッチ観測（DLsite 恒常追加と判断）
+	"is_sound_playable",
 	"is_split_content",
 	"is_timesale_work",
 	"is_title_completed",


### PR DESCRIPTION
## 概要

本番 `fetchDLsiteUnifiedData` の Cloud Logging で `jsonPayload.alert="dlsite_schema_drift"` の WARNING が 2026-06-24 から全 run（4時間ごと）で継続発火していたため、ベースラインに `is_sound_playable` を追加して alert を沈静化する。

## 判断根拠

- newFields は一貫して `["is_sound_playable"]` のみ
- バッチ内 50/50 件に出現 ＝ 特定作品でなく API 全体への恒常追加
- → DLsite Individual Info API に正規追加された新フィールドと判断

## 変更内容

- `dlsite-known-api-fields.ts`: `KNOWN_DLSITE_API_FIELDS` に `is_sound_playable` を追加（アルファベット順・意味の推測と観測経緯を近接コメントで記録。ヘッダーに手動追記の経緯も併記）
- `schema-drift.test.ts`: `KNOWN_FIELDS` に `is_sound_playable` が含まれることの回帰ガードを追加

検出ロジック（`schema-drift.ts`）は無変更。`KNOWN_FIELDS` はベースライン ∪ Zod キーの union のため、この追加のみで次回 run から WARNING は出なくなる。

## スコープ外

- アプリでの `is_sound_playable` 利用（Zod スキーマへのモデル化）は別判断。利用する際に `tools:capture` で実データの型・値を検証する
- `docs/reference/external-apis/dlsite-api.md` への追記は行わない（2025年時点のスナップショット分析であり、既知フィールドの正本はコード側ベースライン。二重管理の版ズレ負債を避ける）

## 検証

- `pnpm verify` 全パス（lint:docs + lint:tokens + lint + typecheck + test）
- 本番での alert 停止はデプロイ後の次回 run（4時間ごと）の Cloud Logging で確認

## マージ区分

Two-Way Door（ベースライン1行の追加のみ・容易に戻せる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)