### PR TITLE
feat(ui): DockedPanel の stories を追加し design-sync のカードに載せる

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -238,9 +238,13 @@ component-style 配下／未分類が大量に出る（報告値: 89 件 compone
 - **churn 内容**: story/コンポーネント source は全 41 unchanged。deps bump（#697/#726）+ DockedPanel 追加（#744）で
   bundleSha 変化 → **bundle/styling/aux? 全 re-ship・全 41 renderHash churn（trigger=render_churn）**。canary spot-check
   で全 match（両側が一緒に動いたパターン）。deletePaths=[]・aux=false。
-- **DockedPanel（#744 新規・`custom/index` 経由で bundle には載る）は stories 未作成のため sync 対象外**（カード化されない）。
-  Claude Design のピッカーに出したければ `docked-panel.stories.tsx` を書く（storybook shape のロスターは story 起点）。
-  barrel `ds-entry.tsx` は `export * from custom/index` なので編集不要だった。
+- **DockedPanel（#744 新規・`custom/index` 経由で bundle には載る）は当初 stories 未作成で sync 対象外だった → 同日
+  `docked-panel.stories.tsx` を追加して解消**（42 component 目として同期済み・4 story 全 match）。
+  barrel `ds-entry.tsx` は `export * from custom/index` なので編集不要だった。DockedPanel 固有の知見:
+  - **`position:fixed` コンポーネントの story は transform 付きデコレータで containing block を作る**とデモ枠内に
+    ドッキングし、storybook / preview 両側で同一に描画される（story ファイル内のデコレータは preview にもコンパイルされる）。
+  - それでも grid カードの幾何チェックは `[GRID_OVERFLOW] escape` を出すため
+    `cfg.overrides.DockedPanel = { cardMode: "single", primaryStory: "Default" }` を適用（警告の suggestedOverride どおり）。
 - **[GENERAL] fresh worktree/clone では canary が収束しない**: canary pick は「capture json が `pendingGrade:false`（clean）
   なものを優先、無ければランダム」。fresh clone は `.cache/compare/` が空なので毎 driver 実行ごとにランダム pick →
   fresh capture → pendingGrade が新規 3-5 件ずつ湧く（#6 では run1: Alert/Button/Input/Skeleton/ConfigurableList、

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -26,6 +26,7 @@
 		"ToggleGroup": { "cardMode": "column", "skip": ["ui-togglegroup--switch-selection"] },
 		"LoadingSkeleton": { "cardMode": "column", "skip": ["custom-utility-loadingskeleton--form"] },
 		"AudioButton": { "cardMode": "column" },
+		"DockedPanel": { "cardMode": "single", "primaryStory": "Default" },
 		"YouTubePlayer": { "cardMode": "column" },
 		"ListPageLayout": { "cardMode": "column" },
 		"ConfigurableList": { "cardMode": "column" },

--- a/packages/ui/src/components/custom/docked-panel.stories.tsx
+++ b/packages/ui/src/components/custom/docked-panel.stories.tsx
@@ -1,0 +1,168 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Check, Cookie, X } from "lucide-react";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { DockedPanel } from "./docked-panel";
+
+const meta = {
+	title: "Custom/Layout/DockedPanel",
+	component: DockedPanel,
+	parameters: {
+		layout: "padded",
+	},
+	tags: ["autodocs"],
+	// DockedPanel は position:fixed でビューポート角にドッキングする。story では
+	// transform 付きコンテナを containing block にして、パネルをデモ枠内に収める
+	// （コンポーネント自体のクラスは無加工＝実挙動のまま基準点だけを枠に変える）。
+	decorators: [
+		(Story) => (
+			<div className="transform-gpu relative h-[380px] w-full overflow-hidden rounded-lg border bg-muted/30">
+				<p className="p-4 text-sm text-muted-foreground">
+					背後のページコンテンツ（パネルはブロッキングしない）
+				</p>
+				<Story />
+			</div>
+		),
+	],
+	argTypes: {
+		position: {
+			control: "radio",
+			options: ["bottom-right", "bottom-left"],
+			description: "広い画面での配置角",
+		},
+		variant: {
+			control: "radio",
+			options: ["card", "pill"],
+			description: "card（角丸xl。年齢確認カード等）か pill（角丸full。Cookieバー等）",
+		},
+		role: {
+			control: "radio",
+			options: ["region", "status"],
+			description: "ランドマークロール（通知的な内容は status）",
+		},
+		mobileSheet: {
+			control: "boolean",
+			description: "狭い画面で全幅ボトムシート化するか（常時コンパクトな要素は false）",
+		},
+	},
+} satisfies Meta<typeof DockedPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 年齢確認カード（apps/web の表示モード確認）を模した card variant。 */
+export const Default: Story = {
+	args: {
+		position: "bottom-right",
+		variant: "card",
+	},
+	render: (args) => (
+		<DockedPanel
+			{...args}
+			aria-label="表示モードの確認"
+			className="flex w-full flex-col gap-3 p-5 sm:max-w-[360px]"
+		>
+			<div className="flex items-center gap-2">
+				<Badge variant="destructive">R18</Badge>
+				<h3 className="text-sm font-bold text-foreground">表示モードの確認</h3>
+			</div>
+			<p className="text-xs leading-relaxed text-muted-foreground">
+				このサイトは18歳未満の方に適さないコンテンツを含みます。現在は
+				<strong className="text-foreground">全年齢作品のみ</strong>表示しています。
+			</p>
+			<div className="flex flex-col gap-2">
+				<Button className="w-full">18歳以上 — すべての作品を表示</Button>
+				<Button variant="outline" className="w-full">
+					全年齢のみで続ける
+				</Button>
+			</div>
+			<p className="text-[11px] leading-relaxed text-muted-foreground">
+				選択は30日間このブラウザに記憶されます。
+			</p>
+		</DockedPanel>
+	),
+};
+
+/** Cookie 同意バー（apps/web）を模した pill variant・bottom-left。 */
+export const Pill: Story = {
+	args: {
+		position: "bottom-left",
+		variant: "pill",
+	},
+	render: (args) => (
+		<DockedPanel
+			{...args}
+			aria-label="クッキーの使用"
+			className="flex flex-wrap items-center gap-3 px-4 py-3 sm:flex-nowrap sm:py-2 sm:pr-2 sm:pl-4"
+		>
+			<Cookie className="h-4 w-4 flex-shrink-0 text-primary" />
+			<span className="min-w-0 flex-1 text-xs text-foreground sm:flex-none sm:whitespace-nowrap">
+				サイト改善のためクッキーを使用します
+			</span>
+			<button type="button" className="whitespace-nowrap text-xs text-primary underline">
+				詳細設定
+			</button>
+			<div className="flex w-full gap-2 sm:w-auto">
+				<Button variant="outline" size="sm" className="flex-1 sm:flex-none">
+					拒否
+				</Button>
+				<Button size="sm" className="flex-1 sm:flex-none">
+					許可
+				</Button>
+			</div>
+		</DockedPanel>
+	),
+};
+
+/** 選択確定後の確認トースト（role="status"）を模したコンパクトな card。 */
+export const StatusCard: Story = {
+	args: {
+		position: "bottom-right",
+		variant: "card",
+		role: "status",
+	},
+	render: (args) => (
+		<DockedPanel
+			{...args}
+			aria-label="表示モードの確認"
+			className="flex max-w-full items-center gap-3 p-3.5 sm:max-w-[400px]"
+		>
+			<div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-success/10 text-success">
+				<Check className="h-4 w-4" />
+			</div>
+			<span className="text-sm text-foreground">全年齢対象の作品のみ表示します</span>
+			<button type="button" className="whitespace-nowrap text-xs text-primary underline">
+				変更
+			</button>
+			<button
+				type="button"
+				aria-label="閉じる"
+				className="text-muted-foreground hover:text-foreground"
+			>
+				<X className="h-3.5 w-3.5" />
+			</button>
+		</DockedPanel>
+	),
+};
+
+/** 表示設定の再オープンピル: mobileSheet=false で狭い画面でもコンパクトに留まる。 */
+export const CompactPill: Story = {
+	args: {
+		position: "bottom-right",
+		variant: "pill",
+		mobileSheet: false,
+	},
+	render: (args) => (
+		<DockedPanel {...args} aria-label="表示設定を開く" className="px-1 py-1">
+			<button
+				type="button"
+				className="flex items-center gap-2 rounded-full px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground"
+			>
+				<Badge variant="outline" className="px-1.5 text-[10px]">
+					全年齢
+				</Badge>
+				表示設定
+			</button>
+		</DockedPanel>
+	),
+};


### PR DESCRIPTION
## 概要

[#750](https://github.com/nothink-jp/suzumina.click/pull/750) に載せるつもりだった stories コミットが、マージ（ブランチ自動削除）の**後**に push されてしまい main に入っていなかったため、最新 main に cherry-pick して再提出。

**Claude Design プロジェクト側のアップロードは完了済み**（42 component・4 story 全 match・render-check クリーン）。この PR はその同期状態の正本（stories / config / NOTES）をリポジトリに残すもの。

## 内容

- `docked-panel.stories.tsx` — 実利用（年齢確認カード / Cookie 同意ピル / 確認トースト / 再オープンピル）をミラーした 4 story。`position:fixed` は transform デコレータで containing block を作りデモ枠内にドッキング（storybook / design-sync preview 両側で同一描画・compare 画像判定で全 match）
- `.design-sync/config.json` — validate の `[GRID_OVERFLOW] escape` 指示どおり `DockedPanel: { cardMode: "single", primaryStory: "Default" }` を追加
- `.design-sync/NOTES.md` — DockedPanel の穴解消と fixed 配置 story の containment 手法を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)