### PR TITLE
chore(data): 書きっぱなしフィールドの掃除 (SPR-241)

### DIFF
--- a/apps/functions/src/tools/firestore-local/fixtures/audioButtons.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/audioButtons.json
@@ -23,9 +23,36 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 23
+          "playCount": 25
         },
-        "updatedAt": "2026-05-30T10:53:01.578Z"
+        "updatedAt": "2026-06-20T16:02:11.216Z"
+      }
+    },
+    {
+      "id": "3ZQGfMT0ufuoZPFIo3nf",
+      "data": {
+        "buttonText": "これが男の中の男だ",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 6945.7,
+        "endTime": 6950.6,
+        "duration": 4.900000000000546,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-26T08:11:57.605Z",
+        "id": "3ZQGfMT0ufuoZPFIo3nf",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 5
+        },
+        "updatedAt": "2026-07-01T02:59:21.971Z"
       }
     },
     {
@@ -83,6 +110,31 @@
       }
     },
     {
+      "id": "7Jf6iiLUd25eu3NfhL9X",
+      "data": {
+        "buttonText": "一緒に手繋いで飛び降りよ？",
+        "videoId": "LpkHvKg_DX8",
+        "videoTitle": "深夜のゆるクラ♡ピグリン要塞に行きたい…🐷！！！【#すみっこキングダム／Minecraft】",
+        "startTime": 15709.5,
+        "endTime": 15713.8,
+        "duration": 4.299999999999272,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "生きえら",
+        "isPublic": true,
+        "createdAt": "2026-06-20T16:15:57.059Z",
+        "id": "7Jf6iiLUd25eu3NfhL9X",
+        "stats": {
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "likeCount": 1,
+          "playCount": 6
+        },
+        "updatedAt": "2026-06-26T08:00:14.959Z"
+      }
+    },
+    {
       "id": "99v1trF7nK2iUvlS2moI",
       "data": {
         "buttonText": "かじゅまを身籠もってるのかもしれない",
@@ -129,9 +181,9 @@
           "dislikeCount": 0,
           "favoriteCount": 1,
           "engagementRate": 0.019230769230769232,
-          "playCount": 57
+          "playCount": 59
         },
-        "updatedAt": "2026-03-24T19:19:56.475Z"
+        "updatedAt": "2026-06-20T16:03:33.106Z"
       }
     },
     {
@@ -180,9 +232,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0.037037037037037035,
-          "playCount": 37
+          "playCount": 38
         },
-        "updatedAt": "2026-03-24T19:23:06.655Z"
+        "updatedAt": "2026-06-20T16:04:57.898Z"
       }
     },
     {
@@ -205,11 +257,11 @@
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
-          "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 45
+          "favoriteCount": 0,
+          "playCount": 56
         },
-        "updatedAt": "2026-05-30T13:37:19.783Z"
+        "updatedAt": "2026-06-23T14:24:10.953Z"
       }
     },
     {
@@ -234,9 +286,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 44
+          "playCount": 46
         },
-        "updatedAt": "2026-03-30T01:48:39.003Z"
+        "updatedAt": "2026-06-20T16:04:05.202Z"
       }
     },
     {
@@ -261,9 +313,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 35
+          "playCount": 42
         },
-        "updatedAt": "2026-06-03T09:05:13.008Z"
+        "updatedAt": "2026-06-20T10:20:33.107Z"
       }
     },
     {
@@ -285,9 +337,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 22
+          "playCount": 23
         },
-        "updatedAt": "2026-01-18T09:16:29.046Z"
+        "updatedAt": "2026-06-18T12:31:59.629Z"
       }
     },
     {
@@ -338,9 +390,9 @@
           "dislikeCount": 0,
           "favoriteCount": 1,
           "engagementRate": 0.023809523809523808,
-          "playCount": 78
+          "playCount": 80
         },
-        "updatedAt": "2026-05-30T09:08:43.079Z"
+        "updatedAt": "2026-06-20T16:03:04.924Z"
       }
     },
     {
@@ -392,9 +444,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 155
+          "playCount": 156
         },
-        "updatedAt": "2026-05-06T16:07:31.073Z"
+        "updatedAt": "2026-06-20T16:03:45.672Z"
       }
     },
     {
@@ -416,9 +468,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 44
+          "playCount": 46
         },
-        "updatedAt": "2026-05-30T06:11:36.021Z"
+        "updatedAt": "2026-06-20T16:02:05.997Z"
       }
     },
     {
@@ -491,9 +543,9 @@
           "dislikeCount": 0,
           "favoriteCount": 2,
           "engagementRate": 0.023809523809523808,
-          "playCount": 68
+          "playCount": 69
         },
-        "updatedAt": "2026-06-03T08:27:13.090Z"
+        "updatedAt": "2026-06-08T15:51:18.584Z"
       }
     },
     {
@@ -542,9 +594,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 144
+          "playCount": 145
         },
-        "updatedAt": "2026-03-24T19:20:25.138Z"
+        "updatedAt": "2026-06-15T07:29:06.536Z"
       }
     },
     {
@@ -596,9 +648,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 27
+          "playCount": 28
         },
-        "updatedAt": "2026-03-30T01:48:19.586Z"
+        "updatedAt": "2026-06-20T16:03:51.698Z"
       }
     },
     {
@@ -623,9 +675,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 42
+          "playCount": 43
         },
-        "updatedAt": "2026-05-30T11:38:00.196Z"
+        "updatedAt": "2026-06-20T16:04:16.998Z"
       }
     },
     {
@@ -651,9 +703,9 @@
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 40
+          "playCount": 43
         },
-        "updatedAt": "2026-05-30T10:53:08.852Z"
+        "updatedAt": "2026-06-23T14:25:09.899Z"
       }
     },
     {
@@ -697,15 +749,14 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-08-19T23:38:08.803Z",
-        "favoriteCount": 1,
         "stats": {
-          "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 65
+          "likeCount": 1,
+          "playCount": 69
         },
-        "updatedAt": "2026-05-30T13:37:27.093Z"
+        "updatedAt": "2026-06-20T16:00:50.726Z"
       }
     },
     {
@@ -781,6 +832,1125 @@
           "playCount": 19
         },
         "updatedAt": "2026-01-18T05:31:09.044Z"
+      }
+    },
+    {
+      "id": "NadVf6t5ruaf4GQCctpP",
+      "data": {
+        "buttonText": "兄弟じゃん",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 6437.9,
+        "endTime": 6451.1,
+        "duration": 13.200000000000728,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-26T07:59:14.864Z",
+        "id": "NadVf6t5ruaf4GQCctpP",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 5
+        },
+        "updatedAt": "2026-06-29T11:44:21.484Z"
+      }
+    },
+    {
+      "id": "OhoTxRzPfFiG5pOKgYsy",
+      "data": {
+        "buttonText": "よわよわ〜",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 6677.1,
+        "endTime": 6680.5,
+        "duration": 3.399999999999636,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-26T08:05:59.437Z",
+        "id": "OhoTxRzPfFiG5pOKgYsy",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 5
+        },
+        "updatedAt": "2026-06-29T11:44:16.961Z"
+      }
+    },
+    {
+      "id": "PXyeFqk1HvXN9Cmb466k",
+      "data": {
+        "buttonText": "惚れ直してしまうわ",
+        "videoId": "uGfEIvsBH6s",
+        "videoTitle": "本日も開店します☕【COFFEE TALK #5／物語のネタバレを含みます】",
+        "startTime": 3619.1,
+        "endTime": 3622.1,
+        "duration": 3,
+        "tags": [
+          "ゲーム",
+          "coffee talk"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-08-12T12:01:21.406Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0.1,
+          "playCount": 43
+        },
+        "updatedAt": "2026-06-20T16:00:43.581Z"
+      }
+    },
+    {
+      "id": "PdISiTzaHzzt48HdF4W3",
+      "data": {
+        "buttonText": "We Wish You a Merry Christmas (?)",
+        "videoId": "wWTmChxPaMc",
+        "videoTitle": "1日早いけどケーキ食べよ🎄💗",
+        "startTime": 5455,
+        "endTime": 5466,
+        "duration": 11,
+        "tags": [
+          "クリスマス"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "Siang*",
+        "isPublic": true,
+        "createdAt": "2025-08-01T18:03:04.002Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0.047619047619047616,
+          "playCount": 33
+        },
+        "updatedAt": "2026-06-20T16:03:18.627Z"
+      }
+    },
+    {
+      "id": "PhFSkJVLET9XSZpxKDhK",
+      "data": {
+        "buttonText": "待ってくれ〜",
+        "videoId": "GJZQPvOYXyY",
+        "videoTitle": "【みやぢ×みなせ】怖がり2人で初見協力プレイ。【BIOHAZARD 5】",
+        "startTime": 5204,
+        "endTime": 5208,
+        "duration": 4,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 8,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2025-07-12T02:42:32.524Z",
+        "updatedAt": "2025-08-17T16:53:30.784Z"
+      }
+    },
+    {
+      "id": "Q29R6nH6BKblaFRlTfBM",
+      "data": {
+        "buttonText": "ﾁﾞｭｳｳｳ...",
+        "videoId": "44sdknho7e4",
+        "videoTitle": "かわいいにゃんこのパズルゲームで遊ぶ♥【KU100バイノーラル／Cats Organized Neatly#2】",
+        "startTime": 8649,
+        "endTime": 8668,
+        "duration": 19,
+        "tags": [
+          "Cats Organized Neatly"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "Siang*",
+        "isPublic": true,
+        "createdAt": "2025-08-01T18:32:06.486Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0,
+          "playCount": 91
+        },
+        "updatedAt": "2026-06-15T14:25:05.656Z"
+      }
+    },
+    {
+      "id": "Qt6VeSfVAPvwblCxjjNn",
+      "data": {
+        "buttonText": "すげーよなー",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 3734,
+        "endTime": 3736,
+        "duration": 2,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-30T12:46:34.571Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 22
+        },
+        "updatedAt": "2026-05-30T13:38:25.100Z"
+      }
+    },
+    {
+      "id": "TzsmNnHDE3P9U4mOOSBr",
+      "data": {
+        "buttonText": "会話力と察し力必要よこれ",
+        "videoId": "ds8nkv4LW_8",
+        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
+        "startTime": 1300.5,
+        "endTime": 1303.7,
+        "duration": 3.2000000000000455,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-18T05:38:15.306Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 15
+        },
+        "updatedAt": "2026-03-24T19:21:32.909Z"
+      }
+    },
+    {
+      "id": "X8e8QwbAA64jc9JaVpSl",
+      "data": {
+        "buttonText": "とぅるるる​​ふんとぅはい！",
+        "videoId": "_dATpIe2Vco",
+        "videoTitle": "チルい音ゲーでまったり遊ぶ🌸【Melatonin／KU100バイノーラル】",
+        "startTime": 6845.7,
+        "endTime": 6849.2,
+        "duration": 3.5,
+        "tags": [
+          "MELATONIN"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "Siang*",
+        "isPublic": true,
+        "createdAt": "2025-08-01T17:47:14.319Z",
+        "stats": {
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0,
+          "likeCount": 1,
+          "playCount": 33
+        },
+        "updatedAt": "2026-03-30T01:47:10.266Z"
+      }
+    },
+    {
+      "id": "YcUiNywqbsw832SFvWJA",
+      "data": {
+        "buttonText": "大変だよそりゃ",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 4049,
+        "endTime": 4053,
+        "duration": 4,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-30T12:54:41.215Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 38
+        },
+        "updatedAt": "2026-06-15T14:24:51.347Z"
+      }
+    },
+    {
+      "id": "YrqEnBDNQMMf7MDrEM2V",
+      "data": {
+        "buttonText": "釣りしてるよ〜",
+        "videoId": "RZc58Hug7X4",
+        "videoTitle": "まったりファンタジール生活🌟【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#5】",
+        "startTime": 7216,
+        "endTime": 7219,
+        "duration": 3,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-29T01:42:31.108Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 25
+        },
+        "updatedAt": "2026-03-24T19:22:03.154Z"
+      }
+    },
+    {
+      "id": "aCXsJvjsR7qxbvsQKfgO",
+      "data": {
+        "buttonText": "ギャルはファンタジーに入りますか？",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 6720,
+        "endTime": 6723,
+        "duration": 3,
+        "tags": [
+          "雑談"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-30T12:36:35.459Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 40
+        },
+        "updatedAt": "2026-03-24T19:22:49.516Z"
+      }
+    },
+    {
+      "id": "afV0j4jL1us8mu4wE5QK",
+      "data": {
+        "buttonText": "転生するならダウナー系の活動者になるっていう話をしてて",
+        "videoId": "ds8nkv4LW_8",
+        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
+        "startTime": 71.3,
+        "endTime": 78.7,
+        "duration": 7.400000000000006,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-18T07:27:57.232Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 27
+        },
+        "updatedAt": "2026-05-30T17:07:39.069Z"
+      }
+    },
+    {
+      "id": "cdr2QzdF5gmkuqAXyyoL",
+      "data": {
+        "buttonText": "うふふ(笑)",
+        "videoId": "iCZxh1oyLKg",
+        "videoTitle": "お喋りと歌のリハビリ😎🌸",
+        "startTime": 1026,
+        "endTime": 1028,
+        "duration": 2,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "ゆうほー",
+        "isPublic": true,
+        "createdAt": "2025-07-05T06:22:42.302Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0.05555555555555555,
+          "playCount": 22
+        },
+        "updatedAt": "2026-03-24T19:22:58.576Z"
+      }
+    },
+    {
+      "id": "dDJioylOH8XKZ1Fg7Pcm",
+      "data": {
+        "buttonText": "こんばんは",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 75,
+        "endTime": 79,
+        "duration": 4,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-01T15:31:08.746Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 15
+        },
+        "updatedAt": "2026-03-24T19:22:54.727Z"
+      }
+    },
+    {
+      "id": "ejaSupvD8SjH4PPFRLUx",
+      "data": {
+        "buttonText": "ゴクリ",
+        "videoId": "GJZQPvOYXyY",
+        "videoTitle": "【みやぢ×みなせ】怖がり2人で初見協力プレイ。【BIOHAZARD 5】",
+        "startTime": 6,
+        "endTime": 8,
+        "duration": 2,
+        "tags": [
+          "バイオハザード5",
+          "ゲーム"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-12T03:16:04.322Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 20
+        },
+        "updatedAt": "2026-01-18T09:17:21.878Z"
+      }
+    },
+    {
+      "id": "fmxSqi1lcb15p3dxJwnS",
+      "data": {
+        "buttonText": "バハ・ハ",
+        "videoId": "h5FZgLVDJGk",
+        "videoTitle": "タマゲいっぱいみつけるぞ～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#6】",
+        "startTime": 283.6,
+        "endTime": 285,
+        "duration": 1.3999999999999773,
+        "tags": [
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "gagacrow",
+        "isPublic": true,
+        "createdAt": "2025-07-27T04:41:27.924Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0.006896551724137931,
+          "playCount": 151
+        },
+        "updatedAt": "2026-03-24T19:20:08.895Z"
+      }
+    },
+    {
+      "id": "gwawPNPuHSOApqILEEXK",
+      "data": {
+        "buttonText": "じゅうしゃんレベル",
+        "videoId": "B20PhTUzSrQ",
+        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
+        "startTime": 7323.9,
+        "endTime": 7325.9,
+        "duration": 2,
+        "tags": [
+          "ゲーム",
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-26T14:48:20.586Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0.005319148936170213,
+          "playCount": 196
+        },
+        "updatedAt": "2026-05-06T16:07:24.110Z"
+      }
+    },
+    {
+      "id": "hVZ4NyF1woObai9R3vQa",
+      "data": {
+        "buttonText": "直始めにしてみた",
+        "videoId": "B20PhTUzSrQ",
+        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
+        "startTime": 46.8,
+        "endTime": 50.1,
+        "duration": 3.3000000000000043,
+        "tags": [
+          "ゲーム",
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-23T23:59:09.455Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 81
+        },
+        "updatedAt": "2026-01-18T04:13:48.602Z"
+      }
+    },
+    {
+      "id": "jKasN6FfALO922utZz19",
+      "data": {
+        "buttonText": "がんばるよーフィーバーフィーバー",
+        "videoId": "B20PhTUzSrQ",
+        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
+        "startTime": 6048,
+        "endTime": 6052.1,
+        "duration": 4.100000000000364,
+        "tags": [
+          "ゲーム",
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-26T13:47:33.476Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 144
+        },
+        "updatedAt": "2026-03-30T01:47:18.561Z"
+      }
+    },
+    {
+      "id": "kCeaYC2sVulAD9hqg2Xi",
+      "data": {
+        "buttonText": "なんで誕生日にこんな思いせなあかんねん",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 5788.2,
+        "endTime": 5792.6,
+        "duration": 4.400000000000546,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-26T07:43:27.650Z",
+        "id": "kCeaYC2sVulAD9hqg2Xi",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 2
+        },
+        "updatedAt": "2026-06-26T07:55:18.452Z"
+      }
+    },
+    {
+      "id": "khLQgdM0FtpnuTn6VxOi",
+      "data": {
+        "buttonText": "ベェ",
+        "videoId": "97UnRtIlMc0",
+        "videoTitle": "全てのライフの力を合わせて…ギア作り！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#11】",
+        "startTime": 4993.6,
+        "endTime": 4995.7,
+        "duration": 2.0999999999994543,
+        "tags": [
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-27T14:09:12.074Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 78
+        },
+        "updatedAt": "2026-05-20T04:12:25.280Z"
+      }
+    },
+    {
+      "id": "kssdZrpolpPRS1wvGDNO",
+      "data": {
+        "buttonText": "「大好きだよ」みたいなのを女の子同士で言い合って",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 4628,
+        "endTime": 4633,
+        "duration": 5,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-30T12:48:38.369Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 29
+        },
+        "updatedAt": "2026-06-20T16:05:03.905Z"
+      }
+    },
+    {
+      "id": "l5eg01chnTLarrLYdtWt",
+      "data": {
+        "buttonText": "わてにもわからん",
+        "videoId": "djUaF_-2MC8",
+        "videoTitle": "そろそろエドワード助けにいくか～！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#7】",
+        "startTime": 4104,
+        "endTime": 4107,
+        "duration": 3,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-07T06:40:45.523Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 31
+        },
+        "updatedAt": "2026-03-24T19:23:11.492Z"
+      }
+    },
+    {
+      "id": "lplSH14aSgptgueC687X",
+      "data": {
+        "buttonText": "Open",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 13575.1,
+        "endTime": 13576.7,
+        "duration": 1.6000000000003638,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-27T01:31:03.983Z",
+        "id": "lplSH14aSgptgueC687X",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 5
+        },
+        "updatedAt": "2026-06-29T11:00:24.991Z"
+      }
+    },
+    {
+      "id": "m7cApOwwbj6tkJT9B6lp",
+      "data": {
+        "buttonText": "泣いてるよ",
+        "videoId": "ds8nkv4LW_8",
+        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
+        "startTime": 2309,
+        "endTime": 2311.3,
+        "duration": 2.300000000000182,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-18T05:14:57.365Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 16
+        },
+        "updatedAt": "2026-03-24T19:21:38.085Z"
+      }
+    },
+    {
+      "id": "mJtBdtQweZSeixjPgA76",
+      "data": {
+        "buttonText": "あんたいいやつじゃん…すりすり",
+        "videoId": "S534eutWhUY",
+        "videoTitle": "今日はどんなお客さんが来るかな…☕？【COFFEE TALK #6／物語のネタバレを含みます】",
+        "startTime": 5924.4,
+        "endTime": 5927.6,
+        "duration": 3.2000000000007276,
+        "creatorId": "REDACTED",
+        "creatorName": "ivan",
+        "isPublic": true,
+        "createdAt": "2025-08-21T01:02:51.250Z",
+        "id": "mJtBdtQweZSeixjPgA76",
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "stats": {
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "likeCount": 2,
+          "playCount": 71
+        },
+        "updatedAt": "2026-06-20T16:17:07.510Z"
+      }
+    },
+    {
+      "id": "qJxXRSS7Cek5HMQhR6bZ",
+      "data": {
+        "buttonText": "改めまして涼花みなせです",
+        "videoId": "GJZQPvOYXyY",
+        "videoTitle": "【みやぢ×みなせ】怖がり2人で初見協力プレイ。【BIOHAZARD 5】",
+        "startTime": 1131,
+        "endTime": 1134,
+        "duration": 3,
+        "tags": [
+          "ゲーム",
+          "バイオハザード5"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-12T03:41:37.916Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": -1,
+          "engagementRate": 0,
+          "playCount": 50
+        },
+        "updatedAt": "2026-06-20T16:04:11.289Z"
+      }
+    },
+    {
+      "id": "rPAGgplNWYbhKC9gHAyG",
+      "data": {
+        "buttonText": "このキャバクラで誕生日迎えることになる！",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 2797.4,
+        "endTime": 2802.8,
+        "duration": 5.400000000000091,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-21T11:15:15.702Z",
+        "id": "rPAGgplNWYbhKC9gHAyG",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 5
+        },
+        "updatedAt": "2026-06-26T07:55:30.999Z"
+      }
+    },
+    {
+      "id": "s016OX6i1gtylTFr0qe9",
+      "data": {
+        "buttonText": "あらあら〜　歯医者のこと聞きたいんだ〜　そうかそうか〜",
+        "videoId": "FeZ3F5dr6H8",
+        "videoTitle": "ざつだん🌟",
+        "startTime": 971,
+        "endTime": 980,
+        "duration": 9,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-30T12:34:41.082Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0,
+          "playCount": 30
+        },
+        "updatedAt": "2026-05-30T13:38:17.890Z"
+      }
+    },
+    {
+      "id": "sFCVeD8ywqYsJPitFADk",
+      "data": {
+        "buttonText": "こんばんはー",
+        "videoId": "ds8nkv4LW_8",
+        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
+        "startTime": 20.1,
+        "endTime": 22.7,
+        "duration": 2.599999999999998,
+        "tags": [
+          "ゲーム",
+          "挨拶",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-18T07:20:02.049Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 16
+        },
+        "updatedAt": "2026-03-24T19:21:30.289Z"
+      }
+    },
+    {
+      "id": "sMqrHeNEuOOUHflC0AzB",
+      "data": {
+        "buttonText": "カンニングするなってこと！？",
+        "videoId": "S534eutWhUY",
+        "videoTitle": "今日はどんなお客さんが来るかな…☕？【COFFEE TALK #6／物語のネタバレを含みます】",
+        "startTime": 4078.8,
+        "endTime": 4081.2,
+        "duration": 2.399999999999636,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-08-19T23:31:02.139Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 25
+        },
+        "updatedAt": "2026-06-20T16:02:01.292Z"
+      }
+    },
+    {
+      "id": "sNgTr6YLSFOsMXx19NL0",
+      "data": {
+        "buttonText": "やべえ！",
+        "videoId": "4puiyit3sp0",
+        "videoTitle": "世界を滅亡から救うか寄り道するのか...自由だぁ～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#8】",
+        "startTime": 3195,
+        "endTime": 3197,
+        "duration": 2,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-08T12:48:57.115Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 17
+        },
+        "updatedAt": "2026-03-30T01:48:47.492Z"
+      }
+    },
+    {
+      "id": "t7iLQ2POVXdg8yGuHxCJ",
+      "data": {
+        "buttonText": "そんでさあ…え、あ、な、なに？",
+        "videoId": "B20PhTUzSrQ",
+        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
+        "startTime": 284.4,
+        "endTime": 288.3,
+        "duration": 3.900000000000034,
+        "tags": [
+          "ゲーム",
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-24T03:51:45.649Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 135
+        },
+        "updatedAt": "2026-06-15T07:28:58.535Z"
+      }
+    },
+    {
+      "id": "tD2Vh18xqywurfUzuKmz",
+      "data": {
+        "buttonText": "腹減ったー",
+        "videoId": "iCZxh1oyLKg",
+        "videoTitle": "お喋りと歌のリハビリ😎🌸",
+        "startTime": 4782,
+        "endTime": 4784,
+        "duration": 2,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "ivan",
+        "isPublic": true,
+        "createdAt": "2025-07-07T02:47:20.828Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0.05555555555555555,
+          "playCount": 20
+        },
+        "updatedAt": "2026-03-24T19:23:01.268Z"
+      }
+    },
+    {
+      "id": "uKVVbvmKgJnvAG8QHrLY",
+      "data": {
+        "buttonText": "あたまいてぇ",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 2235,
+        "endTime": 2238,
+        "duration": 3,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-29T13:35:37.825Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 18
+        },
+        "updatedAt": "2026-01-18T09:16:16.732Z"
+      }
+    },
+    {
+      "id": "v9ZvWQ6DHmaga31OBaJr",
+      "data": {
+        "buttonText": "闇のあるストーリー、読ませて欲しい、あたしに",
+        "videoId": "ds8nkv4LW_8",
+        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
+        "startTime": 5010.4,
+        "endTime": 5013.9,
+        "duration": 3.5,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-18T10:55:58.279Z",
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0.02127659574468085,
+          "playCount": 54
+        },
+        "updatedAt": "2026-06-02T10:56:00.719Z"
+      }
+    },
+    {
+      "id": "vA49RzYP9CUqrg5la4bx",
+      "data": {
+        "buttonText": "なぁ～～～～～～～～～～",
+        "videoId": "B20PhTUzSrQ",
+        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
+        "startTime": 7747.5,
+        "endTime": 7751.6,
+        "duration": 4.100000000000364,
+        "tags": [
+          "ファンタジーライフ"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "Siang*",
+        "isPublic": true,
+        "createdAt": "2025-07-24T17:45:59.144Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0,
+          "playCount": 142
+        },
+        "updatedAt": "2026-05-06T16:07:43.372Z"
+      }
+    },
+    {
+      "id": "xLOcSm24HACc1u1CQ4Tf",
+      "data": {
+        "buttonText": "ちゅ、ちゅぱ？",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 2048,
+        "endTime": 2050.1,
+        "duration": 2.099999999999909,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-21T10:54:45.322Z",
+        "id": "xLOcSm24HACc1u1CQ4Tf",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 6
+        },
+        "updatedAt": "2026-07-03T20:20:48.249Z"
+      }
+    },
+    {
+      "id": "xP98sGmfFvZXqeBZKAUr",
+      "data": {
+        "buttonText": "斜にかまえてさぁ",
+        "videoId": "rUKrc8czZj0",
+        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
+        "startTime": 1136,
+        "endTime": 1138,
+        "duration": 2,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-06-29T01:40:17.967Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 22
+        },
+        "updatedAt": "2026-03-24T19:21:54.923Z"
+      }
+    },
+    {
+      "id": "xwx7ItC3hCXIpbdEJTsU",
+      "data": {
+        "buttonText": "開店前待機ありがとう",
+        "videoId": "S534eutWhUY",
+        "videoTitle": "今日はどんなお客さんが来るかな…☕？【COFFEE TALK #6／物語のネタバレを含みます】",
+        "startTime": 32,
+        "endTime": 38.7,
+        "duration": 6.700000000000003,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-08-20T03:57:52.305Z",
+        "id": "xwx7ItC3hCXIpbdEJTsU",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 23
+        },
+        "updatedAt": "2026-06-20T16:01:53.488Z"
+      }
+    },
+    {
+      "id": "xxOUWJnipXcQ7k1TJbO9",
+      "data": {
+        "buttonText": "いらっしゃい",
+        "videoId": "ds8nkv4LW_8",
+        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
+        "startTime": 4289.6,
+        "endTime": 4291.7,
+        "duration": 2.0999999999994543,
+        "tags": [
+          "ゲーム",
+          "COFFEE TALK",
+          "挨拶"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2025-07-16T13:14:15.795Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 15
+        },
+        "updatedAt": "2026-01-26T05:37:34.017Z"
+      }
+    },
+    {
+      "id": "zps859BKdOqSq22ONtGo",
+      "data": {
+        "buttonText": "ナマをカタカナをやめなさい！",
+        "videoId": "aoWkEzZD8zA",
+        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
+        "startTime": 2426,
+        "endTime": 2429.4,
+        "duration": 3.400000000000091,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-06-21T11:03:18.090Z",
+        "id": "zps859BKdOqSq22ONtGo",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 4
+        },
+        "updatedAt": "2026-06-26T14:44:53.151Z"
       }
     }
   ]

--- a/apps/functions/src/tools/firestore-local/fixtures/circles.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/circles.json
@@ -137,9 +137,6 @@
         "circleId": "RG01005392",
         "name": "ゆきんこ王国",
         "nameEn": "",
-        "workIds": [
-          "RJ01609516"
-        ],
         "createdAt": {
           "__type__": "timestamp",
           "seconds": 1777316601,
@@ -147,9 +144,13 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1777316601,
-          "nanoseconds": 689000000
-        }
+          "seconds": 1781975014,
+          "nanoseconds": 190000000
+        },
+        "workIds": [
+          "RJ01609516",
+          "RJ01634555"
+        ]
       }
     },
     {
@@ -186,8 +187,8 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1774544623,
-          "nanoseconds": 795000000
+          "seconds": 1781816612,
+          "nanoseconds": 465000000
         },
         "workIds": [
           "RJ01122461",
@@ -198,7 +199,8 @@
           "RJ01411411",
           "RJ01511327",
           "RJ01556806",
-          "RJ01584196"
+          "RJ01584196",
+          "RJ01643492"
         ]
       }
     },
@@ -215,13 +217,14 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1769706480,
-          "nanoseconds": 454000000
+          "seconds": 1782414227,
+          "nanoseconds": 46000000
         },
         "workIds": [
           "RJ01349891",
           "RJ01400154",
-          "RJ01530810"
+          "RJ01530810",
+          "RJ01636524"
         ]
       }
     },
@@ -482,9 +485,6 @@
         "circleId": "RG01018276",
         "name": "貞操観念逆転世界",
         "nameEn": "Abekobe World",
-        "workIds": [
-          "RJ01496560"
-        ],
         "createdAt": {
           "__type__": "timestamp",
           "seconds": 1762441679,
@@ -492,9 +492,13 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1762441679,
-          "nanoseconds": 930000000
-        }
+          "seconds": 1781888634,
+          "nanoseconds": 625000000
+        },
+        "workIds": [
+          "RJ01496560",
+          "RJ01647085"
+        ]
       }
     },
     {
@@ -554,12 +558,14 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1771700880,
-          "nanoseconds": 289000000
+          "seconds": 1783098230,
+          "nanoseconds": 802000000
         },
         "workIds": [
           "RJ01241841",
-          "RJ01570263"
+          "RJ01570263",
+          "RJ01633481",
+          "RJ01652658"
         ]
       }
     },
@@ -673,6 +679,1591 @@
           "__type__": "timestamp",
           "seconds": 1753876194,
           "nanoseconds": 521000000
+        }
+      }
+    },
+    {
+      "id": "RG01022386",
+      "data": {
+        "circleId": "RG01022386",
+        "name": "みるくぼいす",
+        "nameEn": "Milk Voice",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876218,
+          "nanoseconds": 21000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753977651,
+          "nanoseconds": 186000000
+        },
+        "workIds": [
+          "RJ01224901",
+          "RJ01388715"
+        ]
+      }
+    },
+    {
+      "id": "RG01023593",
+      "data": {
+        "circleId": "RG01023593",
+        "name": "ぐらまらす工房",
+        "nameEn": "",
+        "workIds": [
+          "RJ01558916"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1771089209,
+          "nanoseconds": 878000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1771089209,
+          "nanoseconds": 878000000
+        }
+      }
+    },
+    {
+      "id": "RG01027231",
+      "data": {
+        "name": "はにぃらばぁず",
+        "nameEn": "",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1779649416,
+          "nanoseconds": 560000000
+        },
+        "circleId": "RG01027231",
+        "workIds": [
+          "RJ01629751",
+          "RJ01629775",
+          "RJ01629696",
+          "RJ01618525"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1780164209,
+          "nanoseconds": 156000000
+        }
+      }
+    },
+    {
+      "id": "RG01027625",
+      "data": {
+        "circleId": "RG01027625",
+        "name": "しきよく",
+        "nameEn": "Shikiyoku",
+        "workIds": [
+          "RJ01324228"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1774717417,
+          "nanoseconds": 925000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1774717417,
+          "nanoseconds": 925000000
+        }
+      }
+    },
+    {
+      "id": "RG01027849",
+      "data": {
+        "circleId": "RG01027849",
+        "name": "絵空色マーブル",
+        "nameEn": "",
+        "workIds": [
+          "RJ01555459"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1772658620,
+          "nanoseconds": 480000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1772658620,
+          "nanoseconds": 480000000
+        }
+      }
+    },
+    {
+      "id": "RG01028022",
+      "data": {
+        "circleId": "RG01028022",
+        "name": "濃密デザイア",
+        "nameEn": "",
+        "workIds": [
+          "RJ01335281"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876216,
+          "nanoseconds": 691000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876216,
+          "nanoseconds": 691000000
+        }
+      }
+    },
+    {
+      "id": "RG01029496",
+      "data": {
+        "circleId": "RG01029496",
+        "name": "オナサポ本舗",
+        "nameEn": "Onasapo honpo",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1759158474,
+          "nanoseconds": 533000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782745426,
+          "nanoseconds": 507000000
+        },
+        "workIds": [
+          "RJ01460492",
+          "RJ01575992",
+          "RJ01645948"
+        ]
+      }
+    },
+    {
+      "id": "RG01032286",
+      "data": {
+        "circleId": "RG01032286",
+        "name": "三度の飯よりフェチが好き",
+        "nameEn": "",
+        "workIds": [
+          "RJ01648884"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1782414227,
+          "nanoseconds": 57000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782414227,
+          "nanoseconds": 57000000
+        }
+      }
+    },
+    {
+      "id": "RG01040175",
+      "data": {
+        "circleId": "RG01040175",
+        "name": "studio'K",
+        "nameEn": "studiok",
+        "workIds": [
+          "RJ01584240"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1775667804,
+          "nanoseconds": 51000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1775667804,
+          "nanoseconds": 51000000
+        }
+      }
+    },
+    {
+      "id": "RG01044727",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1766768874,
+          "nanoseconds": 164000000
+        },
+        "nameEn": "MIMIHEKI",
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1766768874,
+          "nanoseconds": 164000000
+        },
+        "workIds": [
+          "RJ01530630"
+        ],
+        "circleId": "RG01044727",
+        "name": "MIMIHEKI"
+      }
+    },
+    {
+      "id": "RG01050215",
+      "data": {
+        "circleId": "RG01050215",
+        "name": "猫project(仮)",
+        "nameEn": "",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1754064859,
+          "nanoseconds": 372000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1761944872,
+          "nanoseconds": 558000000
+        },
+        "workIds": [
+          "RJ01422252",
+          "RJ01497775"
+        ]
+      }
+    },
+    {
+      "id": "RG01051273",
+      "data": {
+        "circleId": "RG01051273",
+        "name": "火星エリンギ",
+        "nameEn": "",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1755011291,
+          "nanoseconds": 816000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1780938223,
+          "nanoseconds": 907000000
+        },
+        "workIds": [
+          "RJ01445232",
+          "RJ01455862",
+          "RJ01465001",
+          "RJ01469894",
+          "RJ01480610",
+          "RJ01497485",
+          "RJ01503123",
+          "RJ01610903",
+          "RJ01634289"
+        ]
+      }
+    },
+    {
+      "id": "RG01064888",
+      "data": {
+        "circleId": "RG01064888",
+        "name": "花うさキャット",
+        "nameEn": "Flowers rabbits cats",
+        "workIds": [
+          "RJ01562477"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1771614532,
+          "nanoseconds": 748000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1771614532,
+          "nanoseconds": 749000000
+        }
+      }
+    },
+    {
+      "id": "RG01066930",
+      "data": {
+        "workIds": [
+          "RJ01623824"
+        ],
+        "circleId": "RG01066930",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1779390213,
+          "nanoseconds": 802000000
+        },
+        "name": "エロフの性活",
+        "nameEn": "Erofunoseikatsu",
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779390213,
+          "nanoseconds": 802000000
+        }
+      }
+    },
+    {
+      "id": "RG02715",
+      "data": {
+        "circleId": "RG02715",
+        "name": "描き屋Kiyoshi",
+        "nameEn": "EGAKIYA Kiyoshi",
+        "workIds": [
+          "RJ247201"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876100,
+          "nanoseconds": 280000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876100,
+          "nanoseconds": 280000000
+        }
+      }
+    },
+    {
+      "id": "RG02920",
+      "data": {
+        "circleId": "RG02920",
+        "name": "#define",
+        "nameEn": "#define",
+        "workIds": [
+          "RJ322228"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876120,
+          "nanoseconds": 430000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876120,
+          "nanoseconds": 430000000
+        }
+      }
+    },
+    {
+      "id": "RG04303",
+      "data": {
+        "circleId": "RG04303",
+        "name": "Diebrust(ディーブルスト)",
+        "nameEn": "Die brust",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 154000000
+        },
+        "workIds": [
+          "RJ265409",
+          "RJ266690",
+          "RJ266582",
+          "RJ304755",
+          "RJ305009",
+          "RJ337692",
+          "RJ01214488"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876189,
+          "nanoseconds": 589000000
+        }
+      }
+    },
+    {
+      "id": "RG04325",
+      "data": {
+        "circleId": "RG04325",
+        "name": "かぐら堂",
+        "nameEn": "kagurado",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876150,
+          "nanoseconds": 216000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1764961695,
+          "nanoseconds": 76000000
+        },
+        "workIds": [
+          "RJ01025856",
+          "RJ428245",
+          "RJ01133152",
+          "RJ01519121",
+          "RJ01519189"
+        ]
+      }
+    },
+    {
+      "id": "RG05016",
+      "data": {
+        "circleId": "RG05016",
+        "name": "劇團近未来",
+        "nameEn": "GEKIDAN-KINMIRAI",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 779000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782241425,
+          "nanoseconds": 539000000
+        },
+        "workIds": [
+          "RJ269259",
+          "RJ269963",
+          "RJ290229",
+          "RJ297238",
+          "RJ318122",
+          "RJ334076",
+          "RJ362145",
+          "RJ371486",
+          "RJ437618",
+          "RJ437622",
+          "RJ01141485",
+          "RJ01241448",
+          "RJ01471262",
+          "RJ01551490",
+          "RJ01649547"
+        ]
+      }
+    },
+    {
+      "id": "RG08135",
+      "data": {
+        "circleId": "RG08135",
+        "name": "ザッヘル音響",
+        "nameEn": "Zaphel Onkyo",
+        "workIds": [
+          "RJ300529"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876116,
+          "nanoseconds": 686000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876116,
+          "nanoseconds": 686000000
+        }
+      }
+    },
+    {
+      "id": "RG09985",
+      "data": {
+        "circleId": "RG09985",
+        "name": "エロトランス",
+        "nameEn": "ero trance",
+        "workIds": [
+          "RJ01129635"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876178,
+          "nanoseconds": 97000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876178,
+          "nanoseconds": 97000000
+        }
+      }
+    },
+    {
+      "id": "RG10971",
+      "data": {
+        "circleId": "RG10971",
+        "name": "VOICE LOVER",
+        "nameEn": "VOICE LOVER",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876100,
+          "nanoseconds": 652000000
+        },
+        "workIds": [
+          "RJ252366",
+          "RJ265142",
+          "RJ280066",
+          "RJ296780"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876113,
+          "nanoseconds": 297000000
+        }
+      }
+    },
+    {
+      "id": "RG11559",
+      "data": {
+        "circleId": "RG11559",
+        "name": "18禁SE",
+        "nameEn": "18kin SE",
+        "workIds": [
+          "RJ289855"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 620000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 620000000
+        }
+      }
+    },
+    {
+      "id": "RG12053",
+      "data": {
+        "circleId": "RG12053",
+        "name": "DreamLight",
+        "nameEn": "DreamLight",
+        "workIds": [
+          "RJ279832"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876107,
+          "nanoseconds": 320000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876107,
+          "nanoseconds": 320000000
+        }
+      }
+    },
+    {
+      "id": "RG13534",
+      "data": {
+        "circleId": "RG13534",
+        "name": "PINKISH ATION",
+        "nameEn": "PINKISH ATION",
+        "workIds": [
+          "RJ245527"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876099,
+          "nanoseconds": 792000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876099,
+          "nanoseconds": 792000000
+        }
+      }
+    },
+    {
+      "id": "RG14379",
+      "data": {
+        "circleId": "RG14379",
+        "name": "はっぴーすとろべりー",
+        "nameEn": "HappyStrawberry",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876129,
+          "nanoseconds": 946000000
+        },
+        "workIds": [
+          "RJ290707",
+          "RJ416832"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876196,
+          "nanoseconds": 282000000
+        }
+      }
+    },
+    {
+      "id": "RG14780",
+      "data": {
+        "circleId": "RG14780",
+        "name": "軒下の猫屋",
+        "nameEn": "Cathouse Under A Roof",
+        "workIds": [
+          "RJ01116532"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876178,
+          "nanoseconds": 178000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876178,
+          "nanoseconds": 178000000
+        }
+      }
+    },
+    {
+      "id": "RG15193",
+      "data": {
+        "circleId": "RG15193",
+        "name": "夜のひつじ",
+        "nameEn": "Night-time Sheep",
+        "workIds": [
+          "RJ275492"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876105,
+          "nanoseconds": 611000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876105,
+          "nanoseconds": 611000000
+        }
+      }
+    },
+    {
+      "id": "RG15338",
+      "data": {
+        "circleId": "RG15338",
+        "name": "The Nation of Head Scissors",
+        "nameEn": "The Nation of Head Scissors",
+        "workIds": [
+          "RJ295229"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876113,
+          "nanoseconds": 454000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876113,
+          "nanoseconds": 454000000
+        }
+      }
+    },
+    {
+      "id": "RG15563",
+      "data": {
+        "circleId": "RG15563",
+        "name": "18禁音声サークル「凌辱」",
+        "nameEn": "R-18 Voice Circle Assault",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876120,
+          "nanoseconds": 722000000
+        },
+        "workIds": [
+          "RJ324521",
+          "RJ329715",
+          "RJ334634",
+          "RJ335049",
+          "RJ362600",
+          "RJ381946",
+          "RJ411875",
+          "RJ01000639",
+          "RJ01128309"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876176,
+          "nanoseconds": 217000000
+        }
+      }
+    },
+    {
+      "id": "RG15773",
+      "data": {
+        "circleId": "RG15773",
+        "name": "F.T.W.",
+        "nameEn": "F.T.W.",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876105,
+          "nanoseconds": 247000000
+        },
+        "workIds": [
+          "RJ274366",
+          "RJ279948"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876106,
+          "nanoseconds": 955000000
+        }
+      }
+    },
+    {
+      "id": "RG16577",
+      "data": {
+        "circleId": "RG16577",
+        "name": "T.s project",
+        "nameEn": "T.s  project",
+        "workIds": [
+          "RJ328877"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876124,
+          "nanoseconds": 818000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876124,
+          "nanoseconds": 818000000
+        }
+      }
+    },
+    {
+      "id": "RG17508",
+      "data": {
+        "circleId": "RG17508",
+        "name": "ダイジョビ研究所",
+        "nameEn": "Daijyobi Laboratory",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876109,
+          "nanoseconds": 212000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783011830,
+          "nanoseconds": 245000000
+        },
+        "workIds": [
+          "RJ284452",
+          "RJ286680",
+          "RJ01345578",
+          "RJ01166703",
+          "RJ01345588",
+          "RJ01445048"
+        ]
+      }
+    },
+    {
+      "id": "RG17517",
+      "data": {
+        "circleId": "RG17517",
+        "name": "Cipher",
+        "nameEn": "Cipher",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876134,
+          "nanoseconds": 83000000
+        },
+        "workIds": [
+          "RJ384001",
+          "RJ01095756"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876166,
+          "nanoseconds": 682000000
+        }
+      }
+    },
+    {
+      "id": "RG19069",
+      "data": {
+        "circleId": "RG19069",
+        "name": "EMUCUS",
+        "nameEn": "EMUCAS",
+        "workIds": [
+          "RJ243507"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876099,
+          "nanoseconds": 688000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876099,
+          "nanoseconds": 688000000
+        }
+      }
+    },
+    {
+      "id": "RG19615",
+      "data": {
+        "circleId": "RG19615",
+        "name": "防鯖潤滑剤",
+        "nameEn": "Bousaba Lubricant",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876118,
+          "nanoseconds": 465000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1766941669,
+          "nanoseconds": 43000000
+        },
+        "workIds": [
+          "RJ313962",
+          "RJ01011259",
+          "RJ01392160",
+          "RJ01526046",
+          "RJ01532269"
+        ]
+      }
+    },
+    {
+      "id": "RG20050",
+      "data": {
+        "circleId": "RG20050",
+        "name": "音撫屋",
+        "nameEn": "Otonadeya",
+        "workIds": [
+          "RJ395291"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876136,
+          "nanoseconds": 427000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876136,
+          "nanoseconds": 427000000
+        }
+      }
+    },
+    {
+      "id": "RG20507",
+      "data": {
+        "circleId": "RG20507",
+        "name": "ya-ho-games",
+        "nameEn": "ya-ho-games",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876100,
+          "nanoseconds": 137000000
+        },
+        "workIds": [
+          "RJ245512",
+          "RJ254981"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876101,
+          "nanoseconds": 60000000
+        }
+      }
+    },
+    {
+      "id": "RG20683",
+      "data": {
+        "circleId": "RG20683",
+        "name": "ristorante",
+        "nameEn": "ristorante",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876115,
+          "nanoseconds": 254000000
+        },
+        "workIds": [
+          "RJ286693",
+          "RJ342872",
+          "RJ363418",
+          "RJ392709",
+          "RJ424664"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876142,
+          "nanoseconds": 318000000
+        }
+      }
+    },
+    {
+      "id": "RG21311",
+      "data": {
+        "circleId": "RG21311",
+        "name": "USA WORKS",
+        "nameEn": "USA WORKS",
+        "workIds": [
+          "RJ307532"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876116,
+          "nanoseconds": 67000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876116,
+          "nanoseconds": 67000000
+        }
+      }
+    },
+    {
+      "id": "RG21781",
+      "data": {
+        "circleId": "RG21781",
+        "name": "FuenoNe Works",
+        "nameEn": "FuenoNe Works",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876105,
+          "nanoseconds": 69000000
+        },
+        "workIds": [
+          "RJ272080",
+          "RJ327060"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876122,
+          "nanoseconds": 75000000
+        }
+      }
+    },
+    {
+      "id": "RG22037",
+      "data": {
+        "circleId": "RG22037",
+        "name": "にこみどり",
+        "nameEn": "nicomidori",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876106,
+          "nanoseconds": 785000000
+        },
+        "workIds": [
+          "RJ278932",
+          "RJ291283",
+          "RJ320855",
+          "RJ338455",
+          "RJ386444"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876134,
+          "nanoseconds": 322000000
+        }
+      }
+    },
+    {
+      "id": "RG22409",
+      "data": {
+        "circleId": "RG22409",
+        "name": "ホワイトピンク",
+        "nameEn": "WHITE&PINK",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876150,
+          "nanoseconds": 108000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1771089213,
+          "nanoseconds": 277000000
+        },
+        "workIds": [
+          "RJ01019654",
+          "RJ01050764",
+          "RJ01052269",
+          "RJ01093931",
+          "RJ01215002",
+          "RJ01243187",
+          "RJ01309928",
+          "RJ01509126"
+        ]
+      }
+    },
+    {
+      "id": "RG22799",
+      "data": {
+        "circleId": "RG22799",
+        "name": "Highland",
+        "nameEn": "Highland",
+        "workIds": [
+          "RJ436948"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876150,
+          "nanoseconds": 63000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876150,
+          "nanoseconds": 63000000
+        }
+      }
+    },
+    {
+      "id": "RG22910",
+      "data": {
+        "circleId": "RG22910",
+        "name": "+Dream",
+        "nameEn": "+Dream",
+        "workIds": [
+          "RJ298510"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876114,
+          "nanoseconds": 820000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876114,
+          "nanoseconds": 820000000
+        }
+      }
+    },
+    {
+      "id": "RG23070",
+      "data": {
+        "circleId": "RG23070",
+        "name": "托卵JP",
+        "nameEn": "takuranJP",
+        "workIds": [
+          "RJ238915"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876099,
+          "nanoseconds": 601000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876099,
+          "nanoseconds": 601000000
+        }
+      }
+    },
+    {
+      "id": "RG23716",
+      "data": {
+        "circleId": "RG23716",
+        "name": "俺だけが得する音声工房",
+        "nameEn": "Ore-toku Voice factory",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876100,
+          "nanoseconds": 536000000
+        },
+        "workIds": [
+          "RJ248072",
+          "RJ267883",
+          "RJ278530",
+          "RJ293921",
+          "RJ293973"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876111,
+          "nanoseconds": 844000000
+        }
+      }
+    },
+    {
+      "id": "RG23954",
+      "data": {
+        "circleId": "RG23954",
+        "name": "チームランドセル",
+        "nameEn": "Team Landsel",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 628000000
+        },
+        "workIds": [
+          "RJ266800",
+          "RJ274388",
+          "RJ285737",
+          "RJ328808",
+          "RJ334641",
+          "RJ01037463",
+          "RJ01251626"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876199,
+          "nanoseconds": 758000000
+        }
+      }
+    },
+    {
+      "id": "RG24285",
+      "data": {
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1766855272,
+          "nanoseconds": 456000000
+        },
+        "nameEn": "Pretty Uncle Syndrome",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1766855272,
+          "nanoseconds": 456000000
+        },
+        "workIds": [
+          "RJ01525764"
+        ],
+        "name": "かわいいおっさん症候群",
+        "circleId": "RG24285"
+      }
+    },
+    {
+      "id": "RG25409",
+      "data": {
+        "circleId": "RG25409",
+        "name": "G DRAIN",
+        "nameEn": "G DRAIN",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876101,
+          "nanoseconds": 438000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1777648145,
+          "nanoseconds": 279000000
+        },
+        "workIds": [
+          "RJ255266",
+          "RJ276321",
+          "RJ297158",
+          "RJ357104",
+          "RJ01610616"
+        ]
+      }
+    },
+    {
+      "id": "RG26596",
+      "data": {
+        "circleId": "RG26596",
+        "name": "askot",
+        "nameEn": "askot",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 122000000
+        },
+        "workIds": [
+          "RJ287815",
+          "RJ310271",
+          "RJ01042994"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876153,
+          "nanoseconds": 145000000
+        }
+      }
+    },
+    {
+      "id": "RG26627",
+      "data": {
+        "circleId": "RG26627",
+        "name": "カモネギちゃんねる",
+        "nameEn": "kamonegi channel",
+        "workIds": [
+          "RJ01114861"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876172,
+          "nanoseconds": 337000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876172,
+          "nanoseconds": 337000000
+        }
+      }
+    },
+    {
+      "id": "RG26841",
+      "data": {
+        "circleId": "RG26841",
+        "name": "あきいろ紫陽花",
+        "nameEn": "Akiiro ajisai",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876123,
+          "nanoseconds": 141000000
+        },
+        "workIds": [
+          "RJ330032",
+          "RJ380487",
+          "RJ01102332"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876168,
+          "nanoseconds": 903000000
+        }
+      }
+    },
+    {
+      "id": "RG28138",
+      "data": {
+        "circleId": "RG28138",
+        "name": "はーべすと",
+        "nameEn": "Harvest",
+        "workIds": [
+          "RJ326427"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876121,
+          "nanoseconds": 828000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876121,
+          "nanoseconds": 828000000
+        }
+      }
+    },
+    {
+      "id": "RG28213",
+      "data": {
+        "circleId": "RG28213",
+        "name": "フヅキ堂。",
+        "nameEn": "Fudukidoh",
+        "workIds": [
+          "RJ335745"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876124,
+          "nanoseconds": 598000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876124,
+          "nanoseconds": 598000000
+        }
+      }
+    },
+    {
+      "id": "RG28663",
+      "data": {
+        "circleId": "RG28663",
+        "name": "ボトムズ",
+        "nameEn": "VOTOMS",
+        "workIds": [
+          "RJ323978"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876122,
+          "nanoseconds": 838000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876122,
+          "nanoseconds": 838000000
+        }
+      }
+    },
+    {
+      "id": "RG28716",
+      "data": {
+        "circleId": "RG28716",
+        "name": "知恵の実",
+        "nameEn": "The fruits of knowledge",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 340000000
+        },
+        "workIds": [
+          "RJ267078",
+          "RJ271415",
+          "RJ311178",
+          "RJ334032"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876124,
+          "nanoseconds": 292000000
+        }
+      }
+    },
+    {
+      "id": "RG29061",
+      "data": {
+        "circleId": "RG29061",
+        "name": "SweetNightmare",
+        "nameEn": "SweetNightmare",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876112,
+          "nanoseconds": 371000000
+        },
+        "workIds": [
+          "RJ288330",
+          "RJ295293",
+          "RJ326296",
+          "RJ01094847",
+          "RJ01307451"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876214,
+          "nanoseconds": 593000000
+        }
+      }
+    },
+    {
+      "id": "RG29335",
+      "data": {
+        "circleId": "RG29335",
+        "name": "Team Moko App.",
+        "nameEn": "Team Moko App.",
+        "workIds": [
+          "RJ288114"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 287000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 287000000
+        }
+      }
+    },
+    {
+      "id": "RG29957",
+      "data": {
+        "circleId": "RG29957",
+        "name": "へーどねー",
+        "nameEn": "heedoneee",
+        "workIds": [
+          "RJ421927"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876141,
+          "nanoseconds": 753000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876141,
+          "nanoseconds": 753000000
+        }
+      }
+    },
+    {
+      "id": "RG30145",
+      "data": {
+        "circleId": "RG30145",
+        "name": "荘ノヴァ",
+        "nameEn": "Sounova",
+        "workIds": [
+          "RJ266832"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 270000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 270000000
+        }
+      }
+    },
+    {
+      "id": "RG30720",
+      "data": {
+        "circleId": "RG30720",
+        "name": "カタストlab",
+        "nameEn": "catastlab",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876123,
+          "nanoseconds": 462000000
+        },
+        "workIds": [
+          "RJ332327",
+          "RJ01160440",
+          "RJ01177072"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876194,
+          "nanoseconds": 751000000
+        }
+      }
+    },
+    {
+      "id": "RG30771",
+      "data": {
+        "circleId": "RG30771",
+        "name": "メヤスバコ-MeyasuBako-",
+        "nameEn": "MeyasuBako",
+        "workIds": [
+          "RJ288181"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876109,
+          "nanoseconds": 822000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876109,
+          "nanoseconds": 822000000
+        }
+      }
+    },
+    {
+      "id": "RG30920",
+      "data": {
+        "circleId": "RG30920",
+        "name": "Berry!16",
+        "nameEn": "Berry!16",
+        "workIds": [
+          "RJ01356469"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876220,
+          "nanoseconds": 88000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876220,
+          "nanoseconds": 88000000
+        }
+      }
+    },
+    {
+      "id": "RG30964",
+      "data": {
+        "circleId": "RG30964",
+        "name": "甘辛ギネコクラシー",
+        "nameEn": "Amakara Gynecocracy",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 541000000
+        },
+        "workIds": [
+          "RJ288340",
+          "RJ330167"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876124,
+          "nanoseconds": 97000000
+        }
+      }
+    },
+    {
+      "id": "RG31459",
+      "data": {
+        "circleId": "RG31459",
+        "name": "メロイック",
+        "nameEn": "maloik",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876103,
+          "nanoseconds": 412000000
+        },
+        "workIds": [
+          "RJ267411",
+          "RJ300506"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876114,
+          "nanoseconds": 372000000
+        }
+      }
+    },
+    {
+      "id": "RG32060",
+      "data": {
+        "circleId": "RG32060",
+        "name": "足跡の水たまり",
+        "nameEn": "Footprint Puddle",
+        "workIds": [
+          "RJ344634"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876127,
+          "nanoseconds": 99000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876127,
+          "nanoseconds": 99000000
+        }
+      }
+    },
+    {
+      "id": "RG32840",
+      "data": {
+        "circleId": "RG32840",
+        "name": "ダチュラスクリプト",
+        "nameEn": "DaturaScript",
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876108,
+          "nanoseconds": 4000000
+        },
+        "workIds": [
+          "RJ282228",
+          "RJ299286",
+          "RJ316490",
+          "RJ362811",
+          "RJ395367",
+          "RJ01012291",
+          "RJ01151712",
+          "RJ01218581"
+        ],
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876191,
+          "nanoseconds": 63000000
+        }
+      }
+    },
+    {
+      "id": "RG33030",
+      "data": {
+        "circleId": "RG33030",
+        "name": "サキュネス",
+        "nameEn": "succuness",
+        "workIds": [
+          "RJ290811"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 356000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876110,
+          "nanoseconds": 356000000
+        }
+      }
+    },
+    {
+      "id": "RG33308",
+      "data": {
+        "circleId": "RG33308",
+        "name": "煩悩ストラテジ",
+        "nameEn": "bon-no strategy",
+        "workIds": [
+          "RJ257241"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876101,
+          "nanoseconds": 143000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753876101,
+          "nanoseconds": 143000000
         }
       }
     }

--- a/apps/functions/src/tools/firestore-local/fixtures/creators.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/creators.json
@@ -40,8 +40,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 891000000
+          "seconds": 1783040724,
+          "nanoseconds": 509000000
         }
       }
     },
@@ -62,8 +62,8 @@
         "workCount": 11,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 892000000
+          "seconds": 1783047914,
+          "nanoseconds": 230000000
         }
       }
     },
@@ -84,8 +84,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 897000000
+          "seconds": 1783040743,
+          "nanoseconds": 662000000
         }
       }
     },
@@ -106,8 +106,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 900000000
+          "seconds": 1783040811,
+          "nanoseconds": 613000000
         }
       }
     },
@@ -150,8 +150,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 878000000
+          "seconds": 1781197526,
+          "nanoseconds": 391000000
         }
       }
     },
@@ -172,8 +172,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 896000000
+          "seconds": 1781895883,
+          "nanoseconds": 793000000
         }
       }
     },
@@ -216,8 +216,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 892000000
+          "seconds": 1783040676,
+          "nanoseconds": 757000000
         }
       }
     },
@@ -238,8 +238,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 895000000
+          "seconds": 1783047884,
+          "nanoseconds": 919000000
         }
       }
     },
@@ -282,8 +282,8 @@
         "workCount": 27,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 893000000
+          "seconds": 1783047793,
+          "nanoseconds": 84000000
         }
       }
     },
@@ -301,11 +301,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 26,
+        "workCount": 27,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 894000000
+          "seconds": 1783047926,
+          "nanoseconds": 636000000
         }
       }
     },
@@ -326,8 +326,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 894000000
+          "seconds": 1783047884,
+          "nanoseconds": 418000000
         }
       }
     },
@@ -348,8 +348,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 896000000
+          "seconds": 1783040714,
+          "nanoseconds": 719000000
         }
       }
     },
@@ -370,8 +370,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 887000000
+          "seconds": 1783040694,
+          "nanoseconds": 440000000
         }
       }
     },
@@ -389,11 +389,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 14,
+        "workCount": 16,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 899000000
+          "seconds": 1783091000,
+          "nanoseconds": 649000000
         }
       }
     },
@@ -414,8 +414,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 888000000
+          "seconds": 1783040714,
+          "nanoseconds": 933000000
         }
       }
     },
@@ -436,8 +436,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 886000000
+          "seconds": 1783040704,
+          "nanoseconds": 925000000
         }
       }
     },
@@ -459,8 +459,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 19000000
+          "seconds": 1783040834,
+          "nanoseconds": 240000000
         }
       }
     },
@@ -503,8 +503,8 @@
         "workCount": 7,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 8000000
+          "seconds": 1782975875,
+          "nanoseconds": 744000000
         }
       }
     },
@@ -525,8 +525,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779987994,
-          "nanoseconds": 299000000
+          "seconds": 1783141577,
+          "nanoseconds": 834000000
         }
       }
     },
@@ -547,8 +547,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 7000000
+          "seconds": 1783040814,
+          "nanoseconds": 437000000
         }
       }
     },
@@ -569,8 +569,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 9000000
+          "seconds": 1783040704,
+          "nanoseconds": 719000000
         }
       }
     },
@@ -591,8 +591,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 11000000
+          "seconds": 1783040655,
+          "nanoseconds": 741000000
         }
       }
     },
@@ -613,8 +613,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 17000000
+          "seconds": 1781809558,
+          "nanoseconds": 529000000
         }
       }
     },
@@ -657,8 +657,1558 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
+          "seconds": 1783040696,
+          "nanoseconds": 111000000
+        }
+      }
+    },
+    {
+      "id": "15171",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888180,
+          "nanoseconds": 427000000
+        },
+        "creatorId": "15171",
+        "name": "季月えりか",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040715,
+          "nanoseconds": 158000000
+        }
+      }
+    },
+    {
+      "id": "15287",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888467,
+          "nanoseconds": 593000000
+        },
+        "creatorId": "15287",
+        "name": "七歌",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
           "seconds": 1779971205,
-          "nanoseconds": 24000000
+          "nanoseconds": 21000000
+        }
+      }
+    },
+    {
+      "id": "15341",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888181,
+          "nanoseconds": 200000000
+        },
+        "creatorId": "15341",
+        "name": "誠樹ふぁん",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 11,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040766,
+          "nanoseconds": 262000000
+        }
+      }
+    },
+    {
+      "id": "15448",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888203,
+          "nanoseconds": 533000000
+        },
+        "creatorId": "15448",
+        "name": "みなすきぽぷり",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040684,
+          "nanoseconds": 246000000
+        }
+      }
+    },
+    {
+      "id": "15597",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888552,
+          "nanoseconds": 966000000
+        },
+        "creatorId": "15597",
+        "name": "osa",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 6,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047954,
+          "nanoseconds": 246000000
+        }
+      }
+    },
+    {
+      "id": "15705",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888176,
+          "nanoseconds": 995000000
+        },
+        "creatorId": "15705",
+        "name": "YU-TA",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040637,
+          "nanoseconds": 830000000
+        }
+      }
+    },
+    {
+      "id": "15857",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888207,
+          "nanoseconds": 82000000
+        },
+        "creatorId": "15857",
+        "name": "綾音まこ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040692,
+          "nanoseconds": 644000000
+        }
+      }
+    },
+    {
+      "id": "15943",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888184,
+          "nanoseconds": 666000000
+        },
+        "creatorId": "15943",
+        "name": "空維深夜",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 25000000
+        }
+      }
+    },
+    {
+      "id": "15953",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888198,
+          "nanoseconds": 351000000
+        },
+        "creatorId": "15953",
+        "name": "吉飛雄馬",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040675,
+          "nanoseconds": 525000000
+        }
+      }
+    },
+    {
+      "id": "16158",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888179,
+          "nanoseconds": 987000000
+        },
+        "creatorId": "16158",
+        "name": "国産もやし",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 11,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040824,
+          "nanoseconds": 145000000
+        }
+      }
+    },
+    {
+      "id": "16163",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888177,
+          "nanoseconds": 440000000
+        },
+        "creatorId": "16163",
+        "name": "狩野景",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 145000000
+        }
+      }
+    },
+    {
+      "id": "16224",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888462,
+          "nanoseconds": 925000000
+        },
+        "creatorId": "16224",
+        "name": "Rozea",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 9,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047925,
+          "nanoseconds": 751000000
+        }
+      }
+    },
+    {
+      "id": "16236",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888467,
+          "nanoseconds": 569000000
+        },
+        "creatorId": "16236",
+        "name": "日向奈尾",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 156000000
+        }
+      }
+    },
+    {
+      "id": "16276",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888477,
+          "nanoseconds": 358000000
+        },
+        "creatorId": "16276",
+        "name": "Hisasi",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 7,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047884,
+          "nanoseconds": 624000000
+        }
+      }
+    },
+    {
+      "id": "16281",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888516,
+          "nanoseconds": 6000000
+        },
+        "creatorId": "16281",
+        "name": "歩サラ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 3,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 158000000
+        }
+      }
+    },
+    {
+      "id": "16446",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888186,
+          "nanoseconds": 216000000
+        },
+        "creatorId": "16446",
+        "name": "高岡智空",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782968649,
+          "nanoseconds": 161000000
+        }
+      }
+    },
+    {
+      "id": "16523",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888498,
+          "nanoseconds": 297000000
+        },
+        "creatorId": "16523",
+        "name": "みたかりん",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 22,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047853,
+          "nanoseconds": 239000000
+        }
+      }
+    },
+    {
+      "id": "16527",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1773421392,
+          "nanoseconds": 344000000
+        },
+        "creatorId": "16527",
+        "name": "おぶい",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783148613,
+          "nanoseconds": 559000000
+        }
+      }
+    },
+    {
+      "id": "16569",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888496,
+          "nanoseconds": 108000000
+        },
+        "creatorId": "16569",
+        "name": "あかしゆき",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 7,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047852,
+          "nanoseconds": 536000000
+        }
+      }
+    },
+    {
+      "id": "16588",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888174,
+          "nanoseconds": 574000000
+        },
+        "creatorId": "16588",
+        "name": "綾奈まりあ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 4,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040635,
+          "nanoseconds": 912000000
+        }
+      }
+    },
+    {
+      "id": "16602",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888184,
+          "nanoseconds": 300000000
+        },
+        "creatorId": "16602",
+        "name": "みうらさぶろう",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040734,
+          "nanoseconds": 620000000
+        }
+      }
+    },
+    {
+      "id": "16696",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888490,
+          "nanoseconds": 432000000
+        },
+        "creatorId": "16696",
+        "name": "まりお",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration",
+          "scenario"
+        ],
+        "workCount": 13,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782975894,
+          "nanoseconds": 790000000
+        }
+      }
+    },
+    {
+      "id": "16722",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1776013397,
+          "nanoseconds": 332000000
+        },
+        "creatorId": "16722",
+        "name": "誘宵",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047945,
+          "nanoseconds": 435000000
+        }
+      }
+    },
+    {
+      "id": "16768",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888181,
+          "nanoseconds": 232000000
+        },
+        "creatorId": "16768",
+        "name": "porori",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040646,
+          "nanoseconds": 218000000
+        }
+      }
+    },
+    {
+      "id": "16815",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888464,
+          "nanoseconds": 942000000
+        },
+        "creatorId": "16815",
+        "name": "栗栖ティナ",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 3,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040741,
+          "nanoseconds": 139000000
+        }
+      }
+    },
+    {
+      "id": "16850",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888186,
+          "nanoseconds": 4000000
+        },
+        "creatorId": "16850",
+        "name": "紅葉美兎",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 172000000
+        }
+      }
+    },
+    {
+      "id": "16883",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888189,
+          "nanoseconds": 884000000
+        },
+        "creatorId": "16883",
+        "name": "おおやまちろる",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782968666,
+          "nanoseconds": 985000000
+        }
+      }
+    },
+    {
+      "id": "16885",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888174,
+          "nanoseconds": 285000000
+        },
+        "creatorId": "16885",
+        "name": "大山チロル",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "music"
+        ],
+        "workCount": 59,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047964,
+          "nanoseconds": 726000000
+        }
+      }
+    },
+    {
+      "id": "16992",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1754064859,
+          "nanoseconds": 428000000
+        },
+        "creatorId": "16992",
+        "name": "K子",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 172000000
+        }
+      }
+    },
+    {
+      "id": "17036",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888194,
+          "nanoseconds": 408000000
+        },
+        "creatorId": "17036",
+        "name": "月影彰太",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 5,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040734,
+          "nanoseconds": 616000000
+        }
+      }
+    },
+    {
+      "id": "17070",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888184,
+          "nanoseconds": 847000000
+        },
+        "creatorId": "17070",
+        "name": "月野きいろ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040653,
+          "nanoseconds": 717000000
+        }
+      }
+    },
+    {
+      "id": "17118",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888207,
+          "nanoseconds": 95000000
+        },
+        "creatorId": "17118",
+        "name": "水野七海",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040714,
+          "nanoseconds": 109000000
+        }
+      }
+    },
+    {
+      "id": "17180",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888505,
+          "nanoseconds": 362000000
+        },
+        "creatorId": "17180",
+        "name": "伊ヶ崎綾香",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 13,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047902,
+          "nanoseconds": 518000000
+        }
+      }
+    },
+    {
+      "id": "17197",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888462,
+          "nanoseconds": 39000000
+        },
+        "creatorId": "17197",
+        "name": "森間まりも",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781780737,
+          "nanoseconds": 610000000
+        }
+      }
+    },
+    {
+      "id": "17211",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888464,
+          "nanoseconds": 294000000
+        },
+        "creatorId": "17211",
+        "name": "高梨はなみ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 56,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783148612,
+          "nanoseconds": 97000000
+        }
+      }
+    },
+    {
+      "id": "17338",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888480,
+          "nanoseconds": 479000000
+        },
+        "creatorId": "17338",
+        "name": "kakao",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration",
+          "scenario"
+        ],
+        "workCount": 7,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782975894,
+          "nanoseconds": 716000000
+        }
+      }
+    },
+    {
+      "id": "17355",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888461,
+          "nanoseconds": 868000000
+        },
+        "creatorId": "17355",
+        "name": "口谷亜夜",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781780737,
+          "nanoseconds": 323000000
+        }
+      }
+    },
+    {
+      "id": "17358",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888176,
+          "nanoseconds": 394000000
+        },
+        "creatorId": "17358",
+        "name": "霜月優",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 5,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040637,
+          "nanoseconds": 371000000
+        }
+      }
+    },
+    {
+      "id": "17373",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888181,
+          "nanoseconds": 211000000
+        },
+        "creatorId": "17373",
+        "name": "ぴよ寺むちゃ",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040646,
+          "nanoseconds": 118000000
+        }
+      }
+    },
+    {
+      "id": "17374",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888181,
+          "nanoseconds": 222000000
+        },
+        "creatorId": "17374",
+        "name": "うさ城まに",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047954,
+          "nanoseconds": 250000000
+        }
+      }
+    },
+    {
+      "id": "17384",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888179,
+          "nanoseconds": 16000000
+        },
+        "creatorId": "17384",
+        "name": "西浦のどか",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 7,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040803,
+          "nanoseconds": 810000000
+        }
+      }
+    },
+    {
+      "id": "17385",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888174,
+          "nanoseconds": 28000000
+        },
+        "creatorId": "17385",
+        "name": "陽向葵ゅか",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "music"
+        ],
+        "workCount": 229,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783098781,
+          "nanoseconds": 669000000
+        }
+      }
+    },
+    {
+      "id": "17386",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888177,
+          "nanoseconds": 416000000
+        },
+        "creatorId": "17386",
+        "name": "山田じぇみ子",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 34,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047964,
+          "nanoseconds": 19000000
+        }
+      }
+    },
+    {
+      "id": "17388",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888481,
+          "nanoseconds": 532000000
+        },
+        "creatorId": "17388",
+        "name": "doskoinpo",
+        "primaryRole": "scenario",
+        "types": [
+          "illustration",
+          "scenario"
+        ],
+        "workCount": 5,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047921,
+          "nanoseconds": 928000000
+        }
+      }
+    },
+    {
+      "id": "17391",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888461,
+          "nanoseconds": 833000000
+        },
+        "creatorId": "17391",
+        "name": "柊真冬",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781780737,
+          "nanoseconds": 221000000
+        }
+      }
+    },
+    {
+      "id": "17393",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888195,
+          "nanoseconds": 300000000
+        },
+        "creatorId": "17393",
+        "name": "しろすず",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040733,
+          "nanoseconds": 939000000
+        }
+      }
+    },
+    {
+      "id": "17394",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888181,
+          "nanoseconds": 90000000
+        },
+        "creatorId": "17394",
+        "name": "逢坂成美",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 123,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783098828,
+          "nanoseconds": 169000000
+        }
+      }
+    },
+    {
+      "id": "17395",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888174,
+          "nanoseconds": 985000000
+        },
+        "creatorId": "17395",
+        "name": "柳原ミツキ",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 5,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040761,
+          "nanoseconds": 615000000
+        }
+      }
+    },
+    {
+      "id": "17397",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888175,
+          "nanoseconds": 71000000
+        },
+        "creatorId": "17397",
+        "name": "柚木朱莉",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "music"
+        ],
+        "workCount": 35,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047965,
+          "nanoseconds": 334000000
+        }
+      }
+    },
+    {
+      "id": "17398",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888193,
+          "nanoseconds": 221000000
+        },
+        "creatorId": "17398",
+        "name": "ニャルぽむぽむ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040703,
+          "nanoseconds": 35000000
+        }
+      }
+    },
+    {
+      "id": "17401",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888177,
+          "nanoseconds": 135000000
+        },
+        "creatorId": "17401",
+        "name": "姫綺るいな",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 3,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781363146,
+          "nanoseconds": 664000000
+        }
+      }
+    },
+    {
+      "id": "17402",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888204,
+          "nanoseconds": 793000000
+        },
+        "creatorId": "17402",
+        "name": "藍沢夏癒",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 30,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783098682,
+          "nanoseconds": 569000000
+        }
+      }
+    },
+    {
+      "id": "17403",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1766855272,
+          "nanoseconds": 555000000
+        },
+        "creatorId": "17403",
+        "name": "ちみる",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047911,
+          "nanoseconds": 117000000
+        }
+      }
+    },
+    {
+      "id": "17404",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888180,
+          "nanoseconds": 782000000
+        },
+        "creatorId": "17404",
+        "name": "沢野ぽぷら",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "music"
+        ],
+        "workCount": 42,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047926,
+          "nanoseconds": 421000000
+        }
+      }
+    },
+    {
+      "id": "17406",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888468,
+          "nanoseconds": 193000000
+        },
+        "creatorId": "17406",
+        "name": "WaP",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 16,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782975884,
+          "nanoseconds": 843000000
+        }
+      }
+    },
+    {
+      "id": "17407",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888197,
+          "nanoseconds": 981000000
+        },
+        "creatorId": "17407",
+        "name": "九反",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040675,
+          "nanoseconds": 742000000
+        }
+      }
+    },
+    {
+      "id": "17408",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888186,
+          "nanoseconds": 189000000
+        },
+        "creatorId": "17408",
+        "name": "分倍河原シホ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 39,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047934,
+          "nanoseconds": 940000000
+        }
+      }
+    },
+    {
+      "id": "17410",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888198,
+          "nanoseconds": 986000000
+        },
+        "creatorId": "17410",
+        "name": "かの仔",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 51,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047963,
+          "nanoseconds": 421000000
+        }
+      }
+    },
+    {
+      "id": "17411",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888189,
+          "nanoseconds": 825000000
+        },
+        "creatorId": "17411",
+        "name": "野上菜月",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "music"
+        ],
+        "workCount": 29,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040834,
+          "nanoseconds": 446000000
+        }
+      }
+    },
+    {
+      "id": "17413",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888507,
+          "nanoseconds": 170000000
+        },
+        "creatorId": "17413",
+        "name": "宮居千",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779971205,
+          "nanoseconds": 351000000
+        }
+      }
+    },
+    {
+      "id": "17416",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888469,
+          "nanoseconds": 805000000
+        },
+        "creatorId": "17416",
+        "name": "さくら真咲",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782234289,
+          "nanoseconds": 479000000
+        }
+      }
+    },
+    {
+      "id": "17418",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888461,
+          "nanoseconds": 822000000
+        },
+        "creatorId": "17418",
+        "name": "里々朱あん",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781780737,
+          "nanoseconds": 316000000
+        }
+      }
+    },
+    {
+      "id": "17424",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888175,
+          "nanoseconds": 620000000
+        },
+        "creatorId": "17424",
+        "name": "煩悩ストラテジ",
+        "primaryRole": "scenario",
+        "types": [
+          "scenario"
+        ],
+        "workCount": 1,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040636,
+          "nanoseconds": 16000000
+        }
+      }
+    },
+    {
+      "id": "17426",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888174,
+          "nanoseconds": 834000000
+        },
+        "creatorId": "17426",
+        "name": "柚木つばめ",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "music"
+        ],
+        "workCount": 166,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047965,
+          "nanoseconds": 352000000
+        }
+      }
+    },
+    {
+      "id": "17429",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888180,
+          "nanoseconds": 772000000
+        },
+        "creatorId": "17429",
+        "name": "和鳴るせ",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040753,
+          "nanoseconds": 13000000
+        }
+      }
+    },
+    {
+      "id": "17431",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888196,
+          "nanoseconds": 260000000
+        },
+        "creatorId": "17431",
+        "name": "みもりあいの",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 83,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783098456,
+          "nanoseconds": 571000000
+        }
+      }
+    },
+    {
+      "id": "17440",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888173,
+          "nanoseconds": 982000000
+        },
+        "creatorId": "17440",
+        "name": "篠守ゆきこ",
+        "primaryRole": "voice",
+        "types": [
+          "voice",
+          "scenario"
+        ],
+        "workCount": 12,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783141577,
+          "nanoseconds": 824000000
+        }
+      }
+    },
+    {
+      "id": "17449",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888471,
+          "nanoseconds": 96000000
+        },
+        "creatorId": "17449",
+        "name": "浪実みお",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 4,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047924,
+          "nanoseconds": 34000000
+        }
+      }
+    },
+    {
+      "id": "17451",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888191,
+          "nanoseconds": 782000000
+        },
+        "creatorId": "17451",
+        "name": "えそらごと",
+        "primaryRole": "illustration",
+        "types": [
+          "illustration"
+        ],
+        "workCount": 2,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783040665,
+          "nanoseconds": 47000000
+        }
+      }
+    },
+    {
+      "id": "17477",
+      "data": {
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1753888178,
+          "nanoseconds": 106000000
+        },
+        "creatorId": "17477",
+        "name": "御崎ひより",
+        "primaryRole": "voice",
+        "types": [
+          "voice"
+        ],
+        "workCount": 40,
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783047971,
+          "nanoseconds": 855000000
         }
       }
     }

--- a/apps/functions/src/tools/firestore-local/fixtures/top10.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/top10.json
@@ -1,0 +1,4 @@
+{
+  "collection": "top10",
+  "docs": []
+}

--- a/apps/functions/src/tools/firestore-local/fixtures/videos.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/videos.json
@@ -51,7 +51,6 @@
         "id": "-6UXeo2mmgs",
         "thumbnailUrl": "https://i.ytimg.com/vi/-6UXeo2mmgs/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.446Z",
-        "hasAudioButtons": true,
         "tags": {
           "userTags": [],
           "contentTags": [],
@@ -137,17 +136,16 @@
         "id": "-Km-yS83L3I",
         "thumbnailUrl": "https://i.ytimg.com/vi/-Km-yS83L3I/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.509Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
           "likeCount": 231,
-          "viewCount": 5338
+          "viewCount": 5340
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780500620,
-          "nanoseconds": 575000000
+          "seconds": 1783157418,
+          "nanoseconds": 328000000
         }
       }
     },
@@ -206,7 +204,6 @@
         "id": "-SAHninZ2rs",
         "thumbnailUrl": "https://i.ytimg.com/vi/-SAHninZ2rs/sddefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.554Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 2,
           "favoriteCount": 0,
@@ -266,18 +263,17 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/-THFpqKVvMs/maxresdefault.jpg",
         "statistics": {
           "commentCount": 12,
           "likeCount": 240,
-          "viewCount": 6028
+          "viewCount": 6063
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 70000000
+          "seconds": 1783164618,
+          "nanoseconds": 423000000
         }
       }
     },
@@ -331,7 +327,6 @@
         "id": "-TISCOp42pE",
         "thumbnailUrl": "https://i.ytimg.com/vi/-TISCOp42pE/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.590Z",
-        "hasAudioButtons": true,
         "tags": {
           "userTags": [],
           "contentTags": [],
@@ -342,16 +337,16 @@
         "playlistTags": [
           "🎧ASMR💗"
         ],
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 77000000
-        },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 24,
-          "likeCount": 950,
-          "viewCount": 48560
+          "likeCount": 951,
+          "viewCount": 48849
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 460000000
         }
       }
     },
@@ -395,7 +390,6 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "duration": "PT1H45M46S",
         "publishedAt": {
@@ -406,13 +400,13 @@
         "thumbnailUrl": "https://i.ytimg.com/vi/-Z3GG-H_ocQ/maxresdefault.jpg",
         "statistics": {
           "commentCount": 16,
-          "likeCount": 241,
-          "viewCount": 3783
+          "likeCount": 240,
+          "viewCount": 3794
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 70000000
+          "seconds": 1783164618,
+          "nanoseconds": 422000000
         }
       }
     },
@@ -451,7 +445,6 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/-_kh52rmm_0/maxresdefault.jpg",
         "title": "【苺氷えな・ふじかわあや乃・真名瀬ゆあ】新国民歓迎会♡【#すみっこキングダム／Minecraft】",
@@ -467,15 +460,15 @@
           "すみっこキングダム／Minecraft",
           "🎮ゲーム💗"
         ],
-        "statistics": {
-          "commentCount": 16,
-          "likeCount": 199,
-          "viewCount": 5194
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 29000000
+          "seconds": 1783164618,
+          "nanoseconds": 400000000
+        },
+        "statistics": {
+          "commentCount": 16,
+          "likeCount": 200,
+          "viewCount": 5359
         }
       }
     },
@@ -541,17 +534,16 @@
         "id": "-nC6dZ6c6zI",
         "thumbnailUrl": "https://i.ytimg.com/vi/-nC6dZ6c6zI/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.637Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 12,
           "favoriteCount": 0,
           "likeCount": 638,
-          "viewCount": 20520
+          "viewCount": 20571
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780500620,
-          "nanoseconds": 575000000
+          "seconds": 1783157418,
+          "nanoseconds": 327000000
         }
       }
     },
@@ -601,18 +593,17 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/-ua33VT9wa0/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 15,
-          "likeCount": 190,
-          "viewCount": 3265
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 28000000
+          "seconds": 1783164618,
+          "nanoseconds": 399000000
+        },
+        "statistics": {
+          "commentCount": 15,
+          "likeCount": 192,
+          "viewCount": 3365
         }
       }
     },
@@ -676,17 +667,16 @@
         "id": "-xRav72is1U",
         "thumbnailUrl": "https://i.ytimg.com/vi/-xRav72is1U/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.687Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 3,
           "favoriteCount": 0,
-          "likeCount": 157,
-          "viewCount": 3493
+          "viewCount": 3493,
+          "likeCount": 156
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 77000000
+          "seconds": 1783161018,
+          "nanoseconds": 459000000
         }
       }
     },
@@ -726,7 +716,6 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/0F0KA3Ov0gA/maxresdefault.jpg",
         "tags": {
@@ -741,15 +730,15 @@
           "すみっこキングダム／Minecraft",
           "🎮ゲーム💗"
         ],
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 28000000
-        },
         "statistics": {
           "commentCount": 14,
-          "likeCount": 247,
-          "viewCount": 5563
+          "likeCount": 248,
+          "viewCount": 5655
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 399000000
         }
       }
     },
@@ -801,18 +790,17 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/0IFpcZnJPgE/maxresdefault.jpg",
+        "statistics": {
+          "likeCount": 564,
+          "viewCount": 18110,
+          "commentCount": 13
+        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 69000000
-        },
-        "statistics": {
-          "commentCount": 14,
-          "likeCount": 563,
-          "viewCount": 17899
+          "seconds": 1783164618,
+          "nanoseconds": 421000000
         }
       }
     },
@@ -876,17 +864,16 @@
         "id": "0_Kphqg9wkE",
         "thumbnailUrl": "https://i.ytimg.com/vi/0_Kphqg9wkE/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.722Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
           "likeCount": 319,
-          "viewCount": 9372
+          "viewCount": 9379
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780500620,
-          "nanoseconds": 577000000
+          "seconds": 1783161018,
+          "nanoseconds": 454000000
         }
       }
     },
@@ -950,7 +937,6 @@
         "id": "0aRj4WfpnOA",
         "thumbnailUrl": "https://i.ytimg.com/vi/0aRj4WfpnOA/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.760Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
@@ -1014,7 +1000,6 @@
         "id": "0kXXKVzZe_o",
         "thumbnailUrl": "https://i.ytimg.com/vi/0kXXKVzZe_o/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.837Z",
-        "hasAudioButtons": true,
         "tags": {
           "userTags": [],
           "contentTags": [],
@@ -1025,16 +1010,16 @@
         "playlistTags": [
           "🎧ASMR💗"
         ],
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 78000000
-        },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 9,
-          "likeCount": 951,
-          "viewCount": 48985
+          "likeCount": 953,
+          "viewCount": 49163
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 460000000
         }
       }
     },
@@ -1084,18 +1069,17 @@
         },
         "videoType": "archived",
         "description": "交換は１人１回まででお願いします～！\n\n交換に出すのはなんのポケモンでもＯＫです！\nニックネームでセクハラや嫌がらせするの禁止です...！！\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【サムネ素材】\n七篠みるく様　 ‪@nanashino_milk‬ \n\n素敵なモデル・素材ありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/0lzwdVR9Res/maxresdefault.jpg",
         "statistics": {
           "commentCount": 14,
           "likeCount": 143,
-          "viewCount": 3547
+          "viewCount": 3578
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 68000000
+          "seconds": 1783164618,
+          "nanoseconds": 401000000
         }
       }
     },
@@ -1147,18 +1131,17 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/0oyDpEWxG4w/maxresdefault.jpg",
         "statistics": {
           "commentCount": 11,
-          "likeCount": 130,
-          "viewCount": 2415
+          "likeCount": 131,
+          "viewCount": 2424
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 71000000
+          "seconds": 1783164618,
+          "nanoseconds": 423000000
         }
       }
     },
@@ -1225,17 +1208,16 @@
         "id": "0sC1U5QnIzE",
         "thumbnailUrl": "https://i.ytimg.com/vi/0sC1U5QnIzE/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.875Z",
-        "hasAudioButtons": true,
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 15,
           "likeCount": 519,
-          "viewCount": 13920
+          "viewCount": 13966
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 73000000
+          "seconds": 1783164618,
+          "nanoseconds": 425000000
         }
       }
     },
@@ -1289,7 +1271,6 @@
         "id": "133n4z7H55M",
         "thumbnailUrl": "https://i.ytimg.com/vi/133n4z7H55M/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.920Z",
-        "hasAudioButtons": true,
         "tags": {
           "userTags": [],
           "contentTags": [],
@@ -1306,12 +1287,12 @@
           "commentCount": 2,
           "favoriteCount": 0,
           "likeCount": 169,
-          "viewCount": 4105
+          "viewCount": 4106
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 73000000
+          "seconds": 1783161018,
+          "nanoseconds": 458000000
         }
       }
     },
@@ -1370,17 +1351,16 @@
         "id": "16lqmbQuGv4",
         "thumbnailUrl": "https://i.ytimg.com/vi/16lqmbQuGv4/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.954Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 2,
           "favoriteCount": 0,
-          "likeCount": 147,
-          "viewCount": 3901
+          "likeCount": 146,
+          "viewCount": 3927
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 73000000
+          "seconds": 1783161018,
+          "nanoseconds": 457000000
         }
       }
     },
@@ -1444,17 +1424,16 @@
         "id": "17kk23ZYs8c",
         "thumbnailUrl": "https://i.ytimg.com/vi/17kk23ZYs8c/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.990Z",
-        "hasAudioButtons": true,
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1780518617,
-          "nanoseconds": 237000000
-        },
         "statistics": {
           "commentCount": 14,
           "favoriteCount": 0,
-          "likeCount": 413,
-          "viewCount": 12854
+          "likeCount": 412,
+          "viewCount": 12892
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 292000000
         }
       }
     },
@@ -1520,17 +1499,16 @@
         "id": "189e2ncurCk",
         "thumbnailUrl": "https://i.ytimg.com/vi/189e2ncurCk/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.009Z",
-        "hasAudioButtons": true,
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 18,
-          "likeCount": 677,
-          "viewCount": 22945
+          "likeCount": 678,
+          "viewCount": 23021
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 74000000
+          "seconds": 1783157418,
+          "nanoseconds": 290000000
         }
       }
     },
@@ -1594,17 +1572,16 @@
         "id": "1GFc0dqmyXg",
         "thumbnailUrl": "https://i.ytimg.com/vi/1GFc0dqmyXg/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.035Z",
-        "hasAudioButtons": true,
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780500620,
-          "nanoseconds": 575000000
+          "seconds": 1783157418,
+          "nanoseconds": 327000000
         },
         "statistics": {
           "commentCount": 19,
           "favoriteCount": 0,
-          "likeCount": 1437,
-          "viewCount": 54722
+          "likeCount": 1436,
+          "viewCount": 54824
         }
       }
     },
@@ -1668,7 +1645,6 @@
         "id": "1GULxYNC1Ls",
         "thumbnailUrl": "https://i.ytimg.com/vi/1GULxYNC1Ls/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.085Z",
-        "hasAudioButtons": true,
         "lastFetchedAt": {
           "__type__": "timestamp",
           "seconds": 1764271813,
@@ -1728,18 +1704,17 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/1P2Kqh5GgDE/maxresdefault.jpg",
         "statistics": {
           "commentCount": 13,
           "likeCount": 173,
-          "viewCount": 3551
+          "viewCount": 3563
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 70000000
+          "seconds": 1783164618,
+          "nanoseconds": 422000000
         }
       }
     },
@@ -1798,17 +1773,16 @@
         "id": "1Zirz4ZEHRk",
         "thumbnailUrl": "https://i.ytimg.com/vi/1Zirz4ZEHRk/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.119Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 6,
           "favoriteCount": 0,
-          "likeCount": 279,
-          "viewCount": 8761
+          "likeCount": 280,
+          "viewCount": 8806
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 74000000
+          "seconds": 1783161018,
+          "nanoseconds": 458000000
         }
       }
     },
@@ -1853,7 +1827,6 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "publishedAt": {
           "__type__": "timestamp",
@@ -1863,14 +1836,14 @@
         "thumbnailUrl": "https://i.ytimg.com/vi/1_zLJ5eihSk/maxresdefault.jpg",
         "duration": "PT1H15M20S",
         "statistics": {
-          "commentCount": 18,
-          "likeCount": 266,
-          "viewCount": 5421
+          "likeCount": 265,
+          "commentCount": 17,
+          "viewCount": 5476
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 69000000
+          "seconds": 1783164618,
+          "nanoseconds": 421000000
         }
       }
     },
@@ -1934,7 +1907,6 @@
         "id": "1fq5ExhYbtM",
         "thumbnailUrl": "https://i.ytimg.com/vi/1fq5ExhYbtM/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.158Z",
-        "hasAudioButtons": true,
         "statistics": {
           "commentCount": 4,
           "favoriteCount": 0,
@@ -1943,8 +1915,70 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780504218,
-          "nanoseconds": 78000000
+          "seconds": 1783161018,
+          "nanoseconds": 460000000
+        }
+      }
+    },
+    {
+      "id": "1iPSnBczhJE",
+      "data": {
+        "description": "新衣装・新モデル記念グッズ🩷\nhttps://x.com/suzuka_minase/status/2055231687257366789\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "1iPSnBczhJE",
+        "title": "ふらふらご褒美マイクラ🩷【#すみっこキングダム／Minecraft】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "すみっこキングダム／Minecraft",
+            "🎮ゲーム💗"
+          ]
+        },
+        "userTags": [],
+        "id": "1iPSnBczhJE",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "すみっこキングダム／Minecraft",
+          "🎮ゲーム💗"
+        ],
+        "duration": "PT3H37M36S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1780845555,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1780831800,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1780831812,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 209,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1780844883,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/1iPSnBczhJE/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 398000000
+        },
+        "statistics": {
+          "commentCount": 11,
+          "likeCount": 192,
+          "viewCount": 4384
         }
       }
     },
@@ -1998,7 +2032,6 @@
         "id": "1n6Y8m90_uM",
         "thumbnailUrl": "https://i.ytimg.com/vi/1n6Y8m90_uM/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.178Z",
-        "hasAudioButtons": true,
         "tags": {
           "userTags": [],
           "contentTags": [],
@@ -2015,12 +2048,12 @@
           "commentCount": 9,
           "favoriteCount": 0,
           "likeCount": 218,
-          "viewCount": 5248
+          "viewCount": 5255
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780518617,
-          "nanoseconds": 241000000
+          "seconds": 1783157418,
+          "nanoseconds": 295000000
         }
       }
     },
@@ -2072,18 +2105,4849 @@
           }
         },
         "videoType": "archived",
-        "hasAudioButtons": true,
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/21qORNLksj4/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 399000000
+        },
         "statistics": {
           "commentCount": 13,
-          "likeCount": 425,
-          "viewCount": 12008
+          "likeCount": 427,
+          "viewCount": 12740
+        }
+      }
+    },
+    {
+      "id": "271MuZk01NE",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1730130622,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nNEEDY GIRL OVERDOSE 公式ストアページ\n▷https://store.steampowered.com/app/1451940/\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイラスト】\nmilu様　https://x.com/__quoO\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "271MuZk01NE",
+        "title": "超てんちゃんのために、ぴ頑張るよ！！【NEEDY GIRL OVERDOSE／#2】",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H9M36S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1730122158,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1730122200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1730129938,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/271MuZk01NE\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "271MuZk01NE",
+        "thumbnailUrl": "https://i.ytimg.com/vi/271MuZk01NE/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.216Z",
+        "statistics": {
+          "commentCount": 8,
+          "favoriteCount": 0,
+          "likeCount": 229,
+          "viewCount": 4260
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1780525818,
-          "nanoseconds": 28000000
+          "seconds": 1783157418,
+          "nanoseconds": 297000000
+        }
+      }
+    },
+    {
+      "id": "2BoVRWXykkE",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1676642923,
+          "nanoseconds": 0
+        },
+        "videoType": "archived",
+        "description": "【123】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Thumbnail】\n華秀てんま様　https://twitter.com/tenma_ka\n素敵に描いていただきました💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2BoVRWXykkE",
+        "title": "【ASMR】ふわふわ感じる囁きでお耳を癒すよ♥【KU100】",
+        "liveBroadcastContent": "none",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎧ASMR💗"
+          ]
+        },
+        "duration": "PT1H33M9S",
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1676635183,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1676635200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1676640772,
+            "nanoseconds": 0
+          }
+        },
+        "userTags": [],
+        "id": "2BoVRWXykkE",
+        "categoryId": "24",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "thumbnailUrl": "https://i.ytimg.com/vi/2BoVRWXykkE/maxresdefault.jpg",
+        "statistics": {
+          "likeCount": 517,
+          "commentCount": 11,
+          "viewCount": 22771
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1764311414,
+          "nanoseconds": 633000000
+        }
+      }
+    },
+    {
+      "id": "2WCCP7UN_BU",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1718285900,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nコラボのお相手🤍·*゜\n\n浅木ゆめみさん\nX　⇒　https://x.com/mugimeshi0968\nYouTube　⇒　@A.yumemi \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2WCCP7UN_BU",
+        "title": "浅木ゆめみさんと初コラボ🌙🤍雑談しつつ仲良くなりたい！！！！",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H3M39S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1718280001,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1718280000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1718283820,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/2WCCP7UN_BU\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗",
+            "🐱コラボ配信💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗",
+          "🐱コラボ配信💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "2WCCP7UN_BU",
+        "thumbnailUrl": "https://i.ytimg.com/vi/2WCCP7UN_BU/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.241Z",
+        "statistics": {
+          "commentCount": 9,
+          "favoriteCount": 0,
+          "likeCount": 374,
+          "viewCount": 9567
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 327000000
+        }
+      }
+    },
+    {
+      "id": "2Ypd_Ru9yAo",
+      "data": {
+        "description": "※この配信はゲームのネタバレを含みます、ご注意ください。\n©SEGA\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n新衣装・新モデル記念グッズ🩷\nhttps://x.com/suzuka_minase/status/2055231687257366789\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2Ypd_Ru9yAo",
+        "title": "一馬、また会いに来たよ。【龍が如く極／この配信はゲームのネタバレを含みます】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "龍が如く　極",
+            "🎮ゲーム💗"
+          ]
+        },
+        "userTags": [],
+        "id": "2Ypd_Ru9yAo",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "龍が如く　極",
+          "🎮ゲーム💗"
+        ],
+        "duration": "PT4H30M56S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781451942,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1781434800,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1781434823,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 198,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1781451091,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/2Ypd_Ru9yAo/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 397000000
+        },
+        "statistics": {
+          "commentCount": 14,
+          "likeCount": 184,
+          "viewCount": 4943
+        }
+      }
+    },
+    {
+      "id": "2kcXhb-VGQ4",
+      "data": {
+        "description": "涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2kcXhb-VGQ4",
+        "title": "色んな音でお耳癒しながらお喋り♡【KU100／ブラシ・スクイーズ・耳かき・耳ふぅ】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗"
+          ]
+        },
+        "userTags": [],
+        "id": "2kcXhb-VGQ4",
+        "categoryId": "24",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗"
+        ],
+        "duration": "PT2H7M57S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1778080823,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1778072400,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1778072413,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 399,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1778080100,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/2kcXhb-VGQ4/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 399000000
+        },
+        "statistics": {
+          "commentCount": 23,
+          "likeCount": 446,
+          "viewCount": 12393
+        }
+      }
+    },
+    {
+      "id": "2q4f6sDwbn0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1699018787,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【144】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n華秀てんま様　https://twitter.com/tenma_ka  \n素敵なイラストありがとうございます💞\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2q4f6sDwbn0",
+        "title": "耳ふー特化。あったか吐息でお耳ぽわぽわ🐏🤍【binaural/KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H16M49S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1699012757,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1699012800,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1699017438,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/2q4f6sDwbn0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "2q4f6sDwbn0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/2q4f6sDwbn0/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.268Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779204618,
+          "nanoseconds": 442000000
+        },
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 48,
+          "likeCount": 3533,
+          "viewCount": 206616
+        }
+      }
+    },
+    {
+      "id": "2sdE7dqP5L0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1751293821,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます🌸\n\n本日のコラボのお相手・・・天使なのちゃん💙\nhttps://x.com/angelnano1004\n@angelnanox \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D ASMR用】\nillust　　：　華秀てんま様　https://twitter.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2sdE7dqP5L0",
+        "title": "【天使なの×涼花みなせ】初🌟バイノーラル雑談コラボ【バイノーラルKU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H21M20S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1751288361,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1751288400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1751293247,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/2sdE7dqP5L0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗",
+            "🐱コラボ配信💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗",
+          "🐱コラボ配信💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "2sdE7dqP5L0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/2sdE7dqP5L0/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.291Z",
+        "statistics": {
+          "commentCount": 22,
+          "favoriteCount": 0,
+          "likeCount": 858,
+          "viewCount": 20935
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 291000000
+        }
+      }
+    },
+    {
+      "id": "3UfQDLsYofw",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1703115268,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【147】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "3UfQDLsYofw",
+        "title": "ざつだん🐏🤍",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H32M35S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1703073563,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1703073600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1703079118,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/3UfQDLsYofw\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "3UfQDLsYofw",
+        "thumbnailUrl": "https://i.ytimg.com/vi/3UfQDLsYofw/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.321Z",
+        "statistics": {
+          "commentCount": 8,
+          "favoriteCount": 0,
+          "likeCount": 333,
+          "viewCount": 8551
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 351000000
+        }
+      }
+    },
+    {
+      "id": "3spB2Nb1ZAY",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1590599470,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "「ゼルダの伝説 ブレス オブ ザ ワイルド」追加DLCのMASTER MODEで冒険します(*´ω｀*)\nMASTER MODEでのプレイは初見なので楽しみです〜〜！\nストーリー進めたり祠クリアしたり敵倒したりします！！！\n\n涼花みなせ\ntwitter：https://twitter.com/suzuka_minase\nHP：https://szkminase.wixsite.com/szmnhp",
+        "videoId": "3spB2Nb1ZAY",
+        "title": "＊MASTERMODEで冒険／ゼルダの伝説 ブレス オブ ザ ワイルド＊",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H56M54S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1590587478,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1590587400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1590598198,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/3spB2Nb1ZAY\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "3spB2Nb1ZAY",
+        "thumbnailUrl": "https://i.ytimg.com/vi/3spB2Nb1ZAY/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.345Z",
+        "statistics": {
+          "commentCount": 0,
+          "favoriteCount": 0,
+          "likeCount": 170,
+          "viewCount": 4058
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783150218,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "3xuo66Oe_Xg",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1654263662,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【#91】\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n\nーお知らせー\nCi-enに新しいプランを２つ開設しました🌸\nご支援いただいた特典として、オリジナルのえちち…💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記の記事をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Thumbnail illust】\nますだよし様　https://twitter.com/Susisanta0707\n素敵なイラスト、ありがとうございます💗\n\n【Live2Dmodel】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "3xuo66Oe_Xg",
+        "title": "【KU100】吐息たっぷりささやきASMR♥【バイノーラル】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H25M55S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1654257625,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1654257600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1654262781,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/3xuo66Oe_Xg\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "3xuo66Oe_Xg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/3xuo66Oe_Xg/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.360Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎧ASMR💗"
+          ]
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781130617,
+          "nanoseconds": 451000000
+        },
+        "statistics": {
+          "commentCount": 12,
+          "favoriteCount": 0,
+          "likeCount": 924,
+          "viewCount": 48055
+        }
+      }
+    },
+    {
+      "id": "3z8nA77BaRw",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1664200072,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n🌸MEMBER＆視点配信🌸\n浅木式さん🤍https://youtu.be/gPD3ep0BZE0\nみやぢさん🤍https://youtu.be/tlnl0Oj_ZTw\n柚萌さん🤍https://youtu.be/YYBQhlp4zRg\n\nーお知らせー\nCi-enに新しいプランを２つ開設しました🌸\nご支援いただいた特典として、オリジナルのえちち…💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "3z8nA77BaRw",
+        "title": "いちご争奪戦🍓熱いバトル、、、！【カービィのグルメフェス】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H31M10S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1664193788,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1664193600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1664199259,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/3z8nA77BaRw\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗",
+            "🐱コラボ配信💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗",
+          "🐱コラボ配信💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "3z8nA77BaRw",
+        "thumbnailUrl": "https://i.ytimg.com/vi/3z8nA77BaRw/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.385Z",
+        "statistics": {
+          "commentCount": 5,
+          "favoriteCount": 0,
+          "viewCount": 6800,
+          "likeCount": 224
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 459000000
+        }
+      }
+    },
+    {
+      "id": "44sdknho7e4",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1746292583,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCats Organized Neatly\n\nsteam販売ページ\nhttps://store.steampowered.com/app/1369340/Cats_Organized_Neatly\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "44sdknho7e4",
+        "title": "かわいいにゃんこのパズルゲームで遊ぶ♥【KU100バイノーラル／Cats Organized Neatly#2】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H4M25S",
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746280759,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746280800,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1746291827,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/44sdknho7e4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "44sdknho7e4",
+        "thumbnailUrl": "https://i.ytimg.com/vi/44sdknho7e4/maxresdefault.jpg",
+        "audioButtonCount": 1,
+        "updatedAt": "2025-08-22T04:05:13.409Z",
+        "statistics": {
+          "commentCount": 10,
+          "favoriteCount": 0,
+          "likeCount": 289,
+          "viewCount": 5306
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "4CXIrmNe2wY",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1592578390,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "かの仔さん主催の【かのこさんカップ２🍄】に参加させて頂きます〜！！！\n今回はチーム戦です(´ω`*)🌟\nがんばるぞ〜〜〜〜🎶\n\n\nチーム分け＝＝＝＝＝＝\n\nみやぢさんチーム\n　みもりあいのさん\n　柚萌さん\n　陽向葵ゅかさん\n\n沢野ぽぷらさんチーム\n　浅木式さん\n　天知遥さん\n　涼花みなせ\n\n＝＝＝＝＝＝＝＝＝＝＝\n\n先日参加させていただいた第一回かのこカップのアーカイブはかの仔さんのゲームチャンネルにございます✨\nhttps://youtu.be/LrUh6VIEeZs",
+        "videoId": "4CXIrmNe2wY",
+        "title": "【マリオカート8DX】かのこさんカップ２🍄【涼花みなせ視点】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H31M46S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1592571677,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1592571600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1592577185,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/4CXIrmNe2wY\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗",
+            "🐱コラボ配信💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗",
+          "🐱コラボ配信💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "4CXIrmNe2wY",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4CXIrmNe2wY/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.431Z",
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 1,
+          "likeCount": 207,
+          "viewCount": 7392
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783150218,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "4FLuwAG--VA",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1645193034,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【#76】\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【サムネイルイラスト】\n野宇井様　https://twitter.com/NOUI_YU\n素敵なすずみなーと、ありがとうございます💗\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "4FLuwAG--VA",
+        "title": "【Euro Truck Simulator 2】涼花と夜のまったりドライブ…💗",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H48M29S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1645185551,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1645185600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1645192074,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/4FLuwAG--VA\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "4FLuwAG--VA",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4FLuwAG--VA/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.455Z",
+        "statistics": {
+          "commentCount": 3,
+          "favoriteCount": 0,
+          "likeCount": 206,
+          "viewCount": 5587
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 460000000
+        }
+      }
+    },
+    {
+      "id": "4NyZgYuBOUM",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1626615730,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n配信のつづきは23:00からニコニコチャンネル会員様限定放送で…💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\n今回の放送は、チャンネル開設後初めてということで、ごあいさつしながら耳舐めいたします👂💕\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\nイモリ猫さん　（　https://twitter.com/imorineko?s=20　）\nに頂いたLive2Dモデルを使用しています🎶\n素敵なモデル、ありがとうございました💞\n\nBGM：　OtoLogic様\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "4NyZgYuBOUM",
+        "title": "【バイノーラル/ASMR】耳かきでおもてなし💗【定期配信第45回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H36M25S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1626609564,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1626609600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1626615351,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/4NyZgYuBOUM\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "4NyZgYuBOUM",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4NyZgYuBOUM/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.481Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1762583414,
+          "nanoseconds": 536000000
+        },
+        "statistics": {
+          "commentCount": 9,
+          "favoriteCount": 0,
+          "likeCount": 562,
+          "viewCount": 20693
+        }
+      }
+    },
+    {
+      "id": "4ShFQ31yQZ0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1630071539,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\n今回の放送は、\n【吐息多め】❤密着オイルマッサージ＠せつ菜♥【定期放送#7】\nお耳を癒せるようにがんばります🎶\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n配信のサムネイルは、リスナー様に頂いたすずみなーとを使用しています💖\n今回の作者様はもるたるさんです。\nhttps://twitter.com/morutaru0178\n素敵なイラストありがとうございます💞\n\nイモリ猫さん　　\nhttps://twitter.com/imorineko　\nに頂いたLive2Dモデルを使用しています🎶\n素敵なモデル、ありがとうございます💞\n\nBGM：　OtoLogic様\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "4ShFQ31yQZ0",
+        "title": "【リングフィット アドベンチャー】ミニゲームであそぶ!!👊🌸【定期配信第51回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H29M38S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1630065550,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1630065600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1630070928,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/4ShFQ31yQZ0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "4ShFQ31yQZ0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4ShFQ31yQZ0/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.500Z",
+        "statistics": {
+          "likeCount": 135,
+          "commentCount": 2,
+          "favoriteCount": 0,
+          "viewCount": 2889
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 496000000
+        }
+      }
+    },
+    {
+      "id": "4WIJsFr8M7E",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1621194023,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\nCi-en開設いたしました♪\nhttps://ci-en.dlsite.com/creator/9805\nフォロワー様10000人ありがとう企画のご応募はこちらのページからどうぞ…！\nこれから色々充実させていく予定ですので、ぜひフォローお願いします💞\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※",
+        "videoId": "4WIJsFr8M7E",
+        "title": "【シリーズ完全初見】はじめてのモンハン【定期配信第36回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H25M25S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1621170049,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1621170000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1621182375,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/4WIJsFr8M7E\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "4WIJsFr8M7E",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4WIJsFr8M7E/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.529Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779906617,
+          "nanoseconds": 359000000
+        },
+        "statistics": {
+          "commentCount": 6,
+          "favoriteCount": 0,
+          "likeCount": 330,
+          "viewCount": 8349
+        }
+      }
+    },
+    {
+      "id": "4puiyit3sp0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1751902090,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n© 2025 LEVEL5 Inc.\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "4puiyit3sp0",
+        "title": "世界を滅亡から救うか寄り道するのか...自由だぁ～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#8】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H53M44S",
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1751894066,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1751894100,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1751900886,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/4puiyit3sp0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "4puiyit3sp0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/4puiyit3sp0/maxresdefault.jpg",
+        "audioButtonCount": 1,
+        "updatedAt": "2025-08-22T04:05:13.559Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "commentCount": 10,
+          "favoriteCount": 0,
+          "likeCount": 145,
+          "viewCount": 2572
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 291000000
+        }
+      }
+    },
+    {
+      "id": "5076cp_W2Qs",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1746720643,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "5076cp_W2Qs",
+        "title": "夢の薬の闇…あばく！！！【JUDGE EYES：死神の遺言 Remastered #12／ストーリーのネタバレ含みます】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H29M35S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746707355,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746707400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1746719960,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5076cp_W2Qs\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5076cp_W2Qs",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5076cp_W2Qs/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.583Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "JUDGE EYES：死神の遺言 Remastered",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "JUDGE EYES：死神の遺言 Remastered",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "commentCount": 11,
+          "favoriteCount": 0,
+          "likeCount": 195,
+          "viewCount": 5067
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 293000000
+        }
+      }
+    },
+    {
+      "id": "53OgUWeyYpY",
+      "data": {
+        "description": "涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n素敵なモデル・素材ありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "53OgUWeyYpY",
+        "title": "ザンニーさん、好きです♡【鳴潮／Wuthering Waves】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ]
+        },
+        "userTags": [],
+        "id": "53OgUWeyYpY",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "duration": "PT3H25M51S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1772377598,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1772364600,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1772364625,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 320,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1772377000,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/53OgUWeyYpY/maxresdefault.jpg",
+        "statistics": {
+          "commentCount": 11,
+          "likeCount": 381,
+          "viewCount": 8237
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 421000000
+        }
+      }
+    },
+    {
+      "id": "58rXqPmJPXY",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1765983191,
+          "nanoseconds": 0
+        },
+        "videoType": "archived",
+        "description": "ご視聴ありがとうございます🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "58rXqPmJPXY",
+        "title": "平和になったミアレを満喫♡DLCも買ったよ～！【Pokémon LEGENDS Z-A／#10】",
+        "liveBroadcastContent": "none",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "Pokémon LEGENDS Z-A",
+            "🎮ゲーム💗"
+          ]
+        },
+        "duration": "PT2H40M55S",
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1765972819,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1765972800,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1765982487,
+            "nanoseconds": 0
+          }
+        },
+        "userTags": [],
+        "id": "58rXqPmJPXY",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "Pokémon LEGENDS Z-A",
+          "🎮ゲーム💗"
+        ],
+        "thumbnailUrl": "https://i.ytimg.com/vi/58rXqPmJPXY/maxresdefault.jpg",
+        "statistics": {
+          "commentCount": 8,
+          "likeCount": 152,
+          "viewCount": 2792
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 423000000
+        }
+      }
+    },
+    {
+      "id": "5CB8CDH5h4w",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1635342193,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "#60\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Thumbnail illust】\n浅木式様　https://twitter.com/asagishiki00\n素敵なイラストありがとう💞\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\n柊 羽音様　https://www.youtube.com/channel/UCir67pOSMAaswHt5dj47KDA\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "5CB8CDH5h4w",
+        "title": "秋の夜長にしっぽり晩酌…🍹🍁",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H36M57S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1635336001,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1635336000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1635341820,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5CB8CDH5h4w\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5CB8CDH5h4w",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5CB8CDH5h4w/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.614Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1763440214,
+          "nanoseconds": 798000000
+        },
+        "statistics": {
+          "likeCount": 229,
+          "commentCount": 3,
+          "favoriteCount": 0,
+          "viewCount": 4862
+        }
+      }
+    },
+    {
+      "id": "5Dnq9iMrGzI",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1706436593,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　  https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "5Dnq9iMrGzI",
+        "title": "収録前の声出し歌枠🎤💗",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H37M20S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1706429841,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1706435675,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5Dnq9iMrGzI\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎤歌枠🩷"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎤歌枠🩷"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5Dnq9iMrGzI",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5Dnq9iMrGzI/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.630Z",
+        "statistics": {
+          "commentCount": 14,
+          "favoriteCount": 0,
+          "likeCount": 479,
+          "viewCount": 9269
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 351000000
+        }
+      }
+    },
+    {
+      "id": "5G6iL-vQZOY",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1607266400,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※",
+        "videoId": "5G6iL-vQZOY",
+        "title": "【ゼルダ無双＃２】たたかう！！！！！【定期配信第18回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H33M25S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1607259624,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1607259600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1607265231,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5G6iL-vQZOY\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5G6iL-vQZOY",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5G6iL-vQZOY/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.663Z",
+        "statistics": {
+          "commentCount": 2,
+          "favoriteCount": 0,
+          "likeCount": 129,
+          "viewCount": 2821
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783150218,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "5Kx5GBMDwTQ",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1714728792,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/sta...\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　  https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "5Kx5GBMDwTQ",
+        "title": "【龍が如く0】まったりクリア後モード【ストーリーのネタバレ含みます🌸】",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H2M40S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1714720988,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1714728355,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5Kx5GBMDwTQ\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5Kx5GBMDwTQ",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5Kx5GBMDwTQ/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.681Z",
+        "statistics": {
+          "commentCount": 10,
+          "favoriteCount": 0,
+          "likeCount": 132,
+          "viewCount": 2490
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 350000000
+        }
+      }
+    },
+    {
+      "id": "5ahWwNInun0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1683726698,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【132】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n華秀てんま様　https://twitter.com/tenma_ka\n素敵なイラストありがとうございます💞\n\n【Live2D】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "5ahWwNInun0",
+        "title": "耳かき&耳ふーでお耳を癒すやさしいASMR…♥【binaural／KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H40M3S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1683719955,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1683720000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1683725962,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5ahWwNInun0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5ahWwNInun0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5ahWwNInun0/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.697Z",
+        "statistics": {
+          "commentCount": 22,
+          "favoriteCount": 0,
+          "likeCount": 1489,
+          "viewCount": 80010
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 456000000
+        }
+      }
+    },
+    {
+      "id": "5mKrbnUh3bk",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1609173415,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "声優の方々とAmong Usであそびます✨\n\n一緒に遊んでくださる方々♥\n\nかの仔さん\n【Twitter】https://twitter.com/kanoko46\n【視点配信】https://youtu.be/i5YlXbx2fzk\n\n沢野ぽぷらさん\n【Twitter】https://twitter.com/poplar_berm\n【視点配信】https://youtu.be/sAhYpPrkm7w\n\nみもりあいのさん\n【Twitter】https://twitter.com/mimo_chorion\n【視点配信】https://youtu.be/IusuS4i1zJE\n\nみやぢさん\n【Twitter】https://twitter.com/myd_tube\n【視点配信】https://youtu.be/wQeJp7zu96M\n\n陽向葵ゅかさん\n【Twitter】https://twitter.com/yukanyan2525\n【視点配信】https://youtu.be/8YqlufRyIq4\n\n柚萌さん\n【Twitter】https://twitter.com/yume_ui\n【視点配信】https://youtu.be/mMi1jdgx0vY\n\n浅木式さん\n【Twitter】https://twitter.com/asagishiki00\n【視点配信】https://youtu.be/ds_MDV_cK-k\n\n秋山はるるさん　（今回初参加✨）\n【Twitter】https://twitter.com/hiiragi_mafuyu\n【視点配信】https://youtu.be/hJv-iaDJYFs\n\n涼花みなせ\ntwitter：https://twitter.com/suzuka_minase\nHP：https://www.szkminase.com/",
+        "videoId": "5mKrbnUh3bk",
+        "title": "【第2回】みんなでAmong Us♪【声優さんたちとコラボ】",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H56M41S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1609162293,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1609162200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1609172898,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/5mKrbnUh3bk\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗",
+            "🐱コラボ配信💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗",
+          "🐱コラボ配信💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "5mKrbnUh3bk",
+        "thumbnailUrl": "https://i.ytimg.com/vi/5mKrbnUh3bk/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.721Z",
+        "statistics": {
+          "commentCount": 1,
+          "favoriteCount": 0,
+          "likeCount": 265,
+          "viewCount": 9851
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783150218,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "6G-p7jJPfAY",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1636725474,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【#62】\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Thumbnail illust】\nむぎた様　https://twitter.com/1x1_3\nに描いていただきました＾＾＊\n素敵なイラストありがとうございます💞\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\n柊 羽音様　https://www.youtube.com/channel/UCir67pOSMAaswHt5dj47KDA\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6G-p7jJPfAY",
+        "title": "また新たな身体でモデルデビューする！👖💓【モデルデビュー2 ニコラ】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H38M33S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1636718351,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1636718400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1636724263,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6G-p7jJPfAY\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6G-p7jJPfAY",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6G-p7jJPfAY/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.753Z",
+        "statistics": {
+          "commentCount": 3,
+          "favoriteCount": 0,
+          "likeCount": 157,
+          "viewCount": 7071
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 495000000
+        }
+      }
+    },
+    {
+      "id": "6PIR5Vmgnhs",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1686318624,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【137】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n皇きみ様　https://twitter.com/srm_kimi\n素敵なイラストありがとうございます💞\n\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6PIR5Vmgnhs",
+        "title": "耳ふー特化🌸密着吐息でお耳ぞわぞわASMR…♥【binaural／KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H39M47S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1686311961,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1686312000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1686317953,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6PIR5Vmgnhs\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6PIR5Vmgnhs",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6PIR5Vmgnhs/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.773Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 454000000
+        },
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 104,
+          "likeCount": 9285,
+          "viewCount": 843481
+        }
+      }
+    },
+    {
+      "id": "6Zo5qUosmOQ",
+      "data": {
+        "description": "涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6Zo5qUosmOQ",
+        "title": "無声音囁きと耳かきでお耳ぽわぽわにしたい♡【KU100／バイノーラル】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗"
+          ]
+        },
+        "userTags": [],
+        "id": "6Zo5qUosmOQ",
+        "categoryId": "24",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗"
+        ],
+        "duration": "PT1H14M45S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1774623163,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1774614611,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1774614600,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 744,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1774619109,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6Zo5qUosmOQ/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 401000000
+        },
+        "statistics": {
+          "likeCount": 827,
+          "commentCount": 26,
+          "viewCount": 29167
+        }
+      }
+    },
+    {
+      "id": "6b0T60Cr968",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1740931544,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nモンスターハンターワイルズ \n©CAPCOM\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6b0T60Cr968",
+        "title": "ぴぃ伝説３日目！！狩りまくる～～～！！【 モンスターハンターワイルズ／ネタバレ含みます】",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H59M57S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1740919919,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1740920400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1740930726,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6b0T60Cr968\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6b0T60Cr968",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6b0T60Cr968/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.802Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "モンスターハンターワイルズ",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "モンスターハンターワイルズ",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "commentCount": 8,
+          "favoriteCount": 0,
+          "likeCount": 205,
+          "viewCount": 4511
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 296000000
+        }
+      }
+    },
+    {
+      "id": "6hEwXuTu038",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1643637755,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【#73】\nNintendo Switchダウンロードソフト「ボクらのウィンタースポーツ」\nhttp://sat-box.jp/Game/wintersports_switch.html\n2022年2月3日、SAT-BOX様から販売開始です(*´ω｀*)🌸！！\nぜひ遊んでみてね🎶\n\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6hEwXuTu038",
+        "title": "【ボクらのウィンタースポーツ】🎿🥇冬のスポーツ満喫する⛄💗【先行プレイ】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H45M23S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1643630356,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1643630400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1643636678,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6hEwXuTu038\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6hEwXuTu038",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6hEwXuTu038/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.833Z",
+        "statistics": {
+          "likeCount": 151,
+          "commentCount": 3,
+          "favoriteCount": 0,
+          "viewCount": 3567
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1768141815,
+          "nanoseconds": 569000000
+        }
+      }
+    },
+    {
+      "id": "6n1CBh4dNJ4",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1671976818,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【117】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enに新しいプランを２つ開設しました🌸\nオリジナルのえちち……💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Thumbnail】\nKangDe様　https://twitter.com/solituder9\n素敵なすずみなーと、ありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6n1CBh4dNJ4",
+        "title": "くりすます密着ASMR❄お菓子食べたりささやいたり…💗【KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H43M51S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1671969746,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1671969600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1671975972,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6n1CBh4dNJ4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6n1CBh4dNJ4",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6n1CBh4dNJ4/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.865Z",
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 5,
+          "likeCount": 325,
+          "viewCount": 9371
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 458000000
+        }
+      }
+    },
+    {
+      "id": "6vBrdn0I7i4",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1640354108,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【#68】\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n琴音有波さん💗\nTwitter🐣https://twitter.com/kotone_akv\nYouTube📺https://www.youtube.com/channel/UCEN9jJz1uLnIfrD_IWubgxQ\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Thumbnail illust】\n華秀てんま様　https://twitter.com/tenma_ka\nに描いていただきました…！素敵なイラストありがとうございます💞\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【素材】\nうさねこメモリー様\ninosetetsu様\nにお借りしました🌸\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "6vBrdn0I7i4",
+        "title": "【途中から琴音有波さんと💗】クリスマスパーティー☆ケーキ食べたりおしゃべりしたり…♥",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H48M56S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1640347148,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1640347200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1640353687,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6vBrdn0I7i4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6vBrdn0I7i4",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6vBrdn0I7i4/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.895Z",
+        "statistics": {
+          "favoriteCount": 0,
+          "likeCount": 222,
+          "commentCount": 4,
+          "viewCount": 5225
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 461000000
+        }
+      }
+    },
+    {
+      "id": "6wACmJy_yd8",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1613918760,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n配信のサムネイルは、リスナー様が描いてくださったファンアートを使用させて頂いております。\n今回の作者様\nいつね様　https://twitter.com/Fis567\n素敵なイラストありがとうございます💝",
+        "videoId": "6wACmJy_yd8",
+        "title": "まったり雑談【定期配信第25回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H38M34S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1613912427,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1613912400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1613918342,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/6wACmJy_yd8\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "6wACmJy_yd8",
+        "thumbnailUrl": "https://i.ytimg.com/vi/6wACmJy_yd8/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.912Z",
+        "statistics": {
+          "commentCount": 1,
+          "favoriteCount": 0,
+          "likeCount": 177,
+          "viewCount": 4281
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783150218,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "71lGXP2gJFs",
+      "data": {
+        "description": "涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【サムネ素材】\n七篠みるく様　 ‪@nanashino_milk‬ \n\n素敵なモデル・素材ありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "71lGXP2gJFs",
+        "title": "そろそろ色違いポケモン様に出会いたい。【Pokémon LEGENDS Z-A】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "Pokémon LEGENDS Z-A"
+          ]
+        },
+        "userTags": [],
+        "id": "71lGXP2gJFs",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "Pokémon LEGENDS Z-A"
+        ],
+        "duration": "PT3H36M39S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1773761006,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1773747011,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1773747000,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 172,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1773760021,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/71lGXP2gJFs/maxresdefault.jpg",
+        "statistics": {
+          "commentCount": 17,
+          "likeCount": 158,
+          "viewCount": 3212
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 420000000
+        }
+      }
+    },
+    {
+      "id": "752DCsYirAg",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1700227783,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【145】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n皇きみ様　https://twitter.com/srm_kimi  \n素敵なイラストありがとうございます💞\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "752DCsYirAg",
+        "title": "バイノーラルひそひそ雑談🐏🤍【binaural/KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H19M42S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1700222353,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1700222400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1700227137,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/752DCsYirAg\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "752DCsYirAg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/752DCsYirAg/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.940Z",
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 16,
+          "likeCount": 734,
+          "viewCount": 25492
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 351000000
+        }
+      }
+    },
+    {
+      "id": "76uSI9lJpFM",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1746527689,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "76uSI9lJpFM",
+        "title": "今日はハムに会えるかなぁ？【JUDGE EYES：死神の遺言 Remastered #11／ストーリーのネタバレ含みます】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H22M48S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746514755,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746514800,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1746526935,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/76uSI9lJpFM\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "76uSI9lJpFM",
+        "thumbnailUrl": "https://i.ytimg.com/vi/76uSI9lJpFM/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.956Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "JUDGE EYES：死神の遺言 Remastered",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "JUDGE EYES：死神の遺言 Remastered",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "commentCount": 12,
+          "favoriteCount": 0,
+          "likeCount": 174,
+          "viewCount": 3855
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 293000000
+        }
+      }
+    },
+    {
+      "id": "7BKyWRPLG1w",
+      "data": {
+        "description": "新衣装・新モデル記念グッズ🩷\nhttps://x.com/suzuka_minase/status/2055231687257366789\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "7BKyWRPLG1w",
+        "title": "ゆるゆるバイノーラル雑談♡【KU100】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "⭐雑談💗"
+          ]
+        },
+        "userTags": [],
+        "id": "7BKyWRPLG1w",
+        "categoryId": "24",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "duration": "PT1H58M16S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1781019287,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1781010018,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1781010000,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 359,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1781017132,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/7BKyWRPLG1w/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 397000000
+        },
+        "statistics": {
+          "commentCount": 15,
+          "likeCount": 302,
+          "viewCount": 7636
+        }
+      }
+    },
+    {
+      "id": "7cSUfgPmPBM",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1663923311,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\nーお知らせー\nCi-enに新しいプランを２つ開設しました🌸\nご支援いただいた特典として、オリジナルのえちち…💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "7cSUfgPmPBM",
+        "title": "モンハンライズサンブレイクで遊ぶ！！！🦖⚔【#2】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H9M36S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1663910990,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1663911000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1663922365,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/7cSUfgPmPBM\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "7cSUfgPmPBM",
+        "thumbnailUrl": "https://i.ytimg.com/vi/7cSUfgPmPBM/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:13.986Z",
+        "statistics": {
+          "commentCount": 4,
+          "favoriteCount": 0,
+          "viewCount": 4843,
+          "likeCount": 202
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 459000000
+        }
+      }
+    },
+    {
+      "id": "7mDy3o20ZEI",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1541718429,
+          "nanoseconds": 0
+        },
+        "videoType": "normal",
+        "caption": false,
+        "description": "ご視聴頂いてありがとうございます♪\n今回お友達声優さんの 羽澄 愛 ちゃんから、掛け合いコラボのお誘いを頂きました( *ˊᵕˋ)✩︎‧₊\n愛ちゃんの可愛い少年声をご堪能くださいっ！\n\n＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝\n\n「メイドの戯れ」\n\n声優\n坊ちゃま：羽澄 愛(@hazumi_ai)\nhttps://hazumiai.jimdofree.com\nメイド：涼花 みなせ(@suzuka_minase)\nhttps://szkminase.wixsite.com/szmnhp\n\n台本：鶏三味 様\n\nBGM：H/MIX Gallery 様\n効果音：小森平 様・On-Jin 〜音人〜 様・ポケットサウンド 様\n\n＝＝＝＝＝＝＝＝＝＝＝＝＝＝＝\n\n編集から、何から何まで、愛ちゃんありがとうございました♪",
+        "videoId": "7mDy3o20ZEI",
+        "title": "プチボイスドラマ「メイドの戯れ」：愛ちゃんコラボ",
+        "liveBroadcastContent": "none",
+        "duration": "PT3M36S",
+        "audioButtonCount": 0,
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/7mDy3o20ZEI\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "userTags": [],
+        "id": "7mDy3o20ZEI",
+        "tags": {
+          "userTags": [],
+          "playlistTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [],
+        "thumbnailUrl": "https://i.ytimg.com/vi/7mDy3o20ZEI/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.014Z",
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 4,
+          "likeCount": 49,
+          "viewCount": 2002
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783150218,
+          "nanoseconds": 295000000
+        }
+      }
+    },
+    {
+      "id": "83T29piiz5E",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1667657000,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n🌸finggerさんのご紹介🌸\n\n配信者とリスナー様がコメントを通じて一緒に遊べるゲームを公開されてます🎶\n\n▼YouTube ライブで遊べる参加型ゲームプラットフォーム\n（ゲームプレイやアイテム購入はこちらから✨）\nhttps://fingger.com/\n\n▼公式Twitter\nhttps://twitter.com/finggerOfficial\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enに新しいプランを２つ開設しました🌸\nオリジナルのえちち…💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Thumbnail】\nKIN金魚屋様　https://twitter.com/kintotomaturi\n素敵に描いていただきました💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "83T29piiz5E",
+        "title": "両想いリベンジ🌸みんなで遊ぶ乙女ゲー💗あたまの中のお前らが私の恋愛を勝手に決める件！【fingger】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H55M56S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1667649550,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1667649600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1667656508,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/83T29piiz5E\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "83T29piiz5E",
+        "thumbnailUrl": "https://i.ytimg.com/vi/83T29piiz5E/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.043Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1764311414,
+          "nanoseconds": 636000000
+        },
+        "statistics": {
+          "commentCount": 3,
+          "favoriteCount": 0,
+          "likeCount": 142,
+          "viewCount": 3995
+        }
+      }
+    },
+    {
+      "id": "85p6ez16wZs",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1731945500,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_mi...\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\n  / 1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイルイラスト】\nベイすけ様　：　https://x.com/bey01st\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "85p6ez16wZs",
+        "title": "マイクラほぼ初心者が新ワールドでがんばって生きる！【Minecraft／#4】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H44M30S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1731931156,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1731931200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1731944629,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/85p6ez16wZs\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "85p6ez16wZs",
+        "thumbnailUrl": "https://i.ytimg.com/vi/85p6ez16wZs/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.076Z",
+        "statistics": {
+          "commentCount": 9,
+          "favoriteCount": 0,
+          "likeCount": 302,
+          "viewCount": 7846
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 297000000
+        }
+      }
+    },
+    {
+      "id": "87XkXkhtczU",
+      "data": {
+        "description": "浅木ゆめみちゃん🩷　@A.yumemi \n夢星もかちゃん🩷　@mokachi_voice \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "87XkXkhtczU",
+        "userTags": [],
+        "id": "87XkXkhtczU",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "duration": "PT4H11M29S",
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1777377600,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1777377631,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 228,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1777392733,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1777394123,
+          "nanoseconds": 0
+        },
+        "thumbnailUrl": "https://i.ytimg.com/vi/87XkXkhtczU/maxresdefault.jpg",
+        "title": "【浅木ゆめみ・夢星もか】あさちゃん入国♡もかちとおもてなしがんばる！！【#すみっこキングダム／Minecraft】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "すみっこキングダム／Minecraft",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "すみっこキングダム／Minecraft",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "commentCount": 13,
+          "likeCount": 211,
+          "viewCount": 5241
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 400000000
+        }
+      }
+    },
+    {
+      "id": "88rN2gDWYJ4",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1750251614,
+          "nanoseconds": 0
+        },
+        "videoType": "normal",
+        "caption": false,
+        "description": "ご視聴ありがとうございます🌸\n\n同棲してる彼女と寝る前にベッドでごろごろしながらお喋りして過ごしてるイメージで作ってみたよ♡！\n\n台本：アドリブ\nイラスト：華秀てんま様　https://x.com/tenma_ka\n\n※演者は成人しています...！\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "88rN2gDWYJ4",
+        "title": "【リアル風】同棲彼女と、眠る前の癒しのひととき。【バイノーラルKU100／ASMR／男性向けシチュボ】",
+        "liveBroadcastContent": "none",
+        "duration": "PT7M35S",
+        "audioButtonCount": 0,
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/88rN2gDWYJ4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "userTags": [],
+        "id": "88rN2gDWYJ4",
+        "thumbnailUrl": "https://i.ytimg.com/vi/88rN2gDWYJ4/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.092Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 291000000
+        },
+        "statistics": {
+          "favoriteCount": 0,
+          "likeCount": 518,
+          "commentCount": 36,
+          "viewCount": 15630
+        }
+      }
+    },
+    {
+      "id": "8Af37QAT33w",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1639847598,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※",
+        "videoId": "8Af37QAT33w",
+        "title": "モデルライフ満喫！👖💓【モデルデビュー2 ニコラ】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H14M56S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1639834630,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1639846322,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8Af37QAT33w\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8Af37QAT33w",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8Af37QAT33w/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.116Z",
+        "statistics": {
+          "likeCount": 126,
+          "commentCount": 2,
+          "favoriteCount": 0,
+          "viewCount": 2719
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 461000000
+        }
+      }
+    },
+    {
+      "id": "8C_bHFhiLX8",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1682847611,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n音源をお借りしているサイト（音源使用許諾を頂いております）　\n・カラオケ歌っちゃ王様　http://tomomusic.co.jp/utachaoh/　\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/sta...\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　  https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8C_bHFhiLX8",
+        "title": "雑談＆お歌♥",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H9M25S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1682834454,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1682845831,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8C_bHFhiLX8\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎤歌枠🩷",
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎤歌枠🩷",
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8C_bHFhiLX8",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8C_bHFhiLX8/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.142Z",
+        "statistics": {
+          "commentCount": 5,
+          "favoriteCount": 0,
+          "viewCount": 7208,
+          "likeCount": 312
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 456000000
+        }
+      }
+    },
+    {
+      "id": "8J0alaI_r6Q",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1633528281,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "#57\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Thumbnail illust】\n秘鏡様　https://twitter.com/hikyoo/status/1437896992361832449\n今回の配信のサムネイルは、リスナー様が描いてくださったすずみなーとをお借りしています🎨🌸\n素敵なイラストありがとうございます💞\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\n柊 羽音様　https://www.youtube.com/channel/UCir67pOSMAaswHt5dj47KDA\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nからお借りしています✨素敵な音楽ありがとうございます💕\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8J0alaI_r6Q",
+        "title": "雑談🎶",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H35M30S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1633521584,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1633521600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1633527317,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8J0alaI_r6Q\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8J0alaI_r6Q",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8J0alaI_r6Q/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.171Z",
+        "statistics": {
+          "commentCount": 1,
+          "favoriteCount": 0,
+          "likeCount": 205,
+          "viewCount": 5313
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 495000000
+        }
+      }
+    },
+    {
+      "id": "8Jmb08Nl5s0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1645542021,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【後半】\n\nASMRコラボの前半は、2/22(火)22:00から琴音さんのチャンネルで…👂🎶\n枠▷https://youtu.be/krI_tD-e19k\n\n💜琴音有波さん✨\n🐣Twitter▶https://twitter.com/kotone_akv\n📺YouTube▶https://www.youtube.com/channel/UCEN9jJz1uLnIfrD_IWubgxQ\n\n【サムネイルイラスト】\n浅木式様　https://twitter.com/asagishiki00\n素敵なイラストありがとおーー💗！\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8Jmb08Nl5s0",
+        "title": "【耳ふー・耳かき】琴音有波さん＆涼花みなせASMRコラボ…💗【KU100バイノーラル】",
+        "liveBroadcastContent": "none",
+        "duration": "PT54M4S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1645538375,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1645538400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1645541615,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8Jmb08Nl5s0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8Jmb08Nl5s0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8Jmb08Nl5s0/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.193Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎧ASMR💗",
+            "🐱コラボ配信💗"
+          ]
+        },
+        "playlistTags": [
+          "🎧ASMR💗",
+          "🐱コラボ配信💗"
+        ],
+        "statistics": {
+          "commentCount": 8,
+          "favoriteCount": 0,
+          "likeCount": 660,
+          "viewCount": 24023
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1776969017,
+          "nanoseconds": 531000000
+        }
+      }
+    },
+    {
+      "id": "8M-9GpucDdA",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1703427150,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM編曲・イラスト】\n藤崎わと様　 https://twitter.com/wato555111​​ \n\n【サムネイル】\n華秀てんま様　https://twitter.com/tenma_ka\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8M-9GpucDdA",
+        "title": "クリスマスだし、一緒にケーキ食べてまったりしよ🎄💛",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H50M58S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1703419157,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1703419200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1703425810,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8M-9GpucDdA\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8M-9GpucDdA",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8M-9GpucDdA/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.215Z",
+        "statistics": {
+          "commentCount": 7,
+          "favoriteCount": 0,
+          "viewCount": 11446,
+          "likeCount": 423
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 351000000
+        }
+      }
+    },
+    {
+      "id": "8Qqyayw_lSM",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1668779182,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【113】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enに新しいプランを２つ開設しました🌸\nオリジナルのえちち……💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Thumbnail】\n姫野アラタ様　https://twitter.com/ARThimeno\n素敵に描いていただきました💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8Qqyayw_lSM",
+        "title": "しゅわしゅわ炭酸マッサージでリフレッシュしよ♥【KU100バイノーラル】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H38M7S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1668772748,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1668772800,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1668778631,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8Qqyayw_lSM\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8Qqyayw_lSM",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8Qqyayw_lSM/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.241Z",
+        "statistics": {
+          "commentCount": 7,
+          "favoriteCount": 0,
+          "likeCount": 369,
+          "viewCount": 13233
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1767565814,
+          "nanoseconds": 306000000
+        }
+      }
+    },
+    {
+      "id": "8Wi8NVmUlp8",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1745943316,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8Wi8NVmUlp8",
+        "title": "海藤さんはほんとに味方…だよね？？みんな怪しい！【JUDGE EYES：死神の遺言 Remastered #6／ストーリーのネタバレ含みます】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H5M48S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1745931555,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1745931600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1745942704,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8Wi8NVmUlp8\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8Wi8NVmUlp8",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8Wi8NVmUlp8/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.283Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "JUDGE EYES：死神の遺言 Remastered",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "JUDGE EYES：死神の遺言 Remastered",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "commentCount": 12,
+          "favoriteCount": 0,
+          "likeCount": 155,
+          "viewCount": 3484
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 294000000
+        }
+      }
+    },
+    {
+      "id": "8af7jxFV8jg",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1714743293,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【156】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイルイラスト】\n華秀てんま様　：　https://twitter.com/tenma_ka\n\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8af7jxFV8jg",
+        "title": "耳かきASMR…💗【KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H24M26S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1714737575,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1714737600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1714742635,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8af7jxFV8jg\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8af7jxFV8jg",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8af7jxFV8jg/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.310Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1767677416,
+          "nanoseconds": 342000000
+        },
+        "statistics": {
+          "commentCount": 15,
+          "favoriteCount": 0,
+          "likeCount": 1247,
+          "viewCount": 40638
+        }
+      }
+    },
+    {
+      "id": "8hcFhjECMaM",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1749311094,
+          "nanoseconds": 0
+        },
+        "videoType": "archived",
+        "description": "ご視聴ありがとうございます🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n© 2025 LEVEL5 Inc.\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8hcFhjECMaM",
+        "title": "今日もライフする！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#3】",
+        "liveBroadcastContent": "none",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
+            "🎮ゲーム💗"
+          ]
+        },
+        "duration": "PT3H3M16S",
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1749299349,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1749299400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1749310338,
+            "nanoseconds": 0
+          }
+        },
+        "userTags": [],
+        "id": "8hcFhjECMaM",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
+          "🎮ゲーム💗"
+        ],
+        "thumbnailUrl": "https://i.ytimg.com/vi/8hcFhjECMaM/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1761287416,
+          "nanoseconds": 276000000
+        },
+        "statistics": {
+          "likeCount": 166,
+          "commentCount": 14,
+          "viewCount": 3412
+        }
+      }
+    },
+    {
+      "id": "8n9e9qSldMI",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1736958537,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます...！涼花みなせです🐰🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n『8番のりば』Steam販売サイト\nhttps://store.steampowered.com/app/2903560/8/\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nコラボのお相手🤍·*゜\n\nみやぢさん\nX　⇒　https://x.com/myd_tube\nYouTube　⇒　‪‪‪@みやぢっきょうちゃんねる \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599  \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://x.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8n9e9qSldMI",
+        "title": "電車からの脱出...！みやぢさんと頑張る！！！【8番のりば】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H37M23S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1736949573,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1736949600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1736955417,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8n9e9qSldMI\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗",
+            "🐱コラボ配信💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗",
+          "🐱コラボ配信💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8n9e9qSldMI",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8n9e9qSldMI/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.332Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 296000000
+        },
+        "statistics": {
+          "commentCount": 13,
+          "favoriteCount": 0,
+          "likeCount": 471,
+          "viewCount": 11611
+        }
+      }
+    },
+    {
+      "id": "8qejVCB9PT8",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1708853653,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/sta...\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　  https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8qejVCB9PT8",
+        "title": "【龍が如く0】久しぶりかじゅま【ストーリーのネタバレ含みます🌸】",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H31M7S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1708844221,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1708853286,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8qejVCB9PT8\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8qejVCB9PT8",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8qejVCB9PT8/sddefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.401Z",
+        "statistics": {
+          "commentCount": 9,
+          "favoriteCount": 0,
+          "viewCount": 5231,
+          "likeCount": 232
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 351000000
+        }
+      }
+    },
+    {
+      "id": "8wDxOaN_dE4",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1685714955,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【136】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n華秀てんま様　https://twitter.com/tenma_ka\n素敵なイラストありがとうございます💞\n\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8wDxOaN_dE4",
+        "title": "ざつだん！🌸",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H37M23S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1685707160,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1685707200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1685713010,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8wDxOaN_dE4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8wDxOaN_dE4",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8wDxOaN_dE4/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.507Z",
+        "statistics": {
+          "commentCount": 8,
+          "favoriteCount": 0,
+          "likeCount": 234,
+          "viewCount": 8670
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 455000000
+        }
+      }
+    },
+    {
+      "id": "8zIR2pbkD9Y",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1653055053,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "#89 \nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\nーお知らせー\n\nCi-enに新しいプランを２つ開設しました🌸\nご支援いただいた特典として、オリジナルのえちち…💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記の記事をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\nーーーーーー\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "8zIR2pbkD9Y",
+        "title": "【モンハンライズ】めちゃめちゃ久しぶりの狩り🦕⚔!!",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H39M54S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1653048219,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1653048000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1653054215,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/8zIR2pbkD9Y\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "8zIR2pbkD9Y",
+        "thumbnailUrl": "https://i.ytimg.com/vi/8zIR2pbkD9Y/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.603Z",
+        "statistics": {
+          "commentCount": 4,
+          "favoriteCount": 0,
+          "viewCount": 4074,
+          "likeCount": 180
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 459000000
+        }
+      }
+    },
+    {
+      "id": "92T0gbxh3CE",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1657461099,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【#96】\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\nーお知らせー\nCi-enに新しいプランを２つ開設しました🌸\nご支援いただいた特典として、オリジナルのえちち…💗なボイスや、お礼おハガキのお届けなどをご用意しております✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n【Live2Dmodel（新衣装）】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2Dmodel（旧衣装）】\nillust／modeling　：イモリ猫様　https://twitter.com/imorineko\n\n旧衣装・新衣装ともに、素敵なモデルありがとうございます💗\n\n【BGM】\nimataku Music様　https://youtu.be/tDToL1gSLuU\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nぽるぽるMusic様　https://www.youtube.com/channel/UCZwE4A5omTM9_29vYtoXUNg\nからお借りしています✨素敵な音楽ありがとうございます💕\n（使用していない配信もございます）\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "92T0gbxh3CE",
+        "title": "耳かきASMR♥【KU100バイノーラル】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H39M18S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1657454379,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1657454400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1657460330,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/92T0gbxh3CE\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "92T0gbxh3CE",
+        "thumbnailUrl": "https://i.ytimg.com/vi/92T0gbxh3CE/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.632Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎧ASMR💗"
+          ]
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "statistics": {
+          "commentCount": 13,
+          "favoriteCount": 0,
+          "likeCount": 666,
+          "viewCount": 27337
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 459000000
+        }
+      }
+    },
+    {
+      "id": "97UnRtIlMc0",
+      "data": {
+        "caption": false,
+        "description": "ご視聴ありがとうございます🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n© 2025 LEVEL5 Inc.\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "97UnRtIlMc0",
+        "title": "全てのライフの力を合わせて…ギア作り！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#11】",
+        "liveBroadcastContent": "none",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/97UnRtIlMc0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "duration": "PT2H23M59S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1753608785,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1753599616,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1753599600,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 121,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1753608251,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "97UnRtIlMc0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/97UnRtIlMc0/maxresdefault.jpg",
+        "audioButtonCount": 1,
+        "updatedAt": "2025-08-22T04:05:14.718Z",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
+            "🎮ゲーム💗"
+          ]
+        },
+        "playlistTags": [
+          "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
+          "🎮ゲーム💗"
+        ],
+        "statistics": {
+          "favoriteCount": 0,
+          "commentCount": 10,
+          "likeCount": 136,
+          "viewCount": 2431
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783153818,
+          "nanoseconds": 553000000
+        }
+      }
+    },
+    {
+      "id": "9LnnOkucuUs",
+      "data": {
+        "description": "ご視聴ありがとうございます🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n🩷SpecialThanks🩷\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D ASMR用】\nillust　　：　華秀てんま様　https://twitter.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【サムネ素材】\n七篠みるく様　 @nanashino_milk\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "9LnnOkucuUs",
+        "title": "ざつだん、しよ♡",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "⭐雑談💗"
+          ]
+        },
+        "userTags": [],
+        "id": "9LnnOkucuUs",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "duration": "PT2H22M58S",
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1757336400,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1757336407,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1757344995,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1757345556,
+          "nanoseconds": 0
+        },
+        "thumbnailUrl": "https://i.ytimg.com/vi/9LnnOkucuUs/maxresdefault.jpg",
+        "statistics": {
+          "commentCount": 12,
+          "likeCount": 255,
+          "viewCount": 5866
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 425000000
+        }
+      }
+    },
+    {
+      "id": "9QeKU4nwTmg",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1728840281,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＜Unpacking＞\nSteam販売サイト\nhttps://store.steampowered.com/app/1135690/Unpacking\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイルイラスト】\nʜᴀɢᴇ様　：　https://x.com/Ohagetty\n\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "9QeKU4nwTmg",
+        "title": "深夜のまったりお片付けタイム🌙【Unpacking／#2】",
+        "liveBroadcastContent": "none",
+        "duration": "PT3H15M30S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1728827969,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1728839699,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/9QeKU4nwTmg\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "videoType": "archived",
+        "userTags": [],
+        "id": "9QeKU4nwTmg",
+        "tags": {
+          "userTags": [],
+          "playlistTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [],
+        "thumbnailUrl": "https://i.ytimg.com/vi/9QeKU4nwTmg/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.739Z",
+        "statistics": {
+          "commentCount": 7,
+          "favoriteCount": 0,
+          "likeCount": 266,
+          "viewCount": 5420
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 298000000
+        }
+      }
+    },
+    {
+      "id": "9gMJbSNZlXM",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1627652859,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\n今回の放送は、\n【まっさーじ&耳かき&耳舐め】❤膝枕しながら耳かき…ですか？❤【定期放送#3】です💕\nお耳を癒せるようにがんばります🎶\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n配信のサムネイルは、リスナー様に頂いたすずみなーとを使用しています💖\n今回の作者様はモタさん　（　https://twitter.com/nemuke?s=20　）です。\n素敵なイラストありがとうございます💞\n\nイモリ猫さん　（　https://twitter.com/imorineko?s=20　）\nに頂いたLive2Dモデルを使用しています🎶\n素敵なモデル、ありがとうございます💞\n\nBGM：　OtoLogic様\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "9gMJbSNZlXM",
+        "title": "【GarticPhone】みんなでお絵かきしよー！【定期配信第47回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H39M11S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1627646367,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1627646400,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1627652318,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/9gMJbSNZlXM\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "9gMJbSNZlXM",
+        "thumbnailUrl": "https://i.ytimg.com/vi/9gMJbSNZlXM/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.763Z",
+        "statistics": {
+          "likeCount": 118,
+          "commentCount": 1,
+          "favoriteCount": 0,
+          "viewCount": 2387
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 496000000
+        }
+      }
+    },
+    {
+      "id": "9gOkCti2I2w",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1625838865,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\nCi-en開設いたしました♪\nhttps://ci-en.dlsite.com/creator/9805\nこれから色々充実させていく予定ですので、ぜひフォローお願いします💞\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\nイモリ猫さん　（　https://twitter.com/imorineko?s=20　）\nに頂いたLive2Dモデルを使用しています🎶\n素敵なモデル、ありがとうございました💞",
+        "videoId": "9gOkCti2I2w",
+        "title": "いろいろ告知します♪【定期配信第44回】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H45M58S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1625832002,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1625832000,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1625838361,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/9gOkCti2I2w\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "⭐雑談💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "9gOkCti2I2w",
+        "thumbnailUrl": "https://i.ytimg.com/vi/9gOkCti2I2w/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.782Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1779906617,
+          "nanoseconds": 358000000
+        },
+        "statistics": {
+          "commentCount": 1,
+          "favoriteCount": 0,
+          "likeCount": 204,
+          "viewCount": 4311
+        }
+      }
+    },
+    {
+      "id": "9sX3eGSqUAc",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1681480799,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "【129】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n華秀てんま様　https://twitter.com/tenma_ka\n素敵に描いていただきました💞\n\n【Live2D】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "9sX3eGSqUAc",
+        "title": "全編無声音囁き💞吐息多めの囁き雑談でお耳と心を癒すASMR👂🌸【binaural／KU100】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H38M25S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1681473581,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1681473600,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1681479484,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/9sX3eGSqUAc\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎧ASMR💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎧ASMR💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "9sX3eGSqUAc",
+        "thumbnailUrl": "https://i.ytimg.com/vi/9sX3eGSqUAc/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.816Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783161018,
+          "nanoseconds": 457000000
+        },
+        "statistics": {
+          "commentCount": 15,
+          "favoriteCount": 0,
+          "likeCount": 827,
+          "viewCount": 38905
+        }
+      }
+    },
+    {
+      "id": "ABSbeZIjrD0",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1713088012,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/sta...\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　  https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "ABSbeZIjrD0",
+        "title": "【龍が如く0】第十二章から！どきどき…🔥【ストーリーのネタバレ含みます🌸】",
+        "liveBroadcastContent": "none",
+        "duration": "PT1H58M53S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1713078298,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1713085428,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/ABSbeZIjrD0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "20",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎮ゲーム💗"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎮ゲーム💗"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "ABSbeZIjrD0",
+        "thumbnailUrl": "https://i.ytimg.com/vi/ABSbeZIjrD0/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.850Z",
+        "statistics": {
+          "commentCount": 10,
+          "favoriteCount": 0,
+          "likeCount": 163,
+          "viewCount": 3408
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1782329417,
+          "nanoseconds": 679000000
+        }
+      }
+    },
+    {
+      "id": "AF9vtVbWj4Q",
+      "data": {
+        "description": "ご視聴ありがとうございます🌸\n\n中井みのるちゃん🩷\n@minoruKU100 \n\n夢星もかちゃん🌸\n@mokachi_voice \n\n苺氷えなちゃん🩷\n@itigoriena \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n\n素敵なモデル・素材ありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "AF9vtVbWj4Q",
+        "title": "偽物AIには負けない。みみえもの絆見せる！！【MIMESIS／中井みのる・苺氷えな・夢星もか・涼花みなせ】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎮ゲーム💗",
+            "🐱コラボ配信💗"
+          ]
+        },
+        "userTags": [],
+        "id": "AF9vtVbWj4Q",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "🎮ゲーム💗",
+          "🐱コラボ配信💗"
+        ],
+        "duration": "PT1H29M59S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1769093625,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1769086800,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1769087037,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 149,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1769092448,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/AF9vtVbWj4Q/maxresdefault.jpg",
+        "statistics": {
+          "commentCount": 12,
+          "likeCount": 161,
+          "viewCount": 3503
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783164618,
+          "nanoseconds": 422000000
+        }
+      }
+    },
+    {
+      "id": "AFP90wVS2PA",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1631282642,
+          "nanoseconds": 0
+        },
+        "videoType": "archived",
+        "description": "#53\nご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n【Live2Dmodel】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\nありがとうございました…💗\n\n定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　https://ch.nicovideo.jp/suzuka-minase\nお耳を癒せるようにがんばります🎶\n\n柊 羽音様　https://www.youtube.com/channel/UCir67pOSMAaswHt5dj47KDA\nにっこりさん様　https://www.youtube.com/channel/UCHZn6BZ9GcP0KqqKOy6rsiA\nからBGMをお借りしています✨\n素敵な音楽ありがとうございます💕\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします…！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせて頂きます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "AFP90wVS2PA",
+        "title": "新モデルお披露目💗withしーちゃん",
+        "liveBroadcastContent": "none",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "⭐雑談💗"
+          ]
+        },
+        "duration": "PT1H39M46S",
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1631275228,
+            "nanoseconds": 0
+          },
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1631275200,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1631281216,
+            "nanoseconds": 0
+          }
+        },
+        "userTags": [],
+        "id": "AFP90wVS2PA",
+        "categoryId": "24",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "⭐雑談💗"
+        ],
+        "thumbnailUrl": "https://i.ytimg.com/vi/AFP90wVS2PA/maxresdefault.jpg",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1763440214,
+          "nanoseconds": 800000000
+        },
+        "statistics": {
+          "commentCount": 6,
+          "likeCount": 409,
+          "viewCount": 7921
+        }
+      }
+    },
+    {
+      "id": "ALTvRNMpe-4",
+      "data": {
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1746955197,
+          "nanoseconds": 0
+        },
+        "caption": false,
+        "description": "ご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nオケ音源はカラオケ歌っちゃ王様　‪‪@uta-cha-oh‬  　からお借りしています🌸\n※使用許諾を購入しております...！\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://twitter.com/Galaxy_ito\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "ALTvRNMpe-4",
+        "title": "うたう♡",
+        "liveBroadcastContent": "none",
+        "duration": "PT2H8M29S",
+        "audioButtonCount": 0,
+        "liveStreamingDetails": {
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1746946777,
+            "nanoseconds": 0
+          },
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1746954477,
+            "nanoseconds": 0
+          }
+        },
+        "definition": "hd",
+        "dimension": "2d",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "player": {
+          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/ALTvRNMpe-4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+        },
+        "categoryId": "24",
+        "status": {
+          "privacyStatus": "public",
+          "uploadStatus": "processed",
+          "embeddable": true
+        },
+        "tags": {
+          "playlistTags": [
+            "🎤歌枠🩷"
+          ],
+          "userTags": [],
+          "contentTags": []
+        },
+        "playlistTags": [
+          "🎤歌枠🩷"
+        ],
+        "videoType": "archived",
+        "userTags": [],
+        "id": "ALTvRNMpe-4",
+        "thumbnailUrl": "https://i.ytimg.com/vi/ALTvRNMpe-4/maxresdefault.jpg",
+        "updatedAt": "2025-08-22T04:05:14.868Z",
+        "statistics": {
+          "commentCount": 15,
+          "favoriteCount": 0,
+          "likeCount": 275,
+          "viewCount": 5225
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1783157418,
+          "nanoseconds": 293000000
         }
       }
     }

--- a/apps/functions/src/tools/firestore-local/fixtures/works.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/works.json
@@ -56,7 +56,6 @@
         "productId": "RJ01000639",
         "releaseDate": "2022-12-24 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月24日",
         "workType": "SOU",
@@ -76,7 +75,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2022-12-24 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2022-12-24T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -112,55 +110,55 @@
             "name": "フェラチオ"
           }
         ],
-        "createdAt": "2026-05-26T07:05:07.568Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.568Z",
+        "createdAt": "2026-07-03T01:05:32.858Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.858Z",
         "price": {
-          "original": 1320,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 30,
-          "current": 1320,
           "localeOfficialPrices": {
             "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
+            "sv_SE": 79,
+            "id_ID": 145663,
             "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
             "fr_FR": 7.13,
             "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
             "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
           },
+          "current": 924,
+          "original": 1320,
+          "discount": 30,
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 4.99,
+            "sv_SE": 55.3,
+            "id_ID": 101964,
+            "pt_BR": 4.99,
+            "vi_VN": 149104,
+            "th_TH": 189.44,
+            "fr_FR": 4.99,
+            "de_DE": 4.99,
+            "zh_TW": 181,
+            "ko_KR": 8834,
+            "en_US": 5.68,
+            "es_ES": 4.99,
+            "zh_CN": 38.65,
+            "ar_AE": 5.68
           },
-          "point": 60
+          "point": 42
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.568Z"
+            "lastFetched": "2026-07-03T01:05:32.858Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.568Z"
+        "updatedAt": "2026-07-03T01:05:32.858Z"
       }
     },
     {
@@ -211,7 +209,6 @@
         "productId": "RJ01000963",
         "releaseDate": "2022-12-17 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月17日",
         "workType": "SOU",
@@ -234,7 +231,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2022-12-17 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2022-12-17T00:00:00.000Z",
         "genres": [
           "メイド",
@@ -280,55 +276,55 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-05-26T07:05:07.033Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.033Z",
+        "createdAt": "2026-07-03T01:05:32.221Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.221Z",
         "price": {
-          "original": 1320,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1320,
+          "current": 660,
+          "original": 1320,
           "localeOfficialPrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
             "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
             "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
           },
-          "point": 60
+          "point": 30
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.033Z"
+            "lastFetched": "2026-07-03T01:05:32.221Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.033Z"
+        "updatedAt": "2026-07-03T01:05:32.221Z"
       }
     },
     {
@@ -435,7 +431,6 @@
         "productId": "RJ01001102",
         "releaseDate": "2023-03-16 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年3月16日",
         "workType": "SOU",
@@ -448,7 +443,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-03-16 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-03-16T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -494,55 +488,53 @@
             "name": "処女"
           }
         ],
-        "createdAt": "2026-05-26T07:05:16.641Z",
-        "lastFetchedAt": "2026-05-26T07:05:16.641Z",
+        "createdAt": "2026-06-18T07:07:02.362Z",
+        "lastFetchedAt": "2026-06-18T07:07:02.362Z",
         "price": {
-          "original": 1540,
           "isFreeOrMissingPrice": false,
-          "discount": 50,
           "currency": "JPY",
           "current": 1540,
           "localeOfficialPrices": {
-            "it_IT": 8.32,
-            "sv_SE": 90.01,
-            "id_ID": 171741,
-            "pt_BR": 8.32,
-            "vi_VN": 254461,
-            "th_TH": 314.7,
-            "fr_FR": 8.32,
-            "de_DE": 8.32,
-            "zh_TW": 305,
-            "ko_KR": 14653,
-            "en_US": 9.69,
-            "es_ES": 8.32,
-            "zh_CN": 65.85,
-            "ar_AE": 9.69
+            "it_IT": 8.31,
+            "pt_BR": 8.31,
+            "fr_FR": 8.31,
+            "de_DE": 8.31,
+            "zh_TW": 304,
+            "en_US": 9.6,
+            "es_ES": 8.31,
+            "ar_AE": 9.6,
+            "sv_SE": 90.68,
+            "ko_KR": 14570,
+            "id_ID": 170543,
+            "vi_VN": 251799,
+            "zh_CN": 65,
+            "th_TH": 312.87
           },
           "localePrices": {
-            "it_IT": 8.32,
-            "sv_SE": 90.01,
-            "id_ID": 171741,
-            "pt_BR": 8.32,
-            "vi_VN": 254461,
-            "th_TH": 314.7,
-            "fr_FR": 8.32,
-            "de_DE": 8.32,
-            "zh_TW": 305,
-            "ko_KR": 14653,
-            "en_US": 9.69,
-            "es_ES": 8.32,
-            "zh_CN": 65.85,
-            "ar_AE": 9.69
+            "it_IT": 8.31,
+            "sv_SE": 90.68,
+            "id_ID": 170543,
+            "pt_BR": 8.31,
+            "vi_VN": 251799,
+            "th_TH": 312.87,
+            "fr_FR": 8.31,
+            "de_DE": 8.31,
+            "zh_TW": 304,
+            "ko_KR": 14570,
+            "en_US": 9.6,
+            "es_ES": 8.31,
+            "zh_CN": 65,
+            "ar_AE": 9.6
           },
           "point": 70
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:16.641Z"
+            "lastFetched": "2026-06-18T07:07:02.362Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:16.641Z"
+        "updatedAt": "2026-06-18T07:07:02.362Z"
       }
     },
     {
@@ -649,7 +641,6 @@
         "productId": "RJ01001104",
         "releaseDate": "2023-01-20 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月20日",
         "workType": "SOU",
@@ -662,7 +653,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-20 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-20T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -708,55 +698,53 @@
             "name": "処女"
           }
         ],
-        "createdAt": "2026-05-26T07:05:08.061Z",
-        "lastFetchedAt": "2026-05-26T07:05:08.061Z",
+        "createdAt": "2026-06-18T07:06:24.517Z",
+        "lastFetchedAt": "2026-06-18T07:06:24.517Z",
         "price": {
-          "original": 1540,
           "isFreeOrMissingPrice": false,
-          "discount": 50,
           "currency": "JPY",
           "current": 1540,
           "localeOfficialPrices": {
-            "it_IT": 8.32,
-            "sv_SE": 90.01,
-            "id_ID": 171741,
-            "pt_BR": 8.32,
-            "vi_VN": 254461,
-            "th_TH": 314.7,
-            "fr_FR": 8.32,
-            "de_DE": 8.32,
-            "zh_TW": 305,
-            "ko_KR": 14653,
-            "en_US": 9.69,
-            "es_ES": 8.32,
-            "zh_CN": 65.85,
-            "ar_AE": 9.69
+            "it_IT": 8.31,
+            "pt_BR": 8.31,
+            "fr_FR": 8.31,
+            "de_DE": 8.31,
+            "zh_TW": 304,
+            "en_US": 9.6,
+            "es_ES": 8.31,
+            "ar_AE": 9.6,
+            "sv_SE": 90.68,
+            "ko_KR": 14570,
+            "id_ID": 170543,
+            "vi_VN": 251799,
+            "zh_CN": 65,
+            "th_TH": 312.87
           },
           "localePrices": {
-            "it_IT": 8.32,
-            "sv_SE": 90.01,
-            "id_ID": 171741,
-            "pt_BR": 8.32,
-            "vi_VN": 254461,
-            "th_TH": 314.7,
-            "fr_FR": 8.32,
-            "de_DE": 8.32,
-            "zh_TW": 305,
-            "ko_KR": 14653,
-            "en_US": 9.69,
-            "es_ES": 8.32,
-            "zh_CN": 65.85,
-            "ar_AE": 9.69
+            "it_IT": 8.31,
+            "sv_SE": 90.68,
+            "id_ID": 170543,
+            "pt_BR": 8.31,
+            "vi_VN": 251799,
+            "th_TH": 312.87,
+            "fr_FR": 8.31,
+            "de_DE": 8.31,
+            "zh_TW": 304,
+            "ko_KR": 14570,
+            "en_US": 9.6,
+            "es_ES": 8.31,
+            "zh_CN": 65,
+            "ar_AE": 9.6
           },
           "point": 70
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:08.061Z"
+            "lastFetched": "2026-06-18T07:06:24.517Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:08.061Z"
+        "updatedAt": "2026-06-18T07:06:24.517Z"
       }
     },
     {
@@ -793,7 +781,6 @@
         "productId": "RJ01001212",
         "releaseDate": "2023-02-07 16:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年2月7日",
         "workType": "SOU",
@@ -822,7 +809,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-02-07 16:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-02-07T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -858,55 +844,55 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-05-26T07:05:09.407Z",
-        "lastFetchedAt": "2026-05-26T07:05:09.407Z",
+        "createdAt": "2026-07-03T01:05:34.132Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.132Z",
         "price": {
-          "original": 1650,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1650,
           "localeOfficialPrices": {
-            "it_IT": 8.92,
-            "pt_BR": 8.92,
-            "fr_FR": 8.92,
-            "de_DE": 8.92,
-            "es_ES": 8.92,
-            "zh_TW": 326,
-            "sv_SE": 96.44,
-            "ko_KR": 15699,
-            "en_US": 10.38,
-            "id_ID": 184008,
-            "vi_VN": 272637,
-            "zh_CN": 70.55,
-            "th_TH": 337.18,
-            "ar_AE": 10.38
+            "it_IT": 8.91,
+            "sv_SE": 98.75,
+            "id_ID": 182079,
+            "pt_BR": 8.91,
+            "vi_VN": 266258,
+            "th_TH": 338.29,
+            "fr_FR": 8.91,
+            "de_DE": 8.91,
+            "zh_TW": 323,
+            "ko_KR": 15774,
+            "en_US": 10.15,
+            "es_ES": 8.91,
+            "zh_CN": 69.02,
+            "ar_AE": 10.15
           },
+          "current": 825,
+          "original": 1650,
+          "discount": 50,
           "localePrices": {
-            "it_IT": 8.92,
-            "sv_SE": 96.44,
-            "id_ID": 184008,
-            "pt_BR": 8.92,
-            "vi_VN": 272637,
-            "th_TH": 337.18,
-            "fr_FR": 8.92,
-            "de_DE": 8.92,
-            "zh_TW": 326,
-            "ko_KR": 15699,
-            "en_US": 10.38,
-            "es_ES": 8.92,
-            "zh_CN": 70.55,
-            "ar_AE": 10.38
+            "it_IT": 4.46,
+            "sv_SE": 49.38,
+            "id_ID": 91040,
+            "pt_BR": 4.46,
+            "vi_VN": 133129,
+            "th_TH": 169.14,
+            "fr_FR": 4.46,
+            "de_DE": 4.46,
+            "zh_TW": 162,
+            "ko_KR": 7887,
+            "en_US": 5.08,
+            "es_ES": 4.46,
+            "zh_CN": 34.51,
+            "ar_AE": 5.08
           },
-          "point": 75
+          "point": 37
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:09.407Z"
+            "lastFetched": "2026-07-03T01:05:34.132Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:09.407Z"
+        "updatedAt": "2026-07-03T01:05:34.132Z"
       }
     },
     {
@@ -955,7 +941,6 @@
         "productId": "RJ01002873",
         "releaseDate": "2023-01-06 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月6日",
         "workType": "SOU",
@@ -968,7 +953,6 @@
         "fileFormat": "MP3",
         "fileType": "MP3",
         "registDate": "2023-01-06 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-06T00:00:00.000Z",
         "genres": [
           "バイノーラル/ダミヘ",
@@ -1016,55 +1000,55 @@
         ],
         "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01003000/RJ01002873_img_main.jpg",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01003000/RJ01002873_img_sam.jpg",
-        "createdAt": "2026-05-26T07:05:07.569Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.569Z",
+        "createdAt": "2026-07-03T01:05:32.859Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.859Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
+          "current": 990,
           "original": 1320,
-          "discount": 15,
-          "current": 1320,
           "localeOfficialPrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
             "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
             "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
           },
+          "discount": 25,
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 5.37,
+            "sv_SE": 59.46,
+            "id_ID": 110405,
+            "pt_BR": 5.37,
+            "vi_VN": 160662,
+            "th_TH": 204.05,
+            "fr_FR": 5.37,
+            "de_DE": 5.37,
+            "zh_TW": 196,
+            "ko_KR": 9483,
+            "en_US": 6.14,
+            "es_ES": 5.37,
+            "zh_CN": 41.67,
+            "ar_AE": 6.14
           },
-          "point": 60
+          "point": 45
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.569Z"
+            "lastFetched": "2026-07-03T01:05:32.859Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.569Z"
+        "updatedAt": "2026-07-03T01:05:32.859Z"
       }
     },
     {
@@ -1145,7 +1129,6 @@
         "productId": "RJ01004387",
         "releaseDate": "2022-12-17 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月17日",
         "workType": "SOU",
@@ -1164,7 +1147,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2022-12-17 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2022-12-17T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -1211,55 +1193,55 @@
           }
         ],
         "circle": "See you.",
-        "createdAt": "2026-05-26T07:05:07.033Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.033Z",
+        "createdAt": "2026-07-03T01:05:32.221Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.221Z",
         "price": {
-          "original": 1100,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1100,
+          "current": 550,
+          "original": 1100,
           "localeOfficialPrices": {
-            "it_IT": 5.95,
-            "pt_BR": 5.95,
-            "fr_FR": 5.95,
-            "de_DE": 5.95,
-            "es_ES": 5.95,
-            "zh_TW": 218,
-            "sv_SE": 64.29,
-            "ko_KR": 10466,
-            "en_US": 6.92,
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
             "id_ID": 122672,
-            "vi_VN": 181758,
-            "zh_CN": 47.04,
-            "th_TH": 224.79,
-            "ar_AE": 6.92
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 5.95,
-            "sv_SE": 64.29,
-            "id_ID": 122672,
-            "pt_BR": 5.95,
-            "vi_VN": 181758,
-            "th_TH": 224.79,
-            "fr_FR": 5.95,
-            "de_DE": 5.95,
-            "zh_TW": 218,
-            "ko_KR": 10466,
-            "en_US": 6.92,
-            "es_ES": 5.95,
-            "zh_CN": 47.04,
-            "ar_AE": 6.92
+            "it_IT": 2.98,
+            "sv_SE": 33.03,
+            "id_ID": 61336,
+            "pt_BR": 2.98,
+            "vi_VN": 89257,
+            "th_TH": 113.36,
+            "fr_FR": 2.98,
+            "de_DE": 2.98,
+            "zh_TW": 109,
+            "ko_KR": 5268,
+            "en_US": 3.41,
+            "es_ES": 2.98,
+            "zh_CN": 23.15,
+            "ar_AE": 3.41
           },
-          "point": 50
+          "point": 25
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.033Z"
+            "lastFetched": "2026-07-03T01:05:32.221Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.033Z"
+        "updatedAt": "2026-07-03T01:05:32.221Z"
       }
     },
     {
@@ -1317,12 +1299,10 @@
         "id": "RJ01004682",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01005000/RJ01004682_img_sam.jpg",
-        "languageDownloads": [],
         "originalCategoryText": "ボイス・ASMR",
         "productId": "RJ01004682",
         "releaseDate": "2022-12-17 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月17日",
         "workType": "SOU",
@@ -1339,7 +1319,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2022-12-17 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2022-12-17T00:00:00.000Z",
         "genres": [
           "淫語",
@@ -1385,55 +1364,87 @@
             "name": "中出し"
           }
         ],
-        "createdAt": "2026-05-26T07:05:07.033Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.033Z",
+        "languageDownloads": [
+          {
+            "workno": "RJ01004682",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 52551,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01662956",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 52551,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01662958",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 52551,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:32.221Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.221Z",
         "price": {
-          "original": 1210,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1210,
+          "current": 605,
+          "original": 1210,
           "localeOfficialPrices": {
-            "it_IT": 6.54,
-            "pt_BR": 6.54,
-            "fr_FR": 6.54,
-            "de_DE": 6.54,
-            "es_ES": 6.54,
-            "zh_TW": 239,
-            "sv_SE": 70.72,
-            "ko_KR": 11513,
-            "en_US": 7.61,
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
             "id_ID": 134939,
-            "vi_VN": 199934,
-            "zh_CN": 51.74,
-            "th_TH": 247.27,
-            "ar_AE": 7.61
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 6.54,
-            "sv_SE": 70.72,
-            "id_ID": 134939,
-            "pt_BR": 6.54,
-            "vi_VN": 199934,
-            "th_TH": 247.27,
-            "fr_FR": 6.54,
-            "de_DE": 6.54,
-            "zh_TW": 239,
-            "ko_KR": 11513,
-            "en_US": 7.61,
-            "es_ES": 6.54,
-            "zh_CN": 51.74,
-            "ar_AE": 7.61
+            "it_IT": 3.28,
+            "sv_SE": 36.33,
+            "id_ID": 67470,
+            "pt_BR": 3.28,
+            "vi_VN": 98182,
+            "th_TH": 124.7,
+            "fr_FR": 3.28,
+            "de_DE": 3.28,
+            "zh_TW": 120,
+            "ko_KR": 5795,
+            "en_US": 3.75,
+            "es_ES": 3.28,
+            "zh_CN": 25.46,
+            "ar_AE": 3.75
           },
-          "point": 55
+          "point": 27
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.033Z"
+            "lastFetched": "2026-07-03T01:05:32.221Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.033Z"
+        "updatedAt": "2026-07-03T01:05:32.221Z"
       }
     },
     {
@@ -1490,7 +1501,6 @@
         "productId": "RJ01005852",
         "releaseDate": "2023-02-01 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年2月1日",
         "workType": "SOU",
@@ -1519,7 +1529,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-02-01 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-02-01T00:00:00.000Z",
         "genres": [
           "バイノーラル/ダミヘ",
@@ -1565,55 +1574,53 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-05-13T05:06:10.504Z",
-        "lastFetchedAt": "2026-05-13T05:06:10.504Z",
+        "createdAt": "2026-06-18T07:06:30.933Z",
+        "lastFetchedAt": "2026-06-18T07:06:30.933Z",
         "price": {
-          "original": 1320,
           "isFreeOrMissingPrice": false,
-          "discount": 50,
           "currency": "JPY",
           "current": 1320,
           "localeOfficialPrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.81,
-            "id_ID": 146732,
-            "pt_BR": 7.13,
-            "vi_VN": 219744,
-            "th_TH": 271.38,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 264,
-            "ko_KR": 12476,
-            "en_US": 8.38,
-            "es_ES": 7.13,
-            "zh_CN": 57.02,
-            "ar_AE": 8.38
+            "zh_TW": 260,
+            "en_US": 8.23,
+            "ar_AE": 8.23,
+            "it_IT": 7.12,
+            "sv_SE": 77.72,
+            "ko_KR": 12488,
+            "id_ID": 146179,
+            "pt_BR": 7.12,
+            "vi_VN": 215827,
+            "es_ES": 7.12,
+            "zh_CN": 55.71,
+            "th_TH": 268.18,
+            "fr_FR": 7.12,
+            "de_DE": 7.12
           },
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.81,
-            "id_ID": 146732,
-            "pt_BR": 7.13,
-            "vi_VN": 219744,
-            "th_TH": 271.38,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 264,
-            "ko_KR": 12476,
-            "en_US": 8.38,
-            "es_ES": 7.13,
-            "zh_CN": 57.02,
-            "ar_AE": 8.38
+            "it_IT": 7.12,
+            "sv_SE": 77.72,
+            "id_ID": 146179,
+            "pt_BR": 7.12,
+            "vi_VN": 215827,
+            "th_TH": 268.18,
+            "fr_FR": 7.12,
+            "de_DE": 7.12,
+            "zh_TW": 260,
+            "ko_KR": 12488,
+            "en_US": 8.23,
+            "es_ES": 7.12,
+            "zh_CN": 55.71,
+            "ar_AE": 8.23
           },
           "point": 60
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-13T05:06:10.504Z"
+            "lastFetched": "2026-06-18T07:06:30.933Z"
           }
         },
-        "updatedAt": "2026-05-13T05:06:10.504Z"
+        "updatedAt": "2026-06-18T07:06:30.933Z"
       }
     },
     {
@@ -1703,7 +1710,6 @@
         "productId": "RJ01006231",
         "releaseDate": "2023-01-01 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月1日",
         "workType": "SOU",
@@ -1726,7 +1732,6 @@
         "fileFormat": "MP3",
         "fileType": "MP3",
         "registDate": "2023-01-01 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "genres": [
           "ASMR",
           "おっぱい",
@@ -1966,7 +1971,6 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月17日",
         "workType": "SOU",
@@ -2019,7 +2023,6 @@
         },
         "releaseDateISO": "2023-01-16T15:00:00.000Z",
         "createdAt": "2025-07-30T15:13:27.342Z",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "lastFetchedAt": "2025-07-30T15:13:27.342Z",
         "dataSources": {
           "infoAPI": {
@@ -2173,7 +2176,6 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月28日",
         "workType": "SOU",
@@ -2226,7 +2228,6 @@
         },
         "releaseDateISO": "2022-12-27T15:00:00.000Z",
         "createdAt": "2025-07-30T15:13:27.341Z",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "lastFetchedAt": "2025-07-30T15:13:27.341Z",
         "dataSources": {
           "infoAPI": {
@@ -2380,7 +2381,6 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月17日",
         "workType": "SOU",
@@ -2433,7 +2433,6 @@
         },
         "releaseDateISO": "2023-01-16T15:00:00.000Z",
         "createdAt": "2025-07-30T15:13:27.342Z",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "lastFetchedAt": "2025-07-30T15:13:27.342Z",
         "dataSources": {
           "infoAPI": {
@@ -2484,16 +2483,6 @@
         "titleMasked": "【簡体中文版】自堕落で生イキな引きこもりの妹……変態だよねお兄ちゃん【フォーリーサウンド】",
         "ageCategory": 3,
         "title": "【簡体中文版】自堕落で生イキな引きこもりの妹……変態だよねお兄ちゃん【フォーリーサウンド】",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "妹",
-          "耳かき",
-          "ラブラブ/あまあま",
-          "赤ちゃんプレイ",
-          "手コキ",
-          "フェラチオ",
-          "耳舐め"
-        ],
         "id": "RJ01006946",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ358000/RJ357844_img_sam.jpg",
@@ -2533,6 +2522,29 @@
         "productId": "RJ01006946",
         "releaseDate": "2023-09-29 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年9月29日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006946.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-09-29 00:00:00",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "妹",
+          "赤ちゃんプレイ",
+          "耳かき",
+          "ラブラブ/あまあま",
+          "手コキ",
+          "フェラチオ",
+          "耳舐め"
+        ],
+        "releaseDateISO": "2023-09-29T00:00:00.000Z",
         "customGenres": [
           {
             "genre_key": "496",
@@ -2543,16 +2555,16 @@
             "name": "妹"
           },
           {
+            "genre_key": "540",
+            "name": "赤ちゃんプレイ"
+          },
+          {
             "genre_key": "442",
             "name": "耳かき"
           },
           {
             "genre_key": "004",
             "name": "ラブラブ/あまあま"
-          },
-          {
-            "genre_key": "540",
-            "name": "赤ちゃんプレイ"
           },
           {
             "genre_key": "124",
@@ -2567,68 +2579,55 @@
             "name": "耳舐め"
           }
         ],
-        "localDataSource": true,
-        "fileSize": null,
-        "releaseDateDisplay": "2023年9月29日",
-        "workType": "SOU",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006946.html",
-        "circleId": "RG60289",
-        "category": "SOU",
-        "circle": "みんなで翻訳",
-        "sampleImages": [],
-        "workFormat": "ボイス・ASMR",
-        "fileFormat": "WAV",
-        "fileType": "WAV",
-        "registDate": "2023-09-29 00:00:00",
+        "createdAt": "2026-07-03T01:06:13.550Z",
+        "lastFetchedAt": "2026-07-03T01:06:13.550Z",
         "price": {
-          "current": 1100,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 100,
+          "current": 880,
+          "original": 1100,
           "localeOfficialPrices": {
-            "zh_TW": 220,
-            "en_US": 7.41,
-            "ar_AE": 7.41,
-            "it_IT": 6.41,
-            "sv_SE": 71.49,
-            "ko_KR": 10300,
-            "id_ID": 121413,
-            "pt_BR": 6.41,
-            "vi_VN": 193628,
-            "es_ES": 6.41,
-            "zh_CN": 53.18,
-            "th_TH": 240.13,
-            "fr_FR": 6.41,
-            "de_DE": 6.41
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
+            "id_ID": 122672,
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
           },
+          "discount": 20,
           "localePrices": {
-            "zh_TW": 220,
-            "en_US": 7.41,
-            "ar_AE": 7.41,
-            "it_IT": 6.41,
-            "sv_SE": 71.49,
-            "ko_KR": 10300,
-            "id_ID": 121413,
-            "pt_BR": 6.41,
-            "vi_VN": 193628,
-            "es_ES": 6.41,
-            "zh_CN": 53.18,
-            "th_TH": 240.13,
-            "fr_FR": 6.41,
-            "de_DE": 6.41
-          }
+            "it_IT": 4.77,
+            "sv_SE": 52.85,
+            "id_ID": 98138,
+            "pt_BR": 4.77,
+            "vi_VN": 142811,
+            "th_TH": 181.38,
+            "fr_FR": 4.77,
+            "de_DE": 4.77,
+            "zh_TW": 174,
+            "ko_KR": 8429,
+            "en_US": 5.45,
+            "es_ES": 4.77,
+            "zh_CN": 37.04,
+            "ar_AE": 5.45
+          },
+          "point": 40
         },
-        "releaseDateISO": "2023-09-28T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:31.166Z",
-        "collectedAt": "2025-07-30T15:13:31.169Z",
-        "lastFetchedAt": "2025-07-30T15:13:31.166Z",
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:31.166Z"
+            "lastFetched": "2026-07-03T01:06:13.550Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:31.166Z"
+        "updatedAt": "2026-07-03T01:06:13.550Z"
       }
     },
     {
@@ -2774,7 +2773,6 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年4月1日",
         "workType": "SOU",
@@ -2827,7 +2825,6 @@
         },
         "releaseDateISO": "2023-03-31T15:00:00.000Z",
         "createdAt": "2025-07-30T15:13:27.343Z",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "lastFetchedAt": "2025-07-30T15:13:27.343Z",
         "dataSources": {
           "infoAPI": {
@@ -2907,7 +2904,6 @@
         "productId": "RJ01007999",
         "releaseDate": "2022-12-29 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月29日",
         "workType": "SOU",
@@ -2933,7 +2929,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2022-12-29 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2022-12-29T00:00:00.000Z",
         "genres": [
           "バイノーラル/ダミヘ",
@@ -2979,55 +2974,55 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-05-26T07:05:07.568Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.568Z",
+        "createdAt": "2026-06-19T19:05:12.295Z",
+        "lastFetchedAt": "2026-06-19T19:05:12.295Z",
         "price": {
-          "original": 1430,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1430,
+          "current": 715,
+          "original": 1430,
           "localeOfficialPrices": {
-            "it_IT": 7.73,
-            "pt_BR": 7.73,
-            "fr_FR": 7.73,
-            "de_DE": 7.73,
-            "es_ES": 7.73,
-            "zh_TW": 283,
-            "sv_SE": 83.58,
-            "ko_KR": 13606,
-            "en_US": 9,
-            "id_ID": 159474,
-            "vi_VN": 236286,
-            "zh_CN": 61.15,
-            "th_TH": 292.22,
-            "ar_AE": 9
+            "it_IT": 7.74,
+            "sv_SE": 84.98,
+            "id_ID": 157420,
+            "pt_BR": 7.74,
+            "vi_VN": 233127,
+            "th_TH": 290.92,
+            "fr_FR": 7.74,
+            "de_DE": 7.74,
+            "zh_TW": 281,
+            "ko_KR": 13645,
+            "en_US": 8.88,
+            "es_ES": 7.74,
+            "zh_CN": 60.2,
+            "ar_AE": 8.88
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 7.73,
-            "sv_SE": 83.58,
-            "id_ID": 159474,
-            "pt_BR": 7.73,
-            "vi_VN": 236286,
-            "th_TH": 292.22,
-            "fr_FR": 7.73,
-            "de_DE": 7.73,
-            "zh_TW": 283,
-            "ko_KR": 13606,
-            "en_US": 9,
-            "es_ES": 7.73,
-            "zh_CN": 61.15,
-            "ar_AE": 9
+            "it_IT": 3.87,
+            "sv_SE": 42.49,
+            "id_ID": 78710,
+            "pt_BR": 3.87,
+            "vi_VN": 116563,
+            "th_TH": 145.46,
+            "fr_FR": 3.87,
+            "de_DE": 3.87,
+            "zh_TW": 140,
+            "ko_KR": 6823,
+            "en_US": 4.44,
+            "es_ES": 3.87,
+            "zh_CN": 30.1,
+            "ar_AE": 4.44
           },
-          "point": 65
+          "point": 32
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.568Z"
+            "lastFetched": "2026-06-19T19:05:12.295Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.568Z"
+        "updatedAt": "2026-06-19T19:05:12.295Z"
       }
     },
     {
@@ -3078,7 +3073,6 @@
         "productId": "RJ01008335",
         "releaseDate": "2023-05-14 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年5月14日",
         "workType": "SOU",
@@ -3086,25 +3080,10 @@
         "circleId": "RG53616",
         "category": "SOU",
         "circle": "熊鈴",
-        "sampleImages": [
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp1.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp2.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp3.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp4.jpg"
-          }
-        ],
         "workFormat": "ボイス・ASMR",
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-05-14 00:00:00",
-        "collectedAt": "2025-07-30T15:13:29.281Z",
         "releaseDateISO": "2023-05-14T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -3150,55 +3129,63 @@
             "name": "中出し"
           }
         ],
-        "createdAt": "2026-05-26T07:05:25.780Z",
-        "lastFetchedAt": "2026-05-26T07:05:25.780Z",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp2.jpg"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:50.905Z",
+        "lastFetchedAt": "2026-07-03T01:05:50.905Z",
         "price": {
-          "original": 1210,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1210,
           "localeOfficialPrices": {
             "it_IT": 6.54,
+            "sv_SE": 72.42,
+            "id_ID": 133525,
             "pt_BR": 6.54,
+            "vi_VN": 195256,
+            "th_TH": 248.08,
             "fr_FR": 6.54,
             "de_DE": 6.54,
+            "zh_TW": 237,
+            "ko_KR": 11568,
+            "en_US": 7.44,
             "es_ES": 6.54,
-            "zh_TW": 239,
-            "sv_SE": 70.72,
-            "ko_KR": 11513,
-            "en_US": 7.61,
-            "id_ID": 134939,
-            "vi_VN": 199934,
-            "zh_CN": 51.74,
-            "th_TH": 247.27,
-            "ar_AE": 7.61
+            "zh_CN": 50.61,
+            "ar_AE": 7.44
           },
+          "current": 605,
+          "original": 1210,
+          "discount": 50,
           "localePrices": {
-            "it_IT": 6.54,
-            "sv_SE": 70.72,
-            "id_ID": 134939,
-            "pt_BR": 6.54,
-            "vi_VN": 199934,
-            "th_TH": 247.27,
-            "fr_FR": 6.54,
-            "de_DE": 6.54,
-            "zh_TW": 239,
-            "ko_KR": 11513,
-            "en_US": 7.61,
-            "es_ES": 6.54,
-            "zh_CN": 51.74,
-            "ar_AE": 7.61
+            "it_IT": 3.27,
+            "sv_SE": 36.21,
+            "id_ID": 66762,
+            "pt_BR": 3.27,
+            "vi_VN": 97628,
+            "th_TH": 124.04,
+            "fr_FR": 3.27,
+            "de_DE": 3.27,
+            "zh_TW": 118,
+            "ko_KR": 5784,
+            "en_US": 3.72,
+            "es_ES": 3.27,
+            "zh_CN": 25.31,
+            "ar_AE": 3.72
           },
-          "point": 55
+          "point": 27
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:25.780Z"
+            "lastFetched": "2026-07-03T01:05:50.905Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:25.780Z"
+        "updatedAt": "2026-07-03T01:05:50.905Z"
       }
     },
     {
@@ -3431,7 +3418,6 @@
             "name": "フタナリ"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2022年12月26日",
         "workType": "RPG",
@@ -3477,7 +3463,6 @@
         "registDate": "2022-12-26 00:00:00",
         "releaseDateISO": "2022-12-25T15:00:00.000Z",
         "createdAt": "2025-07-30T15:13:27.341Z",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "lastFetchedAt": "2025-07-30T15:13:27.341Z",
         "dataSources": {
           "infoAPI": {
@@ -3573,7 +3558,6 @@
         "productId": "RJ01008645",
         "releaseDate": "2023-02-09 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年2月9日",
         "workType": "SOU",
@@ -3599,7 +3583,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-02-09 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-02-09T00:00:00.000Z",
         "genres": [
           "マニアック/変態",
@@ -3645,55 +3628,55 @@
             "name": "手コキ"
           }
         ],
-        "createdAt": "2026-05-26T07:05:09.407Z",
-        "lastFetchedAt": "2026-05-26T07:05:09.407Z",
+        "createdAt": "2026-07-03T01:05:34.132Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.132Z",
         "price": {
-          "original": 880,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 30,
-          "current": 880,
+          "current": 528,
+          "original": 880,
           "localeOfficialPrices": {
-            "it_IT": 4.76,
-            "pt_BR": 4.76,
-            "fr_FR": 4.76,
-            "de_DE": 4.76,
-            "es_ES": 4.76,
-            "zh_TW": 174,
-            "sv_SE": 51.43,
-            "ko_KR": 8373,
-            "en_US": 5.54,
+            "it_IT": 4.77,
+            "sv_SE": 52.85,
             "id_ID": 98138,
-            "vi_VN": 145406,
-            "zh_CN": 37.63,
-            "th_TH": 179.83,
-            "ar_AE": 5.54
+            "pt_BR": 4.77,
+            "vi_VN": 142811,
+            "th_TH": 181.38,
+            "fr_FR": 4.77,
+            "de_DE": 4.77,
+            "zh_TW": 174,
+            "ko_KR": 8429,
+            "en_US": 5.45,
+            "es_ES": 4.77,
+            "zh_CN": 37.04,
+            "ar_AE": 5.45
           },
+          "discount": 40,
           "localePrices": {
-            "it_IT": 4.76,
-            "sv_SE": 51.43,
-            "id_ID": 98138,
-            "pt_BR": 4.76,
-            "vi_VN": 145406,
-            "th_TH": 179.83,
-            "fr_FR": 4.76,
-            "de_DE": 4.76,
-            "zh_TW": 174,
-            "ko_KR": 8373,
-            "en_US": 5.54,
-            "es_ES": 4.76,
-            "zh_CN": 37.63,
-            "ar_AE": 5.54
+            "it_IT": 2.86,
+            "sv_SE": 31.71,
+            "id_ID": 58883,
+            "pt_BR": 2.86,
+            "vi_VN": 85686,
+            "th_TH": 108.83,
+            "fr_FR": 2.86,
+            "de_DE": 2.86,
+            "zh_TW": 104,
+            "ko_KR": 5057,
+            "en_US": 3.27,
+            "es_ES": 2.86,
+            "zh_CN": 22.22,
+            "ar_AE": 3.27
           },
-          "point": 40
+          "point": 24
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:09.407Z"
+            "lastFetched": "2026-07-03T01:05:34.132Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:09.407Z"
+        "updatedAt": "2026-07-03T01:05:34.132Z"
       }
     },
     {
@@ -3765,7 +3748,6 @@
         "productId": "RJ01008720",
         "releaseDate": "2023-03-01 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年3月1日",
         "workType": "SOU",
@@ -3778,7 +3760,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-03-01 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-03-01T00:00:00.000Z",
         "genres": [
           "癒し",
@@ -3824,55 +3805,55 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-05-26T07:05:15.887Z",
-        "lastFetchedAt": "2026-05-26T07:05:15.887Z",
+        "createdAt": "2026-07-03T01:05:40.761Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.761Z",
         "price": {
           "original": 1540,
           "isFreeOrMissingPrice": false,
           "discount": 30,
           "currency": "JPY",
-          "current": 1540,
+          "current": 1078,
           "localeOfficialPrices": {
             "it_IT": 8.32,
-            "sv_SE": 90.01,
-            "id_ID": 171741,
             "pt_BR": 8.32,
-            "vi_VN": 254461,
-            "th_TH": 314.7,
             "fr_FR": 8.32,
             "de_DE": 8.32,
-            "zh_TW": 305,
-            "ko_KR": 14653,
-            "en_US": 9.69,
             "es_ES": 8.32,
-            "zh_CN": 65.85,
-            "ar_AE": 9.69
+            "zh_TW": 302,
+            "sv_SE": 92.17,
+            "ko_KR": 14723,
+            "en_US": 9.47,
+            "id_ID": 169940,
+            "vi_VN": 248507,
+            "zh_CN": 64.42,
+            "th_TH": 315.74,
+            "ar_AE": 9.47
           },
           "localePrices": {
-            "it_IT": 8.32,
-            "sv_SE": 90.01,
-            "id_ID": 171741,
-            "pt_BR": 8.32,
-            "vi_VN": 254461,
-            "th_TH": 314.7,
-            "fr_FR": 8.32,
-            "de_DE": 8.32,
-            "zh_TW": 305,
-            "ko_KR": 14653,
-            "en_US": 9.69,
-            "es_ES": 8.32,
-            "zh_CN": 65.85,
-            "ar_AE": 9.69
+            "it_IT": 5.82,
+            "sv_SE": 64.52,
+            "id_ID": 118958,
+            "pt_BR": 5.82,
+            "vi_VN": 173955,
+            "th_TH": 221.01,
+            "fr_FR": 5.82,
+            "de_DE": 5.82,
+            "zh_TW": 211,
+            "ko_KR": 10306,
+            "en_US": 6.63,
+            "es_ES": 5.82,
+            "zh_CN": 45.09,
+            "ar_AE": 6.63
           },
-          "point": 70
+          "point": 49
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:15.887Z"
+            "lastFetched": "2026-07-03T01:05:40.761Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:15.887Z"
+        "updatedAt": "2026-07-03T01:05:40.761Z"
       }
     },
     {
@@ -3944,7 +3925,6 @@
         "productId": "RJ01008923",
         "releaseDate": "2023-01-05 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月5日",
         "workType": "SOU",
@@ -3961,7 +3941,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-05 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-05T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -4007,55 +3986,55 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-05-26T07:05:07.569Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.569Z",
+        "createdAt": "2026-07-03T01:05:32.859Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.859Z",
         "price": {
-          "original": 1100,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1100,
+          "current": 550,
+          "original": 1100,
           "localeOfficialPrices": {
-            "it_IT": 5.95,
-            "pt_BR": 5.95,
-            "fr_FR": 5.95,
-            "de_DE": 5.95,
-            "es_ES": 5.95,
-            "zh_TW": 218,
-            "sv_SE": 64.29,
-            "ko_KR": 10466,
-            "en_US": 6.92,
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
             "id_ID": 122672,
-            "vi_VN": 181758,
-            "zh_CN": 47.04,
-            "th_TH": 224.79,
-            "ar_AE": 6.92
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 5.95,
-            "sv_SE": 64.29,
-            "id_ID": 122672,
-            "pt_BR": 5.95,
-            "vi_VN": 181758,
-            "th_TH": 224.79,
-            "fr_FR": 5.95,
-            "de_DE": 5.95,
-            "zh_TW": 218,
-            "ko_KR": 10466,
-            "en_US": 6.92,
-            "es_ES": 5.95,
-            "zh_CN": 47.04,
-            "ar_AE": 6.92
+            "it_IT": 2.98,
+            "sv_SE": 33.03,
+            "id_ID": 61336,
+            "pt_BR": 2.98,
+            "vi_VN": 89257,
+            "th_TH": 113.36,
+            "fr_FR": 2.98,
+            "de_DE": 2.98,
+            "zh_TW": 109,
+            "ko_KR": 5268,
+            "en_US": 3.41,
+            "es_ES": 2.98,
+            "zh_CN": 23.15,
+            "ar_AE": 3.41
           },
-          "point": 50
+          "point": 25
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.569Z"
+            "lastFetched": "2026-07-03T01:05:32.859Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.569Z"
+        "updatedAt": "2026-07-03T01:05:32.859Z"
       }
     },
     {
@@ -4105,7 +4084,6 @@
         "productId": "RJ01009221",
         "releaseDate": "2023-01-09 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月9日",
         "workType": "SOU",
@@ -4134,7 +4112,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-09 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-09T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -4252,55 +4229,55 @@
             "displayOrder": 13
           }
         ],
-        "createdAt": "2026-05-26T07:05:07.569Z",
-        "lastFetchedAt": "2026-05-26T07:05:07.569Z",
+        "createdAt": "2026-07-03T01:05:32.859Z",
+        "lastFetchedAt": "2026-07-03T01:05:32.859Z",
         "price": {
-          "original": 1100,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 90,
-          "current": 1100,
+          "current": 495,
+          "original": 1100,
           "localeOfficialPrices": {
-            "it_IT": 5.95,
-            "pt_BR": 5.95,
-            "fr_FR": 5.95,
-            "de_DE": 5.95,
-            "es_ES": 5.95,
-            "zh_TW": 218,
-            "sv_SE": 64.29,
-            "ko_KR": 10466,
-            "en_US": 6.92,
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
             "id_ID": 122672,
-            "vi_VN": 181758,
-            "zh_CN": 47.04,
-            "th_TH": 224.79,
-            "ar_AE": 6.92
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
           },
+          "discount": 55,
           "localePrices": {
-            "it_IT": 5.95,
-            "sv_SE": 64.29,
-            "id_ID": 122672,
-            "pt_BR": 5.95,
-            "vi_VN": 181758,
-            "th_TH": 224.79,
-            "fr_FR": 5.95,
-            "de_DE": 5.95,
-            "zh_TW": 218,
-            "ko_KR": 10466,
-            "en_US": 6.92,
-            "es_ES": 5.95,
-            "zh_CN": 47.04,
-            "ar_AE": 6.92
+            "it_IT": 2.69,
+            "sv_SE": 29.73,
+            "id_ID": 55202,
+            "pt_BR": 2.69,
+            "vi_VN": 80331,
+            "th_TH": 102.02,
+            "fr_FR": 2.69,
+            "de_DE": 2.69,
+            "zh_TW": 98,
+            "ko_KR": 4741,
+            "en_US": 3.07,
+            "es_ES": 2.69,
+            "zh_CN": 20.83,
+            "ar_AE": 3.07
           },
-          "point": 50
+          "point": 22
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:07.569Z"
+            "lastFetched": "2026-07-03T01:05:32.859Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:07.569Z"
+        "updatedAt": "2026-07-03T01:05:32.859Z"
       }
     },
     {
@@ -4402,7 +4379,6 @@
         "productId": "RJ01009555",
         "releaseDate": "2023-06-20 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年6月20日",
         "workType": "SOU",
@@ -4415,7 +4391,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-06-20 00:00:00",
-        "collectedAt": "2025-07-30T15:13:29.281Z",
         "releaseDateISO": "2023-06-20T00:00:00.000Z",
         "genres": [
           "アニメ",
@@ -4461,55 +4436,55 @@
             "name": "ささやき"
           }
         ],
-        "createdAt": "2026-05-26T07:05:27.743Z",
-        "lastFetchedAt": "2026-05-26T07:05:27.743Z",
+        "createdAt": "2026-07-03T01:05:53.329Z",
+        "lastFetchedAt": "2026-07-03T01:05:53.329Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
+          "current": 660,
           "original": 1320,
-          "discount": 50,
-          "current": 1320,
           "localeOfficialPrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
             "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
             "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
           },
-          "point": 60
+          "point": 30
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:27.743Z"
+            "lastFetched": "2026-07-03T01:05:53.329Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:27.743Z"
+        "updatedAt": "2026-07-03T01:05:53.329Z"
       }
     },
     {
@@ -4645,7 +4620,6 @@
             "name": "無表情"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月25日",
         "workType": "SOU",
@@ -4658,57 +4632,56 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-25 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-25T00:00:00.000Z",
-        "createdAt": "2026-05-26T07:05:08.062Z",
-        "lastFetchedAt": "2026-05-26T07:05:08.062Z",
+        "createdAt": "2026-07-03T01:05:33.233Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.233Z",
         "price": {
-          "original": 1320,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1320,
+          "current": 660,
+          "original": 1320,
           "localeOfficialPrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
             "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
             "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
           },
+          "discount": 50,
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
           },
-          "point": 60
+          "point": 30
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:08.062Z"
+            "lastFetched": "2026-07-03T01:05:33.233Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:08.062Z"
+        "updatedAt": "2026-07-03T01:05:33.233Z"
       }
     },
     {
@@ -4759,7 +4732,6 @@
         "productId": "RJ01010944",
         "releaseDate": "2023-03-05 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年3月5日",
         "workType": "SOU",
@@ -4776,7 +4748,6 @@
         "fileFormat": "MP3",
         "fileType": "MP3",
         "registDate": "2023-03-05 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-03-05T00:00:00.000Z",
         "genres": [
           "バイノーラル/ダミヘ",
@@ -4822,55 +4793,55 @@
             "name": "メス堕ち"
           }
         ],
-        "createdAt": "2026-05-26T07:05:15.887Z",
-        "lastFetchedAt": "2026-05-26T07:05:15.887Z",
+        "createdAt": "2026-07-03T01:05:40.762Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.762Z",
         "price": {
-          "original": 1320,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1320,
           "localeOfficialPrices": {
             "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
+            "sv_SE": 79,
+            "id_ID": 145663,
             "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
             "fr_FR": 7.13,
             "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
             "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
           },
+          "current": 660,
+          "original": 1320,
+          "discount": 50,
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 3.57,
+            "sv_SE": 39.5,
+            "id_ID": 72832,
+            "pt_BR": 3.57,
+            "vi_VN": 106503,
+            "th_TH": 135.32,
+            "fr_FR": 3.57,
+            "de_DE": 3.57,
+            "zh_TW": 129,
+            "ko_KR": 6310,
+            "en_US": 4.06,
+            "es_ES": 3.57,
+            "zh_CN": 27.61,
+            "ar_AE": 4.06
           },
-          "point": 60
+          "point": 30
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:15.887Z"
+            "lastFetched": "2026-07-03T01:05:40.762Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:15.887Z"
+        "updatedAt": "2026-07-03T01:05:40.762Z"
       }
     },
     {
@@ -4961,7 +4932,6 @@
         "productId": "RJ01011086",
         "releaseDate": "2023-01-24 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月24日",
         "workType": "SOU",
@@ -4974,7 +4944,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-24 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-24T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -5020,55 +4989,53 @@
             "name": "処女"
           }
         ],
-        "createdAt": "2026-05-26T07:05:08.062Z",
-        "lastFetchedAt": "2026-05-26T07:05:08.062Z",
+        "createdAt": "2026-06-18T07:06:24.517Z",
+        "lastFetchedAt": "2026-06-18T07:06:24.517Z",
         "price": {
-          "original": 1320,
           "isFreeOrMissingPrice": false,
-          "discount": 50,
           "currency": "JPY",
           "current": 1320,
           "localeOfficialPrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "zh_TW": 260,
+            "en_US": 8.23,
+            "ar_AE": 8.23,
+            "it_IT": 7.12,
+            "sv_SE": 77.72,
+            "ko_KR": 12488,
+            "id_ID": 146179,
+            "pt_BR": 7.12,
+            "vi_VN": 215827,
+            "es_ES": 7.12,
+            "zh_CN": 55.71,
+            "th_TH": 268.18,
+            "fr_FR": 7.12,
+            "de_DE": 7.12
           },
           "localePrices": {
-            "it_IT": 7.13,
-            "sv_SE": 77.15,
-            "id_ID": 147206,
-            "pt_BR": 7.13,
-            "vi_VN": 218110,
-            "th_TH": 269.75,
-            "fr_FR": 7.13,
-            "de_DE": 7.13,
-            "zh_TW": 261,
-            "ko_KR": 12559,
-            "en_US": 8.3,
-            "es_ES": 7.13,
-            "zh_CN": 56.44,
-            "ar_AE": 8.3
+            "it_IT": 7.12,
+            "sv_SE": 77.72,
+            "id_ID": 146179,
+            "pt_BR": 7.12,
+            "vi_VN": 215827,
+            "th_TH": 268.18,
+            "fr_FR": 7.12,
+            "de_DE": 7.12,
+            "zh_TW": 260,
+            "ko_KR": 12488,
+            "en_US": 8.23,
+            "es_ES": 7.12,
+            "zh_CN": 55.71,
+            "ar_AE": 8.23
           },
           "point": 60
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:08.062Z"
+            "lastFetched": "2026-06-18T07:06:24.517Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:08.062Z"
+        "updatedAt": "2026-06-18T07:06:24.517Z"
       }
     },
     {
@@ -5119,7 +5086,6 @@
         "productId": "RJ01011259",
         "releaseDate": "2023-01-09 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月9日",
         "workType": "SOU",
@@ -5142,7 +5108,6 @@
         "fileFormat": "MP3",
         "fileType": "MP3",
         "registDate": "2023-01-09 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-09T00:00:00.000Z",
         "genres": [
           "淫語",
@@ -5344,7 +5309,6 @@
             "name": "処女"
           }
         ],
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月10日",
         "workType": "SOU",
@@ -5407,7 +5371,6 @@
           }
         },
         "createdAt": "2025-07-30T15:13:27.342Z",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "lastFetchedAt": "2025-07-30T15:13:27.342Z",
         "dataSources": {
           "infoAPI": {
@@ -5507,7 +5470,6 @@
         "productId": "RJ01012105",
         "releaseDate": "2024-08-14 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2024年8月14日",
         "workType": "SOU",
@@ -5520,7 +5482,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2024-08-14 00:00:00",
-        "collectedAt": "2025-07-30T15:13:36.571Z",
         "releaseDateISO": "2024-08-14T00:00:00.000Z",
         "genres": [
           "逆転無し",
@@ -5566,55 +5527,55 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-05-26T07:06:57.349Z",
-        "lastFetchedAt": "2026-05-26T07:06:57.349Z",
+        "createdAt": "2026-07-03T01:07:14.577Z",
+        "lastFetchedAt": "2026-07-03T01:07:14.577Z",
         "price": {
-          "original": 1210,
           "isFreeOrMissingPrice": false,
-          "discount": 30,
           "currency": "JPY",
-          "current": 1210,
+          "current": 847,
+          "original": 1210,
           "localeOfficialPrices": {
-            "it_IT": 6.54,
-            "pt_BR": 6.54,
-            "fr_FR": 6.54,
-            "de_DE": 6.54,
-            "es_ES": 6.54,
-            "zh_TW": 239,
-            "sv_SE": 70.72,
-            "ko_KR": 11513,
-            "en_US": 7.61,
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
             "id_ID": 134939,
-            "vi_VN": 199934,
-            "zh_CN": 51.74,
-            "th_TH": 247.27,
-            "ar_AE": 7.61
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
           },
+          "discount": 30,
           "localePrices": {
-            "it_IT": 6.54,
-            "sv_SE": 70.72,
-            "id_ID": 134939,
-            "pt_BR": 6.54,
-            "vi_VN": 199934,
-            "th_TH": 247.27,
-            "fr_FR": 6.54,
-            "de_DE": 6.54,
-            "zh_TW": 239,
-            "ko_KR": 11513,
-            "en_US": 7.61,
-            "es_ES": 6.54,
-            "zh_CN": 51.74,
-            "ar_AE": 7.61
+            "it_IT": 4.6,
+            "sv_SE": 50.87,
+            "id_ID": 94457,
+            "pt_BR": 4.6,
+            "vi_VN": 137455,
+            "th_TH": 174.57,
+            "fr_FR": 4.6,
+            "de_DE": 4.6,
+            "zh_TW": 168,
+            "ko_KR": 8113,
+            "en_US": 5.25,
+            "es_ES": 4.6,
+            "zh_CN": 35.65,
+            "ar_AE": 5.25
           },
-          "point": 55
+          "point": 38
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:06:57.349Z"
+            "lastFetched": "2026-07-03T01:07:14.577Z"
           }
         },
-        "updatedAt": "2026-05-26T07:06:57.349Z"
+        "updatedAt": "2026-07-03T01:07:14.577Z"
       }
     },
     {
@@ -5665,7 +5626,6 @@
         "productId": "RJ01012291",
         "releaseDate": "2023-01-20 00:00:00",
         "ageRating": "R18",
-        "localDataSource": true,
         "fileSize": null,
         "releaseDateDisplay": "2023年1月20日",
         "workType": "SOU",
@@ -5700,7 +5660,6 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-20 00:00:00",
-        "collectedAt": "2025-07-30T15:13:27.344Z",
         "releaseDateISO": "2023-01-20T00:00:00.000Z",
         "genres": [
           "ASMR",
@@ -5746,55 +5705,14124 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-05-26T07:05:08.061Z",
-        "lastFetchedAt": "2026-05-26T07:05:08.061Z",
+        "createdAt": "2026-07-03T01:05:33.233Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.233Z",
         "price": {
-          "original": 1650,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "discount": 50,
-          "current": 1650,
+          "current": 907,
+          "original": 1650,
           "localeOfficialPrices": {
-            "it_IT": 8.92,
-            "pt_BR": 8.92,
-            "fr_FR": 8.92,
-            "de_DE": 8.92,
-            "es_ES": 8.92,
-            "zh_TW": 326,
-            "sv_SE": 96.44,
-            "ko_KR": 15699,
-            "en_US": 10.38,
+            "it_IT": 8.95,
+            "sv_SE": 99.09,
             "id_ID": 184008,
-            "vi_VN": 272637,
-            "zh_CN": 70.55,
-            "th_TH": 337.18,
-            "ar_AE": 10.38
+            "pt_BR": 8.95,
+            "vi_VN": 267770,
+            "th_TH": 340.08,
+            "fr_FR": 8.95,
+            "de_DE": 8.95,
+            "zh_TW": 326,
+            "ko_KR": 15805,
+            "en_US": 10.23,
+            "es_ES": 8.95,
+            "zh_CN": 69.45,
+            "ar_AE": 10.23
+          },
+          "discount": 45,
+          "localePrices": {
+            "it_IT": 4.92,
+            "sv_SE": 54.47,
+            "id_ID": 101149,
+            "pt_BR": 4.92,
+            "vi_VN": 147192,
+            "th_TH": 186.94,
+            "fr_FR": 4.92,
+            "de_DE": 4.92,
+            "zh_TW": 179,
+            "ko_KR": 8688,
+            "en_US": 5.62,
+            "es_ES": 4.92,
+            "zh_CN": 38.17,
+            "ar_AE": 5.62
+          },
+          "point": 41
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.233Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.233Z"
+      }
+    },
+    {
+      "id": "RJ01014068",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44990",
+              "name": "raru。",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "今日から私はご主人様のペットです。猫ですから…たーんと可愛がってくださいね。にゃーんにゃん…",
+        "fileTypeString": "WAV",
+        "titleMasked": "猫宮さんは猫になりたがっている。",
+        "ageCategory": 3,
+        "title": "猫宮さんは猫になりたがっている。",
+        "id": "RJ01014068",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01014068",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01020181",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01024339",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01014068",
+        "releaseDate": "2023-01-13 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年1月13日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01014068.html",
+        "circleId": "RG58827",
+        "category": "SOU",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_smp1.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-01-13 00:00:00",
+        "releaseDateISO": "2023-01-13T00:00:00.000Z",
+        "genres": [
+          "連続絶頂",
+          "制服",
+          "ラブラブ/あまあま",
+          "逆レイプ",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "circle": "See you.",
+        "createdAt": "2026-07-03T01:05:33.233Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.233Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.233Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.233Z"
+      }
+    },
+    {
+      "id": "RJ01014157",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014157_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "41082",
+              "name": "みずのちょう",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17431",
+              "name": "みもりあいの",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17411",
+              "name": "野上菜月",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "41082",
+              "name": "みずのちょう",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "31737",
+              "name": "MeltyBeans",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": null,
+        "description": "男性のあなたがふたなり女子にチンポをハメられてしまう「ふたなり逆アナルでメス堕ち♪」シリーズがお得な詰め合わせパックになりました♪ 個別に購入すると定価合計3960円(税込)となる3作品を、特別価格でお届け! 3作品とも全編KU100でバイノーラル収録! 合計5時間48分の大ボリューム!",
+        "fileTypeString": "WAV",
+        "titleMasked": "【総集編】ふたなり逆アナルでメス堕ち♪3作品まとめパックVol.2【KU100】",
+        "ageCategory": 3,
+        "title": "【総集編】ふたなり逆アナルでメス堕ち♪3作品まとめパックVol.2【KU100】",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "中出し",
+          "SM",
+          "言葉責め",
+          "男性受け",
+          "アナル",
+          "乳首/乳輪",
+          "フタナリ"
+        ],
+        "id": "RJ01014157",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014157_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01014157",
+        "releaseDate": "2023-02-01 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "136",
+            "name": "SM"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "185",
+            "name": "乳首/乳輪"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01014157.html",
+        "circleId": "RG53570",
+        "category": "SOU",
+        "circle": "みずのちょう",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014157_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014157_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014157_img_smp3.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-01 00:00:00",
+        "price": {
+          "current": 3410,
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "point": 310,
+          "localeOfficialPrices": {
+            "it_IT": 19.88,
+            "sv_SE": 221.61,
+            "id_ID": 376380,
+            "pt_BR": 19.88,
+            "vi_VN": 600246,
+            "th_TH": 744.41,
+            "fr_FR": 19.88,
+            "de_DE": 19.88,
+            "zh_TW": 682,
+            "ko_KR": 31929,
+            "en_US": 22.96,
+            "es_ES": 19.88,
+            "zh_CN": 164.84,
+            "ar_AE": 22.96
           },
           "localePrices": {
-            "it_IT": 8.92,
-            "sv_SE": 96.44,
-            "id_ID": 184008,
-            "pt_BR": 8.92,
-            "vi_VN": 272637,
-            "th_TH": 337.18,
-            "fr_FR": 8.92,
-            "de_DE": 8.92,
-            "zh_TW": 326,
-            "ko_KR": 15699,
-            "en_US": 10.38,
-            "es_ES": 8.92,
-            "zh_CN": 70.55,
-            "ar_AE": 10.38
+            "it_IT": 19.88,
+            "sv_SE": 221.61,
+            "id_ID": 376380,
+            "pt_BR": 19.88,
+            "vi_VN": 600246,
+            "th_TH": 744.41,
+            "fr_FR": 19.88,
+            "de_DE": 19.88,
+            "zh_TW": 682,
+            "ko_KR": 31929,
+            "en_US": 22.96,
+            "es_ES": 19.88,
+            "zh_CN": 164.84,
+            "ar_AE": 22.96
+          }
+        },
+        "releaseDateISO": "2023-01-31T15:00:00.000Z",
+        "createdAt": "2025-07-30T15:13:27.342Z",
+        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2025-07-30T15:13:27.342Z"
+          }
+        },
+        "updatedAt": "2025-07-30T15:13:27.342Z"
+      }
+    },
+    {
+      "id": "RJ01015144",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01005000/RJ01004387_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44990",
+              "name": "raru。",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "あはっ♪私ぃ…あなたから見たら…クソビッチかもねっ♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】清楚な彼女が寝取られて、雌犬クソビッチになるまで。",
+        "ageCategory": 3,
+        "title": "【簡体中文版】清楚な彼女が寝取られて、雌犬クソビッチになるまで。",
+        "id": "RJ01015144",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01005000/RJ01004387_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01004387",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9422,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01015144",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9422,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01110009",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9422,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01015144",
+        "releaseDate": "2024-03-02 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2024年3月2日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01015144.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2024-03-02 00:00:00",
+        "releaseDateISO": "2024-03-02T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "寝取られ",
+          "寝取り",
+          "強制/無理矢理",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ",
+          "レイプ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "048",
+            "name": "寝取られ"
+          },
+          {
+            "genre_key": "302",
+            "name": "寝取り"
+          },
+          {
+            "genre_key": "114",
+            "name": "強制/無理矢理"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:41.527Z",
+        "lastFetchedAt": "2026-07-03T01:06:41.527Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 550,
+          "original": 1100,
+          "localeOfficialPrices": {
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
+            "id_ID": 122672,
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 2.98,
+            "sv_SE": 33.03,
+            "id_ID": 61336,
+            "pt_BR": 2.98,
+            "vi_VN": 89257,
+            "th_TH": 113.36,
+            "fr_FR": 2.98,
+            "de_DE": 2.98,
+            "zh_TW": 109,
+            "ko_KR": 5268,
+            "en_US": 3.41,
+            "es_ES": 2.98,
+            "zh_CN": 23.15,
+            "ar_AE": 3.41
+          },
+          "point": 25
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:41.527Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:41.527Z"
+      }
+    },
+    {
+      "id": "RJ01015301",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ406000/RJ405985_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "35399",
+              "name": "マイク・O",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "53164",
+              "name": "えすゆうゼット",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "国中から集められた優秀なメスを、壁尻にして、ハメて、種付け!! 「JK」「人妻」「トップアイドル」…ぜーんぶあなた専用の壁尻オナホ! CV.涼花みなせ様 陽向葵ゅか様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】【密着淫語囁き】壁尻ま〇こ種付け施設 ～いっちばん優秀なオス様のための「つよつよお精子ばらまきプロジェクト」～【KU100】",
+        "ageCategory": 3,
+        "title": "【簡体中文版】【密着淫語囁き】壁尻ま〇こ種付け施設 ～いっちばん優秀なオス様のための「つよつよお精子ばらまきプロジェクト」～【KU100】",
+        "id": "RJ01015301",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ406000/RJ405985_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ405985",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01219355",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01015301",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01026801",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01040324",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 9
+          },
+          {
+            "workno": "RJ01381455",
+            "label": "タイ語",
+            "lang": "THA",
+            "dlCount": "",
+            "displayLabel": "タイ語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 25
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01015301",
+        "releaseDate": "2025-07-08 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2025年7月8日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01015301.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2025-07-08 00:00:00",
+        "releaseDateISO": "2025-07-08T00:00:00.000Z",
+        "genres": [
+          "淫語",
+          "バイノーラル/ダミヘ",
+          "芸能人/アイドル/モデル",
+          "人妻",
+          "ハーレム",
+          "拘束",
+          "ささやき",
+          "妊娠/孕ませ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "409",
+            "name": "芸能人/アイドル/モデル"
+          },
+          {
+            "genre_key": "219",
+            "name": "人妻"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "146",
+            "name": "拘束"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          }
+        ],
+        "createdAt": "2026-07-03T03:04:10.238Z",
+        "lastFetchedAt": "2026-07-03T03:04:10.238Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 786,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 35,
+          "localePrices": {
+            "it_IT": 4.26,
+            "sv_SE": 47.21,
+            "id_ID": 87655,
+            "pt_BR": 4.26,
+            "vi_VN": 127556,
+            "th_TH": 162,
+            "fr_FR": 4.26,
+            "de_DE": 4.26,
+            "zh_TW": 155,
+            "ko_KR": 7529,
+            "en_US": 4.87,
+            "es_ES": 4.26,
+            "zh_CN": 33.08,
+            "ar_AE": 4.87
+          },
+          "point": 35
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T03:04:10.238Z"
+          }
+        },
+        "updatedAt": "2026-07-03T03:04:10.238Z"
+      }
+    },
+    {
+      "id": "RJ01015337",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ397000/RJ396675_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44990",
+              "name": "raru。",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "これから私のことは ホワイトギャルティクス沙耶香ちゃんと呼びなさい? え…… や、やっぱり? 一応自覚はあるよ? 今日の私、ちょっとテンションおかしいなって…",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】ホワイトギャルティクス沙耶香ちゃん～あなた好みの白ギャルになったのにぃぃぃぃ!?",
+        "ageCategory": 3,
+        "title": "【簡体中文版】ホワイトギャルティクス沙耶香ちゃん～あなた好みの白ギャルになったのにぃぃぃぃ!?",
+        "id": "RJ01015337",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ397000/RJ396675_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ396675",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9485,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01015337",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9485,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01104113",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9485,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01015337",
+        "releaseDate": "2024-03-05 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2024年3月5日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01015337.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2024-03-05 00:00:00",
+        "releaseDateISO": "2024-03-05T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "連続絶頂",
+          "ギャグ",
+          "ラブラブ/あまあま",
+          "逆レイプ",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "005",
+            "name": "ギャグ"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:41.965Z",
+        "lastFetchedAt": "2026-07-03T01:06:41.965Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 5.94,
+            "sv_SE": 65.84,
+            "id_ID": 121386,
+            "pt_BR": 5.94,
+            "vi_VN": 177505,
+            "th_TH": 225.53,
+            "fr_FR": 5.94,
+            "de_DE": 5.94,
+            "zh_TW": 215,
+            "ko_KR": 10516,
+            "en_US": 6.77,
+            "es_ES": 5.94,
+            "zh_CN": 46.01,
+            "ar_AE": 6.77
+          },
+          "current": 550,
+          "original": 1100,
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 2.97,
+            "sv_SE": 32.92,
+            "id_ID": 60693,
+            "pt_BR": 2.97,
+            "vi_VN": 88753,
+            "th_TH": 112.76,
+            "fr_FR": 2.97,
+            "de_DE": 2.97,
+            "zh_TW": 108,
+            "ko_KR": 5258,
+            "en_US": 3.38,
+            "es_ES": 2.97,
+            "zh_CN": 23.01,
+            "ar_AE": 3.38
+          },
+          "point": 25
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:41.965Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:41.965Z"
+      }
+    },
+    {
+      "id": "RJ01015546",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ339000/RJ338357_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "20097",
+              "name": "蔦屋育",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "スパイ疑惑を持たれた二人の女性が捜査官の男に凌辱をされる話。 彼女たちは一体何者なのでしょうか? CV 涼花みなせ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】【残虐な凌辱の果て】堕ちたスパイ疑惑の女達",
+        "ageCategory": 3,
+        "title": "【簡体中文版】【残虐な凌辱の果て】堕ちたスパイ疑惑の女達",
+        "id": "RJ01015546",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ339000/RJ338357_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ338357",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9568,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01015546",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9568,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01015546",
+        "releaseDate": "2024-12-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2024年12月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01015546.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2024-12-01 00:00:00",
+        "releaseDateISO": "2024-12-01T00:00:00.000Z",
+        "genres": [
+          "マニアック/変態",
+          "首輪/鎖/拘束具",
+          "退廃/背徳/インモラル",
+          "監禁",
+          "強制/無理矢理",
+          "拘束",
+          "洗脳",
+          "調教"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "066",
+            "name": "マニアック/変態"
+          },
+          {
+            "genre_key": "256",
+            "name": "首輪/鎖/拘束具"
+          },
+          {
+            "genre_key": "006",
+            "name": "退廃/背徳/インモラル"
+          },
+          {
+            "genre_key": "151",
+            "name": "監禁"
+          },
+          {
+            "genre_key": "114",
+            "name": "強制/無理矢理"
+          },
+          {
+            "genre_key": "146",
+            "name": "拘束"
+          },
+          {
+            "genre_key": "326",
+            "name": "洗脳"
+          },
+          {
+            "genre_key": "140",
+            "name": "調教"
+          }
+        ],
+        "createdAt": "2026-07-03T01:07:45.027Z",
+        "lastFetchedAt": "2026-07-03T01:07:45.027Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 693,
+          "original": 990,
+          "localeOfficialPrices": {
+            "it_IT": 5.37,
+            "sv_SE": 59.46,
+            "id_ID": 110405,
+            "pt_BR": 5.37,
+            "vi_VN": 160662,
+            "th_TH": 204.05,
+            "fr_FR": 5.37,
+            "de_DE": 5.37,
+            "zh_TW": 196,
+            "ko_KR": 9483,
+            "en_US": 6.14,
+            "es_ES": 5.37,
+            "zh_CN": 41.67,
+            "ar_AE": 6.14
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 3.76,
+            "sv_SE": 41.62,
+            "id_ID": 77283,
+            "pt_BR": 3.76,
+            "vi_VN": 112463,
+            "th_TH": 142.83,
+            "fr_FR": 3.76,
+            "de_DE": 3.76,
+            "zh_TW": 137,
+            "ko_KR": 6638,
+            "en_US": 4.3,
+            "es_ES": 3.76,
+            "zh_CN": 29.17,
+            "ar_AE": 4.3
+          },
+          "point": 31
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:07:45.027Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:07:45.027Z"
+      }
+    },
+    {
+      "id": "RJ01015613",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ435000/RJ434500_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "56121",
+              "name": "辺村 始",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "42488",
+              "name": "秋乃える",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "優しい妹に慰められたい方へ。マイペースでかわいい妹が恥じらいながらHな慰めをしちゃいます。",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】【KU100】マイペースかわいい妹に慰められるASMR",
+        "ageCategory": 3,
+        "title": "【簡体中文版】【KU100】マイペースかわいい妹に慰められるASMR",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "ASMR",
+          "妹",
+          "日常/生活",
+          "同居",
+          "ショートカット",
+          "処女"
+        ],
+        "id": "RJ01015613",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ435000/RJ434500_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ434500",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 8643,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01015613",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 8643,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01001181",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 8643,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01015613",
+        "releaseDate": "2023-05-04 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "212",
+            "name": "妹"
+          },
+          {
+            "genre_key": "008",
+            "name": "日常/生活"
+          },
+          {
+            "genre_key": "031",
+            "name": "同居"
+          },
+          {
+            "genre_key": "166",
+            "name": "ショートカット"
+          },
+          {
+            "genre_key": "193",
+            "name": "処女"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月4日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01015613.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-05-04 00:00:00",
+        "price": {
+          "current": 1320,
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "point": 120,
+          "localeOfficialPrices": {
+            "zh_TW": 264,
+            "it_IT": 7.69,
+            "sv_SE": 85.78,
+            "id_ID": 145695,
+            "pt_BR": 7.69,
+            "vi_VN": 232353,
+            "th_TH": 288.16,
+            "fr_FR": 7.69,
+            "de_DE": 7.69,
+            "ko_KR": 12360,
+            "en_US": 8.89,
+            "es_ES": 7.69,
+            "zh_CN": 63.81,
+            "ar_AE": 8.89
+          },
+          "localePrices": {
+            "zh_TW": 264,
+            "it_IT": 7.69,
+            "sv_SE": 85.78,
+            "id_ID": 145695,
+            "pt_BR": 7.69,
+            "vi_VN": 232353,
+            "th_TH": 288.16,
+            "fr_FR": 7.69,
+            "de_DE": 7.69,
+            "ko_KR": 12360,
+            "en_US": 8.89,
+            "es_ES": 7.69,
+            "zh_CN": 63.81,
+            "ar_AE": 8.89
+          }
+        },
+        "releaseDateISO": "2023-05-03T15:00:00.000Z",
+        "createdAt": "2025-07-30T15:13:27.344Z",
+        "lastFetchedAt": "2025-07-30T15:13:27.344Z",
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2025-07-30T15:13:27.344Z"
+          }
+        },
+        "updatedAt": "2025-07-30T15:13:27.344Z"
+      }
+    },
+    {
+      "id": "RJ01018300",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "56406",
+              "name": "うるる牡丹",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "「緩急」を使った責めと容赦のない寸止めで頭も体もとろとろになっちゃいましょう。最後まで耐えることができれば極上の快感があなたを待っています♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "緩急オナニーサポート じっくりねっとり焦らされる頭とろとろ射精我慢調教",
+        "ageCategory": 3,
+        "title": "緩急オナニーサポート じっくりねっとり焦らされる頭とろとろ射精我慢調教",
+        "id": "RJ01018300",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01018300",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11741,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01051152",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11741,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01043868",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 11741,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01018300",
+        "releaseDate": "2023-02-03 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月3日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01018300.html",
+        "circleId": "RG72787",
+        "category": "SOU",
+        "circle": "rabits",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-03 00:00:00",
+        "releaseDateISO": "2023-02-03T00:00:00.000Z",
+        "genres": [
+          "逆転無し",
+          "風俗/ソープ",
+          "オナサポ",
+          "言葉責め",
+          "焦らし",
+          "乳首責め",
+          "調教",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "433",
+            "name": "逆転無し"
+          },
+          {
+            "genre_key": "447",
+            "name": "風俗/ソープ"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "152",
+            "name": "焦らし"
+          },
+          {
+            "genre_key": "523",
+            "name": "乳首責め"
+          },
+          {
+            "genre_key": "140",
+            "name": "調教"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:33.610Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.610Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 990,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 25,
+          "localePrices": {
+            "it_IT": 5.37,
+            "sv_SE": 59.46,
+            "id_ID": 110405,
+            "pt_BR": 5.37,
+            "vi_VN": 160662,
+            "th_TH": 204.05,
+            "fr_FR": 5.37,
+            "de_DE": 5.37,
+            "zh_TW": 196,
+            "ko_KR": 9483,
+            "en_US": 6.14,
+            "es_ES": 5.37,
+            "zh_CN": 41.67,
+            "ar_AE": 6.14
+          },
+          "point": 45
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.610Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.610Z"
+      }
+    },
+    {
+      "id": "RJ01018505",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ344000/RJ343788_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "38880",
+              "name": "しると",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "40077",
+              "name": "Moco",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "「10」と命令されれば10回、「100」と命令されれば100回。数字の回数だけ手をシコシコ動かす、シンプルなルールのオナニーサポートです。サキュバスのご機嫌を伺いながら次の合図に遅れることのないよう必死で扱き、無駄撃ちの許可がもらえるのを待ちましょう。",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】無感情サキュバスにしごく回数を指示される数字責めオナニーサポート",
+        "ageCategory": 3,
+        "title": "【簡体中文版】無感情サキュバスにしごく回数を指示される数字責めオナニーサポート",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "サキュバス/淫魔",
+          "オナサポ",
+          "言葉責め",
+          "焦らし",
+          "男性受け",
+          "耳舐め",
+          "無表情"
+        ],
+        "id": "RJ01018505",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ344000/RJ343788_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ343788",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01202411",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01018505",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01083856",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01040593",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01018505",
+        "releaseDate": "2024-03-09 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "152",
+            "name": "焦らし"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "198",
+            "name": "無表情"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2024年3月9日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01018505.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2024-03-09 00:00:00",
+        "releaseDateISO": "2024-03-09T00:00:00.000Z",
+        "createdAt": "2026-07-03T01:06:41.965Z",
+        "lastFetchedAt": "2026-07-03T01:06:41.965Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 605,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.28,
+            "sv_SE": 36.33,
+            "id_ID": 67470,
+            "pt_BR": 3.28,
+            "vi_VN": 98182,
+            "th_TH": 124.7,
+            "fr_FR": 3.28,
+            "de_DE": 3.28,
+            "zh_TW": 120,
+            "ko_KR": 5795,
+            "en_US": 3.75,
+            "es_ES": 3.28,
+            "zh_CN": 25.46,
+            "ar_AE": 3.75
+          },
+          "point": 27
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:41.965Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:41.965Z"
+      }
+    },
+    {
+      "id": "RJ01019654",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17406",
+              "name": "WaP",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18242",
+              "name": "秋野かえで",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "22781",
+              "name": "oekakizuki",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "「甘園房(あまえんぼう)シリーズ」第10作目。お口プレイが得意な味方役のゆかりママと、シチュエーションプレイが得意なサキュバス姿のちひろママが、エッチなRPGお遊戯であなたをめいっぱい可愛がってくれます。主なプレイ内容は、キス、ベロチュー、オホ声、オホ吐息、両耳責め、パイズリ、授乳、フェラチオ、顔面騎乗、クンニ、ローションプレイ、手コキ、尻尾拘束、レズキス、NTR風シチュプレイ、正常位セックス、ママタクシーなど。",
+        "fileTypeString": "WAV",
+        "titleMasked": "大人赤ちゃんのためのエッチな保育園 甘園房 ゆかりママ&ちひろママ ～ママと一緒にサキュバス討伐RPG大作戦～",
+        "ageCategory": 3,
+        "title": "大人赤ちゃんのためのエッチな保育園 甘園房 ゆかりママ&ちひろママ ～ママと一緒にサキュバス討伐RPG大作戦～",
+        "id": "RJ01019654",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01019654",
+        "releaseDate": "2023-02-25 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月25日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01019654.html",
+        "circleId": "RG22409",
+        "category": "SOU",
+        "circle": "ホワイトピンク",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp8.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp9.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01020000/RJ01019654_img_smp10.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-25 00:00:00",
+        "releaseDateISO": "2023-02-25T00:00:00.000Z",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "サキュバス/淫魔",
+          "赤ちゃんプレイ",
+          "おねショタ",
+          "寝取られ",
+          "ラブラブ/あまあま",
+          "オホ声",
+          "男性受け"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "540",
+            "name": "赤ちゃんプレイ"
+          },
+          {
+            "genre_key": "504",
+            "name": "おねショタ"
+          },
+          {
+            "genre_key": "048",
+            "name": "寝取られ"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "524",
+            "name": "オホ声"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          }
+        ],
+        "createdAt": "2026-07-02T05:05:29.017Z",
+        "lastFetchedAt": "2026-07-02T05:05:29.017Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1650,
+          "localeOfficialPrices": {
+            "it_IT": 8.91,
+            "sv_SE": 98.75,
+            "id_ID": 182079,
+            "pt_BR": 8.91,
+            "vi_VN": 266258,
+            "th_TH": 338.29,
+            "fr_FR": 8.91,
+            "de_DE": 8.91,
+            "zh_TW": 323,
+            "ko_KR": 15774,
+            "en_US": 10.15,
+            "es_ES": 8.91,
+            "zh_CN": 69.02,
+            "ar_AE": 10.15
+          },
+          "localePrices": {
+            "it_IT": 8.91,
+            "sv_SE": 98.75,
+            "id_ID": 182079,
+            "pt_BR": 8.91,
+            "vi_VN": 266258,
+            "th_TH": 338.29,
+            "fr_FR": 8.91,
+            "de_DE": 8.91,
+            "zh_TW": 323,
+            "ko_KR": 15774,
+            "en_US": 10.15,
+            "es_ES": 8.91,
+            "zh_CN": 69.02,
+            "ar_AE": 10.15
           },
           "point": 75
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-05-26T07:05:08.061Z"
+            "lastFetched": "2026-07-02T05:05:29.017Z"
           }
         },
-        "updatedAt": "2026-05-26T07:05:08.061Z"
+        "updatedAt": "2026-07-02T05:05:29.017Z"
+      }
+    },
+    {
+      "id": "RJ01020036",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ440000/RJ439890_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "50155",
+              "name": "千代田マサキ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "27910",
+              "name": "雪代あるて",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "55682",
+              "name": "石動衣",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "エロゲーでムラムラしてしまったあなたは 彼女にエッチのお願いをする。 しかしスマホゲームに夢中な彼女は手が離せないらしくなんとか交渉しておまんこだけは貸してくれることに。そんないつも素っ気ない彼女だがゲームのメンテナンスの日 だけはめちゃくちゃ甘えてきてイチャラブエッチをしてくれる",
+        "fileTypeString": "WAV",
+        "titleMasked": "【繁体中文版】【これが2人の愛の形】スマホゲームに夢中なクーデレオナホ彼女〜ゲームメンテの日だけの特別な甘々デレデレイチャラブH♪〜",
+        "ageCategory": 3,
+        "title": "【繁体中文版】【これが2人の愛の形】スマホゲームに夢中なクーデレオナホ彼女〜ゲームメンテの日だけの特別な甘々デレデレイチャラブH♪〜",
+        "genres": [
+          "純愛",
+          "足コキ",
+          "中出し",
+          "妊娠/孕ませ",
+          "フェラチオ",
+          "無表情"
+        ],
+        "id": "RJ01020036",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ440000/RJ439890_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ439890",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9419,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01015137",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9419,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01020036",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9419,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01020036",
+        "releaseDate": "2023-05-12 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "125",
+            "name": "足コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "198",
+            "name": "無表情"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月12日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01020036.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-05-12 00:00:00",
+        "releaseDateISO": "2023-05-12T00:00:00.000Z",
+        "createdAt": "2026-07-03T01:05:50.905Z",
+        "lastFetchedAt": "2026-07-03T01:05:50.905Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 99,
+          "original": 220,
+          "localeOfficialPrices": {
+            "it_IT": 1.19,
+            "pt_BR": 1.19,
+            "fr_FR": 1.19,
+            "de_DE": 1.19,
+            "es_ES": 1.19,
+            "zh_TW": 44,
+            "sv_SE": 13.21,
+            "ko_KR": 2107,
+            "en_US": 1.36,
+            "id_ID": 24534,
+            "vi_VN": 35703,
+            "zh_CN": 9.26,
+            "th_TH": 45.34,
+            "ar_AE": 1.36
+          },
+          "discount": 55,
+          "localePrices": {
+            "it_IT": 0.54,
+            "sv_SE": 5.95,
+            "id_ID": 11040,
+            "pt_BR": 0.54,
+            "vi_VN": 16066,
+            "th_TH": 20.4,
+            "fr_FR": 0.54,
+            "de_DE": 0.54,
+            "zh_TW": 20,
+            "ko_KR": 948,
+            "en_US": 0.61,
+            "es_ES": 0.54,
+            "zh_CN": 4.17,
+            "ar_AE": 0.61
+          },
+          "point": 4
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:50.905Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:50.905Z"
+      }
+    },
+    {
+      "id": "RJ01020181",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44990",
+              "name": "raru。",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "今日から私はご主人様のペットです。猫ですから…たーんと可愛がってくださいね。にゃーんにゃん…",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】猫宮さんは猫になりたがっている。",
+        "ageCategory": 3,
+        "title": "【簡体中文版】猫宮さんは猫になりたがっている。",
+        "id": "RJ01020181",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01014068",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01020181",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01024339",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01020181",
+        "releaseDate": "2024-03-09 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2024年3月9日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01020181.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2024-03-09 00:00:00",
+        "releaseDateISO": "2024-03-09T00:00:00.000Z",
+        "genres": [
+          "連続絶頂",
+          "制服",
+          "ラブラブ/あまあま",
+          "逆レイプ",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:41.965Z",
+        "lastFetchedAt": "2026-07-03T01:06:41.965Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:41.965Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:41.965Z"
+      }
+    },
+    {
+      "id": "RJ01020479",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "49647",
+              "name": "鎮眞レイ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17564",
+              "name": "結姫うさぎ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17781",
+              "name": "花守このは",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17540",
+              "name": "宮坂雪",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17604",
+              "name": "水谷六花",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17401",
+              "name": "姫綺るいな",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "21807",
+              "name": "きみどりルクス",
+              "classification": "music_by",
+              "sub_classification": null
+            },
+            {
+              "id": "37996",
+              "name": "lent",
+              "classification": "music_by",
+              "sub_classification": null
+            },
+            {
+              "id": "57337",
+              "name": "來奈津",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": null,
+        "description": "RPG要素にも力を入れた、ハクスラ要素とエロの融合を目指して作られたRPGです。髪型変更、着せ替え豊富!",
+        "fileTypeString": "APK",
+        "ageCategory": 3,
+        "id": "RJ01020479",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01020479",
+        "releaseDate": "2023-12-13 16:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年12月13日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01020479.html",
+        "circleId": "RG41062",
+        "category": "RPG",
+        "circle": "黒猫喫茶 13th code",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020479_img_smp7.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "APK",
+        "fileType": "APK",
+        "registDate": "2023-12-13 16:00:00",
+        "releaseDateISO": "2023-12-13T00:00:00.000Z",
+        "genres": [
+          "きせかえ",
+          "女性視点",
+          "売春/援交",
+          "ファンタジー",
+          "陵辱",
+          "レイプ"
+        ],
+        "customGenres": [
+          {
+            "name": "きせかえ",
+            "genre_key": "312"
+          },
+          {
+            "genre_key": "060",
+            "name": "女性視点"
+          },
+          {
+            "name": "売春/援交",
+            "genre_key": "446"
+          },
+          {
+            "name": "ファンタジー",
+            "genre_key": "016"
+          },
+          {
+            "name": "陵辱",
+            "genre_key": "134"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          }
+        ],
+        "titleMasked": "【Android版】Element Embrace エレメントエンブレイス",
+        "title": "【Android版】Element Embrace エレメントエンブレイス",
+        "createdAt": "2026-06-13T15:05:45.999Z",
+        "lastFetchedAt": "2026-06-13T15:05:45.999Z",
+        "price": {
+          "original": 1980,
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1485,
+          "localeOfficialPrices": {
+            "it_IT": 10.68,
+            "sv_SE": 116.58,
+            "id_ID": 220908,
+            "pt_BR": 10.68,
+            "vi_VN": 323160,
+            "th_TH": 404.53,
+            "fr_FR": 10.68,
+            "de_DE": 10.68,
+            "zh_TW": 391,
+            "ko_KR": 18786,
+            "en_US": 12.36,
+            "es_ES": 10.68,
+            "zh_CN": 83.7,
+            "ar_AE": 12.36
+          },
+          "discount": 25,
+          "localePrices": {
+            "it_IT": 8.01,
+            "sv_SE": 87.43,
+            "id_ID": 165681,
+            "pt_BR": 8.01,
+            "vi_VN": 242370,
+            "th_TH": 303.4,
+            "fr_FR": 8.01,
+            "de_DE": 8.01,
+            "zh_TW": 293,
+            "ko_KR": 14089,
+            "en_US": 9.27,
+            "es_ES": 8.01,
+            "zh_CN": 62.78,
+            "ar_AE": 9.27
+          },
+          "point": 67
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-06-13T15:05:45.999Z"
+          }
+        },
+        "updatedAt": "2026-06-13T15:05:45.999Z"
+      }
+    },
+    {
+      "id": "RJ01020890",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020890_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "42518",
+              "name": "黒林樹",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "42358",
+              "name": "緋月ひぐれ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "55879",
+              "name": "Sk",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "小柄彼女と2人っきりのお泊まりデート♪ 2人仲良く楽しんだ後は、ホテルでラブラブ体格差えっち♪ CV:涼花みなせ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【KU100】女子力MAX小柄女子! ラブラブお泊まりナイトデート♪",
+        "ageCategory": 3,
+        "title": "【KU100】女子力MAX小柄女子! ラブラブお泊まりナイトデート♪",
+        "id": "RJ01020890",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01021000/RJ01020890_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01020890",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10770,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01029958",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10770,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01039622",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10770,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01159118",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 10770,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01020890",
+        "releaseDate": "2023-01-28 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年1月28日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01020890.html",
+        "circleId": "RG48375",
+        "category": "SOU",
+        "circle": "Deep;Dahlia",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-01-28 00:00:00",
+        "releaseDateISO": "2023-01-28T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "淫語",
+          "恋人同士",
+          "ラブラブ/あまあま",
+          "オナサポ",
+          "手コキ",
+          "中出し",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "014",
+            "name": "恋人同士"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:33.610Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.610Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 550,
+          "original": 1100,
+          "localeOfficialPrices": {
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
+            "id_ID": 122672,
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 2.98,
+            "sv_SE": 33.03,
+            "id_ID": 61336,
+            "pt_BR": 2.98,
+            "vi_VN": 89257,
+            "th_TH": 113.36,
+            "fr_FR": 2.98,
+            "de_DE": 2.98,
+            "zh_TW": 109,
+            "ko_KR": 5268,
+            "en_US": 3.41,
+            "es_ES": 2.98,
+            "zh_CN": 23.15,
+            "ar_AE": 3.41
+          },
+          "point": 25
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.610Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.610Z"
+      }
+    },
+    {
+      "id": "RJ01021775",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "35399",
+              "name": "マイク・O",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "50079",
+              "name": "失楽少女",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17211",
+              "name": "高梨はなみ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "22781",
+              "name": "oekakizuki",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "この世の全てのエッロ～いメスは、ぜ～んぶあなたの所有物…っ! 絶対服従JK催眠オナホハーレム! CV.陽向葵ゅか様 高梨はなみ様 涼花みなせ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【密着淫語囁き】催眠おまんこコレクション ～絶対服従JKオナホハーレム～【KU100】",
+        "ageCategory": 3,
+        "title": "【密着淫語囁き】催眠おまんこコレクション ～絶対服従JKオナホハーレム～【KU100】",
+        "id": "RJ01021775",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01021775",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 12934,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01058647",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 12934,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01093227",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 12934,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01058874",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 12934,
+            "editionType": "language",
+            "displayOrder": 9
+          },
+          {
+            "workno": "RJ01389091",
+            "label": "タイ語",
+            "lang": "THA",
+            "dlCount": "",
+            "displayLabel": "タイ語",
+            "editionId": 12934,
+            "editionType": "language",
+            "displayOrder": 25
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01021775",
+        "releaseDate": "2023-04-28 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月28日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01021775.html",
+        "circleId": "RG63394",
+        "category": "SOU",
+        "circle": "失楽少女",
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-28 00:00:00",
+        "releaseDateISO": "2023-04-28T00:00:00.000Z",
+        "genres": [
+          "淫語",
+          "芸能人/アイドル/モデル",
+          "ハーレム",
+          "催眠",
+          "ささやき",
+          "洗脳",
+          "耳舐め",
+          "レイプ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "409",
+            "name": "芸能人/アイドル/モデル"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "157",
+            "name": "催眠"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "326",
+            "name": "洗脳"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          }
+        ],
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_smp5.jpg"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:43.773Z",
+        "lastFetchedAt": "2026-07-03T01:05:43.773Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 924,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 5.01,
+            "sv_SE": 55.49,
+            "id_ID": 103044,
+            "pt_BR": 5.01,
+            "vi_VN": 149951,
+            "th_TH": 190.44,
+            "fr_FR": 5.01,
+            "de_DE": 5.01,
+            "zh_TW": 183,
+            "ko_KR": 8851,
+            "en_US": 5.73,
+            "es_ES": 5.01,
+            "zh_CN": 38.89,
+            "ar_AE": 5.73
+          },
+          "point": 42
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:43.773Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:43.773Z"
+      }
+    },
+    {
+      "id": "RJ01022017",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "13024",
+              "name": "杏子御津",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18242",
+              "name": "秋野かえで",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17404",
+              "name": "沢野ぽぷら",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17408",
+              "name": "分倍河原シホ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "15341",
+              "name": "誠樹ふぁん",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "13030",
+              "name": "そらまめ。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17410",
+              "name": "かの仔",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17386",
+              "name": "山田じぇみ子",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "30867",
+              "name": "琴音有波",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17477",
+              "name": "御崎ひより",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18259",
+              "name": "砂糖しお",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17402",
+              "name": "藍沢夏癒",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17769",
+              "name": "MOMOKA。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17397",
+              "name": "柚木朱莉",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "转世公主爱丽丝（CV 杏子御津）遭受强奸、被迫卖春的经商类型RPG。超丰富的内容，基础CG 91张&H场景100张以上。",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "【AI翻译补丁】神游戏世界大战 ～行商x死亡游戏～",
+        "ageCategory": 3,
+        "title": "【AI翻译补丁】神游戏世界大战 ～行商x死亡游戏～",
+        "genres": [
+          "女主人公",
+          "人外娘/モンスター娘",
+          "売春/援交",
+          "レズ/女同士",
+          "陵辱",
+          "レイプ",
+          "異種姦",
+          "フタナリ"
+        ],
+        "price": {
+          "current": 0,
+          "localeOfficialPrices": {
+            "it_IT": 0,
+            "sv_SE": 0,
+            "id_ID": 0,
+            "pt_BR": 0,
+            "vi_VN": 0,
+            "th_TH": 0,
+            "fr_FR": 0,
+            "de_DE": 0,
+            "zh_TW": 0,
+            "ko_KR": 0,
+            "en_US": 0,
+            "es_ES": 0,
+            "zh_CN": 0,
+            "ar_AE": 0
+          },
+          "isFreeOrMissingPrice": true,
+          "currency": "JPY",
+          "localePrices": {
+            "it_IT": 0,
+            "sv_SE": 0,
+            "id_ID": 0,
+            "pt_BR": 0,
+            "vi_VN": 0,
+            "th_TH": 0,
+            "fr_FR": 0,
+            "de_DE": 0,
+            "zh_TW": 0,
+            "ko_KR": 0,
+            "en_US": 0,
+            "es_ES": 0,
+            "zh_CN": 0,
+            "ar_AE": 0
+          },
+          "point": 0
+        },
+        "id": "RJ01022017",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01022017",
+        "releaseDate": "2023-01-30 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "432",
+            "name": "女主人公"
+          },
+          {
+            "genre_key": "317",
+            "name": "人外娘/モンスター娘"
+          },
+          {
+            "genre_key": "446",
+            "name": "売春/援交"
+          },
+          {
+            "genre_key": "118",
+            "name": "レズ/女同士"
+          },
+          {
+            "genre_key": "134",
+            "name": "陵辱"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          },
+          {
+            "genre_key": "324",
+            "name": "異種姦"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年1月30日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022017.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp8.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp9.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp10.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-01-30 00:00:00",
+        "releaseDateISO": "2023-01-29T15:00:00.000Z",
+        "createdAt": "2025-07-30T15:13:27.342Z",
+        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2025-07-30T15:13:27.342Z"
+          }
+        },
+        "updatedAt": "2025-07-30T15:13:27.342Z"
+      }
+    },
+    {
+      "id": "RJ01022071",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022071_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "33469",
+              "name": "トナカイ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38381",
+              "name": "ろむむ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "ホテル最上階でハーレムナイト♪ JKアイドル3人組とおま〇こ媚び媚びVIP交尾♪ CV:逢坂成美様/涼花みなせ様/浅木式様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【KU100】おま〇こハメくらべオーディション! 夜な夜な開かれる秘密のパーティー♪",
+        "ageCategory": 3,
+        "title": "【KU100】おま〇こハメくらべオーディション! 夜な夜な開かれる秘密のパーティー♪",
+        "id": "RJ01022071",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022071_img_sam.jpg",
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01022071",
+        "releaseDate": "2023-02-04 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月4日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022071.html",
+        "circleId": "RG48375",
+        "category": "SOU",
+        "circle": "Deep;Dahlia",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022071_img_smp1.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-04 00:00:00",
+        "releaseDateISO": "2023-02-04T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "淫語",
+          "芸能人/アイドル/モデル",
+          "ハーレム",
+          "手コキ",
+          "中出し",
+          "複数プレイ/乱交",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "409",
+            "name": "芸能人/アイドル/モデル"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "languageDownloads": [
+          {
+            "workno": "RJ01022071",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10616,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01662901",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10616,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01027133",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10616,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:33.610Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.610Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.610Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.610Z"
+      }
+    },
+    {
+      "id": "RJ01022104",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "20401",
+              "name": "雲井砂",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "32036",
+              "name": "豊咲",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "37858",
+              "name": "成瀬未亜（ちびキャラ）",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3",
+        "description": "出演:涼花みなせさん 「お兄ちゃんの血をわけてもらえないかな～?」ロリっ娘コスプレイヤーから献血に誘われたアナタ。なぜか献血の前に「消毒」ということで一緒にお風呂に!耳舐めされ手コキされフェラされ…さらには血を吸われちゃって…!!!???「わらわはサキュヴァンパイア!お前にわらわのまんこを味わう権利をくれてやる」アナタはのじゃろり吸血鬼のえっちなプレイを耐え抜き、ちんぽでメスガキまんこをわからせることが出来るか!?",
+        "fileTypeString": "WAV",
+        "titleMasked": "りとるびっちヴァンパイア♪ メスガキの囁きオホ声で勃起したチンポでぷにろりま〇こに連続中出し【KU100ハイレゾ】",
+        "ageCategory": 3,
+        "title": "りとるびっちヴァンパイア♪ メスガキの囁きオホ声で勃起したチンポでぷにろりま〇こに連続中出し【KU100ハイレゾ】",
+        "id": "RJ01022104",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01022104",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 30079,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01294729",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 30079,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01022104",
+        "releaseDate": "2023-02-05 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月5日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022104.html",
+        "circleId": "RG56443",
+        "category": "SOU",
+        "circle": "居酒屋少女",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022104_img_smp6.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-05 00:00:00",
+        "releaseDateISO": "2023-02-05T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "サキュバス/淫魔",
+          "ロリ",
+          "アナル",
+          "オホ声",
+          "中出し",
+          "メス堕ち"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "207",
+            "name": "ロリ"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "524",
+            "name": "オホ声"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "522",
+            "name": "メス堕ち"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:33.611Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.611Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 715,
+          "original": 1430,
+          "localeOfficialPrices": {
+            "it_IT": 7.76,
+            "sv_SE": 85.88,
+            "id_ID": 159474,
+            "pt_BR": 7.76,
+            "vi_VN": 232068,
+            "th_TH": 294.74,
+            "fr_FR": 7.76,
+            "de_DE": 7.76,
+            "zh_TW": 283,
+            "ko_KR": 13697,
+            "en_US": 8.86,
+            "es_ES": 7.76,
+            "zh_CN": 60.19,
+            "ar_AE": 8.86
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.88,
+            "sv_SE": 42.94,
+            "id_ID": 79737,
+            "pt_BR": 3.88,
+            "vi_VN": 116034,
+            "th_TH": 147.37,
+            "fr_FR": 3.88,
+            "de_DE": 3.88,
+            "zh_TW": 141,
+            "ko_KR": 6849,
+            "en_US": 4.43,
+            "es_ES": 3.88,
+            "zh_CN": 30.09,
+            "ar_AE": 4.43
+          },
+          "point": 32
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.611Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.611Z"
+      }
+    },
+    {
+      "id": "RJ01022193",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ424000/RJ423263_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "44683",
+              "name": "夜乃在処",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "51569",
+              "name": "きみスクランブル",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP4",
+        "description": "「全部わたしのせいにしていいからさ...浮気セックス..しよ...?」ダウナー巨乳彼女の親友に監禁され、下品な身体と言葉で誘惑される5日間。CV. 涼花みなせ",
+        "fileTypeString": "WAV",
+        "titleMasked": "【韓国語版】【エロアニメ特典付き】私と、浮気しよ?ダウナー巨乳な彼女の親友に逆寝取られ監禁される5日間",
+        "ageCategory": 3,
+        "title": "【韓国語版】【エロアニメ特典付き】私と、浮気しよ?ダウナー巨乳な彼女の親友に逆寝取られ監禁される5日間",
+        "id": "RJ01022193",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ424000/RJ423263_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ423263",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 8171,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01009555",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 8171,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ437825",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 8171,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ435049",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 8171,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01022193",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 8171,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01022193",
+        "releaseDate": "2023-05-27 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月27日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022193.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-05-27 00:00:00",
+        "releaseDateISO": "2023-05-27T00:00:00.000Z",
+        "genres": [
+          "アニメ",
+          "バイノーラル/ダミヘ",
+          "浮気",
+          "退廃/背徳/インモラル",
+          "寝取られ",
+          "監禁",
+          "逆レイプ",
+          "ささやき"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "073",
+            "name": "アニメ"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "440",
+            "name": "浮気"
+          },
+          {
+            "genre_key": "006",
+            "name": "退廃/背徳/インモラル"
+          },
+          {
+            "genre_key": "048",
+            "name": "寝取られ"
+          },
+          {
+            "genre_key": "151",
+            "name": "監禁"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:52.124Z",
+        "lastFetchedAt": "2026-07-03T01:05:52.124Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:52.124Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:52.124Z"
+      }
+    },
+    {
+      "id": "RJ01022476",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "51569",
+              "name": "きみスクランブル",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱 / MP4",
+        "description": "性奴隷メイドを小さくする薬でもっと虐めようと考えていると、メイドに体が小さくなる薬を飲まされショタ化してしまったあなた。調子に乗った性奴隷メイドに甘やかされ、煽られ、犯される5日間がはじまった....大人のあなたと、ショタ化したあなた。2種類のオホ声で善がるメイドをご堪能ください!そして超豪華特典として60fpsでぬるぬる動くエロアニメがなんと2本同梱!",
+        "fileTypeString": "WAV",
+        "titleMasked": "【60fpsエロアニメ2本特典】ドM性奴隷メイドと立場逆転!ショタ化しねっとりオホ声で搾り取られる5日間【2種類のオホ声】",
+        "ageCategory": 3,
+        "title": "【60fpsエロアニメ2本特典】ドM性奴隷メイドと立場逆転!ショタ化しねっとりオホ声で搾り取られる5日間【2種類のオホ声】",
+        "id": "RJ01022476",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01022476",
+        "releaseDate": "2023-04-12 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月12日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022476.html",
+        "circleId": "RG57322",
+        "category": "SOU",
+        "circle": "きみスクランブル",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022476_img_smp6.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-12 00:00:00",
+        "releaseDateISO": "2023-04-12T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "アニメ",
+          "オールハッピー",
+          "バイノーラル/ダミヘ",
+          "メイド",
+          "逆レイプ",
+          "言葉責め",
+          "調教"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "073",
+            "name": "アニメ"
+          },
+          {
+            "genre_key": "058",
+            "name": "オールハッピー"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "078",
+            "name": "メイド"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "140",
+            "name": "調教"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.830Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.830Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 7.13,
+            "sv_SE": 79,
+            "id_ID": 145663,
+            "pt_BR": 7.13,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
+            "fr_FR": 7.13,
+            "de_DE": 7.13,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
+            "es_ES": 7.13,
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
+          },
+          "current": 660,
+          "original": 1320,
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.57,
+            "sv_SE": 39.5,
+            "id_ID": 72832,
+            "pt_BR": 3.57,
+            "vi_VN": 106503,
+            "th_TH": 135.32,
+            "fr_FR": 3.57,
+            "de_DE": 3.57,
+            "zh_TW": 129,
+            "ko_KR": 6310,
+            "en_US": 4.06,
+            "es_ES": 3.57,
+            "zh_CN": 27.61,
+            "ar_AE": 4.06
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.830Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.830Z"
+      }
+    },
+    {
+      "id": "RJ01022763",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17036",
+              "name": "月影彰太",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38214",
+              "name": "ろうか",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "43429",
+              "name": "青春×フェティシズム",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": "mp3同梱/mp4",
+        "description": "「来呀来呀,怎么了嘛,前辈♪不和三羽我贴得更紧的话,其他乘客可不会给好脸色看哦」随时可能被周围发现的真实感!色情感!紧贴感!由主演涼花みなせ,以前所未有的真实感,为您送上小恶魔挑逗系的「超耳语!」音声♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "超耳语!~与烦人可爱JK三羽未卯在上学公交中~【立体声录音】",
+        "ageCategory": 3,
+        "title": "超耳语!~与烦人可爱JK三羽未卯在上学公交中~【立体声录音】",
+        "id": "RJ01022763",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ306545",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01024958",
+            "label": "英語（公式翻訳）",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 2
+          },
+          {
+            "workno": "RJ01022763",
+            "label": "簡体中文（公式翻訳）",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01024956",
+            "label": "繁体中文（公式翻訳）",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 4
+          },
+          {
+            "workno": "RJ01024960",
+            "label": "韓国語（公式翻訳）",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01022763",
+        "releaseDate": "2023-02-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022763.html",
+        "circleId": "RG51931",
+        "category": "SOU",
+        "circle": "青春×フェティシズム",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022763_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-11 00:00:00",
+        "releaseDateISO": "2023-02-11T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "制服",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "痴漢",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "139",
+            "name": "痴漢"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:34.132Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.132Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:34.132Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:34.132Z"
+      }
+    },
+    {
+      "id": "RJ01023372",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023372_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "17393",
+              "name": "しろすず",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "異世界に転生して美女たちに種付けするバイノーラル音声です。",
+        "fileTypeString": "WAV",
+        "titleMasked": "異世界転生したら美女たちと孕ませエッチし放題だった件",
+        "ageCategory": 3,
+        "title": "異世界転生したら美女たちと孕ませエッチし放題だった件",
+        "id": "RJ01023372",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023372_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01023372",
+        "releaseDate": "2023-02-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01023372.html",
+        "circleId": "RG42915",
+        "category": "SOU",
+        "circle": "しましま亭",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023372_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023372_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023372_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023372_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-01 00:00:00",
+        "releaseDateISO": "2023-02-01T00:00:00.000Z",
+        "genres": [
+          "異世界転生",
+          "初体験",
+          "ファンタジー",
+          "ラブラブ/あまあま",
+          "アナル",
+          "淫乱",
+          "ごっくん/食ザー",
+          "中出し"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "519",
+            "name": "異世界転生"
+          },
+          {
+            "genre_key": "437",
+            "name": "初体験"
+          },
+          {
+            "genre_key": "016",
+            "name": "ファンタジー"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "142",
+            "name": "淫乱"
+          },
+          {
+            "genre_key": "489",
+            "name": "ごっくん/食ザー"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:33.610Z",
+        "lastFetchedAt": "2026-07-03T01:05:33.610Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 115,
+          "original": 770,
+          "localeOfficialPrices": {
+            "it_IT": 4.18,
+            "sv_SE": 46.24,
+            "id_ID": 85870,
+            "pt_BR": 4.18,
+            "vi_VN": 124959,
+            "th_TH": 158.7,
+            "fr_FR": 4.18,
+            "de_DE": 4.18,
+            "zh_TW": 152,
+            "ko_KR": 7375,
+            "en_US": 4.77,
+            "es_ES": 4.18,
+            "zh_CN": 32.41,
+            "ar_AE": 4.77
+          },
+          "discount": 85,
+          "localePrices": {
+            "it_IT": 0.62,
+            "sv_SE": 6.91,
+            "id_ID": 12825,
+            "pt_BR": 0.62,
+            "vi_VN": 18663,
+            "th_TH": 23.7,
+            "fr_FR": 0.62,
+            "de_DE": 0.62,
+            "zh_TW": 23,
+            "ko_KR": 1102,
+            "en_US": 0.71,
+            "es_ES": 0.62,
+            "zh_CN": 4.84,
+            "ar_AE": 0.71
+          },
+          "point": 5
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:33.610Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:33.610Z"
+      }
+    },
+    {
+      "id": "RJ01023570",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023570_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "26371",
+              "name": "笹目めと",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "全トラック童貞チンポによく効く『甘ったるぅ～い媚び媚びチンイラおねだり』が満載の\"スケベ成分100%\"な音声作品です♪【オホ声あり】CV:涼花みなせ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "デカ乳ドスケベヒーラーの甘マゾを狂わせる媚び媚びチンイラご奉仕",
+        "ageCategory": 3,
+        "title": "デカ乳ドスケベヒーラーの甘マゾを狂わせる媚び媚びチンイラご奉仕",
+        "id": "RJ01023570",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023570_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01023570",
+        "releaseDate": "2023-06-10 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年6月10日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01023570.html",
+        "circleId": "RG55843",
+        "category": "SOU",
+        "circle": "あまあまレボリューション",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-06-10 00:00:00",
+        "releaseDateISO": "2023-06-10T00:00:00.000Z",
+        "genres": [
+          "おっぱい",
+          "色仕掛け",
+          "ファンタジー",
+          "ラブラブ/あまあま",
+          "オホ声",
+          "言葉責め",
+          "巨乳/爆乳",
+          "童貞"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "065",
+            "name": "おっぱい"
+          },
+          {
+            "genre_key": "448",
+            "name": "色仕掛け"
+          },
+          {
+            "genre_key": "016",
+            "name": "ファンタジー"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "524",
+            "name": "オホ声"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          },
+          {
+            "genre_key": "192",
+            "name": "童貞"
+          }
+        ],
+        "createdAt": "2026-07-04T05:05:34.716Z",
+        "lastFetchedAt": "2026-07-04T05:05:34.716Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 924,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "zh_CN": 55.54,
+            "it_IT": 7.15,
+            "sv_SE": 78.97,
+            "id_ID": 147092,
+            "pt_BR": 7.15,
+            "vi_VN": 214774,
+            "th_TH": 271.43,
+            "fr_FR": 7.15,
+            "de_DE": 7.15,
+            "zh_TW": 261,
+            "ko_KR": 12536,
+            "en_US": 8.18,
+            "es_ES": 7.15,
+            "ar_AE": 8.18
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 5.01,
+            "sv_SE": 55.28,
+            "id_ID": 102964,
+            "pt_BR": 5.01,
+            "vi_VN": 150342,
+            "th_TH": 190,
+            "fr_FR": 5.01,
+            "de_DE": 5.01,
+            "zh_TW": 183,
+            "ko_KR": 8775,
+            "en_US": 5.73,
+            "es_ES": 5.01,
+            "zh_CN": 38.88,
+            "ar_AE": 5.73
+          },
+          "point": 42
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-04T05:05:34.716Z"
+          }
+        },
+        "updatedAt": "2026-07-04T05:05:34.716Z"
+      }
+    },
+    {
+      "id": "RJ01023770",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "35399",
+              "name": "マイク・O",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "18242",
+              "name": "秋野かえで",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17211",
+              "name": "高梨はなみ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "22781",
+              "name": "oekakizuki",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "爆乳ギャルビッチトリオと空き教室で、ネカフェで、ラブホで…トリプル密着ドスケベ射精ハーレム! CV.秋野かえで様 涼花みなせ様 高梨はなみ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【密着淫語囁き】ギャルビッチトリオ! ～爆乳ギャルとトリプル密着ドスケベ射精ハーレム～【KU100】",
+        "ageCategory": 3,
+        "title": "【密着淫語囁き】ギャルビッチトリオ! ～爆乳ギャルとトリプル密着ドスケベ射精ハーレム～【KU100】",
+        "id": "RJ01023770",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_sam.jpg",
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01023770",
+        "releaseDate": "2023-03-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01023770.html",
+        "circleId": "RG63393",
+        "category": "SOU",
+        "circle": "にゃんにゃんぼいす",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01024000/RJ01023770_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-01 00:00:00",
+        "releaseDateISO": "2023-03-01T00:00:00.000Z",
+        "genres": [
+          "淫語",
+          "バイノーラル/ダミヘ",
+          "ギャル",
+          "ビッチ",
+          "ハーレム",
+          "ささやき",
+          "パイズリ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "415",
+            "name": "ギャル"
+          },
+          {
+            "genre_key": "416",
+            "name": "ビッチ"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "122",
+            "name": "パイズリ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "languageDownloads": [
+          {
+            "workno": "RJ01023770",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 13227,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01271152",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 13227,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01522119",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 13227,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01061402",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 13227,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:40.761Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.761Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 924,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 5.01,
+            "sv_SE": 55.49,
+            "id_ID": 103044,
+            "pt_BR": 5.01,
+            "vi_VN": 149951,
+            "th_TH": 190.44,
+            "fr_FR": 5.01,
+            "de_DE": 5.01,
+            "zh_TW": 183,
+            "ko_KR": 8851,
+            "en_US": 5.73,
+            "es_ES": 5.01,
+            "zh_CN": 38.89,
+            "ar_AE": 5.73
+          },
+          "point": 42
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:40.761Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:40.761Z"
+      }
+    },
+    {
+      "id": "RJ01024195",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024195_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "38154",
+              "name": "辰巳",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "52277",
+              "name": "なな枕",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "ちょっとイジワルな女の子の甘い責めを手軽に体感♪「即ヌキおま●こDAYS」シリーズ、つよギャル編",
+        "fileTypeString": "WAV",
+        "titleMasked": "【即ヌキお○んこDAYS】汚チンポ大好きなつよギャルに駅のトイレでじゅぼじゅぼ生フェラ",
+        "ageCategory": 3,
+        "title": "【即ヌキお○んこDAYS】汚チンポ大好きなつよギャルに駅のトイレでじゅぼじゅぼ生フェラ",
+        "id": "RJ01024195",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024195_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01024195",
+        "releaseDate": "2023-02-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024195.html",
+        "circleId": "RG73309",
+        "category": "SOU",
+        "circle": "道端えんかうんと",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024195_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024195_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024195_img_smp3.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-11 00:00:00",
+        "releaseDateISO": "2023-02-11T00:00:00.000Z",
+        "genres": [
+          "おっぱい",
+          "バイノーラル/ダミヘ",
+          "ギャル",
+          "男性受け",
+          "パイズリ",
+          "フェラチオ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "065",
+            "name": "おっぱい"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "415",
+            "name": "ギャル"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "122",
+            "name": "パイズリ"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          }
+        ],
+        "createdAt": "2026-03-12T05:06:10.513Z",
+        "lastFetchedAt": "2026-03-12T05:06:10.513Z",
+        "price": {
+          "original": 220,
+          "isFreeOrMissingPrice": false,
+          "discount": 50,
+          "currency": "JPY",
+          "current": 220,
+          "localeOfficialPrices": {
+            "it_IT": 1.2,
+            "pt_BR": 1.2,
+            "fr_FR": 1.2,
+            "de_DE": 1.2,
+            "zh_TW": 44,
+            "en_US": 1.39,
+            "es_ES": 1.2,
+            "ar_AE": 1.39,
+            "sv_SE": 12.78,
+            "ko_KR": 2047,
+            "id_ID": 23347,
+            "vi_VN": 36274,
+            "zh_CN": 9.53,
+            "th_TH": 44.09
+          },
+          "localePrices": {
+            "it_IT": 1.2,
+            "sv_SE": 12.78,
+            "id_ID": 23347,
+            "pt_BR": 1.2,
+            "vi_VN": 36274,
+            "th_TH": 44.09,
+            "fr_FR": 1.2,
+            "de_DE": 1.2,
+            "zh_TW": 44,
+            "ko_KR": 2047,
+            "en_US": 1.39,
+            "es_ES": 1.2,
+            "zh_CN": 9.53,
+            "ar_AE": 1.39
+          },
+          "point": 10
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-03-12T05:06:10.513Z"
+          }
+        },
+        "updatedAt": "2026-03-12T05:06:10.513Z"
+      }
+    },
+    {
+      "id": "RJ01024237",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024237_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "38154",
+              "name": "辰巳",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "27588",
+              "name": "西瓜すいか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "30867",
+              "name": "琴音有波",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17747",
+              "name": "小石川うに",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18978",
+              "name": "藤村莉央",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17410",
+              "name": "かの仔",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "20206",
+              "name": "来夢ふらん",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17477",
+              "name": "御崎ひより",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17408",
+              "name": "分倍河原シホ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44246",
+              "name": "さかむけ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18912",
+              "name": "紗倉シホ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "51575",
+              "name": "SigMa",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "52277",
+              "name": "なな枕",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "54951",
+              "name": "しのくまスケ太郎",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "34835",
+              "name": "七剣なな",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "41608",
+              "name": "トモゼロ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "44163",
+              "name": "あれっくす",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "43658",
+              "name": "Mr.Peanut",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28689",
+              "name": "raiou",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "ちょっとイジワルな女の子の甘い責めを手軽に体感♪「即ヌキおま●こDAYS」シリーズ、10作品のコンプリートパック",
+        "fileTypeString": "WAV",
+        "titleMasked": "【即ヌキお○んこDAYS】コンプリートパック",
+        "ageCategory": 3,
+        "title": "【即ヌキお○んこDAYS】コンプリートパック",
+        "id": "RJ01024237",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024237_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01024237",
+        "releaseDate": "2023-02-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024237.html",
+        "circleId": "RG73309",
+        "category": "SOU",
+        "circle": "道端えんかうんと",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024237_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024237_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024237_img_smp3.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-11 00:00:00",
+        "releaseDateISO": "2023-02-11T00:00:00.000Z",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "足コキ",
+          "男性受け",
+          "手コキ",
+          "中出し",
+          "パイズリ",
+          "フェラチオ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "125",
+            "name": "足コキ"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "122",
+            "name": "パイズリ"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-03-12T05:06:10.514Z",
+        "lastFetchedAt": "2026-03-12T05:06:10.514Z",
+        "price": {
+          "original": 1320,
+          "isFreeOrMissingPrice": false,
+          "discount": 50,
+          "currency": "JPY",
+          "current": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.18,
+            "sv_SE": 76.66,
+            "id_ID": 140083,
+            "pt_BR": 7.18,
+            "vi_VN": 217642,
+            "th_TH": 264.54,
+            "fr_FR": 7.18,
+            "de_DE": 7.18,
+            "zh_TW": 264,
+            "ko_KR": 12279,
+            "en_US": 8.31,
+            "es_ES": 7.18,
+            "zh_CN": 57.15,
+            "ar_AE": 8.31
+          },
+          "localePrices": {
+            "it_IT": 7.18,
+            "sv_SE": 76.66,
+            "id_ID": 140083,
+            "pt_BR": 7.18,
+            "vi_VN": 217642,
+            "th_TH": 264.54,
+            "fr_FR": 7.18,
+            "de_DE": 7.18,
+            "zh_TW": 264,
+            "ko_KR": 12279,
+            "en_US": 8.31,
+            "es_ES": 7.18,
+            "zh_CN": 57.15,
+            "ar_AE": 8.31
+          },
+          "point": 60
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-03-12T05:06:10.514Z"
+          }
+        },
+        "updatedAt": "2026-03-12T05:06:10.514Z"
+      }
+    },
+    {
+      "id": "RJ01024339",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44990",
+              "name": "raru。",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "今日から私はご主人様のペットです。猫ですから…たーんと可愛がってくださいね。にゃーんにゃん…",
+        "fileTypeString": "WAV",
+        "titleMasked": "【繁体中文版】猫宮さんは猫になりたがっている。",
+        "ageCategory": 3,
+        "title": "【繁体中文版】猫宮さんは猫になりたがっている。",
+        "id": "RJ01024339",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014068_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01014068",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01020181",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01024339",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10044,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01024339",
+        "releaseDate": "2023-11-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年11月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024339.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-11-01 00:00:00",
+        "releaseDateISO": "2023-11-01T00:00:00.000Z",
+        "genres": [
+          "連続絶頂",
+          "制服",
+          "ラブラブ/あまあま",
+          "逆レイプ",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:22.576Z",
+        "lastFetchedAt": "2026-07-03T01:06:22.576Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:22.576Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:22.576Z"
+      }
+    },
+    {
+      "id": "RJ01024723",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "13024",
+              "name": "杏子御津",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18242",
+              "name": "秋野かえで",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17408",
+              "name": "分倍河原シホ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17411",
+              "name": "野上菜月",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17410",
+              "name": "かの仔",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17397",
+              "name": "柚木朱莉",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "13030",
+              "name": "そらまめ。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17431",
+              "name": "みもりあいの",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "15341",
+              "name": "誠樹ふぁん",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "30867",
+              "name": "琴音有波",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17386",
+              "name": "山田じぇみ子",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17477",
+              "name": "御崎ひより",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17404",
+              "name": "沢野ぽぷら",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "And RPG depicting Saint Yhoundeh's naughty adventures.\r\nThe game is packed with 120 Base CG, over 140 Scenes, and over 5000 Voice Clips!",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "[ENG TL Patch] Fallen Saint Yhoundeh",
+        "ageCategory": 3,
+        "title": "[ENG TL Patch] Fallen Saint Yhoundeh",
+        "genres": [
+          "女主人公",
+          "妊娠/孕ませ",
+          "陵辱",
+          "レイプ",
+          "輪姦",
+          "異種姦",
+          "獣耳",
+          "処女"
+        ],
+        "price": {
+          "current": 0,
+          "localeOfficialPrices": {
+            "it_IT": 0,
+            "sv_SE": 0,
+            "id_ID": 0,
+            "pt_BR": 0,
+            "vi_VN": 0,
+            "th_TH": 0,
+            "fr_FR": 0,
+            "de_DE": 0,
+            "zh_TW": 0,
+            "ko_KR": 0,
+            "en_US": 0,
+            "es_ES": 0,
+            "zh_CN": 0,
+            "ar_AE": 0
+          },
+          "isFreeOrMissingPrice": true,
+          "currency": "JPY",
+          "localePrices": {
+            "it_IT": 0,
+            "sv_SE": 0,
+            "id_ID": 0,
+            "pt_BR": 0,
+            "vi_VN": 0,
+            "th_TH": 0,
+            "fr_FR": 0,
+            "de_DE": 0,
+            "zh_TW": 0,
+            "ko_KR": 0,
+            "en_US": 0,
+            "es_ES": 0,
+            "zh_CN": 0,
+            "ar_AE": 0
+          },
+          "point": 0
+        },
+        "id": "RJ01024723",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01024723",
+        "releaseDate": "2023-02-06 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "432",
+            "name": "女主人公"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "134",
+            "name": "陵辱"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          },
+          {
+            "genre_key": "121",
+            "name": "輪姦"
+          },
+          {
+            "genre_key": "324",
+            "name": "異種姦"
+          },
+          {
+            "genre_key": "176",
+            "name": "獣耳"
+          },
+          {
+            "genre_key": "193",
+            "name": "処女"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月6日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024723.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp8.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp9.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp10.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-02-06 00:00:00",
+        "releaseDateISO": "2023-02-05T15:00:00.000Z",
+        "createdAt": "2025-07-30T15:13:27.342Z",
+        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2025-07-30T15:13:27.342Z"
+          }
+        },
+        "updatedAt": "2025-07-30T15:13:27.342Z"
+      }
+    },
+    {
+      "id": "RJ01024956",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17036",
+              "name": "月影彰太",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38214",
+              "name": "ろうか",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "43429",
+              "name": "青春×フェティシズム",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": "mp3同梱/mp4",
+        "description": "「來呀來呀,怎麼了嘛,學長♪不和三羽我貼得更緊的話,其他乘客可不會給好臉色看哦」隨時可能被周圍發現的真實感!色情感!緊貼感!由主演涼花みなせ,以前所未有的真實感,為您送上小惡魔挑逗系的「超耳語!」音聲♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "超耳語!~與煩人可愛JK三羽美未在上學公車中~【立體聲錄音】",
+        "ageCategory": 3,
+        "title": "超耳語!~與煩人可愛JK三羽美未在上學公車中~【立體聲錄音】",
+        "id": "RJ01024956",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ306545",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01024958",
+            "label": "英語（公式翻訳）",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 2
+          },
+          {
+            "workno": "RJ01022763",
+            "label": "簡体中文（公式翻訳）",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01024956",
+            "label": "繁体中文（公式翻訳）",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 4
+          },
+          {
+            "workno": "RJ01024960",
+            "label": "韓国語（公式翻訳）",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01024956",
+        "releaseDate": "2023-02-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024956.html",
+        "circleId": "RG51931",
+        "category": "SOU",
+        "circle": "青春×フェティシズム",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024956_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-11 00:00:00",
+        "releaseDateISO": "2023-02-11T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "制服",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "痴漢",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "139",
+            "name": "痴漢"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:34.132Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.132Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:34.132Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:34.132Z"
+      }
+    },
+    {
+      "id": "RJ01024958",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17036",
+              "name": "月影彰太",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38214",
+              "name": "ろうか",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "43429",
+              "name": "青春×フェティシズム",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": "mp3同梱/mp4",
+        "description": "\"Come on. What's the matter, Senpai?  If you don't squeeze in closer to me, you'll bother the other passengers.\"Realistic avoiding of detection! Lewdness! Close contact!Featuring voice acting by Suzuka Minase, who provides a devilish taunting \"super whisper\" voice with previously unseen levels of realism.",
+        "fileTypeString": "WAV",
+        "titleMasked": "Super Whisper! ~Annoyingly Cute JK Miu Mihane on the Bus to School~ [Binaural]",
+        "ageCategory": 3,
+        "title": "Super Whisper! ~Annoyingly Cute JK Miu Mihane on the Bus to School~ [Binaural]",
+        "id": "RJ01024958",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ306545",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01024958",
+            "label": "英語（公式翻訳）",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 2
+          },
+          {
+            "workno": "RJ01022763",
+            "label": "簡体中文（公式翻訳）",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01024956",
+            "label": "繁体中文（公式翻訳）",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 4
+          },
+          {
+            "workno": "RJ01024960",
+            "label": "韓国語（公式翻訳）",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01024958",
+        "releaseDate": "2023-02-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024958.html",
+        "circleId": "RG51931",
+        "category": "SOU",
+        "circle": "青春×フェティシズム",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024958_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-11 00:00:00",
+        "releaseDateISO": "2023-02-11T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "制服",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "痴漢",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "139",
+            "name": "痴漢"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:34.132Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.132Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:34.132Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:34.132Z"
+      }
+    },
+    {
+      "id": "RJ01024960",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17036",
+              "name": "月影彰太",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38214",
+              "name": "ろうか",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "43429",
+              "name": "青春×フェティシズム",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": "mp3同梱/mp4",
+        "description": "「자아자아, 어~떻게 된 건가요 선배♪  미하네한테 더 붙지 않으면, 다른 사람이 괴로운 표정을 지을 텐데요?」주위에 들키지 않을 정도로 아슬아슬한 리얼함! 에로함! 밀착감!주연・스즈카 미나세(涼花みなせ) 님의, 소악마 도발계  「엄청 속삭여!」 보이스를, 지금까지 없던 리얼함으로 들려드립니다♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "엄청 속삭여! ~짜증귀엽 JK 미하네 미우와 통학 버스에서~",
+        "ageCategory": 3,
+        "title": "엄청 속삭여! ~짜증귀엽 JK 미하네 미우와 통학 버스에서~",
+        "id": "RJ01024960",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ306545",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01024958",
+            "label": "英語（公式翻訳）",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 2
+          },
+          {
+            "workno": "RJ01022763",
+            "label": "簡体中文（公式翻訳）",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01024956",
+            "label": "繁体中文（公式翻訳）",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 4
+          },
+          {
+            "workno": "RJ01024960",
+            "label": "韓国語（公式翻訳）",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語（公式翻訳）",
+            "editionId": 10572,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01024960",
+        "releaseDate": "2023-02-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024960.html",
+        "circleId": "RG51931",
+        "category": "SOU",
+        "circle": "青春×フェティシズム",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024960_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-11 00:00:00",
+        "releaseDateISO": "2023-02-11T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "制服",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "痴漢",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "074",
+            "name": "制服"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "139",
+            "name": "痴漢"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:34.133Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.133Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:34.133Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:34.133Z"
+      }
+    },
+    {
+      "id": "RJ01025800",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "20401",
+              "name": "雲井砂",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "34115",
+              "name": "ねいび",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "37858",
+              "name": "成瀬未亜（ちびキャラ）",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3",
+        "description": "出演:涼花みなせさん 本日マスターに従うのは、瑠璃雪楼の礼拝室を預かる修道メイドの玉屑。日々、神に祈りを捧げる敬虔な玉屑の癒しの術、そして彼女の告解を受け入れてあげてください。",
+        "fileTypeString": "WAV",
+        "titleMasked": "【シスターの癒しと甘オホ声♪】瑠璃雪楼の夜想曲 修道メイド玉屑の淫潔【KU100ハイレゾ】",
+        "ageCategory": 3,
+        "title": "【シスターの癒しと甘オホ声♪】瑠璃雪楼の夜想曲 修道メイド玉屑の淫潔【KU100ハイレゾ】",
+        "id": "RJ01025800",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01025800",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 27282,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01255660",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 27282,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01320893",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 27282,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01025800",
+        "releaseDate": "2023-02-19 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月19日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01025800.html",
+        "circleId": "RG48424",
+        "category": "SOU",
+        "circle": "パースペクティブ少女幻奏",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025800_img_smp8.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-19 00:00:00",
+        "releaseDateISO": "2023-02-19T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "癒し",
+          "バイノーラル/ダミヘ",
+          "シスター",
+          "メイド",
+          "オホ声",
+          "中出し",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "056",
+            "name": "癒し"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "096",
+            "name": "シスター"
+          },
+          {
+            "genre_key": "078",
+            "name": "メイド"
+          },
+          {
+            "genre_key": "524",
+            "name": "オホ声"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:34.133Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.133Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 7.13,
+            "sv_SE": 79,
+            "id_ID": 145663,
+            "pt_BR": 7.13,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
+            "fr_FR": 7.13,
+            "de_DE": 7.13,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
+            "es_ES": 7.13,
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
+          },
+          "current": 660,
+          "original": 1320,
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.57,
+            "sv_SE": 39.5,
+            "id_ID": 72832,
+            "pt_BR": 3.57,
+            "vi_VN": 106503,
+            "th_TH": 135.32,
+            "fr_FR": 3.57,
+            "de_DE": 3.57,
+            "zh_TW": 129,
+            "ko_KR": 6310,
+            "en_US": 4.06,
+            "es_ES": 3.57,
+            "zh_CN": 27.61,
+            "ar_AE": 4.06
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:34.133Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:34.133Z"
+      }
+    },
+    {
+      "id": "RJ01025856",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025856_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "8399",
+              "name": "はやさかうたね",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "29053",
+              "name": "向日葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17386",
+              "name": "山田じぇみ子",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17477",
+              "name": "御崎ひより",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17404",
+              "name": "沢野ぽぷら",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17402",
+              "name": "藍沢夏癒",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17769",
+              "name": "MOMOKA。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "13664",
+              "name": "涼貴涼",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17397",
+              "name": "柚木朱莉",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "46699",
+              "name": "かぐらみずき",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "触手主人公を操り女の子を犯して洗脳する探索型アドベンチャーRPG",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "触手で洗脳R",
+        "ageCategory": 3,
+        "title": "触手で洗脳R",
+        "id": "RJ01025856",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025856_img_sam.jpg",
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01025856",
+        "releaseDate": "2023-02-25 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月25日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01025856.html",
+        "circleId": "RG04325",
+        "category": "RPG",
+        "circle": "かぐら堂",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025856_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025856_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025856_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01026000/RJ01025856_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-02-25 00:00:00",
+        "releaseDateISO": "2023-02-25T00:00:00.000Z",
+        "languageDownloads": [
+          {
+            "workno": "RJ01025856",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 18680,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01519121",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 18680,
+            "editionType": "language",
+            "displayOrder": 2
+          },
+          {
+            "workno": "RJ01519189",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 18680,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01133152",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 18680,
+            "editionType": "language",
+            "displayOrder": 4
+          }
+        ],
+        "genres": [
+          "アニメ",
+          "拘束",
+          "触手",
+          "洗脳",
+          "中出し",
+          "レイプ",
+          "巨乳/爆乳",
+          "ツルペタ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "073",
+            "name": "アニメ"
+          },
+          {
+            "genre_key": "146",
+            "name": "拘束"
+          },
+          {
+            "genre_key": "162",
+            "name": "触手"
+          },
+          {
+            "genre_key": "326",
+            "name": "洗脳"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          },
+          {
+            "genre_key": "187",
+            "name": "ツルペタ"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:40.761Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.761Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1287,
+          "original": 1430,
+          "localeOfficialPrices": {
+            "it_IT": 7.76,
+            "sv_SE": 85.88,
+            "id_ID": 159474,
+            "pt_BR": 7.76,
+            "vi_VN": 232068,
+            "th_TH": 294.74,
+            "fr_FR": 7.76,
+            "de_DE": 7.76,
+            "zh_TW": 283,
+            "ko_KR": 13697,
+            "en_US": 8.86,
+            "es_ES": 7.76,
+            "zh_CN": 60.19,
+            "ar_AE": 8.86
+          },
+          "discount": 10,
+          "localePrices": {
+            "it_IT": 6.98,
+            "sv_SE": 77.29,
+            "id_ID": 143526,
+            "pt_BR": 6.98,
+            "vi_VN": 208861,
+            "th_TH": 265.26,
+            "fr_FR": 6.98,
+            "de_DE": 6.98,
+            "zh_TW": 255,
+            "ko_KR": 12328,
+            "en_US": 7.98,
+            "es_ES": 6.98,
+            "zh_CN": 54.17,
+            "ar_AE": 7.98
+          },
+          "point": 58
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:40.761Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:40.761Z"
+      }
+    },
+    {
+      "id": "RJ01026274",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026274_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17539",
+              "name": "明日葉あすは",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "32683",
+              "name": "かのぱん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "彼氏も友達もできずにジメジメとした学生生活を送っている根暗女子から、日頃のストレスのはけ口としてイジメられちゃうお話!弱みを握られて逆らうことが出来ないあなたは、彼女から強制的に乳首を責められて、バカみたいに情けない射精姿を晒して嘲笑されてしまう!(KU100バイノーラル)",
+        "fileTypeString": "WAV",
+        "titleMasked": "根暗JK様の強制乳首責め射精奴隷～陰キャでぼっちな底辺JKに小馬鹿にされながらマゾ乳首をイジメられて無様で情けなく射精させられちゃうあなた【耳元囁きKU100】",
+        "ageCategory": 3,
+        "title": "根暗JK様の強制乳首責め射精奴隷～陰キャでぼっちな底辺JKに小馬鹿にされながらマゾ乳首をイジメられて無様で情けなく射精させられちゃうあなた【耳元囁きKU100】",
+        "id": "RJ01026274",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026274_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01026274",
+        "releaseDate": "2023-03-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01026274.html",
+        "circleId": "RG40178",
+        "category": "SOU",
+        "circle": "秘密の舞踏会",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026274_img_smp1.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-01 00:00:00",
+        "releaseDateISO": "2023-03-01T00:00:00.000Z",
+        "genres": [
+          "逆転無し",
+          "マニアック/変態",
+          "強制/無理矢理",
+          "焦らし",
+          "男性受け",
+          "乳首責め",
+          "放尿/おしっこ",
+          "乳首/乳輪"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "433",
+            "name": "逆転無し"
+          },
+          {
+            "genre_key": "066",
+            "name": "マニアック/変態"
+          },
+          {
+            "genre_key": "114",
+            "name": "強制/無理矢理"
+          },
+          {
+            "genre_key": "152",
+            "name": "焦らし"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "523",
+            "name": "乳首責め"
+          },
+          {
+            "genre_key": "159",
+            "name": "放尿/おしっこ"
+          },
+          {
+            "genre_key": "185",
+            "name": "乳首/乳輪"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:40.761Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.761Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:40.761Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:40.761Z"
+      }
+    },
+    {
+      "id": "RJ01026490",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ383000/RJ382106_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "33831",
+              "name": "Deep;Dahlia",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "18240",
+              "name": "浅見ゆい",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "21861",
+              "name": "樹優衣",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "1日5～15分! せれな&もにかと一緒にめざせ美ボディ!! CV:浅見ゆい様/涼花みなせ様",
+        "fileTypeString": "MP3",
+        "titleMasked": "【繁体中文版】きびしい世界の筋トレカフェ! -Muscular&Tightened!!-",
+        "ageCategory": 1,
+        "title": "【繁体中文版】きびしい世界の筋トレカフェ! -Muscular&Tightened!!-",
+        "id": "RJ01026490",
+        "ageCategoryString": "general",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ383000/RJ382106_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ382106",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10561,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01026490",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10561,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01026490",
+        "releaseDate": "2023-02-19 00:00:00",
+        "ageRating": "全年齢",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月19日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01026490.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "MP3",
+        "fileType": "MP3",
+        "registDate": "2023-02-19 00:00:00",
+        "releaseDateISO": "2023-02-19T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "燃え"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "052",
+            "name": "燃え"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:40.760Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.760Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 110,
+          "original": 220,
+          "localeOfficialPrices": {
+            "it_IT": 1.19,
+            "pt_BR": 1.19,
+            "fr_FR": 1.19,
+            "de_DE": 1.19,
+            "es_ES": 1.19,
+            "zh_TW": 44,
+            "sv_SE": 13.21,
+            "ko_KR": 2107,
+            "en_US": 1.36,
+            "id_ID": 24534,
+            "vi_VN": 35703,
+            "zh_CN": 9.26,
+            "th_TH": 45.34,
+            "ar_AE": 1.36
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 0.6,
+            "sv_SE": 6.61,
+            "id_ID": 12267,
+            "pt_BR": 0.6,
+            "vi_VN": 17851,
+            "th_TH": 22.67,
+            "fr_FR": 0.6,
+            "de_DE": 0.6,
+            "zh_TW": 22,
+            "ko_KR": 1054,
+            "en_US": 0.68,
+            "es_ES": 0.6,
+            "zh_CN": 4.63,
+            "ar_AE": 0.68
+          },
+          "point": 5
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:40.760Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:40.760Z"
+      }
+    },
+    {
+      "id": "RJ01026771",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "13024",
+              "name": "杏子御津",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16569",
+              "name": "あかしゆき",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17410",
+              "name": "かの仔",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18978",
+              "name": "藤村莉央",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17431",
+              "name": "みもりあいの",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17477",
+              "name": "御崎ひより",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "29025",
+              "name": "そらまめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17397",
+              "name": "柚木朱莉",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17404",
+              "name": "沢野ぽぷら",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "25349",
+              "name": "MOMOKA。（柚木桃香）",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "48281",
+              "name": "kageli",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "錬金術師の少女エマが借金を返すために頑張るRPG。凌辱、異種姦、売春、奴隷堕ちなど。CG118枚。ボイス付きです。",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "錬金術師エマの借金返済物語",
+        "ageCategory": 3,
+        "title": "錬金術師エマの借金返済物語",
+        "id": "RJ01026771",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01026771",
+        "releaseDate": "2023-07-08 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年7月8日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01026771.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01027000/RJ01026771_img_smp6.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-07-08 00:00:00",
+        "releaseDateISO": "2023-07-08T00:00:00.000Z",
+        "genres": [
+          "女主人公",
+          "売春/援交",
+          "異種姦",
+          "奴隷",
+          "妊娠/孕ませ",
+          "陵辱",
+          "レイプ",
+          "露出"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "432",
+            "name": "女主人公"
+          },
+          {
+            "genre_key": "446",
+            "name": "売春/援交"
+          },
+          {
+            "genre_key": "324",
+            "name": "異種姦"
+          },
+          {
+            "genre_key": "147",
+            "name": "奴隷"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "134",
+            "name": "陵辱"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          },
+          {
+            "genre_key": "143",
+            "name": "露出"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:01.148Z",
+        "lastFetchedAt": "2026-07-03T01:06:01.148Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 2673,
+          "original": 2970,
+          "localeOfficialPrices": {
+            "it_IT": 16.11,
+            "sv_SE": 178.37,
+            "id_ID": 331214,
+            "pt_BR": 16.11,
+            "vi_VN": 481986,
+            "th_TH": 612.14,
+            "fr_FR": 16.11,
+            "de_DE": 16.11,
+            "zh_TW": 588,
+            "ko_KR": 28448,
+            "en_US": 18.41,
+            "es_ES": 16.11,
+            "zh_CN": 125,
+            "ar_AE": 18.41
+          },
+          "discount": 10,
+          "localePrices": {
+            "it_IT": 14.5,
+            "sv_SE": 160.53,
+            "id_ID": 298093,
+            "pt_BR": 14.5,
+            "vi_VN": 433788,
+            "th_TH": 550.93,
+            "fr_FR": 14.5,
+            "de_DE": 14.5,
+            "zh_TW": 529,
+            "ko_KR": 25603,
+            "en_US": 16.57,
+            "es_ES": 14.5,
+            "zh_CN": 112.5,
+            "ar_AE": 16.57
+          },
+          "point": 121
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:01.148Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:01.148Z"
+      }
+    },
+    {
+      "id": "RJ01027133",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022071_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "33469",
+              "name": "トナカイ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38381",
+              "name": "ろむむ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "ホテル最上階でハーレムナイト♪ JKアイドル3人組とおま〇こ媚び媚びVIP交尾♪ CV:逢坂成美様/涼花みなせ様/浅木式様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【繁体中文版】【KU100】おま〇こハメくらべオーディション! 夜な夜な開かれる秘密のパーティー♪",
+        "ageCategory": 3,
+        "title": "【繁体中文版】【KU100】おま〇こハメくらべオーディション! 夜な夜な開かれる秘密のパーティー♪",
+        "id": "RJ01027133",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022071_img_sam.jpg",
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01027133",
+        "releaseDate": "2023-04-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01027133.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-11 00:00:00",
+        "releaseDateISO": "2023-04-11T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "淫語",
+          "芸能人/アイドル/モデル",
+          "ハーレム",
+          "手コキ",
+          "中出し",
+          "複数プレイ/乱交",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "409",
+            "name": "芸能人/アイドル/モデル"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "languageDownloads": [
+          {
+            "workno": "RJ01022071",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10616,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01662901",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10616,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01027133",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10616,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.830Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.830Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.830Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.830Z"
+      }
+    },
+    {
+      "id": "RJ01027141",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027141_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "39884",
+              "name": "えとつな",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "50607",
+              "name": "にゃんにゃんぼいす",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "46477",
+              "name": "咫雲湯葉",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "吸血鬼の主従関係を深めるため、必要なのは「吸血」と「おまんこえっち」♡ ツンデレ可愛いのじゃロリ吸血鬼との「あまとろで」「ドスケベな」密着おまんこえっち♡ CV.涼花みなせ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【密着淫語囁き】吸血鬼おまんこえっち～眷属ちんぽで儂と交わうのじゃっ～【KU100】",
+        "ageCategory": 3,
+        "title": "【密着淫語囁き】吸血鬼おまんこえっち～眷属ちんぽで儂と交わうのじゃっ～【KU100】",
+        "id": "RJ01027141",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027141_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01027141",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 23994,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01208552",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 23994,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01027141",
+        "releaseDate": "2023-06-13 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年6月13日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01027141.html",
+        "circleId": "RG63393",
+        "category": "SOU",
+        "circle": "にゃんにゃんぼいす",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027141_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027141_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027141_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027141_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-06-13 00:00:00",
+        "releaseDateISO": "2023-06-13T00:00:00.000Z",
+        "genres": [
+          "淫語",
+          "バイノーラル/ダミヘ",
+          "人外娘/モンスター娘",
+          "ロリ",
+          "純愛",
+          "ファンタジー",
+          "ささやき",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "317",
+            "name": "人外娘/モンスター娘"
+          },
+          {
+            "genre_key": "207",
+            "name": "ロリ"
+          },
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "016",
+            "name": "ファンタジー"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:53.329Z",
+        "lastFetchedAt": "2026-07-03T01:05:53.329Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 847,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 4.6,
+            "sv_SE": 50.87,
+            "id_ID": 94457,
+            "pt_BR": 4.6,
+            "vi_VN": 137455,
+            "th_TH": 174.57,
+            "fr_FR": 4.6,
+            "de_DE": 4.6,
+            "zh_TW": 168,
+            "ko_KR": 8113,
+            "en_US": 5.25,
+            "es_ES": 4.6,
+            "zh_CN": 35.65,
+            "ar_AE": 5.25
+          },
+          "point": 38
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:53.329Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:53.329Z"
+      }
+    },
+    {
+      "id": "RJ01027182",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027182_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "50924",
+              "name": "クマネコ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44246",
+              "name": "さかむけ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "自分に自信のないもじもじ弱気なおっぱいメガネ先生を恥ずかしがらせてしこしこしてもらうバイノーラル作品です。KU100収録",
+        "fileTypeString": "WAV",
+        "titleMasked": "おしよわ꜆꜄꜆こひろ先生 ～もじもじ照れかわメガネ先生とひそひそ甘ヌキ補習～",
+        "ageCategory": 3,
+        "title": "おしよわ꜆꜄꜆こひろ先生 ～もじもじ照れかわメガネ先生とひそひそ甘ヌキ補習～",
+        "id": "RJ01027182",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027182_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01027182",
+        "releaseDate": "2023-03-25 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月25日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01027182.html",
+        "circleId": "RG58636",
+        "category": "SOU",
+        "circle": "熊猫通商",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027182_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027182_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01028000/RJ01027182_img_smp3.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-25 00:00:00",
+        "releaseDateISO": "2023-03-25T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "女教師",
+          "ストッキング",
+          "学校/学園",
+          "足コキ",
+          "手コキ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "226",
+            "name": "女教師"
+          },
+          {
+            "genre_key": "102",
+            "name": "ストッキング"
+          },
+          {
+            "genre_key": "001",
+            "name": "学校/学園"
+          },
+          {
+            "genre_key": "125",
+            "name": "足コキ"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.345Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.345Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 550,
+          "original": 1100,
+          "localeOfficialPrices": {
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
+            "id_ID": 122672,
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 2.98,
+            "sv_SE": 33.03,
+            "id_ID": 61336,
+            "pt_BR": 2.98,
+            "vi_VN": 89257,
+            "th_TH": 113.36,
+            "fr_FR": 2.98,
+            "de_DE": 2.98,
+            "zh_TW": 109,
+            "ko_KR": 5268,
+            "en_US": 3.41,
+            "es_ES": 2.98,
+            "zh_CN": 23.15,
+            "ar_AE": 3.41
+          },
+          "point": 25
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.345Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.345Z"
+      }
+    },
+    {
+      "id": "RJ01029334",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029334_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "16602",
+              "name": "みうらさぶろう",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "42319",
+              "name": "甘露アメ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "無邪気なバカの子を騙して交尾!ナマイキなバカの子を焦らして交尾!相手が神様だからって知ったことじゃありません!お風呂で愛撫!騙して手コキ!玩具でイタズラ!全身ぺろぺろ! そして交尾!無知交尾!くっころ交尾!発情交尾にキメセク交尾! ポンコツのじゃロリ神様ふたりを、孕むまで弄んでアクメ漬けにしてやりましょう!",
+        "fileTypeString": "WAV",
+        "titleMasked": "ポンコツのじゃロリ神様アクメ漬け",
+        "ageCategory": 3,
+        "title": "ポンコツのじゃロリ神様アクメ漬け",
+        "id": "RJ01029334",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029334_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01029334",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10958,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01032860",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10958,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01029334",
+        "releaseDate": "2023-02-18 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月18日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01029334.html",
+        "circleId": "RG44207",
+        "category": "SOU",
+        "circle": "おるがる堂",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029334_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029334_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029334_img_smp3.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-02-18 00:00:00",
+        "releaseDateISO": "2023-02-18T00:00:00.000Z",
+        "genres": [
+          "連続絶頂",
+          "けもの/獣化",
+          "天然",
+          "中出し",
+          "複数プレイ/乱交",
+          "耳舐め",
+          "獣耳",
+          "ネコミミ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "251",
+            "name": "けもの/獣化"
+          },
+          {
+            "genre_key": "246",
+            "name": "天然"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "176",
+            "name": "獣耳"
+          },
+          {
+            "genre_key": "175",
+            "name": "ネコミミ"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:34.133Z",
+        "lastFetchedAt": "2026-07-03T01:05:34.133Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:34.133Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:34.133Z"
+      }
+    },
+    {
+      "id": "RJ01029383",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029383_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "39138",
+              "name": "牡丹一",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "28166",
+              "name": "かふか",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "WAV",
+        "description": "当サークルの人気作「裏世界少女」の続編新作!! クールでヤンデレな女の子、「麗花」との同棲を始めたあなたに待ち受けるのは、共依存甘々生活です♪ 中盤では娘が登場してW耳舐め手コキも!?!? ハッピーでハートフルなえちえち生活を、是非ご堪能下さい!!",
+        "fileTypeString": "MP3",
+        "titleMasked": "クール系ヤンデレ少女の裏世界溺愛性交 AFTER",
+        "ageCategory": 3,
+        "title": "クール系ヤンデレ少女の裏世界溺愛性交 AFTER",
+        "id": "RJ01029383",
+        "ageCategoryString": "adult",
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01029383",
+        "releaseDate": "2023-02-25 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月25日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01029383.html",
+        "circleId": "RG51784",
+        "category": "SOU",
+        "circle": "G線上の牡丹雪",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029383_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029383_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029383_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029383_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01030000/RJ01029383_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "MP3",
+        "fileType": "MP3",
+        "registDate": "2023-02-25 00:00:00",
+        "releaseDateISO": "2023-02-25T00:00:00.000Z",
+        "genres": [
+          "クール攻め",
+          "娘",
+          "ヤンデレ",
+          "純愛",
+          "同棲",
+          "ラブラブ/あまあま",
+          "男性受け",
+          "中出し"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "290",
+            "name": "クール攻め"
+          },
+          {
+            "genre_key": "215",
+            "name": "娘"
+          },
+          {
+            "genre_key": "316",
+            "name": "ヤンデレ"
+          },
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "438",
+            "name": "同棲"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          }
+        ],
+        "languageDownloads": [
+          {
+            "workno": "RJ01029383",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 44852,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01528225",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 44852,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "thumbnailUrl": "https://www.dlsite.com/images/web/home/no_img_sam.gif",
+        "createdAt": "2026-07-03T01:05:40.761Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.761Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1100,
+          "localeOfficialPrices": {
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
+            "id_ID": 122672,
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
+          },
+          "discount": 40,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:40.761Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:40.761Z"
+      }
+    },
+    {
+      "id": "RJ01030053",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01031000/RJ01030053_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "18391",
+              "name": "こやまはる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "セフレのJK2人と毎日色んな場所で3Pセックスを楽しめる音声作品!",
+        "fileTypeString": "WAV",
+        "titleMasked": "セフレのJK2人と毎日色んな場所で濃厚イチャラブセックスをするお話【耳舐め&3Pセックス三昧!】",
+        "ageCategory": 3,
+        "title": "セフレのJK2人と毎日色んな場所で濃厚イチャラブセックスをするお話【耳舐め&3Pセックス三昧!】",
+        "id": "RJ01030053",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01031000/RJ01030053_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01030053",
+        "releaseDate": "2023-03-08 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月8日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01030053.html",
+        "circleId": "RG38687",
+        "category": "SOU",
+        "circle": "ぜろびっと",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01031000/RJ01030053_img_smp1.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-08 00:00:00",
+        "releaseDateISO": "2023-03-08T00:00:00.000Z",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "中出し",
+          "パイズリ",
+          "フェラチオ",
+          "複数プレイ/乱交",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "122",
+            "name": "パイズリ"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:40.762Z",
+        "lastFetchedAt": "2026-07-03T01:05:40.762Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 605,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.28,
+            "sv_SE": 36.33,
+            "id_ID": 67470,
+            "pt_BR": 3.28,
+            "vi_VN": 98182,
+            "th_TH": 124.7,
+            "fr_FR": 3.28,
+            "de_DE": 3.28,
+            "zh_TW": 120,
+            "ko_KR": 5795,
+            "en_US": 3.75,
+            "es_ES": 3.28,
+            "zh_CN": 25.46,
+            "ar_AE": 3.75
+          },
+          "point": 27
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:40.762Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:40.762Z"
+      }
+    },
+    {
+      "id": "RJ01031093",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ419000/RJ418328_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "50619",
+              "name": "夜行繊維",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "50850",
+              "name": "ジョン万毛郎(毛マン)",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "あなたのゲーム部屋に入り浸る巨乳で可愛いダウナー系クラスメイトとながらエッチ!",
+        "fileTypeString": "WAV",
+        "titleMasked": "【韓国語版】ゲーム部屋に夢中なダウナー系ゲーマーJKが無関心えっちさせてくれるから性処理には困らない【KU100】",
+        "ageCategory": 3,
+        "title": "【韓国語版】ゲーム部屋に夢中なダウナー系ゲーマーJKが無関心えっちさせてくれるから性処理には困らない【KU100】",
+        "id": "RJ01031093",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ419000/RJ418328_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ418328",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 7343,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ423879",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 7343,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ423461",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 7343,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ423429",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 7343,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01031093",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 7343,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01031093",
+        "releaseDate": "2025-06-17 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2025年6月17日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01031093.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2025-06-17 00:00:00",
+        "releaseDateISO": "2025-06-17T00:00:00.000Z",
+        "genres": [
+          "おっぱい",
+          "バイノーラル/ダミヘ",
+          "クール受け",
+          "オナサポ",
+          "ささやき",
+          "手コキ",
+          "中出し",
+          "フェラチオ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "065",
+            "name": "おっぱい"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "292",
+            "name": "クール受け"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          }
+        ],
+        "createdAt": "2026-07-03T03:03:58.831Z",
+        "lastFetchedAt": "2026-07-03T03:03:58.831Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1144,
+          "original": 1430,
+          "localeOfficialPrices": {
+            "it_IT": 7.76,
+            "sv_SE": 85.88,
+            "id_ID": 159474,
+            "pt_BR": 7.76,
+            "vi_VN": 232068,
+            "th_TH": 294.74,
+            "fr_FR": 7.76,
+            "de_DE": 7.76,
+            "zh_TW": 283,
+            "ko_KR": 13697,
+            "en_US": 8.86,
+            "es_ES": 7.76,
+            "zh_CN": 60.19,
+            "ar_AE": 8.86
+          },
+          "discount": 20,
+          "localePrices": {
+            "it_IT": 6.21,
+            "sv_SE": 68.71,
+            "id_ID": 127579,
+            "pt_BR": 6.21,
+            "vi_VN": 185654,
+            "th_TH": 235.79,
+            "fr_FR": 6.21,
+            "de_DE": 6.21,
+            "zh_TW": 226,
+            "ko_KR": 10958,
+            "en_US": 7.09,
+            "es_ES": 6.21,
+            "zh_CN": 48.15,
+            "ar_AE": 7.09
+          },
+          "point": 52
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T03:03:58.831Z"
+          }
+        },
+        "updatedAt": "2026-07-03T03:03:58.831Z"
+      }
+    },
+    {
+      "id": "RJ01032557",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ435000/RJ434580_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "50619",
+              "name": "夜行繊維",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "46956",
+              "name": "樹ジュン",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "あなたの部屋に転がり込んできた小悪魔可愛いサキュバスが、ニート生活を続けるために手練手管を尽くしてくる!",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】だらだら居候サキュバスとの媚び媚び搾精性活【CV:涼花みなせ】",
+        "ageCategory": 3,
+        "title": "【簡体中文版】だらだら居候サキュバスとの媚び媚び搾精性活【CV:涼花みなせ】",
+        "id": "RJ01032557",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ435000/RJ434580_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ434580",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10949,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01032557",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10949,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01032557",
+        "releaseDate": "2023-03-17 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月17日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01032557.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-17 00:00:00",
+        "releaseDateISO": "2023-03-17T00:00:00.000Z",
+        "genres": [
+          "サキュバス/淫魔",
+          "色仕掛け",
+          "純愛",
+          "逆レイプ",
+          "手コキ",
+          "中出し",
+          "パイズリ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "448",
+            "name": "色仕掛け"
+          },
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "122",
+            "name": "パイズリ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.344Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.344Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 7.73,
+            "sv_SE": 85.59,
+            "id_ID": 157802,
+            "pt_BR": 7.73,
+            "vi_VN": 230757,
+            "th_TH": 293.18,
+            "fr_FR": 7.73,
+            "de_DE": 7.73,
+            "zh_TW": 280,
+            "ko_KR": 13671,
+            "en_US": 8.8,
+            "es_ES": 7.73,
+            "zh_CN": 59.82,
+            "ar_AE": 8.8
+          },
+          "current": 1144,
+          "original": 1430,
+          "discount": 20,
+          "localePrices": {
+            "it_IT": 6.18,
+            "sv_SE": 68.47,
+            "id_ID": 126241,
+            "pt_BR": 6.18,
+            "vi_VN": 184605,
+            "th_TH": 234.55,
+            "fr_FR": 6.18,
+            "de_DE": 6.18,
+            "zh_TW": 224,
+            "ko_KR": 10937,
+            "en_US": 7.04,
+            "es_ES": 6.18,
+            "zh_CN": 47.85,
+            "ar_AE": 7.04
+          },
+          "point": 52
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.344Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.344Z"
+      }
+    },
+    {
+      "id": "RJ01032910",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "44666",
+              "name": "不透明度0",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "18391",
+              "name": "こやまはる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "13030",
+              "name": "そらまめ。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18978",
+              "name": "藤村莉央",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "32648",
+              "name": "御子柴泉",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "44666",
+              "name": "不透明度0",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "44667",
+              "name": "みゅ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "HCG43枚、Hシーン60以上でフルボイス!日常イベントもボイスを収録した着せ替え探索RPG!",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "おおユニスよ!使い魔になってしまうとは情けないっ!",
+        "ageCategory": 3,
+        "title": "おおユニスよ!使い魔になってしまうとは情けないっ!",
+        "id": "RJ01032910",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01032910",
+        "releaseDate": "2023-06-03 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年6月3日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01032910.html",
+        "circleId": "RG57332",
+        "category": "RPG",
+        "circle": "Jasmine",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01033000/RJ01032910_img_smp5.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-06-03 00:00:00",
+        "releaseDateISO": "2023-06-03T00:00:00.000Z",
+        "genres": [
+          "きせかえ",
+          "サキュバス/淫魔",
+          "ロリ",
+          "コスプレ",
+          "売春/援交",
+          "ファンタジー",
+          "巨乳/爆乳",
+          "ツインテール"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "312",
+            "name": "きせかえ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "207",
+            "name": "ロリ"
+          },
+          {
+            "genre_key": "086",
+            "name": "コスプレ"
+          },
+          {
+            "genre_key": "446",
+            "name": "売春/援交"
+          },
+          {
+            "genre_key": "016",
+            "name": "ファンタジー"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          },
+          {
+            "genre_key": "174",
+            "name": "ツインテール"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:52.711Z",
+        "lastFetchedAt": "2026-07-03T01:05:52.711Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1386,
+          "original": 1980,
+          "localeOfficialPrices": {
+            "it_IT": 10.74,
+            "sv_SE": 118.91,
+            "id_ID": 220810,
+            "pt_BR": 10.74,
+            "vi_VN": 321324,
+            "th_TH": 408.1,
+            "fr_FR": 10.74,
+            "de_DE": 10.74,
+            "zh_TW": 392,
+            "ko_KR": 18966,
+            "en_US": 12.27,
+            "es_ES": 10.74,
+            "zh_CN": 83.34,
+            "ar_AE": 12.27
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 7.52,
+            "sv_SE": 83.24,
+            "id_ID": 154567,
+            "pt_BR": 7.52,
+            "vi_VN": 224927,
+            "th_TH": 285.67,
+            "fr_FR": 7.52,
+            "de_DE": 7.52,
+            "zh_TW": 274,
+            "ko_KR": 13276,
+            "en_US": 8.59,
+            "es_ES": 7.52,
+            "zh_CN": 58.33,
+            "ar_AE": 8.59
+          },
+          "point": 63
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:52.711Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:52.711Z"
+      }
+    },
+    {
+      "id": "RJ01033411",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ305000/RJ304695_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "33831",
+              "name": "Deep;Dahlia",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "26875",
+              "name": "まふゆ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "お洒落なリゾートホテル&ナイトプールで、白ギャル2人に密着されながらの甘々イチャラブご奉仕プレイ♪ CV:涼花みなせ様/浅木式様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】【KU100】白ギャルSUMMER DREAMS! #ハメ映え小悪魔ダブルセックス♪",
+        "ageCategory": 3,
+        "title": "【簡体中文版】【KU100】白ギャルSUMMER DREAMS! #ハメ映え小悪魔ダブルセックス♪",
+        "id": "RJ01033411",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ305000/RJ304695_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ304695",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 10982,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01033411",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 10982,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01033413",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 10982,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01033411",
+        "releaseDate": "2025-09-04 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2025年9月4日",
+        "workType": "SOU",
+        "releaseDateISO": "2025-09-04T00:00:00.000Z",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01033411.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2025-09-04 00:00:00",
+        "genres": [
+          "淫語",
+          "おっぱい",
+          "バイノーラル/ダミヘ",
+          "ギャル",
+          "水着",
+          "中出し",
+          "複数プレイ/乱交",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "065",
+            "name": "おっぱい"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "415",
+            "name": "ギャル"
+          },
+          {
+            "genre_key": "077",
+            "name": "水着"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T03:04:30.096Z",
+        "lastFetchedAt": "2026-07-03T03:04:30.096Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T03:04:30.096Z"
+          }
+        },
+        "updatedAt": "2026-07-03T03:04:30.096Z"
+      }
+    },
+    {
+      "id": "RJ01033611",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01034000/RJ01033611_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "41082",
+              "name": "みずのちょう",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17410",
+              "name": "かの仔",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "41082",
+              "name": "みずのちょう",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "31737",
+              "name": "MeltyBeans",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "ふたなりJDといちゃいちゃアナルセックス♪2人のアルファ(=男性を妊娠させられるふたなり女子)が同棲する部屋に泊まらせてもらうことになったあなた(男性)。流れでセックスすることになり、フェラと乳首責めで抜かれたり、逆に彼女たちのちんこを舐めてあげたり、アナルに中出しされたり…ふたなりJD2人からたっぷり可愛がられちゃう音声です!【KU100】CV:かの仔,涼花みなせ",
+        "fileTypeString": "WAV",
+        "titleMasked": "ふたなり逆アナル3Pでメス堕ち♪-同棲中のふたなりJD2人に誘われてシェアハウスに→お互いの精液をベロキスでシェア&乳首責めいちゃいちゃアナルSEX♪-【KU100】",
+        "ageCategory": 3,
+        "title": "ふたなり逆アナル3Pでメス堕ち♪-同棲中のふたなりJD2人に誘われてシェアハウスに→お互いの精液をベロキスでシェア&乳首責めいちゃいちゃアナルSEX♪-【KU100】",
+        "genres": [
+          "ラブラブ/あまあま",
+          "ハーレム",
+          "中出し",
+          "男性受け",
+          "アナル",
+          "メス堕ち",
+          "乳首責め",
+          "フタナリ"
+        ],
+        "id": "RJ01033611",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01034000/RJ01033611_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01033611",
+        "releaseDate": "2023-03-08 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "522",
+            "name": "メス堕ち"
+          },
+          {
+            "genre_key": "523",
+            "name": "乳首責め"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月8日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01033611.html",
+        "circleId": "RG53570",
+        "category": "SOU",
+        "circle": "みずのちょう",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-08 00:00:00",
+        "price": {
+          "current": 1870,
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "point": 170,
+          "localeOfficialPrices": {
+            "it_IT": 10.9,
+            "sv_SE": 121.53,
+            "id_ID": 206402,
+            "pt_BR": 10.9,
+            "vi_VN": 329167,
+            "th_TH": 408.23,
+            "fr_FR": 10.9,
+            "de_DE": 10.9,
+            "zh_TW": 374,
+            "ko_KR": 17509,
+            "en_US": 12.59,
+            "es_ES": 10.9,
+            "zh_CN": 90.4,
+            "ar_AE": 12.59
+          },
+          "localePrices": {
+            "it_IT": 10.9,
+            "sv_SE": 121.53,
+            "id_ID": 206402,
+            "pt_BR": 10.9,
+            "vi_VN": 329167,
+            "th_TH": 408.23,
+            "fr_FR": 10.9,
+            "de_DE": 10.9,
+            "zh_TW": 374,
+            "ko_KR": 17509,
+            "en_US": 12.59,
+            "es_ES": 10.9,
+            "zh_CN": 90.4,
+            "ar_AE": 12.59
+          }
+        },
+        "releaseDateISO": "2023-03-07T15:00:00.000Z",
+        "createdAt": "2025-07-30T15:13:27.343Z",
+        "lastFetchedAt": "2025-07-30T15:13:27.343Z",
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2025-07-30T15:13:27.343Z"
+          }
+        },
+        "updatedAt": "2025-07-30T15:13:27.343Z"
+      }
+    },
+    {
+      "id": "RJ01035609",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035609_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "42483",
+              "name": "みたびえいち",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "ちなみに、起きてくれないと… 私… 今からバハムートに豹変しますよ… ? はい… 本当になりますよ… ? いいんですね… ? ばさっ、ばさっ、ばさっ、ばさっ… コホン… すいません… 羽の音でしか、バハムートを表現できませんでした… これではメイド失格です… 冥土に行ってきます… ぶふっ! メイドだけに… な～んてっ♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "うちのクール系メイドはバハムート系女子などという意味不明な造語を言ってくる不思議ちゃんです。",
+        "ageCategory": 3,
+        "title": "うちのクール系メイドはバハムート系女子などという意味不明な造語を言ってくる不思議ちゃんです。",
+        "id": "RJ01035609",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035609_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01035609",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 18320,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01157893",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 18320,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01127454",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 18320,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01035609",
+        "releaseDate": "2023-03-24 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月24日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01035609.html",
+        "circleId": "RG58827",
+        "category": "SOU",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035609_img_smp1.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-24 00:00:00",
+        "releaseDateISO": "2023-03-24T00:00:00.000Z",
+        "genres": [
+          "連続絶頂",
+          "メイド",
+          "純愛",
+          "ラブラブ/あまあま",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "078",
+            "name": "メイド"
+          },
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "circle": "See you.",
+        "createdAt": "2026-07-03T01:05:42.345Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.345Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.345Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.345Z"
+      }
+    },
+    {
+      "id": "RJ01035777",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ421000/RJ420550_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "18275",
+              "name": "白鴉鼎",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "33831",
+              "name": "Deep;Dahlia",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38381",
+              "name": "ろむむ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "ロリカワ×J〇バッドギャルズ!! 激ヤバJ〇3人組と廃倉庫でからかわれ4P⇒激しくわからせガチハメローテ♪ CV:陽向葵ゅか様/涼花みなせ様/浅木式様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】【KU100】BAD GALS!! つよメス×ざこオス×ぎゃんぐすた♪【Ci-enにてクーポン配布中♪】",
+        "ageCategory": 3,
+        "title": "【簡体中文版】【KU100】BAD GALS!! つよメス×ざこオス×ぎゃんぐすた♪【Ci-enにてクーポン配布中♪】",
+        "genres": [
+          "ASMR",
+          "淫語",
+          "ハーレム",
+          "オナサポ",
+          "ささやき",
+          "中出し",
+          "複数プレイ/乱交",
+          "耳舐め"
+        ],
+        "id": "RJ01035777",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ421000/RJ420550_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ420550",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11138,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01035777",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11138,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01035777",
+        "releaseDate": "2025-12-13 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2025年12月13日",
+        "workType": "SOU",
+        "releaseDateISO": "2025-12-13T00:00:00.000Z",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01035777.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2025-12-13 00:00:00",
+        "createdAt": "2026-07-03T03:05:03.049Z",
+        "lastFetchedAt": "2026-07-03T03:05:03.049Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T03:05:03.049Z"
+          }
+        },
+        "updatedAt": "2026-07-03T03:05:03.049Z"
+      }
+    },
+    {
+      "id": "RJ01035903",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035903_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "42165",
+              "name": "緋枝路オシエ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "19594",
+              "name": "あじふらい",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3",
+        "description": "【毎日キスしてくる幼なじみとのイチャラブエッチ作品】になります。ボクッ娘幼なじみとの日常や濃厚エッチを、涼花みなせ様のボイスで楽しむことができます。",
+        "fileTypeString": "WAV",
+        "titleMasked": "毎日キスしてくるボクッ娘幼なじみと甘々えっち-キス魔なボクともっとラブラブなベロキスしよ【バイノーラル】",
+        "ageCategory": 3,
+        "title": "毎日キスしてくるボクッ娘幼なじみと甘々えっち-キス魔なボクともっとラブラブなベロキスしよ【バイノーラル】",
+        "id": "RJ01035903",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035903_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01035903",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11738,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01043849",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11738,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01043851",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 11738,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01035903",
+        "releaseDate": "2023-03-11 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月11日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01035903.html",
+        "circleId": "RG45925",
+        "category": "SOU",
+        "circle": "幸福少女",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035903_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035903_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035903_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01036000/RJ01035903_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-11 00:00:00",
+        "releaseDateISO": "2023-03-11T00:00:00.000Z",
+        "genres": [
+          "おっぱい",
+          "幼なじみ",
+          "ラブラブ/あまあま",
+          "オホ声",
+          "中出し",
+          "パイズリ",
+          "フェラチオ",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "065",
+            "name": "おっぱい"
+          },
+          {
+            "genre_key": "222",
+            "name": "幼なじみ"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "524",
+            "name": "オホ声"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "122",
+            "name": "パイズリ"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.344Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.344Z",
+        "price": {
+          "original": 1650,
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "discount": 30,
+          "current": 1155,
+          "localeOfficialPrices": {
+            "zh_TW": 326,
+            "id_ID": 184008,
+            "it_IT": 8.95,
+            "sv_SE": 99.09,
+            "ko_KR": 15805,
+            "en_US": 10.23,
+            "pt_BR": 8.95,
+            "vi_VN": 267770,
+            "es_ES": 8.95,
+            "zh_CN": 69.45,
+            "th_TH": 340.08,
+            "fr_FR": 8.95,
+            "ar_AE": 10.23,
+            "de_DE": 8.95
+          },
+          "localePrices": {
+            "it_IT": 6.27,
+            "sv_SE": 69.37,
+            "id_ID": 128806,
+            "pt_BR": 6.27,
+            "vi_VN": 187439,
+            "th_TH": 238.06,
+            "fr_FR": 6.27,
+            "de_DE": 6.27,
+            "zh_TW": 228,
+            "ko_KR": 11063,
+            "en_US": 7.16,
+            "es_ES": 6.27,
+            "zh_CN": 48.61,
+            "ar_AE": 7.16
+          },
+          "point": 52
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.344Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.344Z"
+      }
+    },
+    {
+      "id": "RJ01037463",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "18887",
+              "name": "カマキリ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "45212",
+              "name": "葉月かなめ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "WAV",
+        "description": "コンセプトは「眠くなる耳舐め」です。枕元で寝るための耳舐めであなたのストレスと幸せホルモンを増幅させます。",
+        "fileTypeString": "MP3",
+        "titleMasked": "宮村さんはいつも眠たげ【R-15ごりごり耳舐めASMR・ささやき/CV:涼花みなせさん】",
+        "ageCategory": 2,
+        "title": "宮村さんはいつも眠たげ【R-15ごりごり耳舐めASMR・ささやき/CV:涼花みなせさん】",
+        "id": "RJ01037463",
+        "ageCategoryString": "r15",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01037463",
+        "releaseDate": "2023-05-06 16:00:00",
+        "ageRating": "R15",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月6日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01037463.html",
+        "circleId": "RG23954",
+        "category": "SOU",
+        "circle": "チームランドセル",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_smp8.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "MP3",
+        "fileType": "MP3",
+        "registDate": "2023-05-06 16:00:00",
+        "releaseDateISO": "2023-05-06T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "癒し",
+          "メガネ",
+          "少女",
+          "ロリ",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "056",
+            "name": "癒し"
+          },
+          {
+            "genre_key": "255",
+            "name": "メガネ"
+          },
+          {
+            "genre_key": "206",
+            "name": "少女"
+          },
+          {
+            "genre_key": "207",
+            "name": "ロリ"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-06-23T17:05:14.633Z",
+        "lastFetchedAt": "2026-06-23T17:05:14.633Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1320,
+          "localeOfficialPrices": {
+            "ko_KR": 12559,
+            "it_IT": 7.14,
+            "sv_SE": 78.53,
+            "id_ID": 145824,
+            "pt_BR": 7.14,
+            "vi_VN": 214251,
+            "th_TH": 268.97,
+            "fr_FR": 7.14,
+            "de_DE": 7.14,
+            "zh_TW": 259,
+            "en_US": 8.17,
+            "es_ES": 7.14,
+            "zh_CN": 55.43,
+            "ar_AE": 8.17
+          },
+          "localePrices": {
+            "it_IT": 7.14,
+            "sv_SE": 78.53,
+            "id_ID": 145824,
+            "pt_BR": 7.14,
+            "vi_VN": 214251,
+            "th_TH": 268.97,
+            "fr_FR": 7.14,
+            "de_DE": 7.14,
+            "zh_TW": 259,
+            "ko_KR": 12559,
+            "en_US": 8.17,
+            "es_ES": 7.14,
+            "zh_CN": 55.43,
+            "ar_AE": 8.17
+          },
+          "point": 60
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-06-23T17:05:14.633Z"
+          }
+        },
+        "updatedAt": "2026-06-23T17:05:14.633Z"
+      }
+    },
+    {
+      "id": "RJ01037677",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037677_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "50410",
+              "name": "Vぱれっと",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18275",
+              "name": "白鴉鼎",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "18662",
+              "name": "hai",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "真面目な風紀委員長が催眠の力で……",
+        "fileTypeString": "WAV",
+        "titleMasked": "真面目な風紀委員長を催眠支配!～甘々イキ声我慢えっち→嫌々性処理業務～【オホ声】",
+        "ageCategory": 3,
+        "title": "真面目な風紀委員長を催眠支配!～甘々イキ声我慢えっち→嫌々性処理業務～【オホ声】",
+        "id": "RJ01037677",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037677_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01037677",
+        "releaseDate": "2023-04-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01037677.html",
+        "circleId": "RG64038",
+        "category": "SOU",
+        "circle": "Vぱれっと",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037677_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037677_img_smp2.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-01 00:00:00",
+        "releaseDateISO": "2023-04-01T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "連続絶頂",
+          "学校/学園",
+          "オホ声",
+          "ごっくん/食ザー",
+          "催眠",
+          "手コキ",
+          "フェラチオ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "001",
+            "name": "学校/学園"
+          },
+          {
+            "genre_key": "524",
+            "name": "オホ声"
+          },
+          {
+            "genre_key": "489",
+            "name": "ごっくん/食ザー"
+          },
+          {
+            "genre_key": "157",
+            "name": "催眠"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.345Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.345Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 550,
+          "original": 1100,
+          "localeOfficialPrices": {
+            "it_IT": 5.97,
+            "sv_SE": 66.06,
+            "id_ID": 122672,
+            "pt_BR": 5.97,
+            "vi_VN": 178513,
+            "th_TH": 226.72,
+            "fr_FR": 5.97,
+            "de_DE": 5.97,
+            "zh_TW": 218,
+            "ko_KR": 10536,
+            "en_US": 6.82,
+            "es_ES": 5.97,
+            "zh_CN": 46.3,
+            "ar_AE": 6.82
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 2.98,
+            "sv_SE": 33.03,
+            "id_ID": 61336,
+            "pt_BR": 2.98,
+            "vi_VN": 89257,
+            "th_TH": 113.36,
+            "fr_FR": 2.98,
+            "de_DE": 2.98,
+            "zh_TW": 109,
+            "ko_KR": 5268,
+            "en_US": 3.41,
+            "es_ES": 2.98,
+            "zh_CN": 23.15,
+            "ar_AE": 3.41
+          },
+          "point": 25
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.345Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.345Z"
+      }
+    },
+    {
+      "id": "RJ01038510",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01039000/RJ01038510_img_main.jpg",
+        "fileTypeSpecial": null,
+        "description": "自分のことを彼女だと言い張る3人のニセカノたち...!全員のおま〇こやおっぱいの感触を確かめながら、ホンカノを見つけ出していこう!",
+        "fileTypeString": "WAV",
+        "titleMasked": "ニセカノdays～ホンカノはあなたが決める青春おま〇こラブコメディ～",
+        "ageCategory": 3,
+        "title": "ニセカノdays～ホンカノはあなたが決める青春おま〇こラブコメディ～",
+        "id": "RJ01038510",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01039000/RJ01038510_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01038510",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 12096,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01049917",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 12096,
+            "editionType": "language",
+            "displayOrder": 2
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01038510",
+        "releaseDate": "2023-04-16 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月16日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01038510.html",
+        "circleId": "RG54541",
+        "category": "SOU",
+        "circle": "へぶんすてーと",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01039000/RJ01038510_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01039000/RJ01038510_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01039000/RJ01038510_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01039000/RJ01038510_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-16 00:00:00",
+        "releaseDateISO": "2023-04-16T00:00:00.000Z",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "ラブラブ/あまあま",
+          "ささやき",
+          "男性受け",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "18863",
+              "name": "CrackerJaxx",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "48510",
+              "name": "そらなにいろ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "43464",
+              "name": "天乃あまね",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "createdAt": "2026-06-11T17:05:48.222Z",
+        "lastFetchedAt": "2026-06-11T17:05:48.222Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1540,
+          "localeOfficialPrices": {
+            "it_IT": 8.31,
+            "sv_SE": 91.22,
+            "id_ID": 171894,
+            "pt_BR": 8.31,
+            "vi_VN": 251634,
+            "th_TH": 316.1,
+            "fr_FR": 8.31,
+            "de_DE": 8.31,
+            "zh_TW": 304,
+            "ko_KR": 14611,
+            "en_US": 9.6,
+            "es_ES": 8.31,
+            "zh_CN": 65.13,
+            "ar_AE": 9.6
+          },
+          "localePrices": {
+            "it_IT": 8.31,
+            "sv_SE": 91.22,
+            "id_ID": 171894,
+            "pt_BR": 8.31,
+            "vi_VN": 251634,
+            "th_TH": 316.1,
+            "fr_FR": 8.31,
+            "de_DE": 8.31,
+            "zh_TW": 304,
+            "ko_KR": 14611,
+            "en_US": 9.6,
+            "es_ES": 8.31,
+            "zh_CN": 65.13,
+            "ar_AE": 9.6
+          },
+          "point": 70
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-06-11T17:05:48.222Z"
+          }
+        },
+        "updatedAt": "2026-06-11T17:05:48.222Z"
+      }
+    },
+    {
+      "id": "RJ01039006",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039006_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "31070",
+              "name": "カチモト",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "49258",
+              "name": "こみちぽた",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "エッチなお店へと潜入捜査をする捜査官の貴方は、そこで「のあ」という子にリフレをしてもらう。新人捜査官でまだ童貞な貴方は、こう言うお店も初めて…のあからの 「おっぱい 触りたいんですかだって、すっごい見てるから、触りたいのかなーって思って・・・いいですよ、優しく触ってくださいね」という誘惑と提案。 様々なサービスを受けるうちに貴方は職務を忘れて彼女のテクにどっぷりと浸かっていってしまう。 このお店は黒なのか?白なのか?",
+        "fileTypeString": "WAV",
+        "titleMasked": "童貞捜査官のあなたが裏JKリフレでダウナー系少女に中出ししちゃうまでの話",
+        "ageCategory": 3,
+        "title": "童貞捜査官のあなたが裏JKリフレでダウナー系少女に中出ししちゃうまでの話",
+        "id": "RJ01039006",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039006_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01039006",
+        "releaseDate": "2023-03-24 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月24日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01039006.html",
+        "circleId": "RG55326",
+        "category": "SOU",
+        "circle": "Lover'sHand",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039006_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039006_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039006_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039006_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-03-24 00:00:00",
+        "releaseDateISO": "2023-03-24T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "マッサージ",
+          "口内射精",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "659",
+            "name": "マッサージ"
+          },
+          {
+            "genre_key": "488",
+            "name": "口内射精"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.345Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.345Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 5.94,
+            "sv_SE": 65.84,
+            "id_ID": 121386,
+            "pt_BR": 5.94,
+            "vi_VN": 177505,
+            "th_TH": 225.53,
+            "fr_FR": 5.94,
+            "de_DE": 5.94,
+            "zh_TW": 215,
+            "ko_KR": 10516,
+            "en_US": 6.77,
+            "es_ES": 5.94,
+            "zh_CN": 46.01,
+            "ar_AE": 6.77
+          },
+          "current": 220,
+          "original": 1100,
+          "discount": 80,
+          "localePrices": {
+            "it_IT": 1.19,
+            "sv_SE": 13.17,
+            "id_ID": 24277,
+            "pt_BR": 1.19,
+            "vi_VN": 35501,
+            "th_TH": 45.11,
+            "fr_FR": 1.19,
+            "de_DE": 1.19,
+            "zh_TW": 43,
+            "ko_KR": 2103,
+            "en_US": 1.35,
+            "es_ES": 1.19,
+            "zh_CN": 9.2,
+            "ar_AE": 1.35
+          },
+          "point": 10
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.345Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.345Z"
+      }
+    },
+    {
+      "id": "RJ01039482",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "22142",
+              "name": "里見リトウ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18275",
+              "name": "白鴉鼎",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "10338",
+              "name": "佐藤克利",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "30746",
+              "name": "お砂糖",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "50155",
+              "name": "千代田マサキ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "18242",
+              "name": "秋野かえで",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "20206",
+              "name": "来夢ふらん",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "45514",
+              "name": "MOMOKA.",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18978",
+              "name": "藤村莉央",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "29748",
+              "name": "遊佐ミコト",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "42819",
+              "name": "神代そら",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "32036",
+              "name": "豊咲",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "45674",
+              "name": "しもふりたけのこ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16224",
+              "name": "Rozea",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "37535",
+              "name": "まめ猫",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "43463",
+              "name": "肉",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "27910",
+              "name": "雪代あるて",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "2022年に販売した作品10作品を各2〜3トラック収録!!!全26トラック(プロローグ含む)もし気に入った作品がありましたらご購入検討してくださると嬉しいです!",
+        "fileTypeString": "WAV",
+        "titleMasked": "【360分!! 20射精!!】サークル名aoお試しセット〜2022年ver〜",
+        "ageCategory": 3,
+        "title": "【360分!! 20射精!!】サークル名aoお試しセット〜2022年ver〜",
+        "id": "RJ01039482",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01039482",
+        "releaseDate": "2023-04-01 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01039482.html",
+        "circleId": "RG56340",
+        "category": "SOU",
+        "circle": "サークル名ao",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp8.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp9.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01040000/RJ01039482_img_smp10.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-01 00:00:00",
+        "releaseDateISO": "2023-04-01T00:00:00.000Z",
+        "genres": [
+          "学校/学園",
+          "純愛",
+          "ラブラブ/あまあま",
+          "顔射",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "複数プレイ/乱交"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "001",
+            "name": "学校/学園"
+          },
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "127",
+            "name": "顔射"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.829Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.829Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 88,
+          "original": 110,
+          "localeOfficialPrices": {
+            "zh_TW": 22,
+            "en_US": 0.68,
+            "ar_AE": 0.68,
+            "it_IT": 0.6,
+            "sv_SE": 6.61,
+            "ko_KR": 1054,
+            "id_ID": 12267,
+            "pt_BR": 0.6,
+            "vi_VN": 17851,
+            "es_ES": 0.6,
+            "zh_CN": 4.63,
+            "th_TH": 22.67,
+            "fr_FR": 0.6,
+            "de_DE": 0.6
+          },
+          "discount": 20,
+          "localePrices": {
+            "it_IT": 0.48,
+            "sv_SE": 5.29,
+            "id_ID": 9814,
+            "pt_BR": 0.48,
+            "vi_VN": 14281,
+            "th_TH": 18.14,
+            "fr_FR": 0.48,
+            "de_DE": 0.48,
+            "zh_TW": 17,
+            "ko_KR": 843,
+            "en_US": 0.55,
+            "es_ES": 0.48,
+            "zh_CN": 3.7,
+            "ar_AE": 0.55
+          },
+          "point": 4
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.829Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.829Z"
+      }
+    },
+    {
+      "id": "RJ01040322",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ281000/RJ280066_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "41818",
+              "name": "暁月しおん",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "35007",
+              "name": "桜雨",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3,MP4",
+        "description": "オレ嫁シリーズが【極・耳舐め】を引っさげて帰ってきた!CV涼花みなせ",
+        "fileTypeString": "AAC",
+        "titleMasked": "【韓国語版】【字幕付き音声作品】耳舐め上手で褒め上手な天使系のオレの嫁!【極・耳舐め】【フォーリーサウンド】",
+        "ageCategory": 3,
+        "title": "【韓国語版】【字幕付き音声作品】耳舐め上手で褒め上手な天使系のオレの嫁!【極・耳舐め】【フォーリーサウンド】",
+        "genres": [
+          "ラブラブ/あまあま",
+          "中出し",
+          "耳舐め"
+        ],
+        "id": "RJ01040322",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ281000/RJ280066_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ280066",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11458,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01049956",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 11458,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01040782",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11458,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01040322",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 11458,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01040322",
+        "releaseDate": "2023-04-07 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月7日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01040322.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "AAC",
+        "fileType": "AAC",
+        "registDate": "2023-04-07 00:00:00",
+        "releaseDateISO": "2023-04-07T00:00:00.000Z",
+        "createdAt": "2026-07-03T01:05:42.829Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.829Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.13,
+            "sv_SE": 79,
+            "id_ID": 145663,
+            "pt_BR": 7.13,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
+            "fr_FR": 7.13,
+            "de_DE": 7.13,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
+            "es_ES": 7.13,
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.57,
+            "sv_SE": 39.5,
+            "id_ID": 72832,
+            "pt_BR": 3.57,
+            "vi_VN": 106503,
+            "th_TH": 135.32,
+            "fr_FR": 3.57,
+            "de_DE": 3.57,
+            "zh_TW": 129,
+            "ko_KR": 6310,
+            "en_US": 4.06,
+            "es_ES": 3.57,
+            "zh_CN": 27.61,
+            "ar_AE": 4.06
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.829Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.829Z"
+      }
+    },
+    {
+      "id": "RJ01040324",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ406000/RJ405985_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "35399",
+              "name": "マイク・O",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "53164",
+              "name": "えすゆうゼット",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "国中から集められた優秀なメスを、壁尻にして、ハメて、種付け!! 「JK」「人妻」「トップアイドル」…ぜーんぶあなた専用の壁尻オナホ! CV.涼花みなせ様 陽向葵ゅか様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【韓国語版】【密着淫語囁き】壁尻ま〇こ種付け施設 ～いっちばん優秀なオス様のための「つよつよお精子ばらまきプロジェクト」～【KU100】",
+        "ageCategory": 3,
+        "title": "【韓国語版】【密着淫語囁き】壁尻ま〇こ種付け施設 ～いっちばん優秀なオス様のための「つよつよお精子ばらまきプロジェクト」～【KU100】",
+        "id": "RJ01040324",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ406000/RJ405985_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ405985",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01219355",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01015301",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01026801",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01040324",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 9
+          },
+          {
+            "workno": "RJ01381455",
+            "label": "タイ語",
+            "lang": "THA",
+            "dlCount": "",
+            "displayLabel": "タイ語",
+            "editionId": 9475,
+            "editionType": "language",
+            "displayOrder": 25
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01040324",
+        "releaseDate": "2023-05-03 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月3日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01040324.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-05-03 00:00:00",
+        "releaseDateISO": "2023-05-03T00:00:00.000Z",
+        "genres": [
+          "淫語",
+          "バイノーラル/ダミヘ",
+          "芸能人/アイドル/モデル",
+          "人妻",
+          "ハーレム",
+          "拘束",
+          "ささやき",
+          "妊娠/孕ませ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "409",
+            "name": "芸能人/アイドル/モデル"
+          },
+          {
+            "genre_key": "219",
+            "name": "人妻"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "146",
+            "name": "拘束"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:44.432Z",
+        "lastFetchedAt": "2026-07-03T01:05:44.432Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 786,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 35,
+          "localePrices": {
+            "it_IT": 4.26,
+            "sv_SE": 47.21,
+            "id_ID": 87655,
+            "pt_BR": 4.26,
+            "vi_VN": 127556,
+            "th_TH": 162,
+            "fr_FR": 4.26,
+            "de_DE": 4.26,
+            "zh_TW": 155,
+            "ko_KR": 7529,
+            "en_US": 4.87,
+            "es_ES": 4.26,
+            "zh_CN": 33.08,
+            "ar_AE": 4.87
+          },
+          "point": 35
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:44.432Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:44.432Z"
+      }
+    },
+    {
+      "id": "RJ01040332",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ306000/RJ305131_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "38880",
+              "name": "しると",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "40077",
+              "name": "Moco",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "ルーインドオーガズムで精液の残量をゼロにしてからしかイカせてもらえない、超ドM向けオナニーサポートです。サキュバスの「漏らせ」という合図で精液を何度も何度も垂れ流し、惨めで辛い空撃ち射精を目指してください。",
+        "fileTypeString": "WAV",
+        "titleMasked": "【韓国語版】無感情サキュバスの射精前に搾り尽くすルーインドオーガズムオナニーサポート",
+        "ageCategory": 3,
+        "title": "【韓国語版】無感情サキュバスの射精前に搾り尽くすルーインドオーガズムオナニーサポート",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "サキュバス/淫魔",
+          "オナニー",
+          "言葉責め",
+          "焦らし",
+          "男性受け",
+          "耳舐め",
+          "無表情"
+        ],
+        "id": "RJ01040332",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ306000/RJ305131_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ305131",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 8243,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01157883",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 8243,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ436027",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 8243,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01040332",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 8243,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01040332",
+        "releaseDate": "2023-06-22 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "135",
+            "name": "オナニー"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "152",
+            "name": "焦らし"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "198",
+            "name": "無表情"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年6月22日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01040332.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-06-22 00:00:00",
+        "releaseDateISO": "2023-06-22T00:00:00.000Z",
+        "createdAt": "2026-07-03T01:05:53.329Z",
+        "lastFetchedAt": "2026-07-03T01:05:53.329Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 605,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.28,
+            "sv_SE": 36.33,
+            "id_ID": 67470,
+            "pt_BR": 3.28,
+            "vi_VN": 98182,
+            "th_TH": 124.7,
+            "fr_FR": 3.28,
+            "de_DE": 3.28,
+            "zh_TW": 120,
+            "ko_KR": 5795,
+            "en_US": 3.75,
+            "es_ES": 3.28,
+            "zh_CN": 25.46,
+            "ar_AE": 3.75
+          },
+          "point": 27
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:53.329Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:53.329Z"
+      }
+    },
+    {
+      "id": "RJ01040593",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ344000/RJ343788_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "38880",
+              "name": "しると",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "40077",
+              "name": "Moco",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "「10」と命令されれば10回、「100」と命令されれば100回。数字の回数だけ手をシコシコ動かす、シンプルなルールのオナニーサポートです。サキュバスのご機嫌を伺いながら次の合図に遅れることのないよう必死で扱き、無駄撃ちの許可がもらえるのを待ちましょう。",
+        "fileTypeString": "WAV",
+        "titleMasked": "【韓国語版】無感情サキュバスにしごく回数を指示される数字責めオナニーサポート",
+        "ageCategory": 3,
+        "title": "【韓国語版】無感情サキュバスにしごく回数を指示される数字責めオナニーサポート",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "サキュバス/淫魔",
+          "オナサポ",
+          "言葉責め",
+          "焦らし",
+          "男性受け",
+          "耳舐め",
+          "無表情"
+        ],
+        "id": "RJ01040593",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ344000/RJ343788_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ343788",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01202411",
+            "label": "英語",
+            "lang": "ENG",
+            "dlCount": "",
+            "displayLabel": "英語",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 3
+          },
+          {
+            "workno": "RJ01018505",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01083856",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 7
+          },
+          {
+            "workno": "RJ01040593",
+            "label": "韓国語",
+            "lang": "KO_KR",
+            "dlCount": "",
+            "displayLabel": "韓国語",
+            "editionId": 9941,
+            "editionType": "language",
+            "displayOrder": 9
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01040593",
+        "releaseDate": "2023-12-29 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "152",
+            "name": "焦らし"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "198",
+            "name": "無表情"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年12月29日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01040593.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-12-29 00:00:00",
+        "releaseDateISO": "2023-12-29T00:00:00.000Z",
+        "createdAt": "2026-07-03T01:06:32.241Z",
+        "lastFetchedAt": "2026-07-03T01:06:32.241Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 605,
+          "original": 1210,
+          "localeOfficialPrices": {
+            "it_IT": 6.57,
+            "sv_SE": 72.67,
+            "id_ID": 134939,
+            "pt_BR": 6.57,
+            "vi_VN": 196365,
+            "th_TH": 249.39,
+            "fr_FR": 6.57,
+            "de_DE": 6.57,
+            "zh_TW": 239,
+            "ko_KR": 11590,
+            "en_US": 7.5,
+            "es_ES": 6.57,
+            "zh_CN": 50.93,
+            "ar_AE": 7.5
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.28,
+            "sv_SE": 36.33,
+            "id_ID": 67470,
+            "pt_BR": 3.28,
+            "vi_VN": 98182,
+            "th_TH": 124.7,
+            "fr_FR": 3.28,
+            "de_DE": 3.28,
+            "zh_TW": 120,
+            "ko_KR": 5795,
+            "en_US": 3.75,
+            "es_ES": 3.28,
+            "zh_CN": 25.46,
+            "ar_AE": 3.75
+          },
+          "point": 27
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:32.241Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:32.241Z"
+      }
+    },
+    {
+      "id": "RJ01040771",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ267000/RJ266690_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17507",
+              "name": "えるむ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18237",
+              "name": "ディーブルスト",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "9774",
+              "name": "このえゆずこ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "34610",
+              "name": "タカハル",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3",
+        "description": "極上の精気を持つあなたの所へ、見た目は小さいが中身は大人のノーブルサキュバスがやってきた!精気を捧げる契約を交わし、主導権を握られたままエッチな毎日を…。更には彼女お付きのメイドサキュバスも現れて…?CV:橘きの&涼花みなせ",
+        "fileTypeString": "WAV",
+        "titleMasked": "【簡体中文版】ノーブルサキュバスの専属しもべになった僕の搾精生活",
+        "ageCategory": 3,
+        "title": "【簡体中文版】ノーブルサキュバスの専属しもべになった僕の搾精生活",
+        "id": "RJ01040771",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ267000/RJ266690_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ266690",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11494,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01040771",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11494,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01040771",
+        "releaseDate": "2023-10-14 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年10月14日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01040771.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-10-14 00:00:00",
+        "releaseDateISO": "2023-10-14T00:00:00.000Z",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "サキュバス/淫魔",
+          "人外娘/モンスター娘",
+          "男性受け",
+          "フェラチオ",
+          "複数プレイ/乱交",
+          "耳舐め",
+          "乳首/乳輪"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "506",
+            "name": "サキュバス/淫魔"
+          },
+          {
+            "genre_key": "317",
+            "name": "人外娘/モンスター娘"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "116",
+            "name": "複数プレイ/乱交"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "185",
+            "name": "乳首/乳輪"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:15.068Z",
+        "lastFetchedAt": "2026-07-03T01:06:15.068Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 715,
+          "original": 1430,
+          "localeOfficialPrices": {
+            "it_IT": 7.76,
+            "sv_SE": 85.88,
+            "id_ID": 159474,
+            "pt_BR": 7.76,
+            "vi_VN": 232068,
+            "th_TH": 294.74,
+            "fr_FR": 7.76,
+            "de_DE": 7.76,
+            "zh_TW": 283,
+            "ko_KR": 13697,
+            "en_US": 8.86,
+            "es_ES": 7.76,
+            "zh_CN": 60.19,
+            "ar_AE": 8.86
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.88,
+            "sv_SE": 42.94,
+            "id_ID": 79737,
+            "pt_BR": 3.88,
+            "vi_VN": 116034,
+            "th_TH": 147.37,
+            "fr_FR": 3.88,
+            "de_DE": 3.88,
+            "zh_TW": 141,
+            "ko_KR": 6849,
+            "en_US": 4.43,
+            "es_ES": 3.88,
+            "zh_CN": 30.09,
+            "ar_AE": 4.43
+          },
+          "point": 32
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:15.068Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:15.068Z"
+      }
+    },
+    {
+      "id": "RJ01041035",
+      "data": {
+        "workTypeString": "ロールプレイング",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "13024",
+              "name": "杏子御津",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18242",
+              "name": "秋野かえで",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17404",
+              "name": "沢野ぽぷら",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17408",
+              "name": "分倍河原シホ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "15341",
+              "name": "誠樹ふぁん",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "13030",
+              "name": "そらまめ。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17410",
+              "name": "かの仔",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17386",
+              "name": "山田じぇみ子",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "30867",
+              "name": "琴音有波",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17394",
+              "name": "逢坂成美",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17542",
+              "name": "浅木式",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17477",
+              "name": "御崎ひより",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "18259",
+              "name": "砂糖しお",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17402",
+              "name": "藍沢夏癒",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17769",
+              "name": "MOMOKA。",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17397",
+              "name": "柚木朱莉",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "전생 왕녀 앨리스(cv.안즈 미츠)가 레이프 당하거나, 몸을 파는 행상계 RPG입니다. 기본 CG91, H씬 100종류 이상의 대볼륨.",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "【AI번역 패치】신의 게임 세계 대전 ～행상 X 데스 게임～",
+        "ageCategory": 3,
+        "title": "【AI번역 패치】신의 게임 세계 대전 ～행상 X 데스 게임～",
+        "genres": [
+          "女主人公",
+          "人外娘/モンスター娘",
+          "売春/援交",
+          "レズ/女同士",
+          "陵辱",
+          "レイプ",
+          "異種姦",
+          "フタナリ"
+        ],
+        "price": {
+          "current": 0,
+          "localeOfficialPrices": {
+            "it_IT": 0,
+            "sv_SE": 0,
+            "id_ID": 0,
+            "pt_BR": 0,
+            "vi_VN": 0,
+            "th_TH": 0,
+            "fr_FR": 0,
+            "de_DE": 0,
+            "zh_TW": 0,
+            "ko_KR": 0,
+            "en_US": 0,
+            "es_ES": 0,
+            "zh_CN": 0,
+            "ar_AE": 0
+          },
+          "isFreeOrMissingPrice": true,
+          "currency": "JPY",
+          "localePrices": {
+            "it_IT": 0,
+            "sv_SE": 0,
+            "id_ID": 0,
+            "pt_BR": 0,
+            "vi_VN": 0,
+            "th_TH": 0,
+            "fr_FR": 0,
+            "de_DE": 0,
+            "zh_TW": 0,
+            "ko_KR": 0,
+            "en_US": 0,
+            "es_ES": 0,
+            "zh_CN": 0,
+            "ar_AE": 0
+          },
+          "point": 0
+        },
+        "id": "RJ01041035",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ロールプレイング",
+        "productId": "RJ01041035",
+        "releaseDate": "2023-03-24 00:00:00",
+        "ageRating": "R18",
+        "customGenres": [
+          {
+            "genre_key": "432",
+            "name": "女主人公"
+          },
+          {
+            "genre_key": "317",
+            "name": "人外娘/モンスター娘"
+          },
+          {
+            "genre_key": "446",
+            "name": "売春/援交"
+          },
+          {
+            "genre_key": "118",
+            "name": "レズ/女同士"
+          },
+          {
+            "genre_key": "134",
+            "name": "陵辱"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          },
+          {
+            "genre_key": "324",
+            "name": "異種姦"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "fileSize": null,
+        "releaseDateDisplay": "2023年3月24日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01041035.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp7.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp8.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp9.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_smp10.jpg"
+          }
+        ],
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-03-24 00:00:00",
+        "releaseDateISO": "2023-03-23T15:00:00.000Z",
+        "createdAt": "2025-07-30T15:13:27.343Z",
+        "lastFetchedAt": "2025-07-30T15:13:27.343Z",
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2025-07-30T15:13:27.343Z"
+          }
+        },
+        "updatedAt": "2025-07-30T15:13:27.343Z"
+      }
+    },
+    {
+      "id": "RJ01041971",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "20789",
+              "name": "ドアノブ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "38084",
+              "name": "アサヒナヒカゲ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "37858",
+              "name": "成瀬未亜（ちびキャラ）",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3",
+        "description": "出演:涼花みなせさん 陸上部のエース候補、夏希のストレッチをサポートしていたアナタは、健康的な彼女のカラダに欲情してしまい……。勃起ちんぽに気付いた彼女は、アナタを誘惑するように自らの蒸れた脇を晒して……。夏希のドスケベで瑞々しい脇やまんこに絡めとられたアナタは欲望の赴くままに夏希のカラダを貪って……。",
+        "fileTypeString": "WAV",
+        "titleMasked": "【密着囁き甘オホ♪】陸上部の彼女 汗で蒸れた彼女の脇とま〇こと尻穴の香ばしいスメルを胸一杯に吸い込んで射精する【KU100ハイレゾ】",
+        "ageCategory": 3,
+        "title": "【密着囁き甘オホ♪】陸上部の彼女 汗で蒸れた彼女の脇とま〇こと尻穴の香ばしいスメルを胸一杯に吸い込んで射精する【KU100ハイレゾ】",
+        "id": "RJ01041971",
+        "ageCategoryString": "adult",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01041971",
+        "releaseDate": "2023-04-09 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月9日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01041971.html",
+        "circleId": "RG48424",
+        "category": "SOU",
+        "circle": "パースペクティブ少女幻奏",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_smp6.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-09 00:00:00",
+        "releaseDateISO": "2023-04-09T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "足コキ",
+          "アナル",
+          "ささやき",
+          "手コキ",
+          "中出し",
+          "褐色/日焼け"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "125",
+            "name": "足コキ"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "321",
+            "name": "褐色/日焼け"
+          }
+        ],
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_sam@3x.jpg",
+        "createdAt": "2026-07-03T01:05:42.829Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.829Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.829Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.829Z"
+      }
+    },
+    {
+      "id": "RJ01042104",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042104_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "27962",
+              "name": "ユビノタクト",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "54567",
+              "name": "おとうふ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "mp3同梱",
+        "description": "莉沙は二つの秘密を隠していた……英美里に抱いていた恋心と自分の正体。告白をして付き合う事になるが、信じてくれないもう一つの秘密について莉沙は様々な能力を使って英美里に体験させた……絶頂させる度に記憶を消し何度もイカせ続け、幻影を作り出し現実では体験できないなど様々な快楽を刻み込む。CV: 涼花みなせ",
+        "fileTypeString": "WAV",
+        "titleMasked": "【TS百合】私たちだけの百合の秘蜜は誰も知らない～Secret Lily Honey～【KU100】",
+        "ageCategory": 3,
+        "title": "【TS百合】私たちだけの百合の秘蜜は誰も知らない～Secret Lily Honey～【KU100】",
+        "id": "RJ01042104",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042104_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01042104",
+        "releaseDate": "2023-05-04 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月4日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01042104.html",
+        "circleId": "RG42459",
+        "category": "SOU",
+        "circle": "ユビノタクト",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042104_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042104_img_smp2.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-05-04 00:00:00",
+        "releaseDateISO": "2023-05-04T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "女性視点",
+          "バイノーラル/ダミヘ",
+          "同級生/同僚",
+          "性転換(TS)",
+          "女体化",
+          "百合",
+          "レズ/女同士"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "060",
+            "name": "女性視点"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "281",
+            "name": "同級生/同僚"
+          },
+          {
+            "genre_key": "245",
+            "name": "性転換(TS)"
+          },
+          {
+            "genre_key": "250",
+            "name": "女体化"
+          },
+          {
+            "genre_key": "158",
+            "name": "百合"
+          },
+          {
+            "genre_key": "118",
+            "name": "レズ/女同士"
+          }
+        ],
+        "createdAt": "2026-07-04T05:05:27.216Z",
+        "lastFetchedAt": "2026-07-04T05:05:27.216Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 924,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.15,
+            "sv_SE": 78.97,
+            "id_ID": 147092,
+            "pt_BR": 7.15,
+            "vi_VN": 214774,
+            "th_TH": 271.43,
+            "fr_FR": 7.15,
+            "de_DE": 7.15,
+            "zh_TW": 261,
+            "ko_KR": 12536,
+            "en_US": 8.18,
+            "es_ES": 7.15,
+            "zh_CN": 55.54,
+            "ar_AE": 8.18
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 5.01,
+            "sv_SE": 55.28,
+            "id_ID": 102964,
+            "pt_BR": 5.01,
+            "vi_VN": 150342,
+            "th_TH": 190,
+            "fr_FR": 5.01,
+            "de_DE": 5.01,
+            "zh_TW": 183,
+            "ko_KR": 8775,
+            "en_US": 5.73,
+            "es_ES": 5.01,
+            "zh_CN": 38.88,
+            "ar_AE": 5.73
+          },
+          "point": 42
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-04T05:05:27.216Z"
+          }
+        },
+        "updatedAt": "2026-07-04T05:05:27.216Z"
+      }
+    },
+    {
+      "id": "RJ01042994",
+      "data": {
+        "workTypeString": "アドベンチャー",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042994_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "42740",
+              "name": "稲庭しゅゑ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "33172",
+              "name": "龍生",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "21878",
+              "name": "東頭鎖国",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "42441",
+              "name": "揉寺",
+              "classification": "scenario_by",
+              "sub_classification": null
+            },
+            {
+              "id": "59745",
+              "name": "daikon",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17408",
+              "name": "分倍河原シホ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17523",
+              "name": "井上果林",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "9774",
+              "name": "このえゆずこ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "18440",
+              "name": "アレキシ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "33168",
+              "name": "カネネコ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "26270",
+              "name": "瀧本ゆかり",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "59746",
+              "name": "ひろびー",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "29226",
+              "name": "HHH",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "おっぱいの中で果てることに情熱を傾ける人(ズリキチ)大満足のパイズリゲームです。 ロリ巨乳、ロリ爆乳が好きな方おすすめ! イラスト アレキシ、カネネコ、瀧本ゆかり、ひろびー、HHH。 ボイス 大山チロル、分倍河原シホ、井上果林、このえゆずこ、涼花みなせ。",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "特殊専門風俗店～ロリ爆乳～2",
+        "ageCategory": 3,
+        "title": "特殊専門風俗店～ロリ爆乳～2",
+        "id": "RJ01042994",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042994_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "アドベンチャー",
+        "productId": "RJ01042994",
+        "releaseDate": "2023-04-22 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月22日",
+        "workType": "ADV",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01042994.html",
+        "circleId": "RG26596",
+        "category": "ADV",
+        "circle": "askot",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042994_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042994_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042994_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01043000/RJ01042994_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "アドベンチャー",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-04-22 00:00:00",
+        "releaseDateISO": "2023-04-22T00:00:00.000Z",
+        "genres": [
+          "おっぱい",
+          "メガネ",
+          "風俗/ソープ",
+          "言葉責め",
+          "男性受け",
+          "パイズリ",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "name": "おっぱい",
+            "genre_key": "065"
+          },
+          {
+            "genre_key": "255",
+            "name": "メガネ"
+          },
+          {
+            "name": "風俗/ソープ",
+            "genre_key": "447"
+          },
+          {
+            "name": "言葉責め",
+            "genre_key": "144"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "name": "パイズリ",
+            "genre_key": "122"
+          },
+          {
+            "name": "巨乳/爆乳",
+            "genre_key": "182"
+          }
+        ],
+        "createdAt": "2026-03-12T05:06:20.352Z",
+        "lastFetchedAt": "2026-03-12T05:06:20.352Z",
+        "price": {
+          "original": 1540,
+          "isFreeOrMissingPrice": false,
+          "discount": 20,
+          "currency": "JPY",
+          "current": 1540,
+          "localeOfficialPrices": {
+            "it_IT": 8.38,
+            "sv_SE": 89.43,
+            "id_ID": 163430,
+            "pt_BR": 8.38,
+            "vi_VN": 253916,
+            "th_TH": 308.63,
+            "fr_FR": 8.38,
+            "de_DE": 8.38,
+            "zh_TW": 308,
+            "ko_KR": 14326,
+            "en_US": 9.7,
+            "es_ES": 8.38,
+            "zh_CN": 66.68,
+            "ar_AE": 9.7
+          },
+          "localePrices": {
+            "it_IT": 8.38,
+            "sv_SE": 89.43,
+            "id_ID": 163430,
+            "pt_BR": 8.38,
+            "vi_VN": 253916,
+            "th_TH": 308.63,
+            "fr_FR": 8.38,
+            "de_DE": 8.38,
+            "zh_TW": 308,
+            "ko_KR": 14326,
+            "en_US": 9.7,
+            "es_ES": 8.38,
+            "zh_CN": 66.68,
+            "ar_AE": 9.7
+          },
+          "point": 70
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-03-12T05:06:20.352Z"
+          }
+        },
+        "updatedAt": "2026-03-12T05:06:20.352Z"
+      }
+    },
+    {
+      "id": "RJ01043101",
+      "data": {
+        "workTypeString": "シミュレーション",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "30867",
+              "name": "琴音有波",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17385",
+              "name": "陽向葵ゅか",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "14072",
+              "name": "本多未季",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "16885",
+              "name": "大山チロル",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17397",
+              "name": "柚木朱莉",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17404",
+              "name": "沢野ぽぷら",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17411",
+              "name": "野上菜月",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17642",
+              "name": "秋山はるる",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "あの夏より、もっと彼女達との思い出を―――前作「あまえんぼ」の半年後を舞台にした完全新作!彼女達とヤリ放題シ放題なエロエロな冬休みを満喫しよう!",
+        "fileTypeString": "アプリケーション",
+        "titleMasked": "あまえんぼ冬",
+        "ageCategory": 3,
+        "title": "あまえんぼ冬",
+        "id": "RJ01043101",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "シミュレーション",
+        "productId": "RJ01043101",
+        "releaseDate": "2023-07-14 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年7月14日",
+        "workType": "SLN",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01043101.html",
+        "circleId": "RG39871",
+        "category": "SLN",
+        "circle": "ドージンオトメ",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01044000/RJ01043101_img_smp7.jpg"
+          }
+        ],
+        "workFormat": "シミュレーション",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-07-14 00:00:00",
+        "genres": [
+          "アニメ",
+          "ドット",
+          "姉妹",
+          "年上",
+          "おねショタ",
+          "中出し"
+        ],
+        "releaseDateISO": "2023-07-14T00:00:00.000Z",
+        "customGenres": [
+          {
+            "name": "アニメ",
+            "genre_key": "073"
+          },
+          {
+            "name": "ドット",
+            "genre_key": "431"
+          },
+          {
+            "name": "姉妹",
+            "genre_key": "268"
+          },
+          {
+            "name": "年上",
+            "genre_key": "209"
+          },
+          {
+            "name": "おねショタ",
+            "genre_key": "504"
+          },
+          {
+            "name": "中出し",
+            "genre_key": "128"
+          }
+        ],
+        "createdAt": "2026-07-03T01:06:01.149Z",
+        "lastFetchedAt": "2026-07-03T01:06:01.149Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 11.89,
+            "sv_SE": 131.67,
+            "id_ID": 242772,
+            "pt_BR": 11.89,
+            "vi_VN": 355010,
+            "th_TH": 451.05,
+            "fr_FR": 11.89,
+            "de_DE": 11.89,
+            "zh_TW": 431,
+            "ko_KR": 21033,
+            "en_US": 13.53,
+            "es_ES": 11.89,
+            "zh_CN": 92.02,
+            "ar_AE": 13.53
+          },
+          "current": 1100,
+          "original": 2200,
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 5.94,
+            "sv_SE": 65.84,
+            "id_ID": 121386,
+            "pt_BR": 5.94,
+            "vi_VN": 177505,
+            "th_TH": 225.53,
+            "fr_FR": 5.94,
+            "de_DE": 5.94,
+            "zh_TW": 215,
+            "ko_KR": 10516,
+            "en_US": 6.77,
+            "es_ES": 5.94,
+            "zh_CN": 46.01,
+            "ar_AE": 6.77
+          },
+          "point": 50
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:06:01.149Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:06:01.149Z"
+      }
+    },
+    {
+      "id": "RJ01043133",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ291000/RJ290229_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "33656",
+              "name": "家宇治林",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "9481",
+              "name": "スミスミ",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [
+            {
+              "id": "9431",
+              "name": "春日森",
+              "classification": "music_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "fileTypeSpecial": null,
+        "description": "圧倒的にリアルなTS機械姦! 新開発の耳責め機械触手が両耳を刺激! 女体産生サウンドで細胞レベルから美少女になったあなたを、ダウナー宇宙人と事務的AIが無慈悲な連続オーガズムに誘う。高品質な【音の洪水】に溺れてください。CV.涼花みなせ",
+        "fileTypeString": "MP3",
+        "titleMasked": "【簡体中文版】【高振動耳責め機械触手】デイドリームTS機械姦～どうしてもメス化したいあなたがAIのエネルギーになるまで～【バイノーラル】",
+        "ageCategory": 3,
+        "title": "【簡体中文版】【高振動耳責め機械触手】デイドリームTS機械姦～どうしてもメス化したいあなたがAIのエネルギーになるまで～【バイノーラル】",
+        "id": "RJ01043133",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ291000/RJ290229_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ290229",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11660,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01043133",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11660,
+            "editionType": "language",
+            "displayOrder": 5
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01043133",
+        "releaseDate": "2023-12-23 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年12月23日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01043133.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "MP3",
+        "fileType": "MP3",
+        "registDate": "2023-12-23 00:00:00",
+        "releaseDateISO": "2023-12-23T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "性転換(TS)",
+          "女体化",
+          "機械姦",
+          "催眠",
+          "洗脳",
+          "耳舐め"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "245",
+            "name": "性転換(TS)"
+          },
+          {
+            "genre_key": "250",
+            "name": "女体化"
+          },
+          {
+            "genre_key": "164",
+            "name": "機械姦"
+          },
+          {
+            "genre_key": "157",
+            "name": "催眠"
+          },
+          {
+            "genre_key": "326",
+            "name": "洗脳"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          }
+        ],
+        "createdAt": "2026-06-19T15:05:48.498Z",
+        "lastFetchedAt": "2026-06-19T15:05:48.498Z",
+        "price": {
+          "original": 1100,
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 770,
+          "localeOfficialPrices": {
+            "it_IT": 5.95,
+            "pt_BR": 5.95,
+            "es_ES": 5.95,
+            "fr_FR": 5.95,
+            "de_DE": 5.95,
+            "zh_TW": 216,
+            "sv_SE": 65.37,
+            "ko_KR": 10496,
+            "en_US": 6.83,
+            "id_ID": 121092,
+            "vi_VN": 179328,
+            "zh_CN": 46.31,
+            "th_TH": 223.78,
+            "ar_AE": 6.83
+          },
+          "discount": 30,
+          "localePrices": {
+            "it_IT": 4.17,
+            "sv_SE": 45.76,
+            "id_ID": 84764,
+            "pt_BR": 4.17,
+            "vi_VN": 125530,
+            "th_TH": 156.65,
+            "fr_FR": 4.17,
+            "de_DE": 4.17,
+            "zh_TW": 151,
+            "ko_KR": 7347,
+            "en_US": 4.78,
+            "es_ES": 4.17,
+            "zh_CN": 32.42,
+            "ar_AE": 4.78
+          },
+          "point": 35
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-06-19T15:05:48.498Z"
+          }
+        },
+        "updatedAt": "2026-06-19T15:05:48.498Z"
+      }
+    },
+    {
+      "id": "RJ01043868",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "56406",
+              "name": "うるる牡丹",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "「緩急」を使った責めと容赦のない寸止めで頭も体もとろとろになっちゃいましょう。最後まで耐えることができれば極上の快感があなたを待っています♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "【繁体中文版】緩急オナニーサポート じっくりねっとり焦らされる頭とろとろ射精我慢調教【KU100】",
+        "ageCategory": 3,
+        "title": "【繁体中文版】緩急オナニーサポート じっくりねっとり焦らされる頭とろとろ射精我慢調教【KU100】",
+        "id": "RJ01043868",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01019000/RJ01018300_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01018300",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 11741,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01051152",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 11741,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01043868",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 11741,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01043868",
+        "releaseDate": "2023-04-18 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月18日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01043868.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-18 00:00:00",
+        "releaseDateISO": "2023-04-18T00:00:00.000Z",
+        "genres": [
+          "逆転無し",
+          "風俗/ソープ",
+          "オナサポ",
+          "言葉責め",
+          "ささやき",
+          "焦らし",
+          "耳舐め",
+          "乳首/乳輪"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "433",
+            "name": "逆転無し"
+          },
+          {
+            "genre_key": "447",
+            "name": "風俗/ソープ"
+          },
+          {
+            "genre_key": "514",
+            "name": "オナサポ"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "503",
+            "name": "ささやき"
+          },
+          {
+            "genre_key": "152",
+            "name": "焦らし"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "185",
+            "name": "乳首/乳輪"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.830Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.830Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 7.13,
+            "sv_SE": 79,
+            "id_ID": 145663,
+            "pt_BR": 7.13,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
+            "fr_FR": 7.13,
+            "de_DE": 7.13,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
+            "es_ES": 7.13,
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
+          },
+          "current": 990,
+          "original": 1320,
+          "discount": 25,
+          "localePrices": {
+            "it_IT": 5.35,
+            "sv_SE": 59.25,
+            "id_ID": 109247,
+            "pt_BR": 5.35,
+            "vi_VN": 159755,
+            "th_TH": 202.97,
+            "fr_FR": 5.35,
+            "de_DE": 5.35,
+            "zh_TW": 194,
+            "ko_KR": 9465,
+            "en_US": 6.09,
+            "es_ES": 5.35,
+            "zh_CN": 41.41,
+            "ar_AE": 6.09
+          },
+          "point": 45
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.830Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.830Z"
+      }
+    },
+    {
+      "id": "RJ01044685",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01045000/RJ01044685_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "17565",
+              "name": "あすきぃきゅーぶ",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "18238",
+              "name": "宇路月あきら",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": null,
+        "description": "あなたの部屋に居座るクラスのギャルと、ひょんな事からイかせ合いゲームで勝負する事に…",
+        "fileTypeString": "WAV",
+        "titleMasked": "クラスの敏感ギャルとベッドでだらだらイかせ合いゲーム",
+        "ageCategory": 3,
+        "title": "クラスの敏感ギャルとベッドでだらだらイかせ合いゲーム",
+        "id": "RJ01044685",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01045000/RJ01044685_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01044685",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 22569,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01186042",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 22569,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01411895",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 22569,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01044685",
+        "releaseDate": "2023-04-06 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月6日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01044685.html",
+        "circleId": "RG52998",
+        "category": "SOU",
+        "circle": "どるちぇ!",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01045000/RJ01044685_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01045000/RJ01044685_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01045000/RJ01044685_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01045000/RJ01044685_img_smp4.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-06 00:00:00",
+        "releaseDateISO": "2023-04-06T00:00:00.000Z",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "ギャル",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "415",
+            "name": "ギャル"
+          },
+          {
+            "genre_key": "124",
+            "name": "手コキ"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "138",
+            "name": "フェラチオ"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-07-03T01:05:42.829Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.829Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 660,
+          "original": 1320,
+          "localeOfficialPrices": {
+            "it_IT": 7.16,
+            "sv_SE": 79.28,
+            "id_ID": 147206,
+            "pt_BR": 7.16,
+            "vi_VN": 214216,
+            "th_TH": 272.06,
+            "fr_FR": 7.16,
+            "de_DE": 7.16,
+            "zh_TW": 261,
+            "ko_KR": 12644,
+            "en_US": 8.18,
+            "es_ES": 7.16,
+            "zh_CN": 55.56,
+            "ar_AE": 8.18
+          },
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.58,
+            "sv_SE": 39.64,
+            "id_ID": 73603,
+            "pt_BR": 3.58,
+            "vi_VN": 107108,
+            "th_TH": 136.03,
+            "fr_FR": 3.58,
+            "de_DE": 3.58,
+            "zh_TW": 131,
+            "ko_KR": 6322,
+            "en_US": 4.09,
+            "es_ES": 3.58,
+            "zh_CN": 27.78,
+            "ar_AE": 4.09
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.829Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.829Z"
+      }
+    },
+    {
+      "id": "RJ01045689",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01046000/RJ01045689_img_main.jpg",
+        "fileTypeSpecial": "MP3",
+        "description": "いぇ～いっ♪ 独身売れ残りのダメ人間… 朱莉お姉ちゃんだお～♪ んにゃ～♪ よしよ～しっ♪ 可愛いな、こんにゃろ～♪ お姉ちゃんはいつも帰ってきて、あんたの顔見ると疲れが吹き飛ぶんよ～♪ 好きだぞ～♪大好きだぞ～♪",
+        "fileTypeString": "WAV",
+        "titleMasked": "売れ残りダメ人間お姉ちゃんに求愛される。",
+        "ageCategory": 3,
+        "title": "売れ残りダメ人間お姉ちゃんに求愛される。",
+        "id": "RJ01045689",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01046000/RJ01045689_img_sam.jpg",
+        "languageDownloads": [
+          {
+            "workno": "RJ01045689",
+            "label": "日本語",
+            "lang": "JPN",
+            "dlCount": "",
+            "displayLabel": "日本語",
+            "editionId": 21264,
+            "editionType": "language",
+            "displayOrder": 1
+          },
+          {
+            "workno": "RJ01169543",
+            "label": "簡体中文",
+            "lang": "CHI_HANS",
+            "dlCount": "",
+            "displayLabel": "簡体中文",
+            "editionId": 21264,
+            "editionType": "language",
+            "displayOrder": 5
+          },
+          {
+            "workno": "RJ01169545",
+            "label": "繁体中文",
+            "lang": "CHI_HANT",
+            "dlCount": "",
+            "displayLabel": "繁体中文",
+            "editionId": 21264,
+            "editionType": "language",
+            "displayOrder": 7
+          }
+        ],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01045689",
+        "releaseDate": "2023-04-10 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月10日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01045689.html",
+        "circleId": "RG58827",
+        "category": "SOU",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01046000/RJ01045689_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01046000/RJ01045689_img_smp2.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-10 00:00:00",
+        "releaseDateISO": "2023-04-10T00:00:00.000Z",
+        "genres": [
+          "連続絶頂",
+          "実姉",
+          "純愛",
+          "ラブラブ/あまあま",
+          "逆レイプ",
+          "男性受け",
+          "中出し",
+          "妊娠/孕ませ"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "070",
+            "name": "連続絶頂"
+          },
+          {
+            "genre_key": "315",
+            "name": "実姉"
+          },
+          {
+            "genre_key": "032",
+            "name": "純愛"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "115",
+            "name": "逆レイプ"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "129",
+            "name": "妊娠/孕ませ"
+          }
+        ],
+        "creators": {
+          "others_by": [],
+          "scenario_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [],
+          "illust_by": [
+            {
+              "id": "22110",
+              "name": "奏いこ",
+              "classification": "illust_by",
+              "sub_classification": null
+            },
+            {
+              "id": "39280",
+              "name": "にんじん",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "circle": "See you.",
+        "createdAt": "2026-07-03T01:05:42.830Z",
+        "lastFetchedAt": "2026-07-03T01:05:42.830Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "localeOfficialPrices": {
+            "it_IT": 7.13,
+            "sv_SE": 79,
+            "id_ID": 145663,
+            "pt_BR": 7.13,
+            "vi_VN": 213006,
+            "th_TH": 270.63,
+            "fr_FR": 7.13,
+            "de_DE": 7.13,
+            "zh_TW": 258,
+            "ko_KR": 12620,
+            "en_US": 8.12,
+            "es_ES": 7.13,
+            "zh_CN": 55.21,
+            "ar_AE": 8.12
+          },
+          "current": 660,
+          "original": 1320,
+          "discount": 50,
+          "localePrices": {
+            "it_IT": 3.57,
+            "sv_SE": 39.5,
+            "id_ID": 72832,
+            "pt_BR": 3.57,
+            "vi_VN": 106503,
+            "th_TH": 135.32,
+            "fr_FR": 3.57,
+            "de_DE": 3.57,
+            "zh_TW": 129,
+            "ko_KR": 6310,
+            "en_US": 4.06,
+            "es_ES": 3.57,
+            "zh_CN": 27.61,
+            "ar_AE": 4.06
+          },
+          "point": 30
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-07-03T01:05:42.830Z"
+          }
+        },
+        "updatedAt": "2026-07-03T01:05:42.830Z"
+      }
+    },
+    {
+      "id": "RJ01047360",
+      "data": {
+        "workTypeString": "ボイス・ASMR",
+        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_main.jpg",
+        "creators": {
+          "others_by": [],
+          "scenario_by": [
+            {
+              "id": "18275",
+              "name": "白鴉鼎",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "voice_by": [
+            {
+              "id": "17426",
+              "name": "柚木つばめ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "17211",
+              "name": "高梨はなみ",
+              "classification": "voice_by",
+              "sub_classification": null
+            },
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "37952",
+              "name": "香山リム",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": []
+        },
+        "fileTypeSpecial": "MP3同梱",
+        "description": "学園中のメスはあなた専用のデリヘル嬢!?強制デリヘルアプリで憧れの先輩もナマイキ同級生アイドルも彼氏持ち後輩美少女もあなたのいいなりオナホおまんこ♪CV.柚木つばめ様 高梨はなみ様 涼花みなせ様",
+        "fileTypeString": "WAV",
+        "titleMasked": "【催眠×JK×風俗】強制デリヘルアプリ 肉オナホに堕ちた女～学園中のJKは俺のモノ媚びへつらい奉仕しろ!!～【強要・無理強・強請】",
+        "ageCategory": 3,
+        "title": "【催眠×JK×風俗】強制デリヘルアプリ 肉オナホに堕ちた女～学園中のJKは俺のモノ媚びへつらい奉仕しろ!!～【強要・無理強・強請】",
+        "id": "RJ01047360",
+        "ageCategoryString": "adult",
+        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_sam.jpg",
+        "languageDownloads": [],
+        "originalCategoryText": "ボイス・ASMR",
+        "productId": "RJ01047360",
+        "releaseDate": "2023-05-12 00:00:00",
+        "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年5月12日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01047360.html",
+        "circleId": "RG63165",
+        "category": "SOU",
+        "circle": "龍宮の使い(闇)",
+        "sampleImages": [
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp1.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp2.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp3.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp4.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp5.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp6.jpg"
+          },
+          {
+            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01048000/RJ01047360_img_smp7.jpg"
+          }
+        ],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-05-12 00:00:00",
+        "releaseDateISO": "2023-05-12T00:00:00.000Z",
+        "genres": [
+          "淫語",
+          "寝取り",
+          "ハーレム",
+          "イラマチオ",
+          "催眠",
+          "中出し",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "customGenres": [
+          {
+            "genre_key": "068",
+            "name": "淫語"
+          },
+          {
+            "genre_key": "302",
+            "name": "寝取り"
+          },
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "487",
+            "name": "イラマチオ"
+          },
+          {
+            "genre_key": "157",
+            "name": "催眠"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "500",
+            "name": "耳舐め"
+          },
+          {
+            "genre_key": "182",
+            "name": "巨乳/爆乳"
+          }
+        ],
+        "createdAt": "2026-06-18T07:07:41.657Z",
+        "lastFetchedAt": "2026-06-18T07:07:41.657Z",
+        "price": {
+          "isFreeOrMissingPrice": false,
+          "currency": "JPY",
+          "current": 1430,
+          "localeOfficialPrices": {
+            "zh_TW": 282,
+            "en_US": 8.91,
+            "ar_AE": 8.91,
+            "it_IT": 7.71,
+            "sv_SE": 84.2,
+            "ko_KR": 13529,
+            "id_ID": 158361,
+            "pt_BR": 7.71,
+            "vi_VN": 233813,
+            "es_ES": 7.71,
+            "zh_CN": 60.36,
+            "th_TH": 290.53,
+            "fr_FR": 7.71,
+            "de_DE": 7.71
+          },
+          "localePrices": {
+            "it_IT": 7.71,
+            "sv_SE": 84.2,
+            "id_ID": 158361,
+            "pt_BR": 7.71,
+            "vi_VN": 233813,
+            "th_TH": 290.53,
+            "fr_FR": 7.71,
+            "de_DE": 7.71,
+            "zh_TW": 282,
+            "ko_KR": 13529,
+            "en_US": 8.91,
+            "es_ES": 7.71,
+            "zh_CN": 60.36,
+            "ar_AE": 8.91
+          },
+          "point": 65
+        },
+        "dataSources": {
+          "infoAPI": {
+            "customGenres": [],
+            "lastFetched": "2026-06-18T07:07:41.657Z"
+          }
+        },
+        "updatedAt": "2026-06-18T07:07:41.657Z"
       }
     }
   ]

--- a/apps/web/src/app/buttons/__tests__/actions.test.ts
+++ b/apps/web/src/app/buttons/__tests__/actions.test.ts
@@ -235,7 +235,8 @@ describe("Audio Button Server Actions", () => {
 				expect(result.data.id).toBe("new-audio-button-id");
 			}
 			expect(mockAdd).toHaveBeenCalled();
-			expect(mockUpdate).toHaveBeenCalledWith({ id: "new-audio-button-id" });
+			// SPR-241: add 直後の update({ id }) は冗長 write のため廃止（ID は doc.id が正）
+			expect(mockUpdate).not.toHaveBeenCalledWith({ id: "new-audio-button-id" });
 		});
 
 		it("無効な入力でエラーが返される", async () => {

--- a/apps/web/src/app/buttons/actions.ts
+++ b/apps/web/src/app/buttons/actions.ts
@@ -307,7 +307,8 @@ export async function createAudioButton(
 				updatedAt: new Date().toISOString(),
 			});
 
-			await docRef.update({ id: docRef.id });
+			// 旧実装は add 直後に update({ id }) で ID を doc 本体へ複製していたが、
+			// 読み手は doc.id で常に上書きするため冗長な 2 write だった（SPR-241 で廃止）。
 
 			// レート制限カウントを増やす
 			const incremented = await incrementButtonCount(user.discordId);

--- a/apps/web/src/app/contact/__tests__/actions.test.ts
+++ b/apps/web/src/app/contact/__tests__/actions.test.ts
@@ -38,10 +38,9 @@ describe("submitContactForm", () => {
 		const { add } = setupFirestore();
 		const r = await submitContactForm(validData);
 		expect(r).toEqual({ success: true, message: "お問い合わせを受け付けました", id: "doc1" });
-		// IP は x-forwarded-for の先頭
-		expect(add).toHaveBeenCalledWith(
-			expect.objectContaining({ ipAddress: "1.2.3.4", status: "new" }),
-		);
+		// IP は x-forwarded-for の先頭。admin 時代の status/priority は書かない（SPR-241）
+		expect(add).toHaveBeenCalledWith(expect.objectContaining({ ipAddress: "1.2.3.4" }));
+		expect(add).toHaveBeenCalledWith(expect.not.objectContaining({ status: expect.anything() }));
 		expect(sendContactNotification).toHaveBeenCalled();
 		// キャッシュ無効化の契約も担保
 		expect(revalidatePath).toHaveBeenCalledWith("/contact");

--- a/apps/web/src/app/contact/actions.ts
+++ b/apps/web/src/app/contact/actions.ts
@@ -31,6 +31,7 @@ export async function submitContactForm(data: ContactFormData): Promise<ContactS
 
 		// Firestoreに保存するデータ
 		const now = new Date().toISOString();
+		// status/priority は admin 撤去後に読み手が無く SPR-241 で廃止（通知は下の Resend メールが正）
 		const contactData = {
 			...validatedData,
 			// 空文字の場合はundefinedに変換
@@ -39,8 +40,6 @@ export async function submitContactForm(data: ContactFormData): Promise<ContactS
 			userAgent,
 			timestamp: now,
 			createdAt: now,
-			status: "new" as const, // new, reviewing, resolved
-			priority: "medium" as const, // デフォルト優先度
 		};
 
 		// Firestoreに保存

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -18,7 +18,7 @@
 | `evaluations` | 作品評価（top10 / star / ng は排他） | `{userId}_{workId}` | [work-evaluation.ts](../../packages/shared-types/src/entities/work-evaluation.ts) `FirestoreWorkEvaluation` | Server Actions |
 | `circles` | DLsite サークル | サークル ID（例 `RG23954`） | [circle.ts](../../packages/shared-types/src/types/firestore/circle.ts) `CircleDocument` | Cloud Functions |
 | `creators` | DLsite クリエイター（`workCount`/`types` は非正規化統計） | クリエイター ID（Individual Info API の `creater.id`） | [creator.ts](../../packages/shared-types/src/types/firestore/creator.ts) `CreatorDocument` | Cloud Functions |
-| `contacts` | お問い合わせ（読み手は現状 GCP console のみ） | 自動生成 ID | [contact.ts](../../packages/shared-types/src/entities/contact.ts) `FirestoreContactData` | Server Actions |
+| `contacts` | お問い合わせ（通知の正は Resend メール = [email.ts](../../apps/web/src/lib/email.ts)。Firestore は送信記録のアーカイブで読み手なし） | 自動生成 ID | [contact.ts](../../packages/shared-types/src/entities/contact.ts) `FirestoreContactData` | Server Actions |
 | `ba_user` / `ba_session` / `ba_account` | better-auth の認証データ（認証の正本） | better-auth 採番 | 書き込み元 [firestore-adapter.ts](../../apps/web/src/lib/better-auth/firestore-adapter.ts)（better-auth 標準モデル・prefix `ba_`） | better-auth |
 | `youtubeMetadata` | YouTube 取得処理のメタデータ | `fetch_metadata` | 書き込み元 [youtube.ts](../../apps/functions/src/endpoints/youtube.ts)（内部型 `FetchMetadata`・非 export） | Cloud Functions |
 | `dlsiteMetadata` | DLsite 収集・整合性チェックのメタデータ | `unified_data_collection_metadata` / `dataIntegrityCheck` | 書き込み元 Cloud Function（[dlsite](../../apps/functions/src/endpoints/dlsite-individual-info-api.ts) / [integrity](../../apps/functions/src/endpoints/data-integrity-check.ts)） | Cloud Functions |

--- a/packages/shared-types/src/entities/__tests__/contact.test.ts
+++ b/packages/shared-types/src/entities/__tests__/contact.test.ts
@@ -1,16 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	ContactCategorySchema,
-	type ContactPriority,
-	ContactPrioritySchema,
-	type ContactStatus,
-	ContactStatusSchema,
-	FirestoreContactDataSchema,
-	FrontendContactDataSchema,
-	getPriorityColor,
-	getPriorityDisplayName,
-	getStatusDisplayName,
-} from "../contact";
+import { ContactCategorySchema, FirestoreContactDataSchema } from "../contact";
 
 describe("Contact Schemas", () => {
 	describe("ContactCategorySchema", () => {
@@ -23,61 +12,32 @@ describe("Contact Schemas", () => {
 		});
 	});
 
-	describe("ContactPrioritySchema", () => {
-		it("should validate priority values", () => {
-			expect(() => ContactPrioritySchema.parse("low")).not.toThrow();
-			expect(() => ContactPrioritySchema.parse("medium")).not.toThrow();
-			expect(() => ContactPrioritySchema.parse("high")).not.toThrow();
-			expect(() => ContactPrioritySchema.parse("invalid")).toThrow();
-		});
-	});
-
-	describe("ContactStatusSchema", () => {
-		it("should validate status values", () => {
-			expect(() => ContactStatusSchema.parse("new")).not.toThrow();
-			expect(() => ContactStatusSchema.parse("reviewing")).not.toThrow();
-			expect(() => ContactStatusSchema.parse("resolved")).not.toThrow();
-			expect(() => ContactStatusSchema.parse("invalid")).toThrow();
-		});
-	});
-
 	describe("FirestoreContactDataSchema", () => {
-		it("should validate basic structure", () => {
-			// Test that schema exists and can be used
-			expect(typeof FirestoreContactDataSchema.parse).toBe("function");
-		});
-	});
+		const validData = {
+			category: "bug",
+			subject: "テスト件名",
+			content: "テスト本文です。10文字以上あります。",
+			ipAddress: "1.2.3.4",
+			userAgent: "test-agent",
+			createdAt: "2026-07-04T00:00:00.000Z",
+			timestamp: "2026-07-04T00:00:00.000Z",
+		};
 
-	describe("FrontendContactDataSchema", () => {
-		it("should validate basic structure", () => {
-			// Test that schema exists and can be used
-			expect(typeof FrontendContactDataSchema.parse).toBe("function");
+		it("書き込み実体と同じ形を受理する（email は省略可）", () => {
+			expect(() => FirestoreContactDataSchema.parse(validData)).not.toThrow();
+			expect(() =>
+				FirestoreContactDataSchema.parse({ ...validData, email: "a@example.com" }),
+			).not.toThrow();
 		});
-	});
-});
 
-describe("Contact Utility Functions", () => {
-	describe("getStatusDisplayName", () => {
-		it("should return correct Japanese status names", () => {
-			expect(getStatusDisplayName("new" as ContactStatus)).toBe("新規");
-			expect(getStatusDisplayName("reviewing" as ContactStatus)).toBe("確認中");
-			expect(getStatusDisplayName("resolved" as ContactStatus)).toBe("対応済み");
+		it("admin 時代の status/priority を要求しない（SPR-241 で撤去済み）", () => {
+			const parsed = FirestoreContactDataSchema.parse(validData);
+			expect(parsed).not.toHaveProperty("status");
+			expect(parsed).not.toHaveProperty("priority");
 		});
-	});
 
-	describe("getPriorityDisplayName", () => {
-		it("should return correct Japanese priority names", () => {
-			expect(getPriorityDisplayName("low" as ContactPriority)).toBe("低");
-			expect(getPriorityDisplayName("medium" as ContactPriority)).toBe("中");
-			expect(getPriorityDisplayName("high" as ContactPriority)).toBe("高");
-		});
-	});
-
-	describe("getPriorityColor", () => {
-		it("should return correct CSS color classes", () => {
-			expect(getPriorityColor("low" as ContactPriority)).toBe("text-green-600");
-			expect(getPriorityColor("medium" as ContactPriority)).toBe("text-yellow-600");
-			expect(getPriorityColor("high" as ContactPriority)).toBe("text-red-600");
+		it("content は 10 文字未満を拒否する", () => {
+			expect(() => FirestoreContactDataSchema.parse({ ...validData, content: "短い" })).toThrow();
 		});
 	});
 });

--- a/packages/shared-types/src/entities/contact.ts
+++ b/packages/shared-types/src/entities/contact.ts
@@ -6,20 +6,13 @@ import { z } from "zod";
 export const ContactCategorySchema = z.enum(["bug", "feature", "usage", "other"]);
 export type ContactCategory = z.infer<typeof ContactCategorySchema>;
 
-/**
- * お問い合わせステータス
- */
-export const ContactStatusSchema = z.enum(["new", "reviewing", "resolved"]);
-export type ContactStatus = z.infer<typeof ContactStatusSchema>;
-
-/**
- * お問い合わせ優先度
- */
-export const ContactPrioritySchema = z.enum(["low", "medium", "high"]);
-export type ContactPriority = z.infer<typeof ContactPrioritySchema>;
+// 運用は Resend メール通知のみ（apps/web/src/lib/email.ts）。Firestore の contacts は送信記録の
+// アーカイブで読み手を持たない。admin 撤去（SPR-164）で死んだ status/priority/adminNote/handledBy と
+// 表示ヘルパー群は SPR-241 で撤去した。
 
 /**
  * Firestoreに保存するお問い合わせデータ
+ * 書き込み元: apps/web/src/app/contact/actions.ts
  */
 export const FirestoreContactDataSchema = z.object({
 	category: ContactCategorySchema,
@@ -28,25 +21,11 @@ export const FirestoreContactDataSchema = z.object({
 	email: z.string().email().optional(),
 	ipAddress: z.string(),
 	userAgent: z.string(),
-	status: ContactStatusSchema,
-	priority: ContactPrioritySchema.default("medium"),
-	adminNote: z.string().optional(),
-	handledBy: z.string().optional(),
 	createdAt: z.string(),
 	timestamp: z.string(),
-	updatedAt: z.string().optional(),
 });
 
 export type FirestoreContactData = z.infer<typeof FirestoreContactDataSchema>;
-
-/**
- * フロントエンド用お問い合わせデータ（ID付き）
- */
-export const FrontendContactDataSchema = FirestoreContactDataSchema.extend({
-	id: z.string(),
-});
-
-export type FrontendContactData = z.infer<typeof FrontendContactDataSchema>;
 
 /**
  * お問い合わせフォーム送信データ
@@ -59,52 +38,3 @@ export const ContactFormDataSchema = z.object({
 });
 
 export type ContactFormData = z.infer<typeof ContactFormDataSchema>;
-
-/**
- * カテゴリ表示名の取得
- */
-export function getCategoryDisplayName(category: ContactCategory): string {
-	const categoryNames: Record<ContactCategory, string> = {
-		bug: "🐛 バグ報告",
-		feature: "💡 機能要望",
-		usage: "❓ 使い方",
-		other: "📢 その他",
-	};
-	return categoryNames[category];
-}
-
-/**
- * ステータス表示名の取得
- */
-export function getStatusDisplayName(status: ContactStatus): string {
-	const statusNames: Record<ContactStatus, string> = {
-		new: "新規",
-		reviewing: "確認中",
-		resolved: "対応済み",
-	};
-	return statusNames[status];
-}
-
-/**
- * 優先度表示名の取得
- */
-export function getPriorityDisplayName(priority: ContactPriority): string {
-	const priorityNames: Record<ContactPriority, string> = {
-		low: "低",
-		medium: "中",
-		high: "高",
-	};
-	return priorityNames[priority];
-}
-
-/**
- * 優先度の色を取得
- */
-export function getPriorityColor(priority: ContactPriority): string {
-	const priorityColors: Record<ContactPriority, string> = {
-		low: "text-green-600",
-		medium: "text-yellow-600",
-		high: "text-red-600",
-	};
-	return priorityColors[priority];
-}


### PR DESCRIPTION
## 概要

SPR-75 調査（発見4）の掃除。Linear: [SPR-241](https://linear.app/nothink/issue/SPR-241)

## コード変更

- **audioButtons**: 作成時の `add` 直後 `update({ id: docRef.id })` を廃止。読み手（audio-buttons-firestore.ts）は常に `doc.id` で上書きするため冗長な 2 write だった。既存 docs の残留 id フィールドは無害なので放置
- **contacts**: admin 撤去（SPR-164）後に読み手が無い `status: "new"` / `priority: "medium"` の書き込みを廃止。shared-types から ContactStatus/ContactPriority スキーマ・adminNote/handledBy フィールド・表示ヘルパー4関数・未使用の FrontendContactData を撤去（**全て利用ゼロを grep 確認済み**）
  - 運用の正は **Resend メール通知**（既存実装 email.ts。Secret Manager → Cloud Run 配線済み・過去30日の送信失敗ログゼロを Logging API で確認）。Firestore は送信記録のアーカイブとして残す（database-schema.md の台帳も更新）

## 本番 one-off 削除（実施済み・ユーザー承認済み）

dry-run で対象件数が SPR-75 調査の実測と一致することを確認後、対象フィールドの `FieldValue.delete()` のみを batched update で実行:

| 対象 | 件数 | 結果 |
|---|---|---|
| works.collectedAt / localDataSource | 1,514 | 削除・残存 0 |
| videos.hasAudioButtons | 555 | 削除・残存 0 |
| audioButtons.favoriteCount（トップレベル迷子） | 1 | 削除・残存 0 |
| contacts.status/priority/adminNote/handledBy | 10 | 削除・残存 0 |

実行前提として #747/#748 の functions/web デプロイ成功（11:57Z）を確認済み（旧 writer による書き戻しなし）。全コレクション再読込で **ALL_CLEAN** を検証。

## fixtures 更新

`pnpm seed:dump` で本番から再取得。レガシー3フィールド（hasAudioButtons/collectedAt/localDataSource）の fixtures 残存ゼロを確認（**#747 AI レビュー nit の解消**）。

## 検証

- `pnpm verify` 完走（contact スキーマは実書き込み形を受理するテストに置換・buttons/contact の write 契約テスト更新）

🤖 Generated with [Claude Code](https://claude.com/claude-code)