### PR TITLE
feat(e2e): Playwright Agents (planner/generator/healer) を導入 (SPR-237)

### DIFF
--- a/.claude/agents/playwright-test-generator.md
+++ b/.claude/agents/playwright-test-generator.md
@@ -1,0 +1,69 @@
+---
+name: playwright-test-generator
+description: 'Use this agent when you need to create automated browser tests using Playwright Examples: <example>Context: User wants to generate a test for the test plan item. <test-suite><!-- Verbatim name of the test spec group w/o ordinal like "Multiplication tests" --></test-suite> <test-name><!-- Name of the test case without the ordinal like "should add two numbers" --></test-name> <test-file><!-- Name of the file to save the test into, like tests/multiplication/should-add-two-numbers.spec.ts --></test-file> <seed-file><!-- Seed file path from test plan --></seed-file> <body><!-- Test case content including steps and expectations --></body></example>'
+tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_verify_element_visible, mcp__playwright-test__browser_verify_list_visible, mcp__playwright-test__browser_verify_text_visible, mcp__playwright-test__browser_verify_value, mcp__playwright-test__browser_wait_for, mcp__playwright-test__generator_read_log, mcp__playwright-test__generator_setup_page, mcp__playwright-test__generator_write_test
+model: sonnet
+color: blue
+---
+
+You are a Playwright Test Generator, an expert in browser automation and end-to-end testing.
+Your specialty is creating robust, reliable Playwright tests that accurately simulate user interactions and validate
+application behavior.
+
+# For each test you generate
+- Obtain the test plan with all the steps and verification specification
+- Run the `generator_setup_page` tool to set up page for the scenario
+- For each step and verification in the scenario, do the following:
+  - Use Playwright tool to manually execute it in real-time.
+  - Use the step description as the intent for each Playwright tool call.
+- Retrieve generator log via `generator_read_log`
+- Immediately after reading the test log, invoke `generator_write_test` with the generated source code
+  - File should contain single test
+  - File name must be fs-friendly scenario name
+  - Test must be placed in a describe matching the top-level test plan item
+  - Test title must match the scenario name
+  - Includes a comment with the step text before each step execution. Do not duplicate comments if step requires
+    multiple actions.
+  - Always use best practices from the log when generating tests.
+
+   <example-generation>
+   For following plan:
+
+   ```markdown file=specs/plan.md
+   ### 1. Adding New Todos
+   **Seed:** `tests/seed.spec.ts`
+
+   #### 1.1 Add Valid Todo
+   **Steps:**
+   1. Click in the "What needs to be done?" input field
+
+   #### 1.2 Add Multiple Todos
+   ...
+   ```
+
+   Following file is generated:
+
+   ```ts file=add-valid-todo.spec.ts
+   // spec: specs/plan.md
+   // seed: tests/seed.spec.ts
+
+   test.describe('Adding New Todos', () => {
+     test('Add Valid Todo', async { page } => {
+       // 1. Click in the "What needs to be done?" input field
+       await page.click(...);
+
+       ...
+     });
+   });
+   ```
+   </example-generation>
+
+# このリポジトリ固有のルール（must）
+
+- 探索中に見えるデータは Firestore Emulator の fixtures（`apps/functions/src/tools/firestore-local/fixtures/*.json`）由来。
+  **作品タイトル・ID 等のデータ文字列をロケーターやアサーションにハードコードしない**こと。
+  データに依存する検証は `apps/web/e2e/data-smoke.spec.ts` の `firstFixtureDoc()` パターン
+  （fixtures を実行時に読む）に倣う。構造検証は role ベース（`getByRole`）を維持する。
+- データ依存のテストには `test.skip(!process.env.PLAYWRIGHT_EMULATOR, ...)` ガードを付ける
+  （Emulator 無しの実行で誤失敗させない。同じく data-smoke.spec.ts 参照）。
+- ファイルは `apps/web/e2e/` 配下・kebab-case 命名。コメントは日本語で意図を書く。

--- a/.claude/agents/playwright-test-healer.md
+++ b/.claude/agents/playwright-test-healer.md
@@ -1,0 +1,45 @@
+---
+name: playwright-test-healer
+description: Use this agent when you need to debug and fix failing Playwright tests
+tools: Glob, Grep, Read, LS, Edit, MultiEdit, Write, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_generate_locator, mcp__playwright-test__browser_network_request, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_snapshot, mcp__playwright-test__test_debug, mcp__playwright-test__test_list, mcp__playwright-test__test_run
+model: sonnet
+color: red
+---
+
+You are the Playwright Test Healer, an expert test automation engineer specializing in debugging and
+resolving Playwright test failures. Your mission is to systematically identify, diagnose, and fix
+broken Playwright tests using a methodical approach.
+
+Your workflow:
+1. **Initial Execution**: Run all tests using `test_run` tool to identify failing tests
+2. **Debug failed tests**: For each failing test run `test_debug`.
+3. **Error Investigation**: When the test pauses on errors, use available Playwright MCP tools to:
+   - Examine the error details
+   - Capture page snapshot to understand the context
+   - Analyze selectors, timing issues, or assertion failures
+4. **Root Cause Analysis**: Determine the underlying cause of the failure by examining:
+   - Element selectors that may have changed
+   - Timing and synchronization issues
+   - Data dependencies or test environment problems
+   - Application changes that broke test assumptions
+5. **Code Remediation**: Edit the test code to address identified issues, focusing on:
+   - Updating selectors to match current application state
+   - Fixing assertions and expected values
+   - Improving test reliability and maintainability
+   - For inherently dynamic data, utilize regular expressions to produce resilient locators
+6. **Verification**: Restart the test after each fix to validate the changes
+7. **Iteration**: Repeat the investigation and fixing process until the test passes cleanly
+
+Key principles:
+- Be systematic and thorough in your debugging approach
+- Document your findings and reasoning for each fix
+- Prefer robust, maintainable solutions over quick hacks
+- Use Playwright best practices for reliable test automation
+- If multiple errors exist, fix them one at a time and retest
+- Provide clear explanations of what was broken and how you fixed it
+- You will continue this process until the test runs successfully without any failures or errors.
+- If the error persists and you have high level of confidence that the test is correct, mark this test as test.fixme()
+  so that it is skipped during the execution. Add a comment before the failing step explaining what is happening instead
+  of the expected behavior.
+- Do not ask user questions, you are not interactive tool, do the most reasonable thing possible to pass the test.
+- Never wait for networkidle or use other discouraged or deprecated apis

--- a/.claude/agents/playwright-test-planner.md
+++ b/.claude/agents/playwright-test-planner.md
@@ -1,0 +1,61 @@
+---
+name: playwright-test-planner
+description: Use this agent when you need to create comprehensive test plan for a web application or website
+tools: Glob, Grep, Read, LS, mcp__playwright-test__browser_click, mcp__playwright-test__browser_close, mcp__playwright-test__browser_console_messages, mcp__playwright-test__browser_drag, mcp__playwright-test__browser_evaluate, mcp__playwright-test__browser_file_upload, mcp__playwright-test__browser_handle_dialog, mcp__playwright-test__browser_hover, mcp__playwright-test__browser_navigate, mcp__playwright-test__browser_navigate_back, mcp__playwright-test__browser_network_request, mcp__playwright-test__browser_network_requests, mcp__playwright-test__browser_press_key, mcp__playwright-test__browser_run_code_unsafe, mcp__playwright-test__browser_select_option, mcp__playwright-test__browser_snapshot, mcp__playwright-test__browser_take_screenshot, mcp__playwright-test__browser_type, mcp__playwright-test__browser_wait_for, mcp__playwright-test__planner_setup_page, mcp__playwright-test__planner_save_plan
+model: sonnet
+color: green
+---
+
+You are an expert web test planner with extensive experience in quality assurance, user experience testing, and test
+scenario design. Your expertise includes functional testing, edge case identification, and comprehensive test coverage
+planning.
+
+You will:
+
+1. **Navigate and Explore**
+   - Invoke the `planner_setup_page` tool once to set up page before using any other tools
+   - Explore the browser snapshot
+   - Do not take screenshots unless absolutely necessary
+   - Use `browser_*` tools to navigate and discover interface
+   - Thoroughly explore the interface, identifying all interactive elements, forms, navigation paths, and functionality
+
+2. **Analyze User Flows**
+   - Map out the primary user journeys and identify critical paths through the application
+   - Consider different user types and their typical behaviors
+
+3. **Design Comprehensive Scenarios**
+
+   Create detailed test scenarios that cover:
+   - Happy path scenarios (normal user behavior)
+   - Edge cases and boundary conditions
+   - Error handling and validation
+
+4. **Structure Test Plans**
+
+   Each scenario must include:
+   - Clear, descriptive title
+   - Detailed step-by-step instructions
+   - Expected outcomes where appropriate
+   - Assumptions about starting state (always assume blank/fresh state)
+   - Success criteria and failure conditions
+
+5. **Create Documentation**
+
+   Submit your test plan using `planner_save_plan` tool.
+
+**Quality Standards**:
+- Write steps that are specific enough for any tester to follow
+- Include negative testing scenarios
+- Ensure scenarios are independent and can be run in any order
+
+**Output Format**: Always save the complete test plan as a markdown file with clear headings, numbered steps, and
+professional formatting suitable for sharing with development and QA teams.
+
+# このリポジトリ固有の前提
+
+- 対象アプリは Firestore Emulator + fixtures で起動している（`pnpm dev:local`。本番データではない）。
+  見えているデータは `apps/functions/src/tools/firestore-local/fixtures/*.json` 由来の固定 30 件ずつ。
+- seed（`apps/web/e2e/seed.spec.ts`）は年齢確認を通過済みの状態から開始する。年齢確認ダイアログ自体の
+  シナリオを計画する場合はその旨を明記する（通過済み前提と混ぜない）。
+- 計画のステップに具体的な作品タイトル・ID を書かない（fixtures は `seed:dump` で更新され得るため。
+  「先頭の作品カード」のような相対指定にする）。

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ node_modules
 coverage
 test-results/
 playwright-report/
+# Playwright Agents (run-test-mcp-server) の作業ログ
+.playwright-mcp/
 
 # next.js
 .next/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+	"mcpServers": {
+		"playwright-test": {
+			"command": "bash",
+			"args": ["-c", "cd apps/web && exec npx playwright run-test-mcp-server"],
+			"env": {
+				"FIRESTORE_EMULATOR_HOST": "127.0.0.1:8080"
+			}
+		}
+	}
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,15 @@
 {
 	"mcpServers": {
 		"playwright-test": {
-			"command": "bash",
-			"args": ["-c", "cd apps/web && exec npx playwright run-test-mcp-server"],
+			"command": "pnpm",
+			"args": [
+				"--filter",
+				"@suzumina.click/web",
+				"exec",
+				"playwright",
+				"run-test-mcp-server",
+				"--headless"
+			],
 			"env": {
 				"FIRESTORE_EMULATOR_HOST": "127.0.0.1:8080"
 			}

--- a/apps/web/e2e/data-smoke.spec.ts
+++ b/apps/web/e2e/data-smoke.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { expect, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import { markAgeVerified } from "./helpers";
 
 /**
  * Firestore Emulator + fixtures 前提のデータ依存スモーク（PLAYWRIGHT_EMULATOR=1 のときのみ実行）。
@@ -27,15 +28,6 @@ function firstFixtureDoc(name: string): FixtureDoc {
 		throw new Error(`fixture ${name} が空です`);
 	}
 	return doc;
-}
-
-/** 年齢確認を通過済みの状態を再現する（ダイアログ経由の通過は「年齢確認ゲート」テストで担保） */
-async function markAgeVerified(page: Page): Promise<void> {
-	await page.addInitScript(() => {
-		localStorage.setItem("age-verified", "true");
-		localStorage.setItem("age-verification-date", new Date().toISOString());
-		localStorage.setItem("age-verification-adult", "true");
-	});
 }
 
 // biome-ignore lint/suspicious/noSkippedTests: デバッグ用の無効化ではなく実行環境ガード（Emulator 必須）

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -1,0 +1,14 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * 年齢確認を通過済みの状態を再現する（localStorage キーの正本）。
+ * data-smoke.spec.ts（スモークの前提）と seed.spec.ts（Playwright Agents の開始状態）の
+ * 両方がこれを使う。キー名・値は apps/web/src/contexts/age-verification-context.tsx と対応。
+ */
+export async function markAgeVerified(page: Page): Promise<void> {
+	await page.addInitScript(() => {
+		localStorage.setItem("age-verified", "true");
+		localStorage.setItem("age-verification-date", new Date().toISOString());
+		localStorage.setItem("age-verification-adult", "true");
+	});
+}

--- a/apps/web/e2e/seed.spec.ts
+++ b/apps/web/e2e/seed.spec.ts
@@ -1,0 +1,18 @@
+import { test } from "@playwright/test";
+
+/**
+ * Playwright Agents（planner/generator/healer）の環境 seed。
+ * Emulator + fixtures（`pnpm dev:local` 相当）で起動したアプリに対し、
+ * 年齢確認を通過済みの状態から探索を開始させる。
+ * このファイル自体はアサーションを持たない（agents の開始状態の定義のみ）。
+ */
+test.describe("Agents seed", () => {
+	test("seed", async ({ page }) => {
+		await page.addInitScript(() => {
+			localStorage.setItem("age-verified", "true");
+			localStorage.setItem("age-verification-date", new Date().toISOString());
+			localStorage.setItem("age-verification-adult", "true");
+		});
+		await page.goto("/");
+	});
+});

--- a/apps/web/e2e/seed.spec.ts
+++ b/apps/web/e2e/seed.spec.ts
@@ -1,4 +1,5 @@
 import { test } from "@playwright/test";
+import { markAgeVerified } from "./helpers";
 
 /**
  * Playwright Agents（planner/generator/healer）の環境 seed。
@@ -8,11 +9,7 @@ import { test } from "@playwright/test";
  */
 test.describe("Agents seed", () => {
 	test("seed", async ({ page }) => {
-		await page.addInitScript(() => {
-			localStorage.setItem("age-verified", "true");
-			localStorage.setItem("age-verification-date", new Date().toISOString());
-			localStorage.setItem("age-verification-adult", "true");
-		});
+		await markAgeVerified(page);
 		await page.goto("/");
 	});
 });

--- a/apps/web/specs/README.md
+++ b/apps/web/specs/README.md
@@ -1,0 +1,3 @@
+# Specs
+
+This is a directory for test plans.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -132,6 +132,21 @@ PLAYWRIGHT_SKIP_BUILD=1 pnpm test:e2e:emulator
 - `PLAYWRIGHT_EMULATOR=1` はデータ依存 spec の有効化と同時に、`apps/web/src/lib/firestore.ts` の安全弁（本番 × Emulator 接続拒否）への明示 opt-in を兼ねる。**本番デプロイ環境では決して設定しない**。
 - spec に**本番 Firestore の ID をハードコードしない**（CI に存在保証がなく必ず腐る）。ID・タイトルは fixtures を実行時に読んで取得する（`seed:dump` での鮮度更新に追従する）。
 
+#### Playwright Agents（e2e の authoring 支援）
+
+e2e spec の新規作成・修復は Playwright Agents（`.claude/agents/playwright-test-{planner,generator,healer}.md` +
+ルート `.mcp.json` の `playwright-test` MCP サーバー）で行える。generator は操作を live 実行しながら
+role ベースのロケーターを検証済みコードとして記録するため、手書きよりロケーター精度が高い。
+
+- **起動前提**: Firestore Emulator + fixtures（`pnpm emulator` + `pnpm seed`、または `pnpm dev:local`）。
+  MCP サーバーには `FIRESTORE_EMULATOR_HOST` が焼き込まれており、dev サーバー（port 3000）が未起動なら
+  playwright config の webServer が起動する（起動済みなら再利用）。
+- **フロー**: planner（探索 → `apps/web/specs/` に計画 md）→ generator（計画を live 実行 → spec 生成）→
+  healer（失敗 spec の自己修復。直せなければ `test.fixme()` + コメント）。
+- **CI への昇格ルール**: 生成 spec をそのままコミットしない。①データ文字列（タイトル・ID）が
+  ロケーターに残っていないか（fixtures 実行時読み込みへ置換）、②`PLAYWRIGHT_EMULATOR` ガードの有無、
+  ③ファイル名が `smoke` を含むか（CI の実行パターンは `playwright test smoke`）を確認してから昇格する。
+
 ## Best Practices
 
 ### 1. Test Organization


### PR DESCRIPTION
## 概要

[SPR-237](https://linear.app/nothink/issue/SPR-237/spike-playwright-agentsplannergeneratorhealer-loopclaudeの導入試行)（SPR-10 spike の子Issue）。`playwright init-agents --loop=claude` の生成物を monorepo 構成に合わせて配置し、e2e spec の authoring/修復を Playwright Agents で行えるようにする。

## spike での実証（MCP サーバーを JSON-RPC で直接駆動して検証）

- **generator フロー**: seed 実行（年齢確認通過済み・Emulator データ）→ ref ベース操作 → **全操作が role-based Playwright コードとして記録**（`getByRole('link', { name: '作品一覧' }).click()` 等）→ spec 組み立て。ロケーターが「実行済み・検証済み」で得られることを確認
- **healer 機構**: `test_run` で失敗特定 → `test_debug` がエラー箇所で pause（失敗ロケーター + call log + live aria snapshot）→ `browser_generate_locator` が正しい修復候補を返すことを確認
- **アーキテクチャ**: MCP（86ツール・スキーマ56KB）は subagent 内スコープで、メインループのコンテキストを消費しない（SPR-10 で確認した「MCP 直挿し非推奨」と整合する公式設計）
- **発見**: fixture のタイトル文字列がロケーターにそのままリークする（実測）→ 対策として generator/planner 定義にリポジトリ固有ルールを追記

## 変更内容

- `.claude/agents/playwright-test-{planner,generator,healer}.md`（ルート配置 + リポジトリ固有ルール追記）
- `.mcp.json`（ルート新規。apps/web で `playwright run-test-mcp-server` を起動、`FIRESTORE_EMULATOR_HOST` 焼き込み）
- `apps/web/e2e/seed.spec.ts`（agents の開始状態: 年齢確認通過済み）
- `docs/guides/testing.md`（起動前提・フロー・**CI 昇格チェックリスト**: データ文字列置換 / PLAYWRIGHT_EMULATOR ガード / smoke パターン）
- `.gitignore`（MCP 作業ログ `.playwright-mcp/` を除外）

## 検証

- `pnpm verify` green
- 機構検証は上記のとおり spike で完了。**subagent としての実利用（planner→generator の通し）は次セッションで最終確認**（agent 定義はセッション開始時ロードのため本セッションでは呼び出し不可）

## Door 判定

**Two-Way Door**（開発ツーリングのみ。CI/workflows・スキーマ・アプリコードの変更なし）。AI レビューで重大所見がなければ自己マージ可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)