### PR TITLE
fix(terraform): 単一文字列ログはtextPayloadに出るためlog metricを両フィールド対応 (SPR-234)

### DIFF
--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -14,12 +14,16 @@ resource "google_logging_metric" "dlsite_error_count" {
   name    = "dlsite_function_errors"
   project = var.gcp_project_id
 
+  # 除外も textPayload/jsonPayload 両張り: 呼び出しから第2引数が外れると message が
+  # textPayload へ昇格し、jsonPayload 側だけの NOT では除外が静かに効かなくなるため。
   filter = <<-EOT
     resource.type="cloud_run_revision"
     resource.labels.service_name="fetchdlsiteunifieddata"
     severity >= "ERROR"
     NOT jsonPayload.message:"Individual Info API取得エラー"
+    NOT textPayload:"Individual Info API取得エラー"
     NOT jsonPayload.message:"API HTTP Error for"
+    NOT textPayload:"API HTTP Error for"
   EOT
 
   metric_descriptor {

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -91,10 +91,15 @@ resource "google_logging_metric" "dlsite_no_data" {
   name    = "dlsite_no_data_fetched"
   project = var.gcp_project_id
 
+  # 注意: 付加フィールド無しの logger 呼び出しは Cloud Run が message を textPayload へ昇格させる
+  # （jsonPayload は残らない）ため、両フィールドを OR で張る（SPR-234）。
   filter = <<-EOT
     resource.type="cloud_run_revision"
     resource.labels.service_name="fetchdlsiteunifieddata"
-    (jsonPayload.message:"作品ID収集エラー" OR jsonPayload.message:"収集対象の作品IDが見つかりません")
+    (
+      jsonPayload.message:"作品ID収集エラー" OR textPayload:"作品ID収集エラー"
+      OR jsonPayload.message:"収集対象の作品IDが見つかりません" OR textPayload:"収集対象の作品IDが見つかりません"
+    )
   EOT
 
   metric_descriptor {
@@ -226,10 +231,12 @@ resource "google_logging_metric" "dlsite_api_batch_all_failed" {
   name    = "dlsite_api_batch_all_failed"
   project = var.gcp_project_id
 
+  # 「バッチ N: APIレスポンスなし」は付加フィールド無しの warn のため textPayload に出る
+  # （jsonPayload.message には残らない）。将来の引数追加にも耐えるよう両フィールドを張る（SPR-234）。
   filter = <<-EOT
     resource.type="cloud_run_revision"
     resource.labels.service_name="fetchdlsiteunifieddata"
-    jsonPayload.message:"APIレスポンスなし"
+    (jsonPayload.message:"APIレスポンスなし" OR textPayload:"APIレスポンスなし")
   EOT
 
   metric_descriptor {

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -303,6 +303,154 @@ resource "google_monitoring_alert_policy" "dlsite_api_batch_all_failed" {
   ]
 }
 
+# ログベースメトリクス - 定期 run の開始（無音障害検知用ハートビート）
+# Scheduler 停止 / Pub/Sub subscription・Eventarc trigger の破壊 / 関数消失では
+# 「ログが出ない」ため、ログ内容ベースのアラートは全て沈黙する（SPR-234 分類 B1）。
+# run 開始ログ（2h 毎・12回/日）を metric 化し、absence 条件で run 途絶そのものを検知する。
+resource "google_logging_metric" "dlsite_run_started" {
+  name    = "dlsite_run_started"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchdlsiteunifieddata"
+    (jsonPayload.message:"統合データ収集開始" OR textPayload:"統合データ収集開始")
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "DLsite Run Started"
+  }
+}
+
+# DLsite 定期 run 途絶アラート（dead man's switch）
+resource "google_monitoring_alert_policy" "dlsite_run_absent" {
+  display_name = "DLsite Run Absent Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "定期runが3時間以上観測されない"
+
+    # 2h 周期 + 1h マージン。1 run 欠けの時点で異常（過去ログでは欠けゼロ）。
+    condition_absent {
+      filter   = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_run_started.id}\" resource.type=\"cloud_run_revision\""
+      duration = "10800s"
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_COUNT"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # DLsite 定期 run の途絶（3時間以上）
+
+    fetchDLsiteUnifiedData の run 開始ログが3時間以上観測されていません（正常時は
+    2時間毎・12回/日）。ログ自体が出ない障害のため、他の DLsite アラートは沈黙します。
+
+    ## 考えられる原因と確認手順
+    1. Cloud Scheduler 停止/削除: gcloud scheduler jobs describe fetch-dlsite-individual-api-hourly --location=asia-northeast1
+    2. Pub/Sub topic/subscription・Eventarc trigger の破壊: gcloud eventarc triggers list --location=asia-northeast1
+    3. サービス消失/起動不能: gcloud run services describe fetchdlsiteunifieddata --region=asia-northeast1
+    4. 直近のデプロイ・terraform apply の有無を確認
+
+    ## 復旧確認
+    手動トリガで1 run 流す: gcloud scheduler jobs run fetch-dlsite-individual-api-hourly --location=asia-northeast1
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.dlsite_run_started
+  ]
+}
+
+# ログベースメトリクス - API 取得失敗率の上昇（部分劣化）
+# バッチ取得で失敗が 10% を超えるとクライアントが集約 WARN「API取得失敗が多数」を出す
+# （individual-info-api-client.ts）。per-work 一時エラー（常態・除外済み）と「全滅」
+# （dlsite_api_batch_all_failed）の中間帯＝部分劣化を検知する（SPR-234 分類 B2）。
+# 頻度実績は月1〜3回（直近30日で3回・失敗率12〜18%）＝低ノイズ。
+# 単一文字列 warn のため textPayload に出る点に注意（両フィールド張り）。
+resource "google_logging_metric" "dlsite_api_failure_rate_high" {
+  name    = "dlsite_api_failure_rate_high"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchdlsiteunifieddata"
+    (jsonPayload.message:"API取得失敗が多数" OR textPayload:"API取得失敗が多数")
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "DLsite API Failure Rate High"
+  }
+}
+
+# DLsite API 部分劣化アラート（失敗率 >10%）
+resource "google_monitoring_alert_policy" "dlsite_api_failure_rate_high" {
+  display_name = "DLsite API High Failure Rate Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "バッチ取得の失敗率10%超を検出"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_api_failure_rate_high.id}\" resource.type=\"cloud_run_revision\""
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # DLsite API 取得失敗率の上昇（部分劣化）
+
+    バッチ取得の失敗率が 10% を超えました（実績: 月1〜3回・12〜18%）。DLsite 側の
+    部分障害・レート制限・ネットワーク不調の兆候です。単発は自己回復することが
+    多いですが、短時間に連続する場合は全面停止（DLsite API Batch All Failed）へ
+    進行する可能性があるため要調査です。
+
+    ## 確認事項
+    1. ログ確認: "API取得失敗が多数" / "Individual Info API サーバーエラー" を Cloud Logging で検索
+    2. DLsite の稼働状況を手動確認
+    3. 失敗した作品は次 run（2h後）で自動再試行される（手動介入は原則不要）
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.dlsite_api_failure_rate_high
+  ]
+}
+
 # ログベースメトリクス - スキーマドリフト（SPR-140 / SPR-144）
 # 本番フェッチ経路で、既知フィールド集合に無い新フィールドが出現すると
 # logger.warn が jsonPayload.alert="dlsite_schema_drift" 付きで出力される。


### PR DESCRIPTION
## 概要

> **スコープ更新**: #741（無音障害検知 + 部分劣化アラート）がこの PR のブランチへマージされたため（c657c05c）、本 PR は **①textPayload filter 修正 + NOT 除外の両張り防御（cede2fcd まで） + ②新規アラート2本 B1/B2（dlsite_run_started/run_absent・dlsite_api_failure_rate_high）** の全部入りです。この PR のマージ + apply だけで SPR-234 の全対応が main / live に反映されます。②の詳細は #741 の本文を参照。

SPR-234 のログ全量再調査（監視項目の分類作業）の過程で、**#738 で導入した filter に同類の「実ログと形式が合わない」バグ**を発見した対応。#739 の apply は成功しているため、**バグ入り filter が現在 live**。

## 原因（実ログの生エントリで確認済み）

Cloud Run の構造化ログ処理は、JSON ログに `message` 以外の付加フィールドが無い場合、**message を textPayload へ昇格させ jsonPayload を残さない**（severity は解釈される）。本リポジトリの logger は常に構造化 JSON を出すが、**引数なしの `logger.warn/error(文字列)` はこの昇格に該当**する。

実確認: `バッチ 37: 5件の取得失敗`（07-03）の生エントリは `textPayload` のみ・`jsonPayload: null`。

| filter | 対象文言 | 呼び出し形 | 実際の出力先 | #738 filter |
|--|--|--|--|--|
| `dlsite_api_batch_all_failed` | `バッチ N: APIレスポンスなし` | 単一文字列 | **textPayload** | jsonPayload のみ → **全滅検知が完全に空振り** |
| `dlsite_no_data` | `収集対象の作品IDが見つかりません` | 単一文字列 | **textPayload** | jsonPayload のみ → 片翼が空振り |
| `dlsite_no_data` | `作品ID収集エラー` | 引数あり | jsonPayload.message | ✓ 正常 |

## 修正

両 metric の filter を `jsonPayload.message OR textPayload` の両張りに変更（将来のログ引数の追加/削除にも耐える）。再発防止コメント付き。

なお `dlsite_error_count` の NOT 除外2文言は引数ありで jsonPayload に出るため影響なし。severity ベースのマッチは payload 位置に依存しないため、単一文字列 ERROR も従来どおり検知される（確認済み）。

## 検証

- `terraform fmt -check` / `terraform validate` green
- 対象文言の呼び出し形（引数の有無）をコード側で全数確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
