### PR TITLE
fix(functions/web): video-mapper が status を再写像し /videos の total 乖離を止める (SPR-243)

### DIFF
--- a/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
@@ -64,6 +64,24 @@ describe("mapYouTubeToVideoPlainObject", () => {
 		expect(v?.statistics).toBeUndefined();
 	});
 
+	it("status を写像する（/videos の total 集計と埋め込み可否が読む = SPR-243）", () => {
+		const v = mapYouTubeToVideoPlainObject(
+			ytVideo({
+				status: { privacyStatus: "public", uploadStatus: "processed", embeddable: true },
+			}),
+		);
+		expect(v?.status).toEqual({
+			privacyStatus: "public",
+			uploadStatus: "processed",
+			embeddable: true,
+		});
+	});
+
+	it("status 無しは undefined（merge:true で既存値を保持）", () => {
+		const v = mapYouTubeToVideoPlainObject(ytVideo());
+		expect(v?.status).toBeUndefined();
+	});
+
 	it("snippet の欠落フィールドは既定値（空文字 / 空サムネ）で補完する", () => {
 		// 必須 id + 最小 snippet（title 等を持たない）でフォールバック分岐を通す
 		const v = mapYouTubeToVideoPlainObject({

--- a/apps/functions/src/services/mappers/video-mapper.ts
+++ b/apps/functions/src/services/mappers/video-mapper.ts
@@ -142,6 +142,16 @@ export function mapYouTubeToVideoPlainObject(
 				"none") as VideoPlainObject["liveBroadcastContent"],
 			liveStreamingDetails: liveDetails,
 			videoType,
+			// status は /videos の total 集計（where status.privacyStatus=="public" の count()）と
+			// 埋め込み可否判定（status.embeddable）が読む。旧 mapper 撤去時に写像が落ち、
+			// status 無し docs が total から漏れていた（SPR-243。既存分は毎時 cron の再取得で自然 backfill）。
+			status: youtubeVideo.status
+				? {
+						privacyStatus: youtubeVideo.status.privacyStatus || undefined,
+						uploadStatus: youtubeVideo.status.uploadStatus || undefined,
+						embeddable: youtubeVideo.status.embeddable ?? undefined,
+					}
+				: undefined,
 			// Use both new and old format for compatibility
 			tags: {
 				playlistTags,

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -315,8 +315,9 @@ async function getVideosWithFiltering(
 
 	// publicな動画の総数を count() 集計で取得（SPR-88: 毎リクエストの全件 .get()
 	// スキャンを回避。works/actions.ts と同じ count() パターン）。
-	// 注: 旧実装は (public || status未設定) を計上していたが、count()+where では status
-	// 未設定ドキュメントを拾えないため public のみ計上する（厳密化はメタデータ cache を検討）。
+	// 注: status 未設定 doc は count() で拾えない。旧 mapper 撤去期の未設定 doc（2026-07 時点 171/554 件）が
+	// 残っていたが、SPR-243 で mapper が status を再写像し毎時 cron の再取得で自然 backfill される。
+	// 表示側の `|| !video.status` フィルタは移行期の安全弁として残している。
 	const countSnapshot = await firestore
 		.collection("videos")
 		.where("status.privacyStatus", "==", "public")


### PR DESCRIPTION
## 概要

SPR-75 調査（発見4の実害部分）の修正。Linear: [SPR-243](https://linear.app/nothink/issue/SPR-243)

## 問題

- `videos` は 2 世代コホート: 旧パイプライン世代（69%）のみ `status` を持ち、**現行 mapper は YouTube API から status を part 指定で取得済みなのに写像で捨てていた**
- `/videos` の total は `where("status.privacyStatus", "==", "public")` の count() のため、status 未保有の **171/554 件が総数から漏れ**、表示（`public || !status` の in-memory 判定）とズレる
- 新規動画は status を持たないまま増えるので乖離は単調拡大していた

## 対応（Linear の推奨案 1）

- `video-mapper.ts`: `status`（privacyStatus / uploadStatus / embeddable）を写像に追加。**API 呼び出しの変更は不要**（videosFullDetails の part に status は既に含まれている＝quota 影響なし）
- 既存 171 件は毎時 cron の再取得（merge:true）で**自然 backfill**される（全 554 件 ≒ 1 クロール周期で解消）
- `videos/actions.ts` の count() 注記を現状に更新。表示側の `|| !video.status` フィルタは移行期の安全弁として残置
- 副次効果: `status.embeddable` を読む音声ボタン作成の埋め込み可否判定が新規動画でも機能するようになる

## 検証

- `pnpm verify` 完走（mapper に status 写像のテストを追加）
- backfill 完了後、`gcloud` などで `videos total と count(status.privacyStatus==public)` の一致を確認可能（調査時点: total=554 / public=383）

🤖 Generated with [Claude Code](https://claude.com/claude-code)