### PR TITLE
fix(web): /works のSSR初期値をfail-closedにしR18露出を防ぐ

### DIFF
--- a/apps/web/src/app/works/__tests__/page.test.tsx
+++ b/apps/web/src/app/works/__tests__/page.test.tsx
@@ -145,11 +145,13 @@ describe("WorksPage", () => {
 
 		render(<AgeVerificationProvider>{await WorksPage({ searchParams })}</AgeVerificationProvider>);
 
-		// showR18がundefinedで渡される（デフォルトで全作品表示）
+		// fail-closed: showR18指定が無い場合はfalse（R18除外）で渡される。
+		// SSR HTMLはCDNエッジで全訪問者に共有キャッシュされるため、
+		// 未確認訪問者を含む全員に安全な内容のみ返す必要がある
 		expect(getWorks).toHaveBeenCalledWith(
 			expect.objectContaining({
 				search: "宮村",
-				showR18: undefined,
+				showR18: false,
 			}),
 		);
 	});

--- a/apps/web/src/app/works/components/__tests__/works-list.test.tsx
+++ b/apps/web/src/app/works/components/__tests__/works-list.test.tsx
@@ -1,0 +1,99 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ParsedWorksSearchParams } from "../../lib/parse-search-params";
+import WorksList from "../works-list";
+
+// ConfigurableList はこのテストの関心事（補正フェッチの呼び出し条件）に無関係なため、
+// items をそのまま描画するだけの最小実装に差し替える
+vi.mock("@suzumina.click/ui/components/custom", () => ({
+	ConfigurableList: ({ items }: { items: unknown[] }) => (
+		<div data-testid="configurable-list">{items.length}</div>
+	),
+}));
+
+vi.mock("@/components/list/list-wrapper", () => ({
+	ListWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/work/work-list-item", () => ({
+	WorkListItem: () => null,
+}));
+
+const mockGetWorks = vi.fn().mockResolvedValue({ works: [], totalCount: 0 });
+const mockGetPopularGenres = vi.fn().mockResolvedValue([]);
+vi.mock("../../actions", () => ({
+	getWorks: (...args: unknown[]) => mockGetWorks(...args),
+	getPopularGenres: (...args: unknown[]) => mockGetPopularGenres(...args),
+}));
+
+let mockAgeVerification = { showR18Content: false, isLoading: false };
+vi.mock("@/contexts/age-verification-context", () => ({
+	useAgeVerification: () => mockAgeVerification,
+}));
+
+function makeInitialParams(
+	overrides: Partial<ParsedWorksSearchParams> = {},
+): ParsedWorksSearchParams {
+	return {
+		page: 1,
+		limit: 12,
+		sort: "newest",
+		...overrides,
+	};
+}
+
+const emptyInitialData = { works: [], totalCount: 0, hasMore: false };
+
+describe("WorksList - R18補正フェッチ", () => {
+	beforeEach(() => {
+		mockGetWorks.mockClear();
+		mockAgeVerification = { showR18Content: false, isLoading: false };
+	});
+
+	it("未確認/未成年の間は補正フェッチしない", async () => {
+		mockAgeVerification = { showR18Content: false, isLoading: false };
+		render(<WorksList initialData={emptyInitialData} initialParams={makeInitialParams()} />);
+
+		await waitFor(() => expect(mockGetPopularGenres).toHaveBeenCalled());
+		expect(mockGetWorks).not.toHaveBeenCalled();
+	});
+
+	it("verified adult かつURLにshowR18指定が無い場合、showR18:trueで補正フェッチする", async () => {
+		mockAgeVerification = { showR18Content: true, isLoading: false };
+		render(
+			<WorksList
+				initialData={emptyInitialData}
+				initialParams={makeInitialParams({ showR18: undefined })}
+			/>,
+		);
+
+		await waitFor(() => expect(mockGetWorks).toHaveBeenCalledTimes(1));
+		expect(mockGetWorks).toHaveBeenCalledWith(expect.objectContaining({ showR18: true }));
+	});
+
+	it("verified adult でもURLに showR18=false の明示指定がある場合は補正フェッチしない", async () => {
+		mockAgeVerification = { showR18Content: true, isLoading: false };
+		render(
+			<WorksList
+				initialData={emptyInitialData}
+				initialParams={makeInitialParams({ showR18: false })}
+			/>,
+		);
+
+		await waitFor(() => expect(mockGetPopularGenres).toHaveBeenCalled());
+		expect(mockGetWorks).not.toHaveBeenCalled();
+	});
+
+	it("verified adult でもURLに showR18=true の明示指定がある場合は補正フェッチしない（SSRが既に正しい）", async () => {
+		mockAgeVerification = { showR18Content: true, isLoading: false };
+		render(
+			<WorksList
+				initialData={emptyInitialData}
+				initialParams={makeInitialParams({ showR18: true })}
+			/>,
+		);
+
+		await waitFor(() => expect(mockGetPopularGenres).toHaveBeenCalled());
+		expect(mockGetWorks).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/app/works/components/works-list.tsx
+++ b/apps/web/src/app/works/components/works-list.tsx
@@ -2,7 +2,7 @@
 
 import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
 import { ConfigurableList, type StandardListParams } from "@suzumina.click/ui/components/custom";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ListWrapper } from "@/components/list/list-wrapper";
 import { WorkListItem } from "@/components/work/work-list-item";
 import {
@@ -14,16 +14,34 @@ import {
 import { WORK_CATEGORY_OPTIONS, WORK_LANGUAGE_OPTIONS } from "@/constants/work-options";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 import { getPopularGenres, getWorks } from "../actions";
+import type { ParsedWorksSearchParams } from "../lib/parse-search-params";
 
 interface WorksListProps {
 	initialData?: WorkListResultPlain;
+	initialParams: ParsedWorksSearchParams;
 }
 
-export default function WorksList({ initialData }: WorksListProps) {
-	const { showR18Content } = useAgeVerification();
+export default function WorksList({ initialData, initialParams }: WorksListProps) {
+	const { showR18Content, isLoading: isAgeVerificationLoading } = useAgeVerification();
 	const [availableGenres, setAvailableGenres] = useState<Array<{ value: string; label: string }>>(
 		[],
 	);
+	// SSR は年齢確認状態を読めず fail-closed（showR18:false）で initialData を返す
+	// （page.tsx 参照。CDNエッジで全訪問者に共有キャッシュされるため安全側に倒す設計）。
+	// verified adult 確定後、ConfigurableList の内部再フェッチ機構（マウント後の URL 変化でのみ
+	// 発火し、マウント時の initialItems は無条件に信頼する）を経由せず、ここで直接1回だけ
+	// showR18:true で取り直し（page.tsx と同じ initialParams を使用）、結果が来たら key を
+	// 変えて ConfigurableList を再マウントする。
+	const [correctedData, setCorrectedData] = useState<WorkListResultPlain | null>(null);
+	const hasCorrectedRef = useRef(false);
+
+	useEffect(() => {
+		if (isAgeVerificationLoading) return; // localStorage解決前は待つ
+		if (hasCorrectedRef.current) return;
+		if (!showR18Content) return; // 未確認/未成年はSSRのfail-closed結果のままでよい
+		hasCorrectedRef.current = true;
+		void getWorks({ ...initialParams, showR18: true }).then(setCorrectedData);
+	}, [isAgeVerificationLoading, showR18Content, initialParams]);
 
 	// 人気ジャンルを取得
 	useEffect(() => {
@@ -42,11 +60,15 @@ export default function WorksList({ initialData }: WorksListProps) {
 		void fetchGenres();
 	}, []);
 
-	// 初期データを準備
-	const initialItems = initialData?.works || [];
-	const initialTotal = initialData?.totalCount || 0;
+	// 初期データを準備（補正済みデータがあればそちらを使用）
+	const effectiveData = correctedData ?? initialData;
+	const initialItems = effectiveData?.works || [];
+	const initialTotal = effectiveData?.totalCount || 0;
 
 	// データアダプター
+	// 未確認/未成年時はフィルタUI自体を出さない（filters下部参照）ため、
+	// params.filters.showR18 は常に undefined。その場合は showR18Content
+	// （未確認時 false）にフォールバックし、SSR同様 fail-closed を維持する。
 	const dataAdapter = useMemo(
 		() => ({
 			toParams: (params: StandardListParams) => {
@@ -57,13 +79,13 @@ export default function WorksList({ initialData }: WorksListProps) {
 					search: params.search,
 					category: params.filters.category as string | undefined,
 					language: params.filters.language as string | undefined,
-					showR18: params.filters.showR18 as boolean | undefined,
+					showR18: (params.filters.showR18 as boolean | undefined) ?? showR18Content,
 					genres: params.filters.genres as string[] | undefined,
 				};
 			},
 			fromResult: (result: unknown) => result as { items: WorkPlainObject[]; total: number },
 		}),
-		[],
+		[showR18Content],
 	);
 
 	// フェッチ関数
@@ -79,6 +101,9 @@ export default function WorksList({ initialData }: WorksListProps) {
 	return (
 		<ListWrapper>
 			<ConfigurableList<WorkPlainObject>
+				// 補正フェッチ完了時に再マウントし、ConfigurableList に新しい initialItems を
+				// 信頼させる（内部の再フェッチ判定はマウント後のURL変化にしか反応しないため）。
+				key={correctedData ? "corrected" : "initial"}
 				items={initialItems}
 				initialTotal={initialTotal}
 				// 先頭 2 件のみ priority。PR #439 で <6 を試したが /works の DLsite

--- a/apps/web/src/app/works/components/works-list.tsx
+++ b/apps/web/src/app/works/components/works-list.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/constants/list-options";
 import { WORK_CATEGORY_OPTIONS, WORK_LANGUAGE_OPTIONS } from "@/constants/work-options";
 import { useAgeVerification } from "@/contexts/age-verification-context";
+import * as logger from "@/lib/logger";
 import { getPopularGenres, getWorks } from "../actions";
 import type { ParsedWorksSearchParams } from "../lib/parse-search-params";
 
@@ -39,8 +40,17 @@ export default function WorksList({ initialData, initialParams }: WorksListProps
 		if (isAgeVerificationLoading) return; // localStorage解決前は待つ
 		if (hasCorrectedRef.current) return;
 		if (!showR18Content) return; // 未確認/未成年はSSRのfail-closed結果のままでよい
+		// URLに showR18 の明示指定がある場合は SSR が既にその値を正しく反映済みのため補正しない
+		// （例: ?showR18=false は「成人だがR18非表示を選択」であり、無条件に true 補正すると
+		// フィルタUIの表示（URL由来でOFF）と実際の一覧（R18込み）が矛盾する）
+		if (initialParams.showR18 !== undefined) return;
 		hasCorrectedRef.current = true;
-		void getWorks({ ...initialParams, showR18: true }).then(setCorrectedData);
+		getWorks({ ...initialParams, showR18: true })
+			.then(setCorrectedData)
+			.catch((err: unknown) => {
+				logger.error("works: R18補正フェッチに失敗", err);
+				hasCorrectedRef.current = false; // 依存値が変化すれば再試行できるようにする
+			});
 	}, [isAgeVerificationLoading, showR18Content, initialParams]);
 
 	// 人気ジャンルを取得

--- a/apps/web/src/app/works/lib/__tests__/parse-search-params.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/parse-search-params.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseWorksSearchParams } from "../parse-search-params";
+
+function getterFrom(values: Record<string, string>) {
+	return { get: (key: string) => (key in values ? values[key] : null) };
+}
+
+describe("parseWorksSearchParams", () => {
+	it("showR18が未指定の場合はundefinedを返す（fail-closedの適用は呼び出し側の責務）", () => {
+		const result = parseWorksSearchParams(getterFrom({}));
+		expect(result.showR18).toBeUndefined();
+	});
+
+	it("showR18=trueを明示指定した場合はtrueを返す", () => {
+		const result = parseWorksSearchParams(getterFrom({ showR18: "true" }));
+		expect(result.showR18).toBe(true);
+	});
+
+	it("showR18=falseを明示指定した場合はfalseを返す（undefinedと区別できる）", () => {
+		const result = parseWorksSearchParams(getterFrom({ showR18: "false" }));
+		expect(result.showR18).toBe(false);
+	});
+
+	it("page/limitのデフォルト値とバリデーションが機能する", () => {
+		const result = parseWorksSearchParams(getterFrom({ page: "0", limit: "999" }));
+		expect(result.page).toBe(1); // 0以下は1にクランプ
+		expect(result.limit).toBe(12); // 許可外の値はデフォルト12
+	});
+});

--- a/apps/web/src/app/works/lib/parse-search-params.ts
+++ b/apps/web/src/app/works/lib/parse-search-params.ts
@@ -1,0 +1,56 @@
+/**
+ * /works の検索パラメータ解析（Server Component の page.tsx と
+ * クライアント側の再フェッチ補正の両方から同一ロジックで参照する正本）
+ */
+
+interface SearchParamsGetter {
+	get(key: string): string | null | undefined;
+}
+
+// ジャンルパラメータをパースする関数（複雑度を下げるため分離）
+function parseGenres(genresParam: string | null | undefined): string[] | undefined {
+	if (typeof genresParam !== "string") return undefined;
+
+	if (genresParam.includes("|")) {
+		// 新形式: パイプ区切り
+		return genresParam.split("|").filter(Boolean);
+	}
+	if (genresParam.includes(",") && !genresParam.includes(" ")) {
+		// 旧形式: カンマ区切り（スペースを含まない場合のみ）
+		return genresParam.split(",").filter(Boolean);
+	}
+	// 単一の値（スペースを含む可能性がある）
+	return [genresParam];
+}
+
+export interface ParsedWorksSearchParams {
+	page: number;
+	limit: number;
+	sort: string;
+	search?: string;
+	category?: string;
+	language?: string;
+	genres?: string[];
+}
+
+export function parseWorksSearchParams(params: SearchParamsGetter): ParsedWorksSearchParams {
+	const pageNumber = Number.parseInt(params.get("page") ?? "", 10) || 1;
+	const validPage = Math.max(1, pageNumber);
+	const sort = params.get("sort") ?? "newest";
+	const search = params.get("q") ?? undefined;
+	const category = params.get("category") ?? undefined;
+	const language = params.get("language") ?? undefined;
+	const genres = parseGenres(params.get("genres"));
+	const limitValue = Number.parseInt(params.get("limit") ?? "", 10) || 12;
+	const validLimit = [12, 24, 48].includes(limitValue) ? limitValue : 12;
+
+	return {
+		page: validPage,
+		limit: validLimit,
+		sort,
+		search,
+		category,
+		language,
+		genres,
+	};
+}

--- a/apps/web/src/app/works/lib/parse-search-params.ts
+++ b/apps/web/src/app/works/lib/parse-search-params.ts
@@ -31,6 +31,11 @@ export interface ParsedWorksSearchParams {
 	category?: string;
 	language?: string;
 	genres?: string[];
+	/**
+	 * URLの showR18 生値（未指定なら undefined）。fail-closed デフォルトの適用は
+	 * 呼び出し側の責務（page.tsx が SSR 用に、works-list.tsx が明示指定の有無判定に使う）。
+	 */
+	showR18?: boolean;
 }
 
 export function parseWorksSearchParams(params: SearchParamsGetter): ParsedWorksSearchParams {
@@ -43,6 +48,9 @@ export function parseWorksSearchParams(params: SearchParamsGetter): ParsedWorksS
 	const genres = parseGenres(params.get("genres"));
 	const limitValue = Number.parseInt(params.get("limit") ?? "", 10) || 12;
 	const validLimit = [12, 24, 48].includes(limitValue) ? limitValue : 12;
+	const showR18Raw = params.get("showR18");
+	const showR18 =
+		showR18Raw !== null && showR18Raw !== undefined ? showR18Raw === "true" : undefined;
 
 	return {
 		page: validPage,
@@ -52,5 +60,6 @@ export function parseWorksSearchParams(params: SearchParamsGetter): ParsedWorksS
 		category,
 		language,
 		genres,
+		showR18,
 	};
 }

--- a/apps/web/src/app/works/page.tsx
+++ b/apps/web/src/app/works/page.tsx
@@ -13,9 +13,8 @@ export default async function WorksPage({ searchParams }: WorksPageProps) {
 		const value = rawParams[key];
 		return typeof value === "string" ? value : undefined;
 	};
-	const { page, limit, sort, search, category, language, genres } = parseWorksSearchParams({
-		get: getParam,
-	});
+	const parsedParams = parseWorksSearchParams({ get: getParam });
+	const { page, limit, sort, search, category, language, genres, showR18 } = parsedParams;
 
 	// showR18パラメータの処理
 	// 年齢確認状態はlocalStorage駆動でServer Componentからは読めないため、
@@ -23,9 +22,9 @@ export default async function WorksPage({ searchParams }: WorksPageProps) {
 	// このHTMLはCDNエッジで全訪問者に共有キャッシュされる（terraform/cloudflare.tf #5・
 	// next.config.mjsのCache-Control）ため、未確認訪問者を含む全員に安全な内容のみ返す必要がある。
 	// 年齢確認済みの成人はhydration後、クライアント側の再フェッチで showR18: true を明示送信する
-	// （works-list.tsx 参照。ここで解析した initialParams を props で渡し同じ条件で再取得する）。
-	const showR18FromParams = getParam("showR18");
-	const shouldShowR18 = showR18FromParams !== undefined ? showR18FromParams === "true" : false;
+	// （works-list.tsx 参照。parsedParams.showR18 が undefined＝URL未指定の場合のみ補正する。
+	// 明示指定（true/false）がある場合はSSRが既に正しく反映しているため補正しない）。
+	const shouldShowR18 = showR18 ?? false;
 
 	// 初期データを取得
 	const result = await getWorks({
@@ -39,12 +38,7 @@ export default async function WorksPage({ searchParams }: WorksPageProps) {
 		showR18: shouldShowR18,
 	});
 
-	return (
-		<WorksPageClient
-			initialData={result}
-			initialParams={{ page, limit, sort, search, category, language, genres }}
-		/>
-	);
+	return <WorksPageClient initialData={result} initialParams={parsedParams} />;
 }
 
 // メタデータ設定

--- a/apps/web/src/app/works/page.tsx
+++ b/apps/web/src/app/works/page.tsx
@@ -1,63 +1,50 @@
 import { WorksPageClient } from "@/components/content/works-page-client";
 import { getWorks } from "./actions";
-
-// ジャンルパラメータをパースする関数（複雑度を下げるため分離）
-function parseGenres(genresParam: string | undefined): string[] | undefined {
-	if (typeof genresParam !== "string") return undefined;
-
-	// Next.jsのsearchParamsは既にデコード済みの値を提供
-	if (genresParam.includes("|")) {
-		// 新形式: パイプ区切り
-		return genresParam.split("|").filter(Boolean);
-	}
-	if (genresParam.includes(",") && !genresParam.includes(" ")) {
-		// 旧形式: カンマ区切り（スペースを含まない場合のみ）
-		return genresParam.split(",").filter(Boolean);
-	}
-	// 単一の値（スペースを含む可能性がある）
-	return [genresParam];
-}
+import { parseWorksSearchParams } from "./lib/parse-search-params";
 
 interface WorksPageProps {
 	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
 export default async function WorksPage({ searchParams }: WorksPageProps) {
-	const params = await searchParams;
-	const pageNumber = Number.parseInt(params.page as string, 10) || 1;
-	const validPage = Math.max(1, pageNumber);
-	const sort = typeof params.sort === "string" ? params.sort : "newest";
-	const search = typeof params.q === "string" ? params.q : undefined;
-	const category = typeof params.category === "string" ? params.category : undefined;
-	const language = typeof params.language === "string" ? params.language : undefined;
-	const genres = parseGenres(params.genres as string);
-	const limitValue = Number.parseInt(params.limit as string, 10) || 12;
-	const validLimit = [12, 24, 48].includes(limitValue) ? limitValue : 12;
+	const rawParams = await searchParams;
+	// Next.jsのsearchParamsは既にデコード済みの値を提供
+	const getParam = (key: string): string | undefined => {
+		const value = rawParams[key];
+		return typeof value === "string" ? value : undefined;
+	};
+	const { page, limit, sort, search, category, language, genres } = parseWorksSearchParams({
+		get: getParam,
+	});
 
 	// showR18パラメータの処理
-	// URLパラメータが明示的に指定されている場合はその値を使用
-	// 指定されていない場合はundefinedとして、クライアント側で判断させる
-	// 動作仕様:
-	// - undefined: URLにshowR18パラメータがない場合。全作品を表示（R18含む）
-	// - true: showR18=trueの場合。R18作品も表示
-	// - false: showR18=falseの場合。R18作品を除外
-	const showR18FromParams = params.showR18;
-	const shouldShowR18 = showR18FromParams !== undefined ? showR18FromParams === "true" : undefined;
+	// 年齢確認状態はlocalStorage駆動でServer Componentからは読めないため、
+	// URL指定が無い場合は fail-closed（R18除外）をデフォルトにする。
+	// このHTMLはCDNエッジで全訪問者に共有キャッシュされる（terraform/cloudflare.tf #5・
+	// next.config.mjsのCache-Control）ため、未確認訪問者を含む全員に安全な内容のみ返す必要がある。
+	// 年齢確認済みの成人はhydration後、クライアント側の再フェッチで showR18: true を明示送信する
+	// （works-list.tsx 参照。ここで解析した initialParams を props で渡し同じ条件で再取得する）。
+	const showR18FromParams = getParam("showR18");
+	const shouldShowR18 = showR18FromParams !== undefined ? showR18FromParams === "true" : false;
 
 	// 初期データを取得
-	// showR18がundefinedの場合はデフォルトで全件取得（クライアント側でフィルタリング）
 	const result = await getWorks({
-		page: validPage,
-		limit: validLimit,
+		page,
+		limit,
 		sort,
 		search,
 		category,
 		language,
 		genres,
-		showR18: shouldShowR18, // undefinedの場合はundefinedのまま渡す
+		showR18: shouldShowR18,
 	});
 
-	return <WorksPageClient initialData={result} />;
+	return (
+		<WorksPageClient
+			initialData={result}
+			initialParams={{ page, limit, sort, search, category, language, genres }}
+		/>
+	);
 }
 
 // メタデータ設定

--- a/apps/web/src/components/content/works-page-client.tsx
+++ b/apps/web/src/components/content/works-page-client.tsx
@@ -8,13 +8,15 @@ import {
 } from "@suzumina.click/ui/components/custom";
 import { Suspense } from "react";
 import WorksList from "@/app/works/components/works-list";
+import type { ParsedWorksSearchParams } from "@/app/works/lib/parse-search-params";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 
 interface WorksPageClientProps {
 	initialData: WorkListResultPlain;
+	initialParams: ParsedWorksSearchParams;
 }
 
-export function WorksPageClient({ initialData }: WorksPageClientProps) {
+export function WorksPageClient({ initialData, initialParams }: WorksPageClientProps) {
 	// isLoading で early return しない: AgeVerificationOverlay 側が
 	// fixed inset-0 + body scroll lock で未確認ユーザーを覆う設計のため、
 	// ここでさらに gate するとコンテンツ render が遅れるだけで意味がない。
@@ -40,7 +42,7 @@ export function WorksPageClient({ initialData }: WorksPageClientProps) {
 						</div>
 					}
 				>
-					<WorksList initialData={initialData} />
+					<WorksList initialData={initialData} initialParams={initialParams} />
 				</Suspense>
 			</ListPageContent>
 		</ListPageLayout>


### PR DESCRIPTION
## Summary
- SPR-238（R18ゲート/Cookie同意の非ブロッキング再設計）の実装中に見つけた別問題への対応。
- `/works` の SSR HTML は `showR18` パラメータ未指定時に `undefined` を渡して全件（R18含む）を返していたが、この HTML は CDN エッジで全訪問者に共有キャッシュされる（`terraform/cloudflare.tf` rule#5 + `next.config.mjs` の `Cache-Control: public, s-maxage=120, stale-while-revalidate=300`）ため、未確認訪問者にもR18作品が漏れる状態だった。
- デフォルトを `false`（fail-closed）に変更。年齢確認済みの成人には hydration 後、クライアント側で `getWorks({..., showR18: true})` を明示的に再取得し補正する。
  - `ConfigurableList` は「マウント後のURL変化」でしか内部再フェッチを発火しない（マウント時の `initialItems` を無条件に信頼する設計）ため、年齢確認というURL非依存の非同期状態変化では自動補正されなかった。直接 `getWorks` を呼び、結果到着後に `key` を変えて再マウントする方式で対応。
  - page.tsx と works-list.tsx で検索パラメータの解析ロジックが重複しないよう `parseWorksSearchParams` を共通化し、`initialParams` として props 経由で渡す（`useSearchParams()` の追加使用を避けた）。

## Test plan
- [x] `pnpm verify`（lint + typecheck + test）green
- [x] Firestore Emulator (`pnpm dev:local`) 上で実機検証:
  - [x] 未確認訪問者: `/works` で R18 作品 0 件・年齢確認モーダル表示
  - [x] `?showR18=true` 明示指定: R18 作品が正しく含まれる
  - [x] 年齢確認モーダルで「18歳以上」をクリック: hydration後に補正フェッチが走り全作品（R18含む）が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)