### PR TITLE
fix(terraform): DLsite関数の監視アラート/ログsinkをGen2実ログ形式に修正 (SPR-234)

### DIFF
--- a/terraform/logging.tf
+++ b/terraform/logging.tf
@@ -9,10 +9,12 @@ resource "google_logging_project_sink" "application_logs" {
   destination = "storage.googleapis.com/${google_storage_bucket.log_storage.name}"
 
   # Cloud Runとフロントエンドのログをフィルタリング
+  # functions（fetch* = Gen2）のログも cloud_run_revision で出る（Gen1 形式の
+  # cloud_function フィルタは一切マッチせず、関数ログが未アーカイブだった・SPR-234）
   filter = <<-EOT
     (resource.type="cloud_run_revision" AND resource.labels.service_name="suzumina-click-web")
     OR
-    (resource.type="cloud_function" AND resource.labels.function_name=~"fetch.*")
+    (resource.type="cloud_run_revision" AND resource.labels.service_name=~"fetch.*")
     OR
     (jsonPayload.metric_type="frontend_performance" OR jsonPayload.metric_type="core_web_vitals")
   EOT

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -7,7 +7,9 @@
 
 # ログベースメトリクスを作成してアラートに使用
 # per-work の一時エラー（Individual Info API取得エラー / API HTTP Error）は毎日数件出る常態の
-# ため除外し、系統障害（作品ID収集エラー・Firestore書き込み失敗等）のみを対象とする。
+# ため除外し、系統障害（作品ID収集エラー・統合データ収集エラー・予期しないエラー等）のみを対象とする。
+# API 全面停止（全 work が per-work エラー）は除外の副作用でここから漏れるが、
+# バッチ全滅を dlsite_api_batch_all_failed が独立して検知する（役割分担）。
 resource "google_logging_metric" "dlsite_error_count" {
   name    = "dlsite_function_errors"
   project = var.gcp_project_id
@@ -156,14 +158,18 @@ resource "google_monitoring_alert_policy" "dlsite_no_data_fetched" {
   ]
 }
 
-# DLsite関数の実行失敗アラート
+# DLsite関数のプラットフォーム障害アラート（OOM・タイムアウト・クラッシュ）
+# エントリポイント（dlsite-individual-info-api.ts の fetchDLsiteUnifiedData）は catch-all で
+# 例外を ERROR ログ化して正常終了（2xx）するため、アプリレベルの失敗はここでは 5xx にならず
+# dlsite_error_count 側が検知する。この alert はプロセスが応答を返せなかったケース
+# （プラットフォームによる強制終了）専用（役割分担・SPR-234）。
 resource "google_monitoring_alert_policy" "dlsite_function_failure" {
-  display_name = "DLsite Function Execution Failure"
+  display_name = "DLsite Function Platform Failure (5xx)"
   project      = var.gcp_project_id
   combiner     = "OR"
 
   conditions {
-    display_name = "関数実行の失敗"
+    display_name = "プラットフォーム強制終了(5xx)を検出"
 
     condition_threshold {
       # Gen1 の cloudfunctions.googleapis.com/function/execution_count は Gen2 では
@@ -193,21 +199,98 @@ resource "google_monitoring_alert_policy" "dlsite_function_failure" {
 
   documentation {
     content   = <<-EOT
-    # DLsite関数の実行失敗
-    
-    fetchDLsiteUnifiedData関数の実行が失敗しました。
-    
+    # DLsite関数のプラットフォーム障害（5xx）
+
+    fetchDLsiteUnifiedData の呼び出しが 5xx で終了しました。エントリポイントは例外を
+    catch して正常終了するため、これはアプリ内エラーではなく OOM・リクエストタイムアウト・
+    プロセスクラッシュ等、プラットフォームが強制終了したケースを意味します
+    （アプリ内で catch されたエラーは DLsite Function Error Alert 側で検知）。
+
     ## 確認事項
-    1. Cloud Functions のエラーログを確認
-    2. Individual Info API の応答確認
-    3. メモリ不足やタイムアウトの可能性
-    4. 権限エラーの確認
+    1. Cloud Run のログ（resource.type="cloud_run_revision", service_name="fetchdlsiteunifieddata"）を確認
+    2. メモリ使用量・リクエストタイムアウト設定の確認
+    3. 直近のデプロイ・依存更新の有無
     EOT
     mime_type = "text/markdown"
   }
 
   depends_on = [google_monitoring_notification_channel.email]
 }
+# ログベースメトリクス - バッチ全滅（Individual Info API 全面停止の兆候）
+# per-work の一時エラーは dlsite_error_count から除外しているため、「全 work が取得失敗する
+# 全面停止」はこのメトリクスが検知の正本（役割分担・SPR-234）。バッチ内 50件全てが失敗すると
+# processBatch が「バッチ N: APIレスポンスなし」を WARN 出力する（dlsite-individual-info-api.ts）。
+# 平常時は発生しない（過去30日で0件・2026-07-04 実測）ため閾値は >0 でノイズにならない。
+resource "google_logging_metric" "dlsite_api_batch_all_failed" {
+  name    = "dlsite_api_batch_all_failed"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchdlsiteunifieddata"
+    jsonPayload.message:"APIレスポンスなし"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "DLsite API Batch All Failed"
+  }
+}
+
+# DLsite API バッチ全滅アラート
+resource "google_monitoring_alert_policy" "dlsite_api_batch_all_failed" {
+  display_name = "DLsite API Batch All Failed Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "バッチ内全件のAPI取得失敗を検出"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_api_batch_all_failed.id}\" resource.type=\"cloud_run_revision\""
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # DLsite Individual Info API バッチ全滅
+
+    1バッチ（50件）の Individual Info API 取得が全件失敗しました。平常時は発生しない
+    シグナルで、API の全面停止・アクセスブロック・ネットワーク障害の兆候です
+    （個別作品の一時エラーは常態のためアラート対象外。全滅のみここで検知）。
+
+    ## 確認事項
+    1. DLsite の稼働状況を手動確認（Webサイト・Individual Info API）
+    2. レート制限・IPブロックの可能性（Cloud Run の egress IP からのアクセス可否）
+    3. ログ確認: jsonPayload.message:"APIレスポンスなし" を Cloud Logging で検索
+
+    ## 補足
+    連続する場合も works の既存データは保持され、価格履歴のみ当日分が欠落する。
+    復旧後の run で自動的に再開する（手動介入は原則不要）。
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.dlsite_api_batch_all_failed
+  ]
+}
+
 # ログベースメトリクス - スキーマドリフト（SPR-140 / SPR-144）
 # 本番フェッチ経路で、既知フィールド集合に無い新フィールドが出現すると
 # logger.warn が jsonPayload.alert="dlsite_schema_drift" 付きで出力される。

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -216,6 +216,7 @@ resource "google_monitoring_alert_policy" "dlsite_function_failure" {
 
   depends_on = [google_monitoring_notification_channel.email]
 }
+
 # ログベースメトリクス - バッチ全滅（Individual Info API 全面停止の兆候）
 # per-work の一時エラーは dlsite_error_count から除外しているため、「全 work が取得失敗する
 # 全面停止」はこのメトリクスが検知の正本（役割分担・SPR-234）。バッチ内 50件全てが失敗すると

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -1,14 +1,23 @@
 # DLsite関数専用のモニタリング設定
+#
+# 注意（SPR-234）: fetchDLsiteUnifiedData は Gen2（Cloud Run 上で実行）のため、実行ログは
+# resource.type="cloud_run_revision" + resource.labels.service_name="fetchdlsiteunifieddata"
+# （サービス名は小文字）で出力される。Gen1 形式（resource.type="cloud_function" +
+# function_name）でフィルタすると一切マッチせず、アラートは発火不能になる。
 
 # ログベースメトリクスを作成してアラートに使用
+# per-work の一時エラー（Individual Info API取得エラー / API HTTP Error）は毎日数件出る常態の
+# ため除外し、系統障害（作品ID収集エラー・Firestore書き込み失敗等）のみを対象とする。
 resource "google_logging_metric" "dlsite_error_count" {
   name    = "dlsite_function_errors"
   project = var.gcp_project_id
 
   filter = <<-EOT
-    resource.type="cloud_function"
-    resource.labels.function_name="fetchDLsiteUnifiedData"
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchdlsiteunifieddata"
     severity >= "ERROR"
+    NOT jsonPayload.message:"Individual Info API取得エラー"
+    NOT jsonPayload.message:"API HTTP Error for"
   EOT
 
   metric_descriptor {
@@ -28,7 +37,7 @@ resource "google_monitoring_alert_policy" "dlsite_function_error" {
     display_name = "DLsite関数でエラーログ検出"
 
     condition_threshold {
-      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_error_count.id}\" resource.type=\"cloud_function\""
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_error_count.id}\" resource.type=\"cloud_run_revision\""
 
       aggregations {
         alignment_period   = "60s"
@@ -59,7 +68,7 @@ resource "google_monitoring_alert_policy" "dlsite_function_error" {
     
     ## ログ確認コマンド
     ```bash
-    gcloud logging read 'resource.type="cloud_function" AND resource.labels.function_name="fetchDLsiteUnifiedData" AND severity >= "ERROR"' --limit=20 --format=json
+    gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="fetchdlsiteunifieddata" AND severity >= "ERROR"' --limit=20 --format=json
     ```
     EOT
     mime_type = "text/markdown"
@@ -71,15 +80,19 @@ resource "google_monitoring_alert_policy" "dlsite_function_error" {
   ]
 }
 
-# ログベースメトリクス - 0件取得
+# ログベースメトリクス - 作品ID収集の失敗（scrape 失敗 or 0件）
+# 旧 filter の「取得した作品数: 0件」は現行コードに存在しないログ文言だった（SPR-234）。
+# SPR-232 で scrape 失敗時の asset fallback を撤去し run 中断となったため、
+# 「作品ID収集エラー」（scrape 例外）と「収集対象の作品IDが見つかりません」（scrape 成功だが0件）
+# の2つが現行の系統的失敗シグナル。恒常化すると works 更新が止まる（次 run=2h後が自動リトライ）。
 resource "google_logging_metric" "dlsite_no_data" {
   name    = "dlsite_no_data_fetched"
   project = var.gcp_project_id
 
   filter = <<-EOT
-    resource.type="cloud_function"
-    resource.labels.function_name="fetchDLsiteUnifiedData"
-    jsonPayload.message:"取得した作品数: 0件"
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchdlsiteunifieddata"
+    (jsonPayload.message:"作品ID収集エラー" OR jsonPayload.message:"収集対象の作品IDが見つかりません")
   EOT
 
   metric_descriptor {
@@ -99,7 +112,7 @@ resource "google_monitoring_alert_policy" "dlsite_no_data_fetched" {
     display_name = "作品数0件を検出"
 
     condition_threshold {
-      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_no_data.id}\" resource.type=\"cloud_function\""
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_no_data.id}\" resource.type=\"cloud_run_revision\""
 
       aggregations {
         alignment_period   = "300s"
@@ -118,18 +131,21 @@ resource "google_monitoring_alert_policy" "dlsite_no_data_fetched" {
 
   documentation {
     content   = <<-EOT
-    # DLsiteデータ取得0件
-    
-    DLsite関数が実行されましたが、作品データが1件も取得できませんでした。
-    
+    # DLsite作品ID収集の失敗（scrape 失敗 or 0件）
+
+    DLsite関数の作品ID収集が失敗（scrape 例外）または0件でした。
+    この run は中断され、次の定期実行（2時間後）が自動リトライします（SPR-232 で
+    asset fallback を撤去済み）。恒常化すると works の更新が完全に止まります。
+
     ## 考えられる原因
-    1. DLsiteのHTML構造が変更された
+    1. DLsiteのHTML/AJAX構造が変更された
     2. 検索条件が変更された
     3. アクセス制限（レート制限等）
-    
+
     ## 対応方法
     1. DLsiteのWebサイトを手動で確認
-    2. パーサーのアップデートが必要
+    2. work-id-collector（AJAX パーサー）のアップデートが必要
+    3. ログ確認: jsonPayload.message:"作品ID収集エラー" を Cloud Logging で検索
     EOT
     mime_type = "text/markdown"
   }
@@ -150,11 +166,14 @@ resource "google_monitoring_alert_policy" "dlsite_function_failure" {
     display_name = "関数実行の失敗"
 
     condition_threshold {
+      # Gen1 の cloudfunctions.googleapis.com/function/execution_count は Gen2 では
+      # 時系列が生成されない。Gen2 の実行失敗（クラッシュ/タイムアウト）は Cloud Run の
+      # request_count 5xx で観測する（web の monitoring.tf と同型・SPR-234）。
       filter = <<-EOT
-        resource.type="cloud_function"
-        resource.labels.function_name="fetchDLsiteUnifiedData"
-        metric.type="cloudfunctions.googleapis.com/function/execution_count"
-        metric.labels.status!="ok"
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="fetchdlsiteunifieddata"
+        metric.type="run.googleapis.com/request_count"
+        metric.labels.response_code_class="5xx"
       EOT
 
       aggregations {
@@ -197,8 +216,8 @@ resource "google_logging_metric" "dlsite_schema_drift" {
   project = var.gcp_project_id
 
   filter = <<-EOT
-    resource.type="cloud_function"
-    resource.labels.function_name="fetchDLsiteUnifiedData"
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchdlsiteunifieddata"
     jsonPayload.alert="dlsite_schema_drift"
   EOT
 
@@ -219,7 +238,7 @@ resource "google_monitoring_alert_policy" "dlsite_schema_drift" {
     display_name = "既知集合に無い新フィールドを検出"
 
     condition_threshold {
-      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_schema_drift.id}\" resource.type=\"cloud_function\""
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_schema_drift.id}\" resource.type=\"cloud_run_revision\""
 
       aggregations {
         alignment_period   = "300s"
@@ -253,7 +272,7 @@ resource "google_monitoring_alert_policy" "dlsite_schema_drift" {
 
     ## ログ確認コマンド
     ```bash
-    gcloud logging read 'resource.type="cloud_function" AND resource.labels.function_name="fetchDLsiteUnifiedData" AND jsonPayload.alert="dlsite_schema_drift"' --limit=20 --format=json
+    gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="fetchdlsiteunifieddata" AND jsonPayload.alert="dlsite_schema_drift"' --limit=20 --format=json
     ```
     EOT
     mime_type = "text/markdown"


### PR DESCRIPTION
## 概要

[SPR-234](https://linear.app/nothink/issue/SPR-234) の修正。`fetchDLsiteUnifiedData` は Gen2（Cloud Run 上で実行）のため実ログ・メトリクスは `resource.type="cloud_run_revision"` + `service_name="fetchdlsiteunifieddata"`（小文字）で出るが、監視4本 + ログアーカイブ sink が Gen1 形式（`cloud_function` + `function_name`）でフィルタしており**一切マッチせず全て機能していなかった**（実測: cloud_function 側の直近2週間 ERROR ヒット0件。傍証: schema drift WARNING が10日間毎run発火しても通知ゼロ）。

## 変更内容

| リソース | 修正 | 補足 |
|--|--|--|
| `dlsite_error_count`（metric+alert） | resource 修正 + **per-work 一時エラーを除外** | 直近7日の ERROR 62件は全て `Individual Info API取得エラー`/`API HTTP Error`（個別作品のタイムアウト等の常態）。素通しで直すと毎日鳴ってアラート疲れになるため NOT 除外し、系統障害のみ対象に |
| `dlsite_no_data`（metric+alert） | resource 修正 + **対象ログ文言を現行コードに再ポイント** | 旧 `取得した作品数: 0件` は現行コードに存在しない文言（二重に死んでいた）。#737 以降の系統的失敗シグナル `作品ID収集エラー`（scrape 例外→run中断）/ `収集対象の作品IDが見つかりません`（0件）へ。**#737 の「scrape 恒常失敗に気づく安全網」はこれ** |
| `dlsite_function_failure`（alert） | Gen1 専用 metric `cloudfunctions.googleapis.com/function/execution_count` → **`run.googleapis.com/request_count` 5xx** | Gen2 では前者の時系列が生成されない。web の monitoring.tf と同型パターン |
| `dlsite_schema_drift`（metric+alert） | resource 修正 | |
| `logging.tf` application_logs sink | functions レッグを `cloud_run_revision AND service_name=~"fetch.*"` に修正 | **スコープ注意**: SPR-234 の4本に加えた同根の5本目。関数ログが GCS 90日アーカイブから漏れていた。関数ログは DEBUG 込みで量が多く、GCS 保存量は増える（概算 ~数GB/90日・数十円/月）。不要ならこの hunk だけ落としてください |

各修正には再発防止のコメント（Gen2=cloud_run_revision の正本明示）を付けた。

## 検証

- `terraform init -backend=false` + `terraform validate` → **valid**
- live 側に3つの log-based metric（`dlsite_function_errors` / `dlsite_no_data_fetched` / `dlsite_schema_drift`）が存在することを `gcloud logging metrics list` で確認済み（= apply 済み構成のフィルタ更新）
- 除外対象のログ文言が `jsonPayload.message` に出ることを実ログで確認済み

## apply 手順（マージ後・手動）

```bash
# 事前に ADC 再認証が必要（現在 invalid_rapt で失効中）
gcloud auth application-default login

cd terraform && terraform workspace select production
terraform plan \
  -target=google_logging_metric.dlsite_error_count \
  -target=google_logging_metric.dlsite_no_data \
  -target=google_logging_metric.dlsite_schema_drift \
  -target=google_logging_metric.dlsite_api_batch_all_failed \
  -target=google_monitoring_alert_policy.dlsite_function_error \
  -target=google_monitoring_alert_policy.dlsite_no_data_fetched \
  -target=google_monitoring_alert_policy.dlsite_function_failure \
  -target=google_monitoring_alert_policy.dlsite_schema_drift \
  -target=google_monitoring_alert_policy.dlsite_api_batch_all_failed \
  -target=google_logging_project_sink.application_logs
# plan が既存リソースの update + dlsite_api_batch_all_failed 2件の create のみであることを
# 確認して apply（同じ -target 群で）
```

※ 既知の live-vs-config drift があるため **full apply 禁止・-target 必須**（メモリ/SPR-234 記載どおり）。

## AIレビュー所見への対応（d7df367e）

- **所見1（function_failure の検知範囲）**: 役割分担として整理。アプリ内エラーは catch-all の ERROR ログ経由で `dlsite_error_count` が検知し、本 alert は 5xx＝プラットフォーム強制終了専用。display_name / doc を実態に整合（nit の Gen1 文言もここで解消）
- **所見2（API 全面停止が全アラートから漏れる）**: 事実と確認。バッチ全滅時の WARN `APIレスポンスなし`（平常時0件・過去30日実測）を対象にした **`dlsite_api_batch_all_failed` metric + alert を新設**して穴を塞いだ

## 適用後の検証

- Metrics Explorer で `logging.googleapis.com/user/dlsite_function_errors` 等の系列が（次のエラー発生時に）生成されること
- schema drift は次の drift 発生時にメール通知が届くこと（既知の is_sound_playable は #734 でベースライン追加済みのため発火しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
