### PR TITLE
fix(terraform): terraform-apply-sa に logging.configWriter を追加 (SPR-234)

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -342,6 +342,7 @@ resource "google_service_account_iam_binding" "terraform_apply_sa_wif" {
 locals {
   terraform_apply_sa_roles = [
     "roles/editor",                          # 大半のリソース CRUD（run/scheduler/firestore/monitoring/logging/pubsub/AR/functions 等）
+    "roles/logging.configWriter",            # editor は logging.sinks.get/list のみで書き込み不可（logMetrics はフル）。sink 更新（logging.tf）に必須
     "roles/resourcemanager.projectIamAdmin", # google_project_iam_member（プロジェクト IAM、32件）
     "roles/iam.serviceAccountAdmin",         # google_service_account + SA IAM binding
     "roles/iam.roleAdmin",                   # google_project_iam_custom_role（カスタムロール 2件）


### PR DESCRIPTION
## 概要

#738 の apply（[run 28687035320](https://github.com/nothink-jp/suzumina.click/actions/runs/28687035320/job/85081568807)）が `google_logging_project_sink.application_logs` の更新で **403 `logging.sinks.update` denied** となり中断した対応。

## 原因（実測で裏取り済み）

`terraform-apply-sa` の基盤ロール `roles/editor` は **logging.sinks.get/list のみで書き込み系（create/update/delete）を含まない**（`gcloud iam roles describe` で確認）。一方 logMetrics はフル権限のため、失敗 run でも metric 2件の更新は成功していた — エラーの出方と完全に一致する。sink を terraform 管理する以上（logging.tf）、`roles/logging.configWriter`（sinks + logMetrics の CRUD）が必要。iam.tf の「curated strong」セットに1行追加し、editor の穴をコメントで明記した。

## 適用時の注意

- apply-sa は `resourcemanager.projectIamAdmin` を持つため、この binding 自体は CI apply で自己付与できる
- ただし**同一 apply 内で「binding 作成 → sink 更新」の順になっても IAM 伝播遅延（〜数十秒）で sink 更新が再度 403 になりうる**。その場合は apply workflow をもう一度実行すれば収束する（terraform は冪等・失敗分のみ再適用）
- 前回 apply は部分適用で中断（適用済み: error_count metric / function_error alert。未適用: no_data・schema_drift・function_failure・**新設の batch_all_failed ×2**・sink）。本 PR マージ後の apply で全て収束する

## 検証

- `terraform fmt -check` / `terraform validate` → green
- `roles/editor` と `roles/logging.configWriter` の権限セットを `gcloud iam roles describe` で実確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)