### PR TITLE
feat(web): R18ゲート/Cookie同意を非ブロッキングな「ドッキングカード」に再設計 (SPR-238)

### DIFF
--- a/apps/web/e2e/data-smoke.spec.ts
+++ b/apps/web/e2e/data-smoke.spec.ts
@@ -45,16 +45,21 @@ test.skip(
 );
 
 test.describe("@data-smoke 年齢確認ゲート", () => {
-	test("初回訪問でダイアログが表示され、18歳以上を選ぶと通過できる", async ({ page }) => {
+	test("初回訪問で非ブロッキングな確認カードが表示され、閲覧を継続しつつ選択できる", async ({
+		page,
+	}) => {
 		await page.goto("/videos");
 
-		const dialog = page.getByRole("dialog", { name: "年齢確認" });
-		await expect(dialog).toBeVisible();
-		await dialog.getByRole("button", { name: "18歳以上" }).click();
-		await expect(dialog).toBeHidden();
-
-		// 通過後、Emulator の fixtures 由来の動画一覧が描画される
+		// 非モーダル（案A: ドッキングカード）のため、カード表示中でも背後のコンテンツは
+		// 最初から描画・閲覧可能（Emulator の fixtures 由来の動画一覧）
 		await expect(page.locator('a[href^="/videos/"]').first()).toBeVisible();
+
+		const card = page.getByRole("region", { name: "表示モードの確認" });
+		await expect(card).toBeVisible();
+		await card.getByRole("button", { name: "18歳以上 — すべての作品を表示" }).click();
+
+		// 選択後は確認トースト（同じ aria-label のドック領域）に切り替わる
+		await expect(page.getByText("R18作品を含むすべての作品を表示します")).toBeVisible();
 	});
 });
 

--- a/apps/web/src/app/works/components/works-list.tsx
+++ b/apps/web/src/app/works/components/works-list.tsx
@@ -57,13 +57,15 @@ export default function WorksList({ initialData }: WorksListProps) {
 					search: params.search,
 					category: params.filters.category as string | undefined,
 					language: params.filters.language as string | undefined,
-					showR18: params.filters.showR18 as boolean | undefined,
+					// 未確認（showR18Content=false）の間はトグル自体が filters に存在しないため、
+					// ここで明示的に false を強制する。トグルがある場合のみユーザーの選択に従う。
+					showR18: showR18Content ? (params.filters.showR18 as boolean | undefined) : false,
 					genres: params.filters.genres as string[] | undefined,
 				};
 			},
 			fromResult: (result: unknown) => result as { items: WorkPlainObject[]; total: number },
 		}),
-		[],
+		[showR18Content],
 	);
 
 	// フェッチ関数
@@ -78,6 +80,11 @@ export default function WorksList({ initialData }: WorksListProps) {
 
 	return (
 		<ListWrapper>
+			{!showR18Content && (
+				<p className="mb-4 text-xs text-muted-foreground">
+					R18作品は非表示です。18歳以上の方は右下の「表示設定」から表示できます。
+				</p>
+			)}
 			<ConfigurableList<WorkPlainObject>
 				items={initialItems}
 				initialTotal={initialTotal}

--- a/apps/web/src/app/works/components/works-list.tsx
+++ b/apps/web/src/app/works/components/works-list.tsx
@@ -82,7 +82,7 @@ export default function WorksList({ initialData }: WorksListProps) {
 		<ListWrapper>
 			{!showR18Content && (
 				<p className="mb-4 text-xs text-muted-foreground">
-					R18作品は非表示です。18歳以上の方は表示モードの確認、または設定ページから表示に切り替えられます。
+					R18作品は非表示です。18歳以上の方は設定ページから表示に切り替えられます。
 				</p>
 			)}
 			<ConfigurableList<WorkPlainObject>

--- a/apps/web/src/app/works/components/works-list.tsx
+++ b/apps/web/src/app/works/components/works-list.tsx
@@ -82,7 +82,7 @@ export default function WorksList({ initialData }: WorksListProps) {
 		<ListWrapper>
 			{!showR18Content && (
 				<p className="mb-4 text-xs text-muted-foreground">
-					R18作品は非表示です。18歳以上の方は右下の「表示設定」から表示できます。
+					R18作品は非表示です。18歳以上の方は表示モードの確認、または設定ページから表示に切り替えられます。
 				</p>
 			)}
 			<ConfigurableList<WorkPlainObject>

--- a/apps/web/src/components/consent/age-verification-overlay.tsx
+++ b/apps/web/src/components/consent/age-verification-overlay.tsx
@@ -191,7 +191,7 @@ export function AgeVerificationOverlay() {
 				</Button>
 			</div>
 			<p className="text-[11px] leading-relaxed text-muted-foreground">
-				選択は30日間このブラウザに記憶されます。右下の「表示設定」からいつでも変更できます。
+				選択は30日間このブラウザに記憶されます。設定ページからいつでも変更できます。
 			</p>
 		</DockedPanel>
 	);

--- a/apps/web/src/components/consent/age-verification-overlay.tsx
+++ b/apps/web/src/components/consent/age-verification-overlay.tsx
@@ -7,8 +7,8 @@ import { Check, Shield, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 
-// Match the server-side list that previously lived in lib/seo/bot-detection.ts
-// so SEO crawlers and uptime monitors keep bypassing the overlay.
+// lib/seo/bot-detection.ts に以前あったサーバー側リストと同じもの。
+// 検索エンジン/監視サービスのクローラーがこのカードを回避し続けるようにする。
 const BOT_USER_AGENTS = [
 	// Search engines
 	"googlebot",
@@ -55,15 +55,23 @@ const BOT_UA_PATTERN = new RegExp(BOT_USER_AGENTS.join("|"), "i");
 
 type Stage = "hidden" | "ask" | "toast" | "pill";
 
+// Cookie バー（cookie-consent-banner.tsx）と同じ基準。狭い画面ではモバイル用の
+// 全幅ボトムシート挙動に切り替える判定に使う（トースト終了後は表示設定ピルを
+// 出さず hidden にすることで、Cookie バーの全幅シートと重ならないようにする）。
+const NARROW_VIEWPORT_QUERY = "(max-width: 639px)";
+
 /**
- * Non-modal, corner-docked age gate (案A: ドッキングカード). The page is
- * browsable and scrollable from first paint — this never renders a backdrop
- * and never redirects. Choosing "全年齢のみで続ける" just keeps R18 content
- * filtered on the current page; the visitor can reopen the card anytime via
- * the persistent "表示設定" pill.
+ * 非モーダルで角にドッキングする年齢ゲート（案A: ドッキングカード）。
+ * ページは最初の描画からブラウズ・スクロール可能で、backdrop も表示せず
+ * リダイレクトもしない。「全年齢のみで続ける」を選んでも、そのページで
+ * R18コンテンツを絞り込んだまま閲覧を継続できる。デスクトップ幅では
+ * 選択後に常駐の「表示設定」ピルからいつでも再度開けるが、狭い画面では
+ * Cookie バー（同じ全幅ボトムシート領域を使う）と重ならないようピルを
+ * 出さずに閉じる。
  */
 export function AgeVerificationOverlay() {
-	const { isAgeVerified, isLoading, updateAgeVerification } = useAgeVerification();
+	const { isAgeVerified, isLoading, updateAgeVerification, setAgeCardDocked } =
+		useAgeVerification();
 	const [botChecked, setBotChecked] = useState(false);
 	const [stage, setStage] = useState<Stage>("hidden");
 	const [chosenAdult, setChosenAdult] = useState(false);
@@ -76,16 +84,21 @@ export function AgeVerificationOverlay() {
 		setBotChecked(true);
 	}, [updateAgeVerification]);
 
-	// Only drive the ask/toast/pill flow for a visitor who is unverified when this
-	// component mounts. A returning, already-verified visitor sees nothing here —
-	// they can still change their mode anytime via /settings or this same card
-	// once they explicitly reopen it (there's nothing to reopen from on a fresh
-	// page load, so no persistent site-wide pill is shown across sessions).
+	// ask/toast/pill の流れは、このコンポーネントが mount した時点で未確認だった
+	// 訪問者だけに出す。確認済みで再訪した場合はここでは何も表示しない
+	// （/settings や、明示的に再度開いた場合のこのカード自体からいつでも変更可能）。
 	useEffect(() => {
 		if (isLoading || !botChecked || initializedRef.current) return;
 		initializedRef.current = true;
 		setStage(isAgeVerified ? "hidden" : "ask");
 	}, [isLoading, botChecked, isAgeVerified]);
+
+	// ask/toast の間は Cookie バー等の他のドックUIと重ならないよう、ドック占有中
+	// であることを共有シグナルとして公開する（pill/hidden は非占有として扱う。
+	// pill はモバイルでは出さない設計にしたうえで、常にコンパクトな表示に留める）。
+	useEffect(() => {
+		setAgeCardDocked(stage === "ask" || stage === "toast");
+	}, [stage, setAgeCardDocked]);
 
 	const handleChoice = (isAdult: boolean) => {
 		updateAgeVerification(isAdult);
@@ -93,15 +106,27 @@ export function AgeVerificationOverlay() {
 		setStage("toast");
 	};
 
+	const closeToast = () => {
+		// 狭い画面では Cookie バーが全幅ボトムシートになるため、表示設定ピルは
+		// 出さずに閉じる（ピルも全幅化すると Cookie バーと重なってしまうため）。
+		const isNarrowViewport = window.matchMedia(NARROW_VIEWPORT_QUERY).matches;
+		setStage(isNarrowViewport ? "hidden" : "pill");
+	};
+
 	if (stage === "hidden") return null;
 
 	if (stage === "pill") {
 		return (
-			<DockedPanel position="bottom-right" variant="pill" aria-label="表示設定を開く">
+			<DockedPanel
+				position="bottom-right"
+				variant="pill"
+				mobileSheet={false}
+				aria-label="表示設定を開く"
+			>
 				<button
 					type="button"
 					onClick={() => setStage("ask")}
-					className="flex w-full items-center gap-2 px-4 py-2.5 text-xs text-foreground sm:px-3.5 sm:py-2"
+					className="flex items-center gap-2 px-3.5 py-2 text-xs text-foreground"
 				>
 					<Shield className="h-3.5 w-3.5 text-primary" />
 					表示設定
@@ -133,7 +158,7 @@ export function AgeVerificationOverlay() {
 				</button>
 				<button
 					type="button"
-					onClick={() => setStage("pill")}
+					onClick={closeToast}
 					aria-label="閉じる"
 					className="text-muted-foreground hover:text-foreground"
 				>

--- a/apps/web/src/components/consent/age-verification-overlay.tsx
+++ b/apps/web/src/components/consent/age-verification-overlay.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { DockedPanel } from "@suzumina.click/ui/components/custom";
+import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
-import { AlertTriangle, Calendar, Heart, Shield } from "lucide-react";
+import { Check, Shield, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 
@@ -52,16 +53,21 @@ const BOT_USER_AGENTS = [
 ];
 const BOT_UA_PATTERN = new RegExp(BOT_USER_AGENTS.join("|"), "i");
 
+type Stage = "hidden" | "ask" | "toast" | "pill";
+
 /**
- * Client-side overlay that prompts age verification without blocking content render.
- * Renders nothing until the provider's localStorage check resolves, then either
- * stays hidden (verified / bot) or shows a fixed-position confirmation card.
+ * Non-modal, corner-docked age gate (案A: ドッキングカード). The page is
+ * browsable and scrollable from first paint — this never renders a backdrop
+ * and never redirects. Choosing "全年齢のみで続ける" just keeps R18 content
+ * filtered on the current page; the visitor can reopen the card anytime via
+ * the persistent "表示設定" pill.
  */
 export function AgeVerificationOverlay() {
 	const { isAgeVerified, isLoading, updateAgeVerification } = useAgeVerification();
-	const [showMinorMessage, setShowMinorMessage] = useState(false);
 	const [botChecked, setBotChecked] = useState(false);
-	const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [stage, setStage] = useState<Stage>("hidden");
+	const [chosenAdult, setChosenAdult] = useState(false);
+	const initializedRef = useRef(false);
 
 	useEffect(() => {
 		if (BOT_UA_PATTERN.test(navigator.userAgent)) {
@@ -70,134 +76,98 @@ export function AgeVerificationOverlay() {
 		setBotChecked(true);
 	}, [updateAgeVerification]);
 
+	// Only drive the ask/toast/pill flow for a visitor who is unverified when this
+	// component mounts. A returning, already-verified visitor sees nothing here —
+	// they can still change their mode anytime via /settings or this same card
+	// once they explicitly reopen it (there's nothing to reopen from on a fresh
+	// page load, so no persistent site-wide pill is shown across sessions).
 	useEffect(() => {
-		return () => {
-			if (redirectTimerRef.current !== null) {
-				clearTimeout(redirectTimerRef.current);
-			}
-		};
-	}, []);
+		if (isLoading || !botChecked || initializedRef.current) return;
+		initializedRef.current = true;
+		setStage(isAgeVerified ? "hidden" : "ask");
+	}, [isLoading, botChecked, isAgeVerified]);
 
-	const visible = !isLoading && botChecked && (!isAgeVerified || showMinorMessage);
-
-	useEffect(() => {
-		if (!visible) return;
-		const previous = document.body.style.overflow;
-		document.body.style.overflow = "hidden";
-		return () => {
-			document.body.style.overflow = previous;
-		};
-	}, [visible]);
-
-	if (!visible) return null;
-
-	const handleAgeConfirmation = (isAdult: boolean) => {
-		if (isAdult) {
-			updateAgeVerification(true);
-			return;
-		}
-		updateAgeVerification(false);
-		setShowMinorMessage(true);
-		redirectTimerRef.current = setTimeout(() => {
-			window.location.href = "/";
-		}, 3000);
+	const handleChoice = (isAdult: boolean) => {
+		updateAgeVerification(isAdult);
+		setChosenAdult(isAdult);
+		setStage("toast");
 	};
 
-	if (showMinorMessage) {
-		return (
-			<div
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby="age-verification-minor-title"
-				className="fixed inset-0 z-50 flex items-center justify-center suzuka-gradient p-4"
-			>
-				<Card className="w-full max-w-md mx-auto shadow-xl">
-					<CardHeader className="text-center pb-4">
-						<div className="mx-auto w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4">
-							<Shield className="h-8 w-8 text-primary" />
-						</div>
-						<CardTitle
-							id="age-verification-minor-title"
-							className="text-xl font-bold text-foreground"
-						>
-							ありがとうございます
-						</CardTitle>
-					</CardHeader>
+	if (stage === "hidden") return null;
 
-					<CardContent className="space-y-6">
-						<div className="text-center space-y-4">
-							<p className="text-sm text-muted-foreground leading-relaxed">
-								安全なご利用のため、年齢制限のない
-								<br />
-								コンテンツのみご利用いただけます。
-							</p>
-							<div className="flex items-center justify-center gap-2 text-xs text-primary">
-								<Heart className="h-3 w-3" />
-								<span>全年齢対象のコンテンツをお楽しみください</span>
-							</div>
-							<div className="text-xs text-muted-foreground/70 text-center">
-								3秒後にトップページに移動します...
-							</div>
-						</div>
-					</CardContent>
-				</Card>
-			</div>
+	if (stage === "pill") {
+		return (
+			<DockedPanel position="bottom-right" variant="pill" aria-label="表示設定を開く">
+				<button
+					type="button"
+					onClick={() => setStage("ask")}
+					className="flex w-full items-center gap-2 px-4 py-2.5 text-xs text-foreground sm:px-3.5 sm:py-2"
+				>
+					<Shield className="h-3.5 w-3.5 text-primary" />
+					表示設定
+				</button>
+			</DockedPanel>
+		);
+	}
+
+	if (stage === "toast") {
+		return (
+			<DockedPanel
+				role="status"
+				position="bottom-right"
+				aria-label="表示モードの確認"
+				className="flex max-w-full items-center gap-3 p-3.5 sm:max-w-[400px]"
+			>
+				<div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-success/10 text-success">
+					<Check className="h-4 w-4" />
+				</div>
+				<span className="text-sm text-foreground">
+					{chosenAdult ? "R18作品を含むすべての作品を表示します" : "全年齢対象の作品のみ表示します"}
+				</span>
+				<button
+					type="button"
+					onClick={() => setStage("ask")}
+					className="whitespace-nowrap text-xs text-primary underline"
+				>
+					変更
+				</button>
+				<button
+					type="button"
+					onClick={() => setStage("pill")}
+					aria-label="閉じる"
+					className="text-muted-foreground hover:text-foreground"
+				>
+					<X className="h-3.5 w-3.5" />
+				</button>
+			</DockedPanel>
 		);
 	}
 
 	return (
-		<div
-			role="dialog"
-			aria-modal="true"
-			aria-labelledby="age-verification-title"
-			className="fixed inset-0 z-50 flex items-center justify-center suzuka-gradient p-4"
+		<DockedPanel
+			position="bottom-right"
+			aria-label="表示モードの確認"
+			className="flex w-full flex-col gap-3 p-5 sm:max-w-[360px]"
 		>
-			<Card className="w-full max-w-md mx-auto shadow-xl">
-				<CardHeader className="text-center pb-4">
-					<div className="mx-auto w-16 h-16 bg-warning/10 rounded-full flex items-center justify-center mb-4">
-						<AlertTriangle className="h-8 w-8 text-warning" />
-					</div>
-					<CardTitle id="age-verification-title" className="text-xl font-bold text-foreground">
-						年齢確認
-					</CardTitle>
-				</CardHeader>
-
-				<CardContent className="space-y-6">
-					<div className="text-center space-y-3">
-						<p className="text-sm text-muted-foreground leading-relaxed">
-							このサイトには18歳未満の方には適さない
-							<br />
-							コンテンツが含まれています。
-						</p>
-						<div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
-							<Calendar className="h-3 w-3" />
-							<span>あなたは18歳以上ですか？</span>
-						</div>
-					</div>
-
-					<div className="grid grid-cols-2 gap-3">
-						<Button
-							variant="outline"
-							onClick={() => handleAgeConfirmation(false)}
-							className="w-full border-border text-primary hover:bg-accent"
-						>
-							18歳未満
-						</Button>
-						<Button
-							onClick={() => handleAgeConfirmation(true)}
-							className="w-full bg-primary hover:bg-primary/90 text-primary-foreground"
-						>
-							18歳以上
-						</Button>
-					</div>
-
-					<div className="text-xs text-muted-foreground text-center leading-relaxed">
-						この確認は法的要件に基づくものです。
-						<br />
-						30日間記憶され、期限後に再確認が必要です。
-					</div>
-				</CardContent>
-			</Card>
-		</div>
+			<div className="flex items-center gap-2">
+				<Badge variant="destructive">R18</Badge>
+				<h3 className="text-sm font-bold text-foreground">表示モードの確認</h3>
+			</div>
+			<p className="text-xs leading-relaxed text-muted-foreground">
+				このサイトはDLsite作品情報など、18歳未満の方に適さないコンテンツを含みます。現在は
+				<strong className="text-foreground">全年齢作品のみ</strong>表示しています。
+			</p>
+			<div className="flex flex-col gap-2">
+				<Button onClick={() => handleChoice(true)} className="w-full">
+					18歳以上 — すべての作品を表示
+				</Button>
+				<Button variant="outline" onClick={() => handleChoice(false)} className="w-full">
+					全年齢のみで続ける
+				</Button>
+			</div>
+			<p className="text-[11px] leading-relaxed text-muted-foreground">
+				選択は30日間このブラウザに記憶されます。右下の「表示設定」からいつでも変更できます。
+			</p>
+		</DockedPanel>
 	);
 }

--- a/apps/web/src/components/consent/cookie-consent-banner.tsx
+++ b/apps/web/src/components/consent/cookie-consent-banner.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { DockedPanel } from "@suzumina.click/ui/components/custom";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Card, CardContent } from "@suzumina.click/ui/components/ui/card";
-import { Cookie, Settings } from "lucide-react";
+import { Cookie } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { useAgeVerification } from "@/contexts/age-verification-context";
 import { useIsClient } from "@/hooks/use-is-client";
 import {
 	type ConsentState,
@@ -20,11 +21,29 @@ const DEFAULT_CONSENT: ConsentState = {
 	personalization: false,
 };
 
+const NARROW_VIEWPORT_QUERY = "(max-width: 639px)";
+
+/**
+ * 案A: 左下に独立して浮く非モーダルなピル型バー（年齢確認カードは右下・重ならない）。
+ * 狭い画面では両方が全幅ボトムシート化するため、年齢確認が未解決の間はこのバーを
+ * 抑制し、順次表示にする（AgeVerificationProvider の isAgeVerified を読むだけで、
+ * 状態の所有権は移さない）。
+ */
 export function CookieConsentBanner() {
 	const isClient = useIsClient();
+	const { isAgeVerified, isLoading: isAgeLoading } = useAgeVerification();
+	const [isNarrowViewport, setIsNarrowViewport] = useState(false);
 	const [showBanner, setShowBanner] = useState(false);
 	const [showPreferences, setShowPreferences] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		const mediaQuery = window.matchMedia(NARROW_VIEWPORT_QUERY);
+		const update = () => setIsNarrowViewport(mediaQuery.matches);
+		update();
+		mediaQuery.addEventListener("change", update);
+		return () => mediaQuery.removeEventListener("change", update);
+	}, []);
 
 	// Apply consent choices using unified system
 	const applyConsentChoices = useCallback((choices: ConsentState) => {
@@ -80,68 +99,46 @@ export function CookieConsentBanner() {
 		setIsLoading(false);
 	}, [isClient, applyConsentChoices]);
 
-	if (isLoading || !showBanner) {
+	// 狭い画面では年齢確認カードと同時に出さず、決着後に表示する（順次表示）
+	const deferredForMobileAgeGate = isNarrowViewport && !isAgeLoading && !isAgeVerified;
+
+	if (isLoading || !showBanner || deferredForMobileAgeGate) {
 		return null;
 	}
 
 	return (
 		<>
-			{/* Main consent banner */}
-			<div className="fixed bottom-0 left-0 right-0 z-50 p-4">
-				<Card className="max-w-4xl mx-auto bg-white/95 backdrop-blur-sm shadow-xl border border-border">
-					<CardContent className="p-4">
-						<div className="flex flex-col sm:flex-row items-start gap-4">
-							{/* Icon and message */}
-							<div className="flex items-start gap-3 flex-1">
-								<div className="p-2 bg-muted rounded-lg">
-									<Cookie className="h-5 w-5 text-primary" />
-								</div>
-								<div className="space-y-1">
-									<h3 className="font-semibold text-foreground text-sm">クッキーの使用について</h3>
-									<p className="text-sm text-muted-foreground leading-relaxed">
-										サイト改善・分析のためクッキーを使用します。
-										<button
-											type="button"
-											onClick={() => setShowPreferences(true)}
-											className="text-primary hover:text-primary/90 underline ml-1"
-										>
-											詳細設定
-										</button>
-									</p>
-								</div>
-							</div>
-
-							{/* Action buttons - Equal prominence design */}
-							<div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={handleRejectAll}
-									className="border-border text-primary hover:bg-accent text-xs px-3 py-2"
-								>
-									拒否
-								</Button>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setShowPreferences(true)}
-									className="border-border text-primary hover:bg-accent text-xs px-3 py-2"
-								>
-									<Settings className="h-3 w-3 mr-1" />
-									設定
-								</Button>
-								<Button
-									size="sm"
-									onClick={handleAcceptAll}
-									className="bg-primary hover:bg-primary/90 text-primary-foreground text-xs px-3 py-2"
-								>
-									すべて許可
-								</Button>
-							</div>
-						</div>
-					</CardContent>
-				</Card>
-			</div>
+			<DockedPanel
+				position="bottom-left"
+				variant="pill"
+				aria-label="クッキーの使用"
+				className="flex flex-wrap items-center gap-3 px-4 py-3 sm:flex-nowrap sm:py-2 sm:pr-2 sm:pl-4"
+			>
+				<Cookie className="h-4 w-4 flex-shrink-0 text-primary" />
+				<span className="min-w-0 flex-1 text-xs text-foreground sm:flex-none sm:whitespace-nowrap">
+					サイト改善のためクッキーを使用します
+				</span>
+				<button
+					type="button"
+					onClick={() => setShowPreferences(true)}
+					className="whitespace-nowrap text-xs text-primary underline"
+				>
+					詳細設定
+				</button>
+				<div className="flex w-full gap-2 sm:w-auto">
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={handleRejectAll}
+						className="flex-1 sm:flex-none"
+					>
+						拒否
+					</Button>
+					<Button size="sm" onClick={handleAcceptAll} className="flex-1 sm:flex-none">
+						許可
+					</Button>
+				</div>
+			</DockedPanel>
 
 			{/* Preferences panel - use Dialog component directly */}
 			<CookiePreferencesPanel

--- a/apps/web/src/components/consent/cookie-consent-banner.tsx
+++ b/apps/web/src/components/consent/cookie-consent-banner.tsx
@@ -25,13 +25,14 @@ const NARROW_VIEWPORT_QUERY = "(max-width: 639px)";
 
 /**
  * 案A: 左下に独立して浮く非モーダルなピル型バー（年齢確認カードは右下・重ならない）。
- * 狭い画面では両方が全幅ボトムシート化するため、年齢確認が未解決の間はこのバーを
- * 抑制し、順次表示にする（AgeVerificationProvider の isAgeVerified を読むだけで、
- * 状態の所有権は移さない）。
+ * 狭い画面では両方が全幅ボトムシート化しうるため、年齢確認カードがドック占有中
+ * （ask/toast段階）の間はこのバーを抑制し、順次表示にする。読むのは
+ * AgeVerificationProvider の isAgeCardDocked（読み取り専用シグナル）だけで、
+ * 状態の所有権は移さない。
  */
 export function CookieConsentBanner() {
 	const isClient = useIsClient();
-	const { isAgeVerified, isLoading: isAgeLoading } = useAgeVerification();
+	const { isAgeCardDocked } = useAgeVerification();
 	const [isNarrowViewport, setIsNarrowViewport] = useState(false);
 	const [showBanner, setShowBanner] = useState(false);
 	const [showPreferences, setShowPreferences] = useState(false);
@@ -99,8 +100,8 @@ export function CookieConsentBanner() {
 		setIsLoading(false);
 	}, [isClient, applyConsentChoices]);
 
-	// 狭い画面では年齢確認カードと同時に出さず、決着後に表示する（順次表示）
-	const deferredForMobileAgeGate = isNarrowViewport && !isAgeLoading && !isAgeVerified;
+	// 狭い画面では年齢確認カードのドック占有中（ask/toast）は出さず、決着後に表示する（順次表示）
+	const deferredForMobileAgeGate = isNarrowViewport && isAgeCardDocked;
 
 	if (isLoading || !showBanner || deferredForMobileAgeGate) {
 		return null;

--- a/apps/web/src/contexts/age-verification-context.tsx
+++ b/apps/web/src/contexts/age-verification-context.tsx
@@ -13,6 +13,14 @@ interface AgeVerificationContextType {
 	updateAgeVerification: (isAdult: boolean) => void;
 	/** ローディング状態 */
 	isLoading: boolean;
+	/**
+	 * 年齢確認カード（ask/toast段階）が画面下部のドック位置を占有中かどうか。
+	 * Cookieバー等、同じドック位置を使うUIが狭い画面で重ならないよう調整するための
+	 * 読み取り専用シグナル。所有・更新は AgeVerificationOverlay のみが行う。
+	 */
+	isAgeCardDocked: boolean;
+	/** AgeVerificationOverlay 専用。他コンポーネントから呼ばない */
+	setAgeCardDocked: (docked: boolean) => void;
 }
 
 const AgeVerificationContext = createContext<AgeVerificationContextType | null>(null);
@@ -25,6 +33,7 @@ export function AgeVerificationProvider({ children }: AgeVerificationProviderPro
 	const [isAgeVerified, setIsAgeVerified] = useState(false);
 	const [isAdult, setIsAdult] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
+	const [isAgeCardDocked, setAgeCardDocked] = useState(false);
 
 	useEffect(() => {
 		// ローカルストレージから年齢確認状態を読み込み
@@ -71,8 +80,10 @@ export function AgeVerificationProvider({ children }: AgeVerificationProviderPro
 			showR18Content,
 			updateAgeVerification,
 			isLoading,
+			isAgeCardDocked,
+			setAgeCardDocked,
 		}),
-		[isAgeVerified, isAdult, showR18Content, updateAgeVerification, isLoading],
+		[isAgeVerified, isAdult, showR18Content, updateAgeVerification, isLoading, isAgeCardDocked],
 	);
 
 	return (

--- a/packages/ui/src/components/custom/docked-panel.tsx
+++ b/packages/ui/src/components/custom/docked-panel.tsx
@@ -2,23 +2,30 @@ import { cn } from "@suzumina.click/ui/lib/utils";
 import type * as React from "react";
 
 interface DockedPanelProps extends React.ComponentProps<"div"> {
-	/** Screen corner the panel is anchored to on wide viewports. */
+	/** 広い画面での配置角。 */
 	position: "bottom-right" | "bottom-left";
-	/** "card" (rounded-xl, e.g. confirmation cards/toasts) or "pill" (rounded-full, e.g. a compact settings/consent bar). */
+	/** "card"（角丸xl。年齢確認カード/トースト等）か "pill"（角丸full。Cookieバー等）。 */
 	variant?: "card" | "pill";
 	role?: "region" | "status";
+	/**
+	 * 狭い画面で全幅ボトムシート化するか（既定 true）。年齢確認カード/Cookieバー本体は
+	 * コンテンツ量が多く全幅化が必要だが、常時コンパクトに留めたい要素（表示設定の
+	 * 再オープンピル等）は false にする。同じドック位置を使う複数パネルが同時に
+	 * 表示されても重ならないようにするための呼び出し側の責務であり、このコンポーネント
+	 * 自体は複数パネル間の自動スタッキングは行わない。
+	 */
+	mobileSheet?: boolean;
 }
 
 /**
- * Non-modal panel docked to a screen corner: rounded, bordered, shadowed —
- * never a backdrop/blocking overlay. Collapses to a full-width bottom sheet on
- * narrow viewports so multiple docked panels (e.g. age gate + cookie bar) stack
- * predictably instead of overlapping.
+ * 画面の角にドッキングする非モーダルパネル: 角丸・枠線・shadow — backdropで
+ * 塞ぐブロッキングオーバーレイにはしない。
  */
 export function DockedPanel({
 	position,
 	variant = "card",
 	role = "region",
+	mobileSheet = true,
 	className,
 	...props
 }: DockedPanelProps) {
@@ -26,10 +33,16 @@ export function DockedPanel({
 		<div
 			role={role}
 			className={cn(
-				"fixed inset-x-0 bottom-0 z-50 w-full border bg-card text-card-foreground shadow-xl",
-				"rounded-t-2xl sm:inset-x-auto sm:bottom-4 sm:w-auto",
-				variant === "pill" ? "sm:rounded-full sm:shadow-lg" : "sm:rounded-xl",
-				position === "bottom-right" ? "sm:right-4" : "sm:left-4",
+				"fixed z-50 border bg-card text-card-foreground shadow-xl",
+				mobileSheet &&
+					"inset-x-0 bottom-0 w-full rounded-t-2xl sm:inset-x-auto sm:bottom-4 sm:w-auto",
+				mobileSheet && variant === "pill" && "sm:rounded-full sm:shadow-lg",
+				mobileSheet && variant === "card" && "sm:rounded-xl",
+				mobileSheet && position === "bottom-right" && "sm:right-4",
+				mobileSheet && position === "bottom-left" && "sm:left-4",
+				!mobileSheet && "bottom-4 w-auto rounded-full shadow-lg",
+				!mobileSheet && position === "bottom-right" && "right-4",
+				!mobileSheet && position === "bottom-left" && "left-4",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/custom/docked-panel.tsx
+++ b/packages/ui/src/components/custom/docked-panel.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@suzumina.click/ui/lib/utils";
+import type * as React from "react";
+
+interface DockedPanelProps extends React.ComponentProps<"div"> {
+	/** Screen corner the panel is anchored to on wide viewports. */
+	position: "bottom-right" | "bottom-left";
+	/** "card" (rounded-xl, e.g. confirmation cards/toasts) or "pill" (rounded-full, e.g. a compact settings/consent bar). */
+	variant?: "card" | "pill";
+	role?: "region" | "status";
+}
+
+/**
+ * Non-modal panel docked to a screen corner: rounded, bordered, shadowed —
+ * never a backdrop/blocking overlay. Collapses to a full-width bottom sheet on
+ * narrow viewports so multiple docked panels (e.g. age gate + cookie bar) stack
+ * predictably instead of overlapping.
+ */
+export function DockedPanel({
+	position,
+	variant = "card",
+	role = "region",
+	className,
+	...props
+}: DockedPanelProps) {
+	return (
+		<div
+			role={role}
+			className={cn(
+				"fixed inset-x-0 bottom-0 z-50 w-full border bg-card text-card-foreground shadow-xl",
+				"rounded-t-2xl sm:inset-x-auto sm:bottom-4 sm:w-auto",
+				variant === "pill" ? "sm:rounded-full sm:shadow-lg" : "sm:rounded-xl",
+				position === "bottom-right" ? "sm:right-4" : "sm:left-4",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -27,7 +27,7 @@ export {
 	normalizeOptions,
 	transformFilterValue,
 } from "./configurable-list/utils/filter-helpers";
-// Non-modal corner-docked panel shell (age gate / cookie bar etc.)
+// 非モーダルで角にドッキングするパネルの殻（年齢確認ゲート/Cookieバー等）
 export { DockedPanel } from "./docked-panel";
 
 // Utility components

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -27,6 +27,8 @@ export {
 	normalizeOptions,
 	transformFilterValue,
 } from "./configurable-list/utils/filter-helpers";
+// Non-modal corner-docked panel shell (age gate / cookie bar etc.)
+export { DockedPanel } from "./docked-panel";
 
 // Utility components
 export { HighlightText } from "./highlight-text";


### PR DESCRIPTION
## Summary

- claude.ai/design で叩いた再設計案「案A（ドッキングカード）」を採用・実装
- 年齢確認カードを右下の非モーダルカードに変更。backdrop・スクロールロック・「18歳未満」選択時の強制リダイレクトを撤去し、選択後はトースト→常駐ピルでいつでも再変更できるようにした
- Cookie同意バーを左下の独立ピルに変更。狭い画面では年齢確認が決着するまで表示を遅らせ、順次表示にした
- 見た目の共通殻（角丸カード/ピル・角に非モーダル配置・モバイルでの全幅ボトムシート化）を `packages/ui` の `DockedPanel` として切り出し。年齢確認とCookie同意の状態管理（30日 vs 無期限記憶などライフサイクルが異なる）はあえて統合せず分離したまま
- 副次的に発見したバグ修正: `works-list.tsx` は未確認時にR18トグルをUIから隠すだけで実際のフェッチには `showR18` を渡しておらず、全件（R18含む）取得していた。明示的に `showR18: false` を強制し、非表示中である旨の案内文を追加

Linear: [SPR-238](https://linear.app/nothink/issue/SPR-238/designweb-r18ゲートcookie同意を非ブロッキングなドッキングカードに再設計案a)

## スコープ外（別途フォロー）

- R18非表示件数の正確な数値チップ — 既存のR18判定がキーワード部分一致のため安価な集計だと誤カウントの恐れがあり、文言のみの案内に留めた
- SSR初回描画（hydration前）はまだ年齢確認状態を知らないため一瞬R18作品が混じりうる問題を発見。別タスクとして着手済み

## Test plan

- [x] `pnpm verify`（lint:docs + lint:tokens + lint + typecheck + test）green
- [x] Firestore Emulator + seed でブラウザプレビュー確認:
  - [x] トップページ: 年齢確認カード表示 → 「全年齢のみで続ける」でリダイレクトせず閲覧継続 → トースト → 閉じて常駐ピル → ピルから再オープン
  - [x] Cookieバー（左下）: 詳細設定/拒否/許可、年齢カードと重ならない
  - [x] /works: 未確認時はR18非表示＋案内文、「18歳以上」選択後にR18トグル出現・R18作品表示
  - [x] モバイル(375px): 年齢確認ボトムシート→選択後にCookieバーが順次表示（重ならず縦積み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)