### PR TITLE
feat(e2e): Playwright を Firestore Emulator + seed に配線しデータ依存スモークを追加 (SPR-236)

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Install Playwright (chromium)
         run: pnpm --filter @suzumina.click/web exec playwright install --with-deps chromium
 
+      # Firestore Emulator は Java 21+ を要求する（runner 既定の PATH の java は古い）
+      - name: Setup Java 21 (Firestore Emulator requirement)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
       # Emulator は runner 既存の apt 管理 gcloud では components install できないため、
       # action 管理の SDK に component を同梱して導入する（認証は不要。Emulator のみ使用）
       - name: Setup gcloud (Firestore Emulator)

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -2,7 +2,9 @@ name: E2E Smoke (prod build)
 
 # SPR-124（radix NavigationMenu がヘッダーの先頭ナビ項目を本番ビルドでのみ脱落）のような
 # 「next dev / jsdom では再現せず next build でのみ顕在化する回帰」を CI で捕捉する。
-# 本番ビルド(next build → next start)に対して最小スモーク(e2e/smoke.spec.ts)を実行する。
+# 本番ビルドは Firestore Emulator + フィクスチャに接続し（SPR-236）、
+# データ非依存スモーク(e2e/smoke.spec.ts)に加えてデータ依存スモーク(e2e/data-smoke.spec.ts)も実行する。
+# ローカル再現は `pnpm test:e2e:emulator`（scripts/e2e-emulator.sh）。
 
 on:
   pull_request:
@@ -34,15 +36,20 @@ jobs:
               - 'apps/web/**'
               - 'packages/ui/**'
               - 'packages/shared-types/**'
+              # データ依存スモークは fixtures を正本として検証するため、更新時も回す
+              - 'apps/functions/src/tools/firestore-local/**'
+              - 'scripts/e2e-emulator.sh'
+              - 'scripts/emulator-lib.sh'
+              - 'scripts/firestore-emulator.sh'
               - 'pnpm-lock.yaml'
               - '.github/workflows/e2e-smoke.yml'
 
   smoke:
-    name: Header smoke (prod build)
+    name: Smoke (prod build x emulator)
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.ui_or_web == 'true'
-    timeout-minutes: 15
+    timeout-minutes: 20
     env:
       # ブート用のダミー値（実認証は行わない。/ は header を含む layout が描画されれば十分）
       BETTER_AUTH_URL: http://127.0.0.1:3000
@@ -51,6 +58,11 @@ jobs:
       DISCORD_CLIENT_SECRET: dummy
       NEXT_PUBLIC_GA_MEASUREMENT_ID: ""
       NEXT_PUBLIC_GTM_ID: ""
+      # 本番ビルド（build/start とも）を Firestore Emulator + フィクスチャに接続する。
+      # PLAYWRIGHT_EMULATOR=1 は firestore.ts の安全弁（本番 × Emulator 拒否）の明示 opt-in で、
+      # データ依存スモーク(e2e/data-smoke.spec.ts)を有効化する
+      FIRESTORE_EMULATOR_HOST: 127.0.0.1:8080
+      PLAYWRIGHT_EMULATOR: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -71,10 +83,27 @@ jobs:
       - name: Install Playwright (chromium)
         run: pnpm --filter @suzumina.click/web exec playwright install --with-deps chromium
 
-      - name: Build web (production)
+      # Emulator は runner 既存の apt 管理 gcloud では components install できないため、
+      # action 管理の SDK に component を同梱して導入する（認証は不要。Emulator のみ使用）
+      - name: Setup gcloud (Firestore Emulator)
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          install_components: cloud-firestore-emulator
+
+      - name: Start Firestore Emulator and seed fixtures
+        run: |
+          gcloud emulators firestore start --host-port="$FIRESTORE_EMULATOR_HOST" --database-mode=firestore-native &
+          for _ in $(seq 1 60); do
+            if curl -s -o /dev/null "http://$FIRESTORE_EMULATOR_HOST/"; then break; fi
+            sleep 1
+          done
+          curl -s -o /dev/null "http://$FIRESTORE_EMULATOR_HOST/" || { echo "Emulator の起動を確認できませんでした" >&2; exit 1; }
+          pnpm seed
+
+      - name: Build web (production, emulator-backed)
         run: pnpm --filter @suzumina.click/web build
 
-      - name: Run header smoke against prod server
+      - name: Run smoke against prod server (emulator-backed)
         env:
           PLAYWRIGHT_PROD: "1"
         run: pnpm --filter @suzumina.click/web test:e2e:smoke

--- a/apps/web/e2e/data-smoke.spec.ts
+++ b/apps/web/e2e/data-smoke.spec.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+
+/**
+ * Firestore Emulator + fixtures 前提のデータ依存スモーク（PLAYWRIGHT_EMULATOR=1 のときのみ実行）。
+ * ワンショット実行はリポジトリルートの `pnpm test:e2e:emulator`（Emulator 起動 + seed + 本番ビルド + 実行）。
+ *
+ * データの正本は apps/functions/src/tools/firestore-local/fixtures/*.json。
+ * 本番 Firestore の ID をここへハードコードしないこと（CI に存在保証がなく必ず腐る）。
+ * fixtures を実行時に読んで ID・タイトルを取るため、seed:dump で鮮度更新しても spec は追従する。
+ */
+
+const FIXTURES_DIR = join(__dirname, "../../functions/src/tools/firestore-local/fixtures");
+
+interface FixtureDoc {
+	id: string;
+	data: Record<string, unknown>;
+}
+
+/** fixture の先頭ドキュメント（id 昇順）を返す。「どのドキュメントか」を決定論化する */
+function firstFixtureDoc(name: string): FixtureDoc {
+	const raw = readFileSync(join(FIXTURES_DIR, `${name}.json`), "utf-8");
+	const { docs } = JSON.parse(raw) as { docs: FixtureDoc[] };
+	const doc = [...docs].sort((a, b) => a.id.localeCompare(b.id))[0];
+	if (!doc) {
+		throw new Error(`fixture ${name} が空です`);
+	}
+	return doc;
+}
+
+/** 年齢確認を通過済みの状態を再現する（ダイアログ経由の通過は「年齢確認ゲート」テストで担保） */
+async function markAgeVerified(page: Page): Promise<void> {
+	await page.addInitScript(() => {
+		localStorage.setItem("age-verified", "true");
+		localStorage.setItem("age-verification-date", new Date().toISOString());
+		localStorage.setItem("age-verification-adult", "true");
+	});
+}
+
+// biome-ignore lint/suspicious/noSkippedTests: デバッグ用の無効化ではなく実行環境ガード（Emulator 必須）
+test.skip(
+	!process.env.PLAYWRIGHT_EMULATOR,
+	"Emulator + seed 前提（pnpm test:e2e:emulator で実行）",
+);
+
+test.describe("@data-smoke 年齢確認ゲート", () => {
+	test("初回訪問でダイアログが表示され、18歳以上を選ぶと通過できる", async ({ page }) => {
+		await page.goto("/videos");
+
+		const dialog = page.getByRole("dialog", { name: "年齢確認" });
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole("button", { name: "18歳以上" }).click();
+		await expect(dialog).toBeHidden();
+
+		// 通過後、Emulator の fixtures 由来の動画一覧が描画される
+		await expect(page.locator('a[href^="/videos/"]').first()).toBeVisible();
+	});
+});
+
+test.describe("@data-smoke 一覧→詳細（fixtures 由来）", () => {
+	test("/works: R18 作品一覧が並び、先頭の作品詳細へ遷移できる", async ({ page }) => {
+		await markAgeVerified(page);
+		await page.goto("/works");
+
+		// fixtures の works は全件 R18。年齢確認済みユーザーの初回訪問で一覧に並ぶこと
+		const workLink = page.locator('a[href^="/works/RJ"]').first();
+		await expect(workLink).toBeVisible();
+		await workLink.click();
+
+		await expect(page).toHaveURL(/\/works\/RJ/);
+		await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+	});
+});
+
+test.describe("@data-smoke 詳細ページ直行（fixtures 由来）", () => {
+	test("/works/{id}: fixture の作品タイトルが描画される", async ({ page }) => {
+		const work = firstFixtureDoc("works");
+		await markAgeVerified(page);
+		await page.goto(`/works/${work.id}`);
+
+		await expect(
+			page.getByRole("heading", { level: 1, name: String(work.data.title) }),
+		).toBeVisible();
+	});
+
+	test("/videos/{id}: fixture の動画タイトルが描画される", async ({ page }) => {
+		const video = firstFixtureDoc("videos");
+		await markAgeVerified(page);
+		await page.goto(`/videos/${video.id}`);
+
+		await expect(
+			page.getByRole("heading", { level: 1, name: String(video.data.title) }),
+		).toBeVisible();
+	});
+
+	test("/buttons/{id}: fixture のボタンテキストが描画される", async ({ page }) => {
+		const button = firstFixtureDoc("audioButtons");
+		await markAgeVerified(page);
+		await page.goto(`/buttons/${button.id}`);
+
+		await expect(page.getByText(String(button.data.buttonText)).first()).toBeVisible();
+	});
+});

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -29,10 +29,11 @@ test.describe("@smoke グローバルヘッダー", () => {
 });
 
 /**
- * 主要ルートが本番ビルドで 200 を返し、layout（ヘッダー）が描画されることのスモーク（SPR-126）。
- * CI は Firestore creds を持たないため、各ページの動的データは error 境界に落ちうる。
- * よってここでは「データ非依存の layout/ルーティングが壊れていない」ことのみを検証する
+ * 主要ルートが本番ビルドで 200 を返し、layout（ヘッダー）が描画されることのスモーク。
+ * ここでは「データ非依存の layout/ルーティングが壊れていない」ことのみを検証する
  * （ヘッダーは root layout 内なのでデータ取得が失敗しても描画される）。
+ * そのため Firestore 接続の有無に依存せず、PLAYWRIGHT_PROD 単体（Emulator 無し）でも成立する。
+ * CI は Emulator + fixtures 接続で実行され、データ依存の検証は e2e/data-smoke.spec.ts が担う。
  */
 test.describe("@smoke 主要ページの描画", () => {
 	for (const path of ["/", "/videos", "/buttons", "/works"]) {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,5 +1,16 @@
 import { defineConfig, devices } from "@playwright/test";
 
+/* e2e の接続先モード:
+ * - 既定: dev サーバ（`pnpm dev`）
+ * - PLAYWRIGHT_PROD=1: 本番ビルド（next start）。事前に `next build` 済みであること。
+ *   「本番ビルドでのみ顕在化する回帰」は dev では捕捉できないため、smoke はこのモードで回す。
+ * - PLAYWRIGHT_EMULATOR=1: 本番ビルド × Firestore Emulator。データ依存 spec
+ *   （e2e/data-smoke.spec.ts）が有効になる。Emulator 起動 + seed + build を含む
+ *   ワンショットはリポジトリルートの `pnpm test:e2e:emulator`（scripts/e2e-emulator.sh）。
+ */
+const useEmulator = !!process.env.PLAYWRIGHT_EMULATOR;
+const useProdServer = !!process.env.PLAYWRIGHT_PROD || useEmulator;
+
 /**
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -40,17 +51,24 @@ export default defineConfig({
 		},
 	],
 
-	/* テスト前にローカルサーバを起動する。
-	 * PLAYWRIGHT_PROD=1 のときは本番ビルド(next start)に対して実行する。
-	 * SPR-124 のような「本番ビルドでのみ顕在化する回帰」は dev では捕捉できないため、
-	 * スモーク(@smoke / e2e/smoke.spec.ts)はこのモードで回す（事前に `next build` 済みであること）。
-	 * 残った smoke はデータ非依存（layout/routing のみ・データ取得失敗は error 境界に落ちる）なので、
+	/* テスト前にローカルサーバを起動する（モードはファイル冒頭のコメントを参照）。
+	 * smoke.spec.ts はデータ非依存（layout/routing のみ・データ取得失敗は error 境界に落ちる）なので、
 	 * 既定の `pnpm dev` は ADC 無しでも成立する（本番データ前提だった手動 spec は撤去済み）。 */
 	webServer: {
-		command: process.env.PLAYWRIGHT_PROD ? "pnpm start" : "pnpm dev",
+		command: useProdServer ? "pnpm start" : "pnpm dev",
 		url: "http://127.0.0.1:3000",
 		reuseExistingServer: !process.env.CI,
 		// 本番モードは起動のみ(ビルドは事前)だが余裕を持たせる
-		timeout: (process.env.PLAYWRIGHT_PROD ? 180 : 120) * 1000,
+		timeout: (useProdServer ? 180 : 120) * 1000,
+		// Emulator モードでは server プロセスへ接続先と安全弁の opt-in を必ず引き渡す
+		// （firestore.ts は本番ビルド × Emulator を PLAYWRIGHT_EMULATOR=1 のときだけ許可する）
+		...(useEmulator
+			? {
+					env: {
+						FIRESTORE_EMULATOR_HOST: process.env.FIRESTORE_EMULATOR_HOST || "127.0.0.1:8080",
+						PLAYWRIGHT_EMULATOR: "1",
+					},
+				}
+			: {}),
 	},
 });

--- a/apps/web/src/lib/__tests__/firestore.test.ts
+++ b/apps/web/src/lib/__tests__/firestore.test.ts
@@ -55,6 +55,21 @@ describe("firestore module", () => {
 			delete process.env.FIRESTORE_EMULATOR_HOST;
 		});
 
+		it("should allow emulator in production when PLAYWRIGHT_EMULATOR=1 (e2e opt-in)", async () => {
+			const prevNodeEnv = process.env.NODE_ENV;
+			(process.env as Record<string, string | undefined>).NODE_ENV = "production";
+			process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
+			process.env.PLAYWRIGHT_EMULATOR = "1";
+			vi.resetModules();
+
+			const { createFirestoreInstance } = await import("../firestore");
+			expect(() => createFirestoreInstance()).not.toThrow();
+
+			(process.env as Record<string, string | undefined>).NODE_ENV = prevNodeEnv;
+			delete process.env.FIRESTORE_EMULATOR_HOST;
+			delete process.env.PLAYWRIGHT_EMULATOR;
+		});
+
 		it("should create new Firestore instance with fallback project ID when env var is not set", async () => {
 			delete (process.env as Record<string, string | undefined>).GOOGLE_CLOUD_PROJECT;
 			vi.resetModules();

--- a/apps/web/src/lib/firestore.ts
+++ b/apps/web/src/lib/firestore.ts
@@ -15,8 +15,14 @@ export function createFirestoreInstance(): Firestore {
 	const projectId = process.env.GOOGLE_CLOUD_PROJECT || "suzumina-click";
 
 	// 本番ビルドが Emulator に接続するのは致命的な誤設定。明示的に弾く
-	// （ローカル開発では FIRESTORE_EMULATOR_HOST が設定され、SDK が自動で Emulator に接続する）
-	if (process.env.NODE_ENV === "production" && process.env.FIRESTORE_EMULATOR_HOST) {
+	// （ローカル開発では FIRESTORE_EMULATOR_HOST が設定され、SDK が自動で Emulator に接続する）。
+	// 例外: e2e スモークは「本番ビルド × Emulator」で回すため、PLAYWRIGHT_EMULATOR=1 の
+	// 明示 opt-in がある場合のみ許可する（本番デプロイ環境では決して設定しないこと）
+	if (
+		process.env.NODE_ENV === "production" &&
+		process.env.FIRESTORE_EMULATOR_HOST &&
+		process.env.PLAYWRIGHT_EMULATOR !== "1"
+	) {
 		throw new Error(
 			"FIRESTORE_EMULATOR_HOST is set in production. Refusing to connect Firestore to an emulator.",
 		);

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -115,9 +115,22 @@ PLAYWRIGHT_PROD=1 pnpm --filter @suzumina.click/web test:e2e:smoke
 ```
 
 - `playwright.config.ts` は `PLAYWRIGHT_PROD=1` のとき webServer を `next start`（本番）に切り替える。
-- CI: `.github/workflows/e2e-smoke.yml` が web/ui 変更時に `next build` → 本番起動 → スモークを実行する。
-- CI は Firestore creds を持たないため、スモークは**データ非依存の layout/ルーティング**（ヘッダー描画・各ルートが 200）に絞る。データ依存の検証は通常 E2E（dev）側で行う。
+- CI: `.github/workflows/e2e-smoke.yml` が web/ui/fixtures 変更時に Emulator 起動 → seed → `next build` → 本番起動 → スモークを実行する。
 - `@playwright/test` と `playwright` は **lockstep**（同一バージョン）。ズレると `test.describe() not expected` で起動不能になるため一致させる。
+
+#### データ依存スモーク（@data-smoke / Emulator + fixtures）
+
+Firestore のデータに依存する検証は **Emulator + フィクスチャ**（`apps/functions/src/tools/firestore-local/fixtures/*.json`）を正本にして行う（`e2e/data-smoke.spec.ts`）。CI もこの構成で「本番ビルド × Emulator」を実行する。
+
+```bash
+# ワンショット（Emulator 起動 + seed + 本番ビルド + smoke/data-smoke 実行）
+pnpm test:e2e:emulator
+# spec だけ直したい再実行時はビルドを省略できる
+PLAYWRIGHT_SKIP_BUILD=1 pnpm test:e2e:emulator
+```
+
+- `PLAYWRIGHT_EMULATOR=1` はデータ依存 spec の有効化と同時に、`apps/web/src/lib/firestore.ts` の安全弁（本番 × Emulator 接続拒否）への明示 opt-in を兼ねる。**本番デプロイ環境では決して設定しない**。
+- spec に**本番 Firestore の ID をハードコードしない**（CI に存在保証がなく必ず腐る）。ID・タイトルは fixtures を実行時に読んで取得する（`seed:dump` での鮮度更新に追従する）。
 
 ## Best Practices
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"typecheck": "pnpm -r typecheck",
 		"typecheck:fast": "pnpm -r typecheck:fast",
 		"test": "pnpm -r test",
+		"test:e2e:emulator": "bash scripts/e2e-emulator.sh",
 		"test:integration": "bash scripts/test-functions-integration.sh",
 		"verify": "pnpm lint:docs && pnpm lint:tokens && pnpm lint && pnpm typecheck && pnpm test",
 		"test:coverage": "pnpm -r test:coverage",

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -12,39 +12,11 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HOST_PORT="127.0.0.1:8080"
 export FIRESTORE_EMULATOR_HOST="${HOST_PORT}"
 
-STARTED_EMULATOR=0
-EMULATOR_PID=""
+# shellcheck source=scripts/emulator-lib.sh
+source "${ROOT}/scripts/emulator-lib.sh"
+trap emulator_cleanup EXIT INT TERM
 
-cleanup() {
-  if [[ "${STARTED_EMULATOR}" == "1" ]]; then
-    echo "[dev:local] Emulator を停止します"
-    [[ -n "${EMULATOR_PID}" ]] && kill "${EMULATOR_PID}" 2>/dev/null || true
-    # gcloud 配下の Java 子プロセスが取り残されることがあるためフォールバックで掃除
-    pkill -f "cloud-firestore-emulator" 2>/dev/null || true
-  fi
-}
-trap cleanup EXIT INT TERM
-
-emulator_up() {
-  curl -s -o /dev/null "http://${HOST_PORT}/" 2>/dev/null
-}
-
-if emulator_up; then
-  echo "[dev:local] 既存の Emulator (${HOST_PORT}) を利用します"
-else
-  echo "[dev:local] Emulator を起動します..."
-  bash "${ROOT}/scripts/firestore-emulator.sh" &
-  EMULATOR_PID=$!
-  STARTED_EMULATOR=1
-  for _ in $(seq 1 60); do
-    if emulator_up; then break; fi
-    sleep 1
-  done
-  if ! emulator_up; then
-    echo "[dev:local] Emulator の起動を確認できませんでした (${HOST_PORT})" >&2
-    exit 1
-  fi
-fi
+emulator_ensure "${ROOT}"
 
 echo "[dev:local] フィクスチャを投入します"
 pnpm --filter @suzumina.click/functions seed:load

--- a/scripts/e2e-emulator.sh
+++ b/scripts/e2e-emulator.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# e2e ワンショット実行（CI の e2e-smoke と同じ「本番ビルド × Firestore Emulator」構成をローカルで再現する）:
+#   1) Firestore Emulator を起動（未起動なら）
+#   2) フィクスチャを投入（seed:load）
+#   3) web を本番ビルド（PLAYWRIGHT_SKIP_BUILD=1 で省略可。spec だけ直すとき用）
+#   4) Playwright smoke を実行（データ依存 spec: e2e/data-smoke.spec.ts を含む）
+#
+# ADC は不要。本番 Firestore には一切触れない。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOST_PORT="127.0.0.1:8080"
+export FIRESTORE_EMULATOR_HOST="${HOST_PORT}"
+# 本番ビルド × Emulator を許可する安全弁の opt-in（apps/web/src/lib/firestore.ts）
+export PLAYWRIGHT_EMULATOR=1
+# 認証は e2e では使わないが、boot に必要な env を未設定時のみダミーで補う（CI と同じ扱い）
+export BETTER_AUTH_URL="${BETTER_AUTH_URL:-http://127.0.0.1:3000}"
+export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-e2e-local-dummy-not-a-real-secret}"
+
+# shellcheck source=scripts/emulator-lib.sh
+source "${ROOT}/scripts/emulator-lib.sh"
+trap emulator_cleanup EXIT INT TERM
+
+emulator_ensure "${ROOT}"
+
+echo "[e2e] フィクスチャを投入します"
+pnpm --filter @suzumina.click/functions seed:load
+
+if [[ "${PLAYWRIGHT_SKIP_BUILD:-}" == "1" ]]; then
+  echo "[e2e] 本番ビルドを省略します (PLAYWRIGHT_SKIP_BUILD=1)"
+else
+  echo "[e2e] web を本番ビルドします"
+  pnpm --filter @suzumina.click/web build
+fi
+
+echo "[e2e] Playwright smoke を実行します（本番ビルド × Emulator）"
+pnpm --filter @suzumina.click/web test:e2e:smoke

--- a/scripts/emulator-lib.sh
+++ b/scripts/emulator-lib.sh
@@ -1,0 +1,39 @@
+# Firestore Emulator のセッション管理ヘルパー（dev-local.sh / e2e-emulator.sh から source する）。
+# 使い方: HOST_PORT を設定 → `trap emulator_cleanup EXIT INT TERM` → `emulator_ensure "${ROOT}"`。
+# 自前で起動した場合のみ emulator_cleanup が停止する（既存の Emulator には触れない）。
+
+STARTED_EMULATOR=0
+EMULATOR_PID=""
+
+emulator_up() {
+  curl -s -o /dev/null "http://${HOST_PORT}/" 2>/dev/null
+}
+
+emulator_cleanup() {
+  if [[ "${STARTED_EMULATOR}" == "1" ]]; then
+    echo "[emulator] Emulator を停止します"
+    [[ -n "${EMULATOR_PID}" ]] && kill "${EMULATOR_PID}" 2>/dev/null || true
+    # gcloud 配下の Java 子プロセスが取り残されることがあるためフォールバックで掃除
+    pkill -f "cloud-firestore-emulator" 2>/dev/null || true
+  fi
+}
+
+emulator_ensure() {
+  local root="$1"
+  if emulator_up; then
+    echo "[emulator] 既存の Emulator (${HOST_PORT}) を利用します"
+    return 0
+  fi
+  echo "[emulator] Emulator を起動します..."
+  bash "${root}/scripts/firestore-emulator.sh" &
+  EMULATOR_PID=$!
+  STARTED_EMULATOR=1
+  for _ in $(seq 1 60); do
+    if emulator_up; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "[emulator] Emulator の起動を確認できませんでした (${HOST_PORT})" >&2
+  return 1
+}


### PR DESCRIPTION
## 概要

[SPR-236](https://linear.app/nothink/issue/SPR-236/e2e-playwright-を-firestore-emulator-seed-に配線しデータ依存スモークを-ci-可能にする)（SPR-10 spike の子Issue）。データ依存 e2e が「本番 ID ハードコード → CI 未実行 → 腐る」（SPR-202 で実証）だった構造を解消するため、`pnpm dev:local` の Emulator + fixtures を Playwright / CI に配線する。

## 変更内容

- **playwright.config.ts**: `PLAYWRIGHT_EMULATOR=1` モードを追加（本番ビルド × Emulator。webServer プロセスへ `FIRESTORE_EMULATOR_HOST` と opt-in を引き渡す）
- **firestore.ts の安全弁**: 「NODE_ENV=production × FIRESTORE_EMULATOR_HOST は拒否」に `PLAYWRIGHT_EMULATOR=1` の明示 opt-in を追加。本番デプロイでは設定されない env であり、拒否のデフォルトは不変（単体テスト追加済み）
- **e2e/data-smoke.spec.ts（新規・5テスト）**: 年齢確認ゲート通過 / works 一覧→詳細遷移 / works・videos・buttons 詳細直行。**ID・タイトルは fixtures を実行時に読む**（本番 ID ハードコード禁止を spec 冒頭に明記。`seed:dump` の鮮度更新に自動追従）。`PLAYWRIGHT_EMULATOR` 未設定時は skip され、既存の `pnpm test:e2e` を壊さない
- **scripts/e2e-emulator.sh + `pnpm test:e2e:emulator`**: Emulator 起動 → seed → 本番ビルド → 実行のワンショット（`PLAYWRIGHT_SKIP_BUILD=1` でビルド省略可）。dev-local.sh と共通の Emulator セッション管理を `scripts/emulator-lib.sh` へ抽出
- **e2e-smoke.yml**: setup-gcloud で Emulator component を導入し、seed 後に build / test を Emulator-backed で実行。fixtures・scripts 変更でも発火するよう paths-filter を拡張。既存のデータ非依存 smoke も同一 job で実行継続

## 検証

- ローカル `pnpm test:e2e:emulator` ワンショット: **10 passed**（data-smoke 5 + 既存 smoke 5、本番ビルド × Emulator）
- `PLAYWRIGHT_SKIP_BUILD=1` 再実行経路: 10 passed
- `pnpm verify` green（lint:docs / lint:tokens / lint / typecheck / test + カバレッジ閾値）

## レビュー観点（One-Way Door 該当）

- `.github/workflows` 変更 + firestore.ts 安全弁の変更を含むため **セルフレビュー必須**（AI レビューのみでのマージ不可）
- 安全弁 opt-in の設計: 拒否が既定のまま、e2e 専用 env の付与時のみ許可 — 本番 Cloud Run に `PLAYWRIGHT_EMULATOR` が入る経路がないことを確認してください
- CI の setup-gcloud + Emulator 起動はこの PR の CI 実行が初回検証です（runner の apt 管理 gcloud では component install 不可のため action 管理 SDK を使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)