### PR TITLE
fix(ci): Claude Review の max-turns を 20→40 に引き上げ

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -83,6 +83,8 @@ jobs:
             - 問題が無ければ「重大所見なし」とはっきり書く。
           # モデルは固定しない（版ズレ回避: CLAUDE.md 軸1）。action 既定の最新モデルに任せる。
           # 行内コメント投稿ツールと gh コマンドを明示許可（これが無いと投稿できない）。
+          # max-turns 40: CLI 更新で既定モデルが変わるとターン消費が増える（sonnet-4-6→5 で 5-15→21+ に増加し
+          #   20 では枯渇＝レビュー未投稿。run 28672455307）。モデル非固定の方針を維持するため余裕を持たせる。
           claude_args: |
-            --max-turns 20
+            --max-turns 40
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 背景

[run 28672455307](https://github.com/nothink-jp/suzumina.click/actions/runs/28672455307) で Claude AI Review が `Reached maximum number of turns (20)` で失敗し、レビューが未投稿になった（`continue-on-error: true` のため run 自体は緑）。

## 原因

claude-code-action がランタイムでインストールする Claude Code CLI の更新（2.1.195→2.1.199）で、既定モデルが `claude-sonnet-4-6` → `claude-sonnet-5` に変わり、同じレビュータスクのターン消費が増加した。

| 時点 | モデル | 実績 |
|---|---|---|
| 6/29 の各 run | claude-sonnet-4-6 | 5–15 ターン・permission 拒否 0–1（成功） |
| 7/3 16:15 | claude-sonnet-5 | 14 ターン・拒否 3（ギリギリ成功） |
| 7/3 16:24（当該） | claude-sonnet-5 | **21 ターン・拒否 7（上限超過で失敗）** |

## 変更

- `--max-turns` を 20 → 40 に引き上げ。モデル非固定の方針（CLAUDE.md 軸1: 版ズレ回避）を維持したまま、モデル更新によるターン消費増を吸収する。

## 注意

- claude-code-action は workflow が main と同一になるまで実レビューをスキップする仕様のため、この変更は**マージ後の次の PR から**有効になる（この PR 自体では検証されない）。
- `.github/workflows` の変更＝ One-Way Door（セルフマージ・ポリシー上、人間レビュー必須）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)