### PR TITLE
fix(web): not-found メタデータの title 二重サフィックス解消と noindex 明示

### DIFF
--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { Suspense } from "react";
 
 export const metadata: Metadata = {
-	title: "エラー | すずみなくりっく！",
+	title: "エラー",
 	description: "認証中にエラーが発生しました。",
 };
 

--- a/apps/web/src/app/buttons/[id]/page.tsx
+++ b/apps/web/src/app/buttons/[id]/page.tsx
@@ -28,6 +28,7 @@ export async function generateMetadata({ params }: AudioButtonDetailPageProps): 
 		return {
 			title: "音声ボタンが見つかりません",
 			description: "指定された音声ボタンは存在しないか、削除された可能性があります。",
+			robots: { index: false, follow: false },
 		};
 	}
 
@@ -35,6 +36,7 @@ export async function generateMetadata({ params }: AudioButtonDetailPageProps): 
 		return {
 			title: "音声ボタンが見つかりません",
 			description: "指定された音声ボタンは存在しないか、削除された可能性があります。",
+			robots: { index: false, follow: false },
 		};
 	}
 

--- a/apps/web/src/app/favorites/page.tsx
+++ b/apps/web/src/app/favorites/page.tsx
@@ -5,7 +5,7 @@ import { getFavoritesList } from "./actions";
 import FavoritesList from "./components/favorites-list";
 
 export const metadata: Metadata = {
-	title: "お気に入り | すずみなくりっく！",
+	title: "お気に入り",
 	description: "お気に入り登録した音声ボタン一覧",
 };
 

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -6,8 +6,9 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-	title: "404 - ページが見つかりません | すずみなくりっく！",
+	title: "404 - ページが見つかりません",
 	description: "お探しのページは見つかりませんでした。涼花みなせファンコミュニティサイト",
+	robots: { index: false, follow: false },
 };
 
 export default function NotFound() {

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -18,15 +18,17 @@ export async function generateMetadata({ params }: UserProfilePageProps): Promis
 	try {
 		const resolvedParams = await params;
 		const user = await getUserByDiscordId(resolvedParams.userId);
+		// title は layout の title.template がサフィックスを付与するため手書きしない（二重化防止）
 		if (!user) {
 			return {
-				title: "ユーザーが見つかりません | すずみなくりっく！",
+				title: "ユーザーが見つかりません",
 				description: "指定されたユーザーが見つかりません。",
+				robots: { index: false, follow: false },
 			};
 		}
 
 		return {
-			title: `${user.displayName}のプロフィール | すずみなくりっく！`,
+			title: `${user.displayName}のプロフィール`,
 			description: `${user.displayName}さんの作成した音声ボタンをチェック。涼花みなせファンコミュニティ suzumina.click`,
 			alternates: {
 				canonical: `/users/${resolvedParams.userId}`,
@@ -39,7 +41,7 @@ export async function generateMetadata({ params }: UserProfilePageProps): Promis
 		};
 	} catch {
 		return {
-			title: "プロフィール | すずみなくりっく！",
+			title: "プロフィール",
 			description: "ユーザープロフィールページ",
 		};
 	}

--- a/apps/web/src/app/videos/[videoId]/page.tsx
+++ b/apps/web/src/app/videos/[videoId]/page.tsx
@@ -59,14 +59,16 @@ export async function generateMetadata({ params }: VideoDetailPageProps) {
 
 	const video = await getVideoById(videoId);
 
+	// title は layout の title.template がサフィックスを付与するため手書きしない（二重化防止）
 	if (!video) {
 		return {
-			title: "動画が見つかりません | すずみなくりっく！",
+			title: "動画が見つかりません",
+			robots: { index: false, follow: false },
 		};
 	}
 
 	return {
-		title: `${video.title} | すずみなくりっく！`,
+		title: video.title,
 		description: video.description || `涼花みなせさんの動画「${video.title}」の詳細ページです。`,
 		alternates: {
 			canonical: `/videos/${videoId}`,

--- a/apps/web/src/app/works/[workId]/page.tsx
+++ b/apps/web/src/app/works/[workId]/page.tsx
@@ -36,14 +36,16 @@ export async function generateMetadata({ params }: WorkDetailPageProps) {
 
 	const work = await getWorkById(workId);
 
+	// title は layout の title.template がサフィックスを付与するため手書きしない（二重化防止）
 	if (!work) {
 		return {
-			title: "作品が見つかりません | すずみなくりっく！",
+			title: "作品が見つかりません",
+			robots: { index: false, follow: false },
 		};
 	}
 
 	return {
-		title: `${work.title} | すずみなくりっく！`,
+		title: work.title,
 		description:
 			work.description || `涼花みなせさんが出演する音声作品「${work.title}」の詳細ページです。`,
 		alternates: {


### PR DESCRIPTION
## 概要

本番の not-found 系メタデータ 2 件の修正と、soft 404（HTTP 200）の調査結果報告。

### 1. title 二重サフィックス解消

layout の `title.template`（`%s | すずみなくりっく！`）と page 側の手書きサフィックスが二重適用され、works/videos/users 詳細（**not-found 時だけでなく正常系も**）と root not-found・favorites・auth/error で `… | すずみなくりっく！ | すずみなくりっく！` になっていた。page レベル title からサフィックスを除去（`openGraph`/`twitter` の title は template 対象外のため手書き維持）。

### 2. not-found 分岐の robots noindex 明示

works/videos/buttons/users 詳細の not-found 分岐と root not-found に `robots: { index: false, follow: false }` を追加。layout 継承の `index, follow` メタと、streamed notFound 時に Next が自動挿入する `noindex` が矛盾していたのを解消。

### 3. soft 404（欠落 ID で HTTP 200）の調査結果 — 本 PR では status 変更なし

4 詳細ルートとも欠落 ID は 200 + not-found UI（本番確認済み）。原因は cacheComponents + root layout `<Suspense fallback={null}>`（SPR-9）の構造的制約：`notFound()` が status に反映されるのはエラーが Suspense 境界外へ脱出した場合のみ（Next ソース `renderToStream` の catch で確認）。本番相当ビルドで①ページ完全 `'use cache'` 化②HTML-limited bot UA のブロッキングレンダー③`generateStaticParams`（cacheComponents では空配列不可＋ビルド時 Firestore 認証なし）をすべて実験し棄却。crawler 対策は自動挿入 noindex + 本 PR の明示 noindex で担保。URL 自体が不在の route は従来どおり 404。

## 検証

- `next build` + `next start`（本番相当）：works/videos/buttons 欠落 ID → title 単一サフィックス + `noindex, nofollow`（`index, follow` 消滅）、unmatched route → 404 + 単一サフィックス
- `pnpm dev:local`（Emulator + シード）：存在する work/video/button の title 単一サフィックス確認
- `pnpm verify` 全緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)