### PR TITLE
feat(functions): DLsite Individual Info API呼び出しをティア差分で削減 (SPR-229)

### DIFF
--- a/apps/functions/src/endpoints/__tests__/dlsite-individual-info-api.test.ts
+++ b/apps/functions/src/endpoints/__tests__/dlsite-individual-info-api.test.ts
@@ -1,0 +1,370 @@
+/**
+ * dlsite-individual-info-api.ts のテスト（SPR-229: computeDueWorkIds / resolveCycleInfo /
+ * fetchDLsiteUnifiedData 中心）
+ *
+ * レビュー指摘（この専用エンドポイントに直接のテストが無い）への対応。
+ * computeDueWorkIds/resolveCycleInfoの単体テストに加え、fetchDLsiteUnifiedDataの
+ * エントリポイントを外部依存（Firestore・スクレイプ・DLsite API呼び出し・統合処理）を
+ * モックしたうえで新規サイクル/継続run/週次フルスイープ/エラー経路について検証する。
+ */
+
+import type {
+	CollectionMetadata,
+	DLsiteApiResponse,
+	WorkDocument,
+} from "@suzumina.click/shared-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infrastructure/database/firestore", () => {
+	const updateMock = vi.fn().mockResolvedValue(undefined);
+	const getMock = vi.fn().mockResolvedValue({ exists: false });
+	const docRef = { update: updateMock, get: getMock, set: vi.fn() };
+	const collection = vi.fn(() => ({ doc: vi.fn(() => docRef) }));
+
+	return {
+		default: { collection, getAll: vi.fn() },
+		Timestamp: { now: vi.fn(() => ({ seconds: 0, nanoseconds: 0 })) },
+		__updateMock: updateMock,
+		__getMock: getMock,
+	};
+});
+
+vi.mock("../../services/price-history", () => ({
+	bulkCheckPriceHistoryExistsToday: vi.fn().mockResolvedValue(new Set()),
+	getJSTDate: vi.fn(() => "2026-07-05"),
+	savePriceHistory: vi.fn(),
+}));
+
+vi.mock("../../services/dlsite/work-id-collector", () => ({
+	collectWorkIdsForProduction: vi.fn(),
+}));
+
+vi.mock("../../services/dlsite/dlsite-firestore", () => ({
+	getExistingWorksMap: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock("../../services/dlsite/individual-info-api-client", () => ({
+	batchFetchIndividualInfo: vi.fn(),
+}));
+
+vi.mock("../../services/dlsite/unified-data-processor", () => ({
+	processBatchUnifiedDLsiteData: vi.fn(),
+}));
+
+vi.mock("../../services/dlsite/creator-firestore", () => ({
+	recomputeCreatorStats: vi.fn(),
+}));
+
+vi.mock("../../services/dlsite/creator-recompute-queue", () => ({
+	resetCreatorRecomputeQueue: vi.fn(),
+	takeQueuedCreators: vi.fn(() => []),
+}));
+
+vi.mock("../../services/dlsite/dlsite-read-metrics", () => ({
+	resetDlsiteReadMetrics: vi.fn(),
+	getDlsiteReadMetrics: vi.fn(() => ({})),
+}));
+
+vi.mock("../../shared/logger", () => ({
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+}));
+
+const { computeDueWorkIds, resolveCycleInfo, fetchDLsiteUnifiedData } = await import(
+	"../dlsite-individual-info-api"
+);
+const { bulkCheckPriceHistoryExistsToday } = await import("../../services/price-history");
+const { collectWorkIdsForProduction } = await import("../../services/dlsite/work-id-collector");
+const { getExistingWorksMap } = await import("../../services/dlsite/dlsite-firestore");
+const { batchFetchIndividualInfo } = await import(
+	"../../services/dlsite/individual-info-api-client"
+);
+const { processBatchUnifiedDLsiteData } = await import(
+	"../../services/dlsite/unified-data-processor"
+);
+const firestoreMock = vi.mocked(await import("../../infrastructure/database/firestore"));
+const updateMock = (firestoreMock as unknown as { __updateMock: ReturnType<typeof vi.fn> })
+	.__updateMock;
+const getMetadataMock = (firestoreMock as unknown as { __getMock: ReturnType<typeof vi.fn> })
+	.__getMock;
+
+function makeApiResponse(workno: string): DLsiteApiResponse {
+	return { workno, work_name: `テスト作品${workno}`, price: 1000 } as unknown as DLsiteApiResponse;
+}
+
+function pubsubEvent(payload?: Record<string, unknown>) {
+	return {
+		type: "google.cloud.pubsub.topic.v1.messagePublished",
+		data: payload ? { data: Buffer.from(JSON.stringify(payload)).toString("base64") } : undefined,
+	} as unknown as Parameters<typeof fetchDLsiteUnifiedData>[0];
+}
+
+function makeWork(overrides: Partial<WorkDocument> = {}): WorkDocument {
+	return {
+		productId: "RJ000000",
+		releaseDateISO: "2020-01-01T00:00:00Z", // 十分に古い日付（デフォルトはstable）
+		salesStatus: { isSale: false, isSoldOut: false },
+		...overrides,
+	} as WorkDocument;
+}
+
+function makeMetadata(overrides: Partial<CollectionMetadata> = {}): CollectionMetadata {
+	return {
+		lastFetchedAt: null,
+		isInProgress: false,
+		...overrides,
+	} as CollectionMetadata;
+}
+
+describe("computeDueWorkIds", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.DLSITE_TIER_FILTERING_ENABLED;
+	});
+
+	it("DLSITE_TIER_FILTERING_ENABLED=falseの場合、全件を対象にしtieredはnullになる", async () => {
+		process.env.DLSITE_TIER_FILTERING_ENABLED = "false";
+		const result = await computeDueWorkIds(["RJ001", "RJ002"], new Map(), false);
+
+		expect(result.dueWorkIds).toEqual(["RJ001", "RJ002"]);
+		expect(result.tiered).toBeNull();
+		expect(bulkCheckPriceHistoryExistsToday).not.toHaveBeenCalled();
+	});
+
+	it("通常runでは new/volatile/stable(due) のみをdue-setに含め、stable(skip)を除外する", async () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			["RJ_STABLE_SKIP", makeWork({ productId: "RJ_STABLE_SKIP" })],
+			[
+				"RJ_VOLATILE",
+				makeWork({ productId: "RJ_VOLATILE", salesStatus: { isSale: true, isSoldOut: false } }),
+			],
+		]);
+		vi.mocked(bulkCheckPriceHistoryExistsToday).mockResolvedValue(new Set(["RJ_STABLE_SKIP"]));
+
+		const result = await computeDueWorkIds(
+			["RJ_NEW", "RJ_VOLATILE", "RJ_STABLE_SKIP"],
+			existingWorksMap,
+			false,
+		);
+
+		expect(result.dueWorkIds).toEqual(["RJ_NEW", "RJ_VOLATILE"]);
+		expect(result.tiered?.stableSkippedIds).toEqual(["RJ_STABLE_SKIP"]);
+	});
+
+	it("forceFullSweep=trueの場合、stable(skip)も含め全件をdue-setにするがtieredは計算する", async () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			["RJ_STABLE_SKIP", makeWork({ productId: "RJ_STABLE_SKIP" })],
+		]);
+		vi.mocked(bulkCheckPriceHistoryExistsToday).mockResolvedValue(new Set(["RJ_STABLE_SKIP"]));
+
+		const result = await computeDueWorkIds(["RJ_NEW", "RJ_STABLE_SKIP"], existingWorksMap, true);
+
+		expect(result.dueWorkIds).toEqual(["RJ_NEW", "RJ_STABLE_SKIP"]);
+		expect(result.tiered?.stableSkippedIds).toEqual(["RJ_STABLE_SKIP"]);
+	});
+
+	it("bulkCheckPriceHistoryExistsTodayにはstable候補のみを渡す（new/volatileは対象外）", async () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			[
+				"RJ_VOLATILE",
+				makeWork({ productId: "RJ_VOLATILE", salesStatus: { isSale: true, isSoldOut: false } }),
+			],
+			["RJ_STABLE", makeWork({ productId: "RJ_STABLE" })],
+		]);
+		vi.mocked(bulkCheckPriceHistoryExistsToday).mockResolvedValue(new Set());
+
+		await computeDueWorkIds(["RJ_NEW", "RJ_VOLATILE", "RJ_STABLE"], existingWorksMap, false);
+
+		expect(bulkCheckPriceHistoryExistsToday).toHaveBeenCalledWith(["RJ_STABLE"], "2026-07-05");
+	});
+});
+
+describe("resolveCycleInfo（継続run分岐）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("継続run中はティア再判定をせず、保存済みallWorkIdsをそのまま使う", async () => {
+		const metadata = makeMetadata({ isFullSweepCycle: false });
+		const continuationInfo = {
+			isContinuation: true as const,
+			allWorkIds: ["RJ001", "RJ002"],
+			startBatch: 1,
+		};
+
+		const result = await resolveCycleInfo(metadata, continuationInfo, false);
+
+		expect(result?.allWorkIds).toEqual(["RJ001", "RJ002"]);
+		expect(result?.startBatch).toBe(1);
+		expect(result?.wouldSkipStableIds).toBeUndefined();
+	});
+
+	it("継続run中でisFullSweepCycleかつfullSweepWouldSkipWorkIdsがあればwouldSkipStableIdsを復元する", async () => {
+		const metadata = makeMetadata({
+			isFullSweepCycle: true,
+			fullSweepWouldSkipWorkIds: ["RJ_STABLE_SKIP"],
+		});
+		const continuationInfo = {
+			isContinuation: true as const,
+			allWorkIds: ["RJ001"],
+			startBatch: 0,
+		};
+
+		const result = await resolveCycleInfo(metadata, continuationInfo, false);
+
+		expect(result?.wouldSkipStableIds).toEqual(new Set(["RJ_STABLE_SKIP"]));
+	});
+
+	it("週次フルスイープが継続run中に発火した場合、pendingFullSweepをFirestoreに記録し前サイクルのまま継続する", async () => {
+		const metadata = makeMetadata({ isFullSweepCycle: false });
+		const continuationInfo = {
+			isContinuation: true as const,
+			allWorkIds: ["RJ001"],
+			startBatch: 0,
+		};
+
+		const result = await resolveCycleInfo(metadata, continuationInfo, true);
+
+		// 前サイクル（tieredモード）のまま継続する = 週次フルスイープはこのrunには反映されない
+		expect(result?.allWorkIds).toEqual(["RJ001"]);
+		// ただし次の新規サイクルで拾い直せるようpendingFullSweep:trueが書き込まれる
+		expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ pendingFullSweep: true }));
+	});
+
+	it("週次フルスイープでなければpendingFullSweepは書き込まれない", async () => {
+		const metadata = makeMetadata();
+		const continuationInfo = {
+			isContinuation: true as const,
+			allWorkIds: ["RJ001"],
+			startBatch: 0,
+		};
+
+		await resolveCycleInfo(metadata, continuationInfo, false);
+
+		expect(updateMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("fetchDLsiteUnifiedData（エントリポイント統合）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getMetadataMock.mockResolvedValue({ exists: false });
+		vi.mocked(bulkCheckPriceHistoryExistsToday).mockResolvedValue(new Set());
+		vi.mocked(getExistingWorksMap).mockResolvedValue(new Map());
+		vi.mocked(processBatchUnifiedDLsiteData).mockImplementation(async (apiResponses) =>
+			apiResponses.map((r) => ({
+				workId: r.workno ?? "UNKNOWN",
+				success: true,
+				updates: { work: true, circle: true, creators: true, priceHistory: true },
+				errors: [],
+			})),
+		);
+	});
+
+	it("新規サイクルで全件newの場合、収集した作品を全件取得・処理して正常完了する", async () => {
+		vi.mocked(collectWorkIdsForProduction).mockResolvedValue(["RJ001", "RJ002"]);
+		vi.mocked(batchFetchIndividualInfo).mockResolvedValue({
+			results: new Map([
+				["RJ001", makeApiResponse("RJ001")],
+				["RJ002", makeApiResponse("RJ002")],
+			]),
+			failedWorkIds: [],
+		});
+
+		await fetchDLsiteUnifiedData(pubsubEvent());
+
+		expect(collectWorkIdsForProduction).toHaveBeenCalledTimes(1);
+		expect(batchFetchIndividualInfo).toHaveBeenCalledWith(["RJ001", "RJ002"], expect.any(Object));
+		expect(processBatchUnifiedDLsiteData).toHaveBeenCalled();
+		// 完走後、batchProcessingModeがfalseへ戻される（finalizeCompletedProcessing）
+		expect(updateMock).toHaveBeenCalledWith(
+			expect.objectContaining({ batchProcessingMode: false }),
+		);
+	});
+
+	it("stableかつ当日分priceHistoryが既にある作品は通常runのdue-setから除外される", async () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			[
+				"RJ_STABLE_SKIP",
+				{
+					productId: "RJ_STABLE_SKIP",
+					releaseDateISO: "2020-01-01T00:00:00Z",
+					salesStatus: { isSale: false, isSoldOut: false },
+				} as WorkDocument,
+			],
+		]);
+		vi.mocked(collectWorkIdsForProduction).mockResolvedValue(["RJ_NEW", "RJ_STABLE_SKIP"]);
+		vi.mocked(getExistingWorksMap).mockResolvedValue(existingWorksMap);
+		vi.mocked(bulkCheckPriceHistoryExistsToday).mockResolvedValue(new Set(["RJ_STABLE_SKIP"]));
+		vi.mocked(batchFetchIndividualInfo).mockResolvedValue({
+			results: new Map([["RJ_NEW", makeApiResponse("RJ_NEW")]]),
+			failedWorkIds: [],
+		});
+
+		await fetchDLsiteUnifiedData(pubsubEvent());
+
+		// stable-skip作品はAPI取得対象から除外される
+		expect(batchFetchIndividualInfo).toHaveBeenCalledWith(["RJ_NEW"], expect.any(Object));
+	});
+
+	it("週次フルスイープ（mode=weekly_full_sweep）ではstable(skip)相当も含め全件を取得する", async () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			[
+				"RJ_STABLE_SKIP",
+				{
+					productId: "RJ_STABLE_SKIP",
+					releaseDateISO: "2020-01-01T00:00:00Z",
+					salesStatus: { isSale: false, isSoldOut: false },
+				} as WorkDocument,
+			],
+		]);
+		vi.mocked(collectWorkIdsForProduction).mockResolvedValue(["RJ_NEW", "RJ_STABLE_SKIP"]);
+		vi.mocked(getExistingWorksMap).mockResolvedValue(existingWorksMap);
+		vi.mocked(bulkCheckPriceHistoryExistsToday).mockResolvedValue(new Set(["RJ_STABLE_SKIP"]));
+		vi.mocked(batchFetchIndividualInfo).mockResolvedValue({
+			results: new Map([
+				["RJ_NEW", makeApiResponse("RJ_NEW")],
+				["RJ_STABLE_SKIP", makeApiResponse("RJ_STABLE_SKIP")],
+			]),
+			failedWorkIds: [],
+		});
+
+		await fetchDLsiteUnifiedData(pubsubEvent({ mode: "weekly_full_sweep" }));
+
+		// 週次フルスイープなのでstable-skip相当も含め全件取得する
+		const [calledWorkIds] = vi.mocked(batchFetchIndividualInfo).mock.calls[0] ?? [];
+		expect(calledWorkIds).toEqual(expect.arrayContaining(["RJ_NEW", "RJ_STABLE_SKIP"]));
+	});
+
+	it("継続run（batchProcessingMode=true）では作品ID収集をスキップし保存済みバッチを再開する", async () => {
+		getMetadataMock.mockResolvedValue({
+			exists: true,
+			data: () => ({
+				isInProgress: true,
+				batchProcessingMode: true,
+				allWorkIds: ["RJ001"],
+				currentBatch: 0,
+				totalBatches: 1,
+			}),
+		});
+		vi.mocked(batchFetchIndividualInfo).mockResolvedValue({
+			results: new Map([["RJ001", makeApiResponse("RJ001")]]),
+			failedWorkIds: [],
+		});
+
+		await fetchDLsiteUnifiedData(pubsubEvent());
+
+		expect(collectWorkIdsForProduction).not.toHaveBeenCalled();
+		expect(batchFetchIndividualInfo).toHaveBeenCalledWith(["RJ001"], expect.any(Object));
+	});
+
+	it("作品ID収集が失敗した場合、runを中断しエラーを記録する（例外を投げない）", async () => {
+		vi.mocked(collectWorkIdsForProduction).mockRejectedValue(new Error("scrape failed"));
+
+		await expect(fetchDLsiteUnifiedData(pubsubEvent())).resolves.toBeUndefined();
+
+		expect(batchFetchIndividualInfo).not.toHaveBeenCalled();
+	});
+});

--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -29,9 +29,52 @@ import {
 } from "../services/dlsite/unified-data-processor";
 import { collectWorkIdsForProduction } from "../services/dlsite/work-id-collector";
 import { orderNewWorksFirst } from "../services/dlsite/work-ordering";
+import {
+	classifyAndFilterStableTier,
+	getStableCandidateIds,
+	type TieredWorkIds,
+	toDueWorkIds,
+} from "../services/dlsite/work-tiering";
+import { bulkCheckPriceHistoryExistsToday, getJSTDate } from "../services/price-history";
 import { chunkArray } from "../shared/array-utils";
 import { withClearedUndefined } from "../shared/firestore-write";
 import * as logger from "../shared/logger";
+
+/**
+ * SPR-229 Stage②: ティア差分によるdue-setフィルタの有効/無効フラグ。
+ * 緊急時はこの環境変数をfalseにして再デプロイするだけで旧挙動（全件取得）に戻せる
+ * （Firestoreスキーマ変更を伴わないためロールバックの障害はない）。
+ */
+const DLSITE_TIER_FILTERING_ENABLED = process.env.DLSITE_TIER_FILTERING_ENABLED !== "false";
+
+/**
+ * Pub/SubメッセージのPubsubMessage型定義（youtube.tsと同型）
+ */
+interface PubsubMessage {
+	data?: string;
+	attributes?: Record<string, string>;
+}
+
+/**
+ * SPR-229 Stage②: Pub/Subペイロードから`mode`を取り出す。
+ * 週次フルスイープ（`mode==="weekly_full_sweep"`）かどうかの判定に使う。
+ * デコード失敗時は安全側（通常のティア差分run）にフォールバックする。
+ */
+function decodePubsubMode(message: PubsubMessage | undefined): string | undefined {
+	if (!message?.data) {
+		return undefined;
+	}
+	try {
+		const decoded = Buffer.from(message.data, "base64").toString("utf-8");
+		const parsed = JSON.parse(decoded) as { mode?: unknown };
+		return typeof parsed.mode === "string" ? parsed.mode : undefined;
+	} catch (err) {
+		logger.warn("Pub/Subペイロードのデコードに失敗（modeなしとして通常runを続行します）", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return undefined;
+	}
+}
 
 // 統合メタデータ保存用の定数
 const UNIFIED_METADATA_DOC_ID = "unified_data_collection_metadata";
@@ -65,6 +108,8 @@ interface BatchProcessingInfo {
 	workIds: string[];
 	startTime: Timestamp;
 	existingWorksMap?: Map<string, WorkDocument>;
+	/** SPR-229: 週次フルスイープ時、通常runならstableとしてスキップされていたはずの作品ID（取りこぼし検知用） */
+	wouldSkipStableIds?: Set<string>;
 }
 
 /**
@@ -245,10 +290,36 @@ function logBatchComplete(
 }
 
 /**
+ * SPR-229: 週次フルスイープの取りこぼし検知ログ
+ *
+ * `wouldSkipStableIds`（通常runならstableとしてスキップされていたはずの作品）のうち、
+ * 実際にWorkの変化が検出された件数を出す。0件が理想（stableの90日窓が妥当であることの裏付け）。
+ * 非0が続く場合はStage③で`VOLATILE_RELEASE_WINDOW_DAYS`の見直しを検討する。
+ */
+function logFullSweepMissedChanges(
+	batchNumber: number,
+	processingResults: ProcessingResult[],
+	wouldSkipStableIds: Set<string> | undefined,
+): void {
+	if (!wouldSkipStableIds || wouldSkipStableIds.size === 0) {
+		return;
+	}
+
+	const targeted = processingResults.filter((r) => wouldSkipStableIds.has(r.workId));
+	const missed = targeted.filter((r) => r.updates.work);
+
+	logger.info(`バッチ ${batchNumber}: 週次フルスイープ取りこぼし検知`, {
+		stable想定件数: targeted.length,
+		変化検出件数: missed.length,
+		...(missed.length > 0 && { 変化検出workIds: missed.map((r) => r.workId) }),
+	});
+}
+
+/**
  * バッチ処理実行
  */
 async function processBatch(batchInfo: BatchProcessingInfo): Promise<UnifiedFetchResult> {
-	const { batchNumber, totalBatches, workIds, existingWorksMap } = batchInfo;
+	const { batchNumber, totalBatches, workIds, existingWorksMap, wouldSkipStableIds } = batchInfo;
 
 	logger.info(`バッチ ${batchNumber}/${totalBatches} 処理開始: ${workIds.length}件`);
 
@@ -295,6 +366,7 @@ async function processBatch(batchInfo: BatchProcessingInfo): Promise<UnifiedFetc
 
 		// ログ出力
 		logBatchComplete(batchNumber, workIds.length, apiDataMap.size, aggregatedResults);
+		logFullSweepMissedChanges(batchNumber, processingResults, wouldSkipStableIds);
 
 		return createBatchResult(aggregatedResults, workIds.length);
 	} catch (error) {
@@ -347,10 +419,17 @@ function getContinuationInfo(
 
 /**
  * 新規バッチ処理を初期化
+ *
+ * @param tierBreakdown SPR-229: このサイクルのティア別内訳（観測用。省略時=ティアリング無効）
+ * @param isFullSweepCycle SPR-229: 週次フルスイープ実行かどうか
+ * @param fullSweepWouldSkipWorkIds SPR-229: 週次フルスイープ時、通常runならスキップされていた作品ID（取りこぼし検知用）
  */
 async function initializeNewBatchProcessing(
 	allWorkIds: string[],
 	batches: string[][],
+	tierBreakdown?: CollectionMetadata["tierBreakdown"],
+	isFullSweepCycle = false,
+	fullSweepWouldSkipWorkIds?: string[],
 ): Promise<void> {
 	logger.info(
 		`新規バッチ処理開始: 総作品数=${allWorkIds.length}, バッチ数=${batches.length}, バッチサイズ=${BATCH_SIZE}`,
@@ -372,7 +451,71 @@ async function initializeNewBatchProcessing(
 		lastError: undefined,
 		currentBatchStartTime: Timestamp.now(),
 		migrationVersion: "v2",
+		tierBreakdown,
+		isFullSweepCycle,
+		fullSweepWouldSkipWorkIds: isFullSweepCycle ? fullSweepWouldSkipWorkIds : undefined,
 	});
+}
+
+/**
+ * SPR-229 Stage②: ティア差分に基づき、この run で実際に取得すべき作品ID（due-set）を計算する
+ *
+ * stable ティア（変化の少ない旧作）は当日分 priceHistory が存在する場合のみスキップする。
+ * `DLSITE_TIER_FILTERING_ENABLED=false` または `forceFullSweep=true`（週次フルスイープ）の
+ * 場合はティア差分を無視して全件を対象にする。
+ *
+ * read総数について: stable候補に対する`priceHistory/{today}`存在確認は、従来
+ * `savePriceHistory`内で毎run・全作品に個別`get()`として発生していたread（重複防止チェック）を
+ * 前段でバルク`getAll()`にまとめて行うだけであり、新規readは発生しない（対象母数はほぼ不変）。
+ */
+async function computeDueWorkIds(
+	currentWorkIds: string[],
+	existingWorksMap: Map<string, WorkDocument>,
+	forceFullSweep: boolean,
+): Promise<{ dueWorkIds: string[]; tiered: TieredWorkIds | null }> {
+	if (!DLSITE_TIER_FILTERING_ENABLED) {
+		logger.info("ティア差分をスキップして全件を対象にします", {
+			理由: "DLSITE_TIER_FILTERING_ENABLED=false",
+			対象数: currentWorkIds.length,
+		});
+		return { dueWorkIds: currentWorkIds, tiered: null };
+	}
+
+	// 週次フルスイープでも classifyAndFilterStableTier 自体は実行する（取りこぼし検知のため
+	// stable想定の集合が必要）。差はdue-setに反映するかどうかのみ（下記）。
+	const today = new Date();
+	const stableCandidateIds = getStableCandidateIds(currentWorkIds, existingWorksMap, today);
+	const priceHistoryTodayExists = await bulkCheckPriceHistoryExistsToday(
+		stableCandidateIds,
+		getJSTDate(),
+	);
+	const tiered = classifyAndFilterStableTier(
+		currentWorkIds,
+		existingWorksMap,
+		priceHistoryTodayExists,
+		today,
+	);
+
+	logger.info("ティア差分due-set計算完了(SPR-229 Stage②)", {
+		対象総数: currentWorkIds.length,
+		new: tiered.newIds.length,
+		volatile: tiered.volatileIds.length,
+		stable_due: tiered.stableDueIds.length,
+		stable_skip: tiered.stableSkippedIds.length,
+	});
+
+	if (forceFullSweep) {
+		logger.info(
+			"週次フルスイープ: due-setはティア差分を無視して全件にします（取りこぼし検知のためstable分類は維持）",
+			{
+				対象数: currentWorkIds.length,
+				stable_would_skip: tiered.stableSkippedIds.length,
+			},
+		);
+		return { dueWorkIds: currentWorkIds, tiered };
+	}
+
+	return { dueWorkIds: toDueWorkIds(tiered), tiered };
 }
 
 /**
@@ -384,6 +527,7 @@ async function executeBatchLoop(
 	startTime: number,
 	metadata: CollectionMetadata,
 	existingWorksMap?: Map<string, WorkDocument>,
+	wouldSkipStableIds?: Set<string>,
 ): Promise<{
 	totalUpdated: number;
 	totalApiCalls: number;
@@ -429,6 +573,7 @@ async function executeBatchLoop(
 			workIds: batches[i] || [],
 			startTime: Timestamp.now(),
 			existingWorksMap,
+			wouldSkipStableIds,
 		};
 
 		const result = await processBatch(batchInfo);
@@ -476,6 +621,10 @@ async function finalizeCompletedProcessing(
 		totalBatches: undefined,
 		allWorkIds: undefined,
 		completedBatches: undefined,
+		// SPR-229: サイクル終了時にティア/週次フルスイープ関連の一時フィールドをクリアする
+		tierBreakdown: undefined,
+		isFullSweepCycle: undefined,
+		fullSweepWouldSkipWorkIds: undefined,
 	});
 }
 
@@ -487,11 +636,20 @@ async function finalizeCompletedProcessing(
  * になり「登録直後にページに出ない」原因になる。先頭へ置くことで run がタイムアウトしても
  * 最初のバッチで作成される。取得した `existingWorksMap` は後段の skip 判定で再利用する
  * （二重読みを避ける）。
+ *
+ * SPR-229 Stage②: 並べ替えの前に `computeDueWorkIds` でティア差分の due-set 絞り込みを行う。
+ * stable ティア（当日分 priceHistory あり）はこの run の対象から除外される。
+ *
+ * @param forceFullSweep 週次フルスイープ実行時 true（ティア差分を無視して全件を対象にする）
  */
-async function prepareNewBatchProcessing(metadata: CollectionMetadata): Promise<{
+async function prepareNewBatchProcessing(
+	metadata: CollectionMetadata,
+	forceFullSweep = false,
+): Promise<{
 	allWorkIds: string[];
 	batches: string[][];
 	existingWorksMap: Map<string, WorkDocument>;
+	tiered: TieredWorkIds | null;
 } | null> {
 	// scrape 失敗時は stale な一覧でサイクルを回すより run を中断する方が安全。
 	// 次の定期実行(2h)が自然なリトライになる（SPR-232: region 等価性の確認を経て asset fallback を撤去）。
@@ -524,19 +682,39 @@ async function prepareNewBatchProcessing(metadata: CollectionMetadata): Promise<
 		return null;
 	}
 
-	// 既存 works を取得し、新作を先頭へ並べ替える（fast-lane）。
+	// 既存 works を取得し、ティア差分でdue-setを絞り込んでから新作を先頭へ並べ替える（fast-lane）。
 	const existingWorksMap = await getExistingWorksMap(currentWorkIds);
-	const { ordered: allWorkIds, newCount } = orderNewWorksFirst(currentWorkIds, existingWorksMap);
+	const { dueWorkIds, tiered } = await computeDueWorkIds(
+		currentWorkIds,
+		existingWorksMap,
+		forceFullSweep,
+	);
+	const { ordered: allWorkIds, newCount } = orderNewWorksFirst(dueWorkIds, existingWorksMap);
 	logger.info("新規バッチ: 新作を先頭へ並べ替え（SPR-225 Stage 3a・fast-lane）", {
-		総数: currentWorkIds.length,
+		scrape総数: currentWorkIds.length,
+		due対象数: dueWorkIds.length,
 		新作: newCount,
-		既存: currentWorkIds.length - newCount,
+		既存: dueWorkIds.length - newCount,
 	});
 
 	const batches = chunkArray(allWorkIds, BATCH_SIZE);
-	await initializeNewBatchProcessing(allWorkIds, batches);
+	const tierBreakdown = tiered
+		? {
+				newCount: tiered.newIds.length,
+				volatileCount: tiered.volatileIds.length,
+				stableDueCount: tiered.stableDueIds.length,
+				stableSkippedCount: tiered.stableSkippedIds.length,
+			}
+		: undefined;
+	await initializeNewBatchProcessing(
+		allWorkIds,
+		batches,
+		tierBreakdown,
+		forceFullSweep,
+		tiered?.stableSkippedIds,
+	);
 
-	return { allWorkIds, batches, existingWorksMap };
+	return { allWorkIds, batches, existingWorksMap, tiered };
 }
 
 /**
@@ -569,9 +747,71 @@ async function recomputeQueuedCreators(): Promise<void> {
 }
 
 /**
- * 統合データ収集処理の実行
+ * この run が処理すべきサイクル情報（継続 or 新規）
  */
-async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
+interface CycleInfo {
+	allWorkIds: string[];
+	batches: string[][];
+	startBatch: number;
+	/** 新規処理時は prepareNewBatchProcessing で取得済みの既存マップ（二重読み回避、継続時は undefined） */
+	preparedExistingWorksMap?: Map<string, WorkDocument>;
+	/** SPR-229: 週次フルスイープの取りこぼし検知に使う「stable想定」作品ID集合 */
+	wouldSkipStableIds?: Set<string>;
+}
+
+/**
+ * 継続処理かどうかに応じて、この run が処理すべき作品ID/バッチ/取りこぼし検知集合を組み立てる
+ *
+ * SPR-229: due-set/週次モードはサイクル開始時（新規処理）に確定済みのため、継続処理では
+ * 再判定しない。forceFullSweep が渡されていても前サイクルが tiered モードで継続中なら
+ * 今回は反映されない（次の週次発火 or 次サイクルで自然に反映される。低頻度の安全網のため許容）。
+ */
+async function resolveCycleInfo(
+	metadata: CollectionMetadata,
+	continuationInfo: ReturnType<typeof getContinuationInfo>,
+	forceFullSweep: boolean,
+): Promise<CycleInfo | null> {
+	if (continuationInfo.isContinuation === true) {
+		if (forceFullSweep) {
+			logger.warn(
+				"週次フルスイープの発火時に前サイクルが継続中でした。今回は前サイクルの設定のまま継続します",
+			);
+		}
+		const allWorkIds = continuationInfo.allWorkIds;
+		const batches = chunkArray(allWorkIds, BATCH_SIZE);
+		const startBatch = continuationInfo.startBatch;
+		const wouldSkipStableIds =
+			metadata.isFullSweepCycle && metadata.fullSweepWouldSkipWorkIds
+				? new Set(metadata.fullSweepWouldSkipWorkIds)
+				: undefined;
+		logger.info(
+			`継続処理詳細: allWorkIds.length=${allWorkIds.length}, batches.length=${batches.length}, startBatch=${startBatch}`,
+		);
+		return { allWorkIds, batches, startBatch, wouldSkipStableIds };
+	}
+
+	// 新規処理: 作品IDを収集
+	const prepared = await prepareNewBatchProcessing(metadata, forceFullSweep);
+	if (!prepared) {
+		return null;
+	}
+	const wouldSkipStableIds =
+		forceFullSweep && prepared.tiered ? new Set(prepared.tiered.stableSkippedIds) : undefined;
+	return {
+		allWorkIds: prepared.allWorkIds,
+		batches: prepared.batches,
+		startBatch: 0,
+		preparedExistingWorksMap: prepared.existingWorksMap,
+		wouldSkipStableIds,
+	};
+}
+
+/**
+ * 統合データ収集処理の実行
+ *
+ * @param forceFullSweep SPR-229 Stage②: 週次フルスイープ実行時 true（ティア差分を無視して全件を対象にする）
+ */
+async function executeUnifiedDataCollection(forceFullSweep = false): Promise<UnifiedFetchResult> {
 	// SPR-225 Stage 0/P0: dlsite 同期 reads の内訳をこの run の分だけ計測する（挙動は変えない）。
 	resetDlsiteReadMetrics();
 	// SPR-225 Stage 1: 変更 creator の recompute キューを run 開始でクリアする。
@@ -581,38 +821,19 @@ async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 		// メタデータから処理状態を確認
 		const metadata = await getOrCreateUnifiedMetadata();
 
-		// 継続処理かどうかを先に判定
+		// 継続処理かどうかを先に判定し、この run が処理すべきサイクル情報を組み立てる
 		const continuationInfo = getContinuationInfo(metadata);
-
-		let allWorkIds: string[];
-		let batches: string[][];
-		let startBatch = 0;
-		// 新規処理時は prepareNewBatchProcessing で取得済みの既存マップを再利用する（二重読み回避）。
-		let preparedExistingWorksMap: Map<string, WorkDocument> | undefined;
-
-		if (continuationInfo.isContinuation === true) {
-			// 継続処理: 保存済みの作品IDを使用（作品ID収集をスキップして時間を節約）
-			allWorkIds = continuationInfo.allWorkIds;
-			batches = chunkArray(allWorkIds, BATCH_SIZE);
-			startBatch = continuationInfo.startBatch;
-			logger.info(
-				`継続処理詳細: allWorkIds.length=${allWorkIds.length}, batches.length=${batches.length}, startBatch=${startBatch}`,
-			);
-		} else {
-			// 新規処理: 作品IDを収集
-			const prepared = await prepareNewBatchProcessing(metadata);
-			if (!prepared) {
-				return {
-					workCount: 0,
-					apiCallCount: 0,
-					basicDataUpdated: 0,
-					error: "収集対象の作品IDが見つかりません",
-				};
-			}
-			allWorkIds = prepared.allWorkIds;
-			batches = prepared.batches;
-			preparedExistingWorksMap = prepared.existingWorksMap;
+		const cycleInfo = await resolveCycleInfo(metadata, continuationInfo, forceFullSweep);
+		if (!cycleInfo) {
+			return {
+				workCount: 0,
+				apiCallCount: 0,
+				basicDataUpdated: 0,
+				error: "収集対象の作品IDが見つかりません",
+			};
 		}
+		const { allWorkIds, batches, startBatch, preparedExistingWorksMap, wouldSkipStableIds } =
+			cycleInfo;
 
 		// この run が対象とする作品ID（継続時は残りバッチ分・新規時は全件＝startBatch=0）。
 		const remainingWorkIds = batches.slice(startBatch).flat();
@@ -642,6 +863,7 @@ async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 			startTime,
 			metadata,
 			existingWorksMap,
+			wouldSkipStableIds,
 		);
 
 		if (allBatchesCompleted) {
@@ -683,15 +905,20 @@ async function executeUnifiedDataCollection(): Promise<UnifiedFetchResult> {
 /**
  * Cloud Functions エントリーポイント
  */
-export async function fetchDLsiteUnifiedData(event: CloudEvent<unknown>): Promise<void> {
+export async function fetchDLsiteUnifiedData(event: CloudEvent<PubsubMessage>): Promise<void> {
+	const mode = decodePubsubMode(event.data);
+	const isWeeklyFullSweep = mode === "weekly_full_sweep";
+
 	logger.info("統合データ収集開始", {
 		eventType: event.type,
+		mode,
+		週次フルスイープ: isWeeklyFullSweep,
 		timestamp: new Date().toISOString(),
 		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
 	});
 
 	try {
-		const result = await executeUnifiedDataCollection();
+		const result = await executeUnifiedDataCollection(isWeeklyFullSweep);
 
 		if (result.error) {
 			logger.error(`統合データ収集エラー: ${result.error}`);

--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -31,6 +31,7 @@ import { collectWorkIdsForProduction } from "../services/dlsite/work-id-collecto
 import { orderNewWorksFirst } from "../services/dlsite/work-ordering";
 import {
 	classifyAndFilterStableTier,
+	classifyWorkTiers,
 	getStableCandidateIds,
 	type TieredWorkIds,
 	toDueWorkIds,
@@ -44,8 +45,12 @@ import * as logger from "../shared/logger";
  * SPR-229 Stage②: ティア差分によるdue-setフィルタの有効/無効フラグ。
  * 緊急時はこの環境変数をfalseにして再デプロイするだけで旧挙動（全件取得）に戻せる
  * （Firestoreスキーマ変更を伴わないためロールバックの障害はない）。
+ * 呼び出し時に都度読む（モジュール読み込み時点で固定しない）ことで、テストから
+ * `process.env`を切り替えて両分岐を検証できるようにする。
  */
-const DLSITE_TIER_FILTERING_ENABLED = process.env.DLSITE_TIER_FILTERING_ENABLED !== "false";
+function isTierFilteringEnabled(): boolean {
+	return process.env.DLSITE_TIER_FILTERING_ENABLED !== "false";
+}
 
 /**
  * Pub/SubメッセージのPubsubMessage型定義（youtube.tsと同型）
@@ -454,6 +459,9 @@ async function initializeNewBatchProcessing(
 		tierBreakdown,
 		isFullSweepCycle,
 		fullSweepWouldSkipWorkIds: isFullSweepCycle ? fullSweepWouldSkipWorkIds : undefined,
+		// SPR-229: 新規サイクル開始時点で pending 状態は解消済み（effectiveFullSweep に
+		// 反映済み、または今回対象外）のため必ずクリアする。
+		pendingFullSweep: undefined,
 	});
 }
 
@@ -466,14 +474,18 @@ async function initializeNewBatchProcessing(
  *
  * read総数について: stable候補に対する`priceHistory/{today}`存在確認は、従来
  * `savePriceHistory`内で毎run・全作品に個別`get()`として発生していたread（重複防止チェック）を
- * 前段でバルク`getAll()`にまとめて行うだけであり、新規readは発生しない（対象母数はほぼ不変）。
+ * 前段でバルク`getAll()`にまとめて行うもの。**stable-skip**作品（多数派）はread総数が実質不変
+ * （後段の個別readが丸ごと不要になる代わりに前段のバルクreadが乗るだけ）。一方
+ * **stable-due**作品（当日分がまだ無く実際に取得する少数派）は、前段のバルクreadに加えて
+ * `savePriceHistory`側の個別重複チェックも従来通り実行されるため、その件数分だけreadが純増する
+ * （レビュー指摘: 「新規readは発生しない」は無条件には成立しない。stable-dueは通常少数のため実害は小さい）。
  */
-async function computeDueWorkIds(
+export async function computeDueWorkIds(
 	currentWorkIds: string[],
 	existingWorksMap: Map<string, WorkDocument>,
 	forceFullSweep: boolean,
 ): Promise<{ dueWorkIds: string[]; tiered: TieredWorkIds | null }> {
-	if (!DLSITE_TIER_FILTERING_ENABLED) {
+	if (!isTierFilteringEnabled()) {
 		logger.info("ティア差分をスキップして全件を対象にします", {
 			理由: "DLSITE_TIER_FILTERING_ENABLED=false",
 			対象数: currentWorkIds.length,
@@ -483,18 +495,16 @@ async function computeDueWorkIds(
 
 	// 週次フルスイープでも classifyAndFilterStableTier 自体は実行する（取りこぼし検知のため
 	// stable想定の集合が必要）。差はdue-setに反映するかどうかのみ（下記）。
+	// ティア分類は classifyWorkTiers で1回だけ行い、getStableCandidateIds /
+	// classifyAndFilterStableTier の両方で結果を再利用する（同じ作品を2回分類しない）。
 	const today = new Date();
-	const stableCandidateIds = getStableCandidateIds(currentWorkIds, existingWorksMap, today);
+	const tiers = classifyWorkTiers(currentWorkIds, existingWorksMap, today);
+	const stableCandidateIds = getStableCandidateIds(currentWorkIds, tiers);
 	const priceHistoryTodayExists = await bulkCheckPriceHistoryExistsToday(
 		stableCandidateIds,
 		getJSTDate(),
 	);
-	const tiered = classifyAndFilterStableTier(
-		currentWorkIds,
-		existingWorksMap,
-		priceHistoryTodayExists,
-		today,
-	);
+	const tiered = classifyAndFilterStableTier(currentWorkIds, tiers, priceHistoryTodayExists);
 
 	logger.info("ティア差分due-set計算完了(SPR-229 Stage②)", {
 		対象総数: currentWorkIds.length,
@@ -749,7 +759,7 @@ async function recomputeQueuedCreators(): Promise<void> {
 /**
  * この run が処理すべきサイクル情報（継続 or 新規）
  */
-interface CycleInfo {
+export interface CycleInfo {
 	allWorkIds: string[];
 	batches: string[][];
 	startBatch: number;
@@ -764,9 +774,12 @@ interface CycleInfo {
  *
  * SPR-229: due-set/週次モードはサイクル開始時（新規処理）に確定済みのため、継続処理では
  * 再判定しない。forceFullSweep が渡されていても前サイクルが tiered モードで継続中なら
- * 今回は反映されない（次の週次発火 or 次サイクルで自然に反映される。低頻度の安全網のため許容）。
+ * 今回は反映されない。ただしその場合 `pendingFullSweep` をメタデータに記録し、次に新規
+ * サイクルが始まるタイミング（継続中サイクル完了後の次run）で強制フルスイープとして
+ * 拾い直す（レビュー指摘対応: 継続中サイクルとの衝突で週次フルスイープがその週丸ごと
+ * 無音で消えるのを防ぐ。1週間まるまる遅延はしない）。
  */
-async function resolveCycleInfo(
+export async function resolveCycleInfo(
 	metadata: CollectionMetadata,
 	continuationInfo: ReturnType<typeof getContinuationInfo>,
 	forceFullSweep: boolean,
@@ -774,8 +787,9 @@ async function resolveCycleInfo(
 	if (continuationInfo.isContinuation === true) {
 		if (forceFullSweep) {
 			logger.warn(
-				"週次フルスイープの発火時に前サイクルが継続中でした。今回は前サイクルの設定のまま継続します",
+				"週次フルスイープの発火時に前サイクルが継続中でした。pendingFullSweepを記録し次の新規サイクルで拾い直します",
 			);
+			await updateUnifiedMetadata({ pendingFullSweep: true });
 		}
 		const allWorkIds = continuationInfo.allWorkIds;
 		const batches = chunkArray(allWorkIds, BATCH_SIZE);
@@ -790,13 +804,15 @@ async function resolveCycleInfo(
 		return { allWorkIds, batches, startBatch, wouldSkipStableIds };
 	}
 
-	// 新規処理: 作品IDを収集
-	const prepared = await prepareNewBatchProcessing(metadata, forceFullSweep);
+	// 新規処理: 作品IDを収集。前サイクルが継続中で反映できなかった週次フルスイープが
+	// pendingFullSweepとして残っていれば、ここで拾い直す。
+	const effectiveFullSweep = forceFullSweep || metadata.pendingFullSweep === true;
+	const prepared = await prepareNewBatchProcessing(metadata, effectiveFullSweep);
 	if (!prepared) {
 		return null;
 	}
 	const wouldSkipStableIds =
-		forceFullSweep && prepared.tiered ? new Set(prepared.tiered.stableSkippedIds) : undefined;
+		effectiveFullSweep && prepared.tiered ? new Set(prepared.tiered.stableSkippedIds) : undefined;
 	return {
 		allWorkIds: prepared.allWorkIds,
 		batches: prepared.batches,

--- a/apps/functions/src/infrastructure/database/firestore.ts
+++ b/apps/functions/src/infrastructure/database/firestore.ts
@@ -87,6 +87,10 @@ const firestore = {
 	get runTransaction() {
 		return getFirestore().runTransaction.bind(getFirestore());
 	},
+	// SPR-229: 複数ドキュメント参照を1回のRPCでバルク取得する（priceHistory/{today}の存在確認等）。
+	get getAll() {
+		return getFirestore().getAll.bind(getFirestore());
+	},
 };
 
 export default firestore;

--- a/apps/functions/src/services/dlsite/__tests__/unified-data-processor.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/unified-data-processor.test.ts
@@ -418,6 +418,16 @@ describe("unified-data-processor", () => {
 			expect(result.metadataChanged).toBe(false);
 			expect(result.hasAnyChange).toBe(false);
 		});
+
+		it("割引率のみ変化した場合、priceOrSalesChangedのみtrueになる（JPY価格は据え置き）", () => {
+			const existing = { ...mockWorkData, price: { ...mockWorkData.price, discount: 10 } };
+			const updated = { ...mockWorkData, price: { ...mockWorkData.price, discount: 30 } };
+			const result = detectChanges(existing, updated);
+
+			expect(result.priceOrSalesChanged).toBe(true);
+			expect(result.metadataChanged).toBe(false);
+			expect(result.hasAnyChange).toBe(true);
+		});
 	});
 
 	afterEach(() => {

--- a/apps/functions/src/services/dlsite/__tests__/unified-data-processor.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/unified-data-processor.test.ts
@@ -37,7 +37,7 @@ vi.mock("../../../shared/logger", () => ({
 }));
 
 // インポート（モック設定後）
-const { processUnifiedDLsiteData, processBatchUnifiedDLsiteData } = await import(
+const { processUnifiedDLsiteData, processBatchUnifiedDLsiteData, detectChanges } = await import(
 	"../unified-data-processor"
 );
 const { getWorkFromFirestore, saveWorksToFirestore } = await import("../dlsite-firestore");
@@ -373,6 +373,50 @@ describe("unified-data-processor", () => {
 
 			expect(result.success).toBe(true);
 			expect(result.updates.work).toBe(true);
+		});
+	});
+
+	describe("detectChanges", () => {
+		it("価格のみ変化した場合、priceOrSalesChangedのみtrueになる", () => {
+			const existing = { ...mockWorkData, price: { ...mockWorkData.price, current: 800 } };
+			const result = detectChanges(existing, mockWorkData);
+
+			expect(result.priceOrSalesChanged).toBe(true);
+			expect(result.metadataChanged).toBe(false);
+			expect(result.hasAnyChange).toBe(true);
+		});
+
+		it("タイトルのみ変化した場合、metadataChangedのみtrueになる", () => {
+			const existing = { ...mockWorkData, title: "旧タイトル" };
+			const result = detectChanges(existing, mockWorkData);
+
+			expect(result.priceOrSalesChanged).toBe(false);
+			expect(result.metadataChanged).toBe(true);
+			expect(result.hasAnyChange).toBe(true);
+		});
+
+		it("販売終了のみ変化した場合、priceOrSalesChangedのみtrueになる", () => {
+			const existing = {
+				...mockWorkData,
+				salesStatus: { isSale: true, isSoldOut: false },
+			};
+			const updated = {
+				...mockWorkData,
+				salesStatus: { isSale: true, isSoldOut: true },
+			};
+			const result = detectChanges(existing, updated);
+
+			expect(result.priceOrSalesChanged).toBe(true);
+			expect(result.metadataChanged).toBe(false);
+			expect(result.hasAnyChange).toBe(true);
+		});
+
+		it("変化がない場合、いずれもfalseになる", () => {
+			const result = detectChanges(mockWorkData, mockWorkData);
+
+			expect(result.priceOrSalesChanged).toBe(false);
+			expect(result.metadataChanged).toBe(false);
+			expect(result.hasAnyChange).toBe(false);
 		});
 	});
 

--- a/apps/functions/src/services/dlsite/__tests__/work-tiering.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/work-tiering.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
 	classifyAndFilterStableTier,
 	classifyWorkTier,
+	classifyWorkTiers,
 	getStableCandidateIds,
 	toDueWorkIds,
 	VOLATILE_RELEASE_WINDOW_DAYS,
@@ -60,6 +61,22 @@ describe("classifyWorkTier", () => {
 	});
 });
 
+describe("classifyWorkTiers", () => {
+	it("各作品IDをclassifyWorkTierと同じ結果でMapに詰める", () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			["RJ001", makeWork({ productId: "RJ001" })], // stable
+			["RJ002", makeWork({ productId: "RJ002", salesStatus: { isSale: true, isSoldOut: false } })], // volatile
+		]);
+		const workIds = ["RJ001", "RJ002", "RJ003"]; // RJ003はnew（マップ不在）
+
+		const tiers = classifyWorkTiers(workIds, existingWorksMap, TODAY);
+
+		expect(tiers.get("RJ001")).toBe("stable");
+		expect(tiers.get("RJ002")).toBe("volatile");
+		expect(tiers.get("RJ003")).toBe("new");
+	});
+});
+
 describe("getStableCandidateIds", () => {
 	it("stableティアの作品IDのみを返す", () => {
 		const existingWorksMap = new Map<string, WorkDocument>([
@@ -67,8 +84,9 @@ describe("getStableCandidateIds", () => {
 			["RJ002", makeWork({ productId: "RJ002", salesStatus: { isSale: true, isSoldOut: false } })], // volatile
 		]);
 		const workIds = ["RJ001", "RJ002", "RJ003"]; // RJ003はnew（マップ不在）
+		const tiers = classifyWorkTiers(workIds, existingWorksMap, TODAY);
 
-		expect(getStableCandidateIds(workIds, existingWorksMap, TODAY)).toEqual(["RJ001"]);
+		expect(getStableCandidateIds(workIds, tiers)).toEqual(["RJ001"]);
 	});
 });
 
@@ -84,13 +102,9 @@ describe("classifyAndFilterStableTier", () => {
 		]);
 		const workIds = ["RJ_NEW", "RJ_VOLATILE", "RJ_STABLE_DUE", "RJ_STABLE_SKIP"];
 		const priceHistoryTodayExists = new Set(["RJ_STABLE_SKIP"]);
+		const tiers = classifyWorkTiers(workIds, existingWorksMap, TODAY);
 
-		const result = classifyAndFilterStableTier(
-			workIds,
-			existingWorksMap,
-			priceHistoryTodayExists,
-			TODAY,
-		);
+		const result = classifyAndFilterStableTier(workIds, tiers, priceHistoryTodayExists);
 
 		expect(result).toEqual({
 			newIds: ["RJ_NEW"],
@@ -105,15 +119,20 @@ describe("classifyAndFilterStableTier", () => {
 			["RJ001", makeWork({ productId: "RJ001" })],
 			["RJ002", makeWork({ productId: "RJ002" })],
 		]);
-		const result = classifyAndFilterStableTier(
-			["RJ001", "RJ002"],
-			existingWorksMap,
-			new Set(),
-			TODAY,
-		);
+		const workIds = ["RJ001", "RJ002"];
+		const tiers = classifyWorkTiers(workIds, existingWorksMap, TODAY);
+		const result = classifyAndFilterStableTier(workIds, tiers, new Set());
 
 		expect(result.stableDueIds).toEqual(["RJ001", "RJ002"]);
 		expect(result.stableSkippedIds).toEqual([]);
+	});
+
+	it("tiersに存在しないworkIdは安全側でnew扱いになる", () => {
+		const tiers = new Map<string, "new" | "volatile" | "stable">();
+		const result = classifyAndFilterStableTier(["RJ_UNKNOWN"], tiers, new Set());
+
+		expect(result.newIds).toEqual(["RJ_UNKNOWN"]);
+		expect(result.stableDueIds).toEqual([]);
 	});
 });
 

--- a/apps/functions/src/services/dlsite/__tests__/work-tiering.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/work-tiering.test.ts
@@ -1,0 +1,131 @@
+/**
+ * dlsite 作品ティア分類ユーティリティ（SPR-229）のテスト
+ */
+
+import type { WorkDocument } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import {
+	classifyAndFilterStableTier,
+	classifyWorkTier,
+	getStableCandidateIds,
+	toDueWorkIds,
+	VOLATILE_RELEASE_WINDOW_DAYS,
+} from "../work-tiering";
+
+const TODAY = new Date("2026-07-05T00:00:00.000Z");
+
+function makeWork(overrides: Partial<WorkDocument> = {}): WorkDocument {
+	return {
+		productId: "RJ000000",
+		releaseDateISO: "2020-01-01T00:00:00Z", // 十分に古い日付（デフォルトはstable）
+		salesStatus: { isSale: false, isSoldOut: false },
+		...overrides,
+	} as WorkDocument;
+}
+
+describe("classifyWorkTier", () => {
+	it("既存作品が存在しない場合はnewになる", () => {
+		expect(classifyWorkTier(undefined, TODAY)).toBe("new");
+	});
+
+	it("salesStatus.isSale=trueの場合はvolatileになる", () => {
+		const work = makeWork({ salesStatus: { isSale: true, isSoldOut: false } });
+		expect(classifyWorkTier(work, TODAY)).toBe("volatile");
+	});
+
+	it("releaseDateISOが直近90日以内の場合はvolatileになる", () => {
+		const work = makeWork({ releaseDateISO: "2026-06-01T00:00:00Z" }); // 34日前
+		expect(classifyWorkTier(work, TODAY)).toBe("volatile");
+	});
+
+	it("releaseDateISOがちょうど閾値の場合はvolatileになる（境界値）", () => {
+		const boundary = new Date(TODAY.getTime() - VOLATILE_RELEASE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+		const work = makeWork({ releaseDateISO: boundary.toISOString() });
+		expect(classifyWorkTier(work, TODAY)).toBe("volatile");
+	});
+
+	it("releaseDateISOが90日超前かつisSale=falseの場合はstableになる", () => {
+		const work = makeWork({ releaseDateISO: "2020-01-01T00:00:00Z" });
+		expect(classifyWorkTier(work, TODAY)).toBe("stable");
+	});
+
+	it("releaseDateISO欠損の場合は安全側でvolatileになる", () => {
+		const work = makeWork({ releaseDateISO: undefined });
+		expect(classifyWorkTier(work, TODAY)).toBe("volatile");
+	});
+
+	it("releaseDateISOが不正な文字列の場合は安全側でvolatileになる", () => {
+		const work = makeWork({ releaseDateISO: "invalid-date" });
+		expect(classifyWorkTier(work, TODAY)).toBe("volatile");
+	});
+});
+
+describe("getStableCandidateIds", () => {
+	it("stableティアの作品IDのみを返す", () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			["RJ001", makeWork({ productId: "RJ001" })], // stable
+			["RJ002", makeWork({ productId: "RJ002", salesStatus: { isSale: true, isSoldOut: false } })], // volatile
+		]);
+		const workIds = ["RJ001", "RJ002", "RJ003"]; // RJ003はnew（マップ不在）
+
+		expect(getStableCandidateIds(workIds, existingWorksMap, TODAY)).toEqual(["RJ001"]);
+	});
+});
+
+describe("classifyAndFilterStableTier", () => {
+	it("new/volatile/stable(due)/stable(skip)に正しく振り分ける", () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			["RJ_STABLE_DUE", makeWork({ productId: "RJ_STABLE_DUE" })],
+			["RJ_STABLE_SKIP", makeWork({ productId: "RJ_STABLE_SKIP" })],
+			[
+				"RJ_VOLATILE",
+				makeWork({ productId: "RJ_VOLATILE", salesStatus: { isSale: true, isSoldOut: false } }),
+			],
+		]);
+		const workIds = ["RJ_NEW", "RJ_VOLATILE", "RJ_STABLE_DUE", "RJ_STABLE_SKIP"];
+		const priceHistoryTodayExists = new Set(["RJ_STABLE_SKIP"]);
+
+		const result = classifyAndFilterStableTier(
+			workIds,
+			existingWorksMap,
+			priceHistoryTodayExists,
+			TODAY,
+		);
+
+		expect(result).toEqual({
+			newIds: ["RJ_NEW"],
+			volatileIds: ["RJ_VOLATILE"],
+			stableDueIds: ["RJ_STABLE_DUE"],
+			stableSkippedIds: ["RJ_STABLE_SKIP"],
+		});
+	});
+
+	it("全件stableでpriceHistoryが存在しない場合、全てdueになる", () => {
+		const existingWorksMap = new Map<string, WorkDocument>([
+			["RJ001", makeWork({ productId: "RJ001" })],
+			["RJ002", makeWork({ productId: "RJ002" })],
+		]);
+		const result = classifyAndFilterStableTier(
+			["RJ001", "RJ002"],
+			existingWorksMap,
+			new Set(),
+			TODAY,
+		);
+
+		expect(result.stableDueIds).toEqual(["RJ001", "RJ002"]);
+		expect(result.stableSkippedIds).toEqual([]);
+	});
+});
+
+describe("toDueWorkIds", () => {
+	it("new→volatile→stableDueの順に結合する（既存の並び順を維持）", () => {
+		const tiered = {
+			newIds: ["N1", "N2"],
+			volatileIds: ["V1"],
+			stableDueIds: ["S1", "S2"],
+			stableSkippedIds: ["SKIP1"],
+		};
+
+		expect(toDueWorkIds(tiered)).toEqual(["N1", "N2", "V1", "S1", "S2"]);
+	});
+});

--- a/apps/functions/src/services/dlsite/unified-data-processor.ts
+++ b/apps/functions/src/services/dlsite/unified-data-processor.ts
@@ -161,7 +161,7 @@ async function shouldSkipUpdate(
 		existingWork = await getWorkFromFirestore(workData.productId);
 	}
 
-	return !!(existingWork && !hasSignificantChanges(existingWork, workData));
+	return !!(existingWork && !detectChanges(existingWork, workData).hasAnyChange);
 }
 
 /**
@@ -321,21 +321,46 @@ function hasNewGenres(existing: WorkDocument, updated: WorkDocument): boolean {
 }
 
 /**
- * 重要な変更があるかチェック
+ * 変更種別の分類結果
+ *
+ * SPR-229 Stage①: 価格/販売状態の変化とメタ情報の変化を分離して集計する。
+ * 「価格のみ変化」を切り出せるようにしておくことで、後続のティア差分判定や
+ * 取りこぼし検知ログで変化の質を区別できるようにする（本Stageでは動作は変えない）。
+ */
+export interface ChangeDetectionResult {
+	/** 価格・販売状態（セール/売り切れ）の変化 */
+	priceOrSalesChanged: boolean;
+	/** タイトル・評価・ジャンルなどメタ情報の変化 */
+	metadataChanged: boolean;
+	/** いずれかの変化があるか（既存の hasSignificantChanges 相当） */
+	hasAnyChange: boolean;
+}
+
+/**
+ * 既存作品と更新後データの変更種別を分類する
  *
  * @param existing 既存のWorkDocument
  * @param updated 更新されたWorkDocument
- * @returns 重要な変更があればtrue
+ * @returns 変更種別ごとの分類結果
  */
-function hasSignificantChanges(existing: WorkDocument, updated: WorkDocument): boolean {
-	return (
+export function detectChanges(
+	existing: WorkDocument,
+	updated: WorkDocument,
+): ChangeDetectionResult {
+	const priceOrSalesChanged =
 		hasPriceChanged(existing, updated) ||
-		hasTitleChanged(existing, updated) ||
 		hasSalesStatusChanged(existing, updated) ||
+		isSoldOut(existing, updated);
+	const metadataChanged =
+		hasTitleChanged(existing, updated) ||
 		hasRatingChanged(existing, updated) ||
-		isSoldOut(existing, updated) ||
-		hasNewGenres(existing, updated)
-	);
+		hasNewGenres(existing, updated);
+
+	return {
+		priceOrSalesChanged,
+		metadataChanged,
+		hasAnyChange: priceOrSalesChanged || metadataChanged,
+	};
 }
 
 /**

--- a/apps/functions/src/services/dlsite/unified-data-processor.ts
+++ b/apps/functions/src/services/dlsite/unified-data-processor.ts
@@ -248,11 +248,21 @@ export async function processUnifiedDLsiteData(
 
 /**
  * 価格変更をチェック
+ *
+ * 本体価格（current）だけでなく割引率（discount）も見る。DLsiteのセールでJPY価格は
+ * 据え置きのまま割引率だけ変わるケースがあり、currentのみの比較では検知できないため
+ * （レビュー指摘: 割引率のみの変化がShouldSkipUpdate/取りこぼし検知の両方で見逃される）。
  */
 function hasPriceChanged(existing: WorkDocument, updated: WorkDocument): boolean {
 	if (existing.price.current !== updated.price.current) {
 		logger.info(
 			`価格変更検出: ${existing.productId} - ${existing.price.current} → ${updated.price.current}`,
+		);
+		return true;
+	}
+	if (existing.price.discount !== updated.price.discount) {
+		logger.info(
+			`割引率変更検出: ${existing.productId} - ${existing.price.discount} → ${updated.price.discount}`,
 		);
 		return true;
 	}

--- a/apps/functions/src/services/dlsite/work-tiering.ts
+++ b/apps/functions/src/services/dlsite/work-tiering.ts
@@ -1,0 +1,132 @@
+/**
+ * dlsite 作品のティア分類ユーティリティ（SPR-229）
+ *
+ * 作品を「変化の質×頻度」で new/volatile/stable に分類し、per-run で取得すべき
+ * 作品ID（due-set）を絞り込む。ティア判定は既に取得済みの existingWorksMap のみを見て行い、
+ * 追加の Firestore 読み取りは発生しない。stable ティアのみ、当日分 priceHistory が
+ * 存在するかどうかで実際の取得要否（due）を決める（この Firestore 読み取り自体は
+ * 呼び出し側であらかじめバルク確認した結果を Set として受け取る。cf. dlsite-individual-info-api.ts）。
+ */
+
+import type { WorkDocument } from "@suzumina.click/shared-types";
+
+export type WorkTier = "new" | "volatile" | "stable";
+
+/** volatile 判定に使うリリース直近日数の閾値（暫定値、SPR-229 Stage③で本番実測を見て調整） */
+export const VOLATILE_RELEASE_WINDOW_DAYS = 90;
+
+/**
+ * releaseDateISO が基準日から直近 windowDays 日以内かどうかを判定する
+ *
+ * @param releaseDateISO ISO8601形式のリリース日時
+ * @param windowDays 直近とみなす日数
+ * @param today 基準日時（テスト容易性のため注入。JST/UTCどちらでも日数差分は変わらない）
+ */
+function isWithinRecentDays(
+	releaseDateISO: string | undefined,
+	windowDays: number,
+	today: Date,
+): boolean {
+	if (!releaseDateISO) {
+		// リリース日不明は情報不足であり、stable（低頻度）に倒すと更新機会を失うリスクが
+		// あるため安全側（volatile）に倒す。本番実測ではreleaseDateISO欠損率は0%（2026-07-05確認）。
+		return true;
+	}
+
+	const releaseDate = new Date(releaseDateISO);
+	if (Number.isNaN(releaseDate.getTime())) {
+		return true;
+	}
+
+	const diffDays = (today.getTime() - releaseDate.getTime()) / (1000 * 60 * 60 * 24);
+	return diffDays <= windowDays;
+}
+
+/**
+ * 既存作品情報からティアを判定する
+ *
+ * @param existing 既存のWorkDocument（`works` 不在なら undefined）
+ * @param today 基準日時（テスト容易性のため注入）
+ */
+export function classifyWorkTier(existing: WorkDocument | undefined, today: Date): WorkTier {
+	if (!existing) {
+		return "new";
+	}
+	if (existing.salesStatus?.isSale === true) {
+		return "volatile";
+	}
+	if (isWithinRecentDays(existing.releaseDateISO, VOLATILE_RELEASE_WINDOW_DAYS, today)) {
+		return "volatile";
+	}
+	return "stable";
+}
+
+/**
+ * stable候補（= new/volatile以外）の作品IDを抽出する
+ *
+ * 呼び出し側（dlsite-individual-info-api.ts）はこの結果に対してのみ
+ * `priceHistory/{today}` の存在確認をバルクで行う（stable候補以外は対象外にすることで
+ * 無駄な読み取りを避ける）。
+ */
+export function getStableCandidateIds(
+	workIds: string[],
+	existingWorksMap: Map<string, WorkDocument>,
+	today: Date,
+): string[] {
+	return workIds.filter((id) => classifyWorkTier(existingWorksMap.get(id), today) === "stable");
+}
+
+/** ティア別に振り分けた作品ID */
+export interface TieredWorkIds {
+	newIds: string[];
+	volatileIds: string[];
+	/** stable のうち当日分 priceHistory が不在 → 今回取得対象 */
+	stableDueIds: string[];
+	/** stable のうち当日分 priceHistory が存在 → 今回スキップ */
+	stableSkippedIds: string[];
+}
+
+/**
+ * 作品IDをティア別に分類し、stableティアは当日分priceHistoryの有無でdue/skipに振り分ける
+ *
+ * @param workIds 対象の全作品ID（scrape順）
+ * @param existingWorksMap 既存 works のマップ（追加読み取りなしで再利用）
+ * @param priceHistoryTodayExists 当日分 priceHistory が既に存在する作品IDの集合
+ *   （`getStableCandidateIds` で絞った候補のみを対象にあらかじめバルク確認した結果を渡す）
+ * @param today 基準日時（テスト容易性のため注入）
+ */
+export function classifyAndFilterStableTier(
+	workIds: string[],
+	existingWorksMap: Map<string, WorkDocument>,
+	priceHistoryTodayExists: Set<string>,
+	today: Date,
+): TieredWorkIds {
+	const newIds: string[] = [];
+	const volatileIds: string[] = [];
+	const stableDueIds: string[] = [];
+	const stableSkippedIds: string[] = [];
+
+	for (const workId of workIds) {
+		const tier = classifyWorkTier(existingWorksMap.get(workId), today);
+		if (tier === "new") {
+			newIds.push(workId);
+		} else if (tier === "volatile") {
+			volatileIds.push(workId);
+		} else if (priceHistoryTodayExists.has(workId)) {
+			stableSkippedIds.push(workId);
+		} else {
+			stableDueIds.push(workId);
+		}
+	}
+
+	return { newIds, volatileIds, stableDueIds, stableSkippedIds };
+}
+
+/**
+ * ティア分類の結果から、今回のrunで実際に取得すべき作品ID（due-set）を組み立てる
+ *
+ * 並び順は new → volatile → stable の順を保つ（新作fast-lane・work-ordering.tsの意図を踏襲）。
+ */
+export function toDueWorkIds(tiered: TieredWorkIds): string[] {
+	return [...tiered.newIds, ...tiered.volatileIds, ...tiered.stableDueIds];
+}

--- a/apps/functions/src/services/dlsite/work-tiering.ts
+++ b/apps/functions/src/services/dlsite/work-tiering.ts
@@ -62,18 +62,36 @@ export function classifyWorkTier(existing: WorkDocument | undefined, today: Date
 }
 
 /**
+ * 作品IDをティアへ一括分類する（各IDにつき classifyWorkTier は1回だけ呼ぶ）
+ *
+ * `getStableCandidateIds` と `classifyAndFilterStableTier` はこの結果（Map）を再利用する。
+ * 呼び出し側で個別に分類し直すと同じ作品を2回ずつ分類することになるため、
+ * 分類は必ずここで1回だけ行う。
+ */
+export function classifyWorkTiers(
+	workIds: string[],
+	existingWorksMap: Map<string, WorkDocument>,
+	today: Date,
+): Map<string, WorkTier> {
+	const tiers = new Map<string, WorkTier>();
+	for (const id of workIds) {
+		tiers.set(id, classifyWorkTier(existingWorksMap.get(id), today));
+	}
+	return tiers;
+}
+
+/**
  * stable候補（= new/volatile以外）の作品IDを抽出する
  *
  * 呼び出し側（dlsite-individual-info-api.ts）はこの結果に対してのみ
  * `priceHistory/{today}` の存在確認をバルクで行う（stable候補以外は対象外にすることで
  * 無駄な読み取りを避ける）。
+ *
+ * @param workIds 対象の作品ID
+ * @param tiers `classifyWorkTiers` で事前に計算したティア分類結果
  */
-export function getStableCandidateIds(
-	workIds: string[],
-	existingWorksMap: Map<string, WorkDocument>,
-	today: Date,
-): string[] {
-	return workIds.filter((id) => classifyWorkTier(existingWorksMap.get(id), today) === "stable");
+export function getStableCandidateIds(workIds: string[], tiers: Map<string, WorkTier>): string[] {
+	return workIds.filter((id) => tiers.get(id) === "stable");
 }
 
 /** ティア別に振り分けた作品ID */
@@ -90,16 +108,15 @@ export interface TieredWorkIds {
  * 作品IDをティア別に分類し、stableティアは当日分priceHistoryの有無でdue/skipに振り分ける
  *
  * @param workIds 対象の全作品ID（scrape順）
- * @param existingWorksMap 既存 works のマップ（追加読み取りなしで再利用）
+ * @param tiers `classifyWorkTiers` で事前に計算したティア分類結果（`getStableCandidateIds` と
+ *   同じ結果を再利用し、作品ごとの分類を2回行わない）
  * @param priceHistoryTodayExists 当日分 priceHistory が既に存在する作品IDの集合
  *   （`getStableCandidateIds` で絞った候補のみを対象にあらかじめバルク確認した結果を渡す）
- * @param today 基準日時（テスト容易性のため注入）
  */
 export function classifyAndFilterStableTier(
 	workIds: string[],
-	existingWorksMap: Map<string, WorkDocument>,
+	tiers: Map<string, WorkTier>,
 	priceHistoryTodayExists: Set<string>,
-	today: Date,
 ): TieredWorkIds {
 	const newIds: string[] = [];
 	const volatileIds: string[] = [];
@@ -107,7 +124,10 @@ export function classifyAndFilterStableTier(
 	const stableSkippedIds: string[] = [];
 
 	for (const workId of workIds) {
-		const tier = classifyWorkTier(existingWorksMap.get(workId), today);
+		// tiers に無い workId は呼び出し側の不整合（classifyWorkTiers に渡した workIds と
+		// 異なる集合を渡した場合）。安全側（毎run取得＝new扱い）に倒し、stable-skipへの
+		// 誤混入を防ぐ。
+		const tier = tiers.get(workId) ?? "new";
 		if (tier === "new") {
 			newIds.push(workId);
 		} else if (tier === "volatile") {

--- a/apps/functions/src/services/price-history/__tests__/price-history-saver.test.ts
+++ b/apps/functions/src/services/price-history/__tests__/price-history-saver.test.ts
@@ -1,0 +1,173 @@
+/**
+ * price-history-saver.ts のテスト（SPR-229: bulkCheckPriceHistoryExistsToday 中心）
+ */
+
+import type { DLsiteApiResponse } from "@suzumina.click/shared-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function makeRef(workId: string, today: string, state: { getResult: unknown; setMock: unknown }) {
+	return {
+		id: today,
+		parent: { parent: { id: workId } },
+		get: vi.fn().mockImplementation(async () => state.getResult),
+		set: state.setMock,
+	};
+}
+
+vi.mock("../../../infrastructure/database/firestore", () => {
+	const getAll = vi.fn();
+	const state = {
+		getResult: { exists: false } as { exists: boolean; data?: () => unknown },
+		setMock: vi.fn().mockResolvedValue(undefined),
+	};
+	const collection = vi.fn((name: string) => {
+		if (name !== "works") {
+			throw new Error(`unexpected collection: ${name}`);
+		}
+		return {
+			doc: (workId: string) => ({
+				collection: (sub: string) => {
+					if (sub !== "priceHistory") {
+						throw new Error(`unexpected subcollection: ${sub}`);
+					}
+					return {
+						doc: (today: string) => makeRef(workId, today, state),
+					};
+				},
+			}),
+		};
+	});
+
+	return {
+		default: { collection, getAll },
+		__state: state,
+	};
+});
+
+vi.mock("../../../shared/logger", () => ({
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+}));
+
+const { bulkCheckPriceHistoryExistsToday, savePriceHistory } = await import(
+	"../price-history-saver"
+);
+const firestoreMock = vi.mocked(await import("../../../infrastructure/database/firestore"));
+const mockState = (firestoreMock as unknown as { __state: unknown }).__state as {
+	getResult: { exists: boolean; data?: () => unknown };
+	setMock: ReturnType<typeof vi.fn>;
+};
+
+const baseApiResponse: DLsiteApiResponse = {
+	workno: "RJ000001",
+	price: 1000,
+} as unknown as DLsiteApiResponse;
+
+describe("savePriceHistory", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockState.getResult = { exists: false };
+	});
+
+	it("worknoが存在しない場合は保存せずfalseを返す", async () => {
+		const result = await savePriceHistory("RJ000001", { ...baseApiResponse, workno: undefined });
+
+		expect(result).toBe(false);
+		expect(mockState.setMock).not.toHaveBeenCalled();
+	});
+
+	it("当日分が既に存在する場合は保存をスキップしtrueを返す", async () => {
+		mockState.getResult = {
+			exists: true,
+			data: () => ({ capturedAt: "2026-07-05T00:00:00+09:00" }),
+		};
+
+		const result = await savePriceHistory("RJ000001", baseApiResponse);
+
+		expect(result).toBe(true);
+		expect(mockState.setMock).not.toHaveBeenCalled();
+	});
+
+	it("有効な価格データがある場合、価格情報を保存する", async () => {
+		const result = await savePriceHistory("RJ000001", baseApiResponse);
+
+		expect(result).toBe(true);
+		expect(mockState.setMock).toHaveBeenCalledWith(
+			expect.objectContaining({ workId: "RJ000001", price: 1000 }),
+		);
+	});
+
+	it("有効な価格データがない場合、null埋めで保存する", async () => {
+		const result = await savePriceHistory("RJ000001", {
+			...baseApiResponse,
+			price: undefined,
+			locale_price: undefined,
+		});
+
+		expect(result).toBe(true);
+		expect(mockState.setMock).toHaveBeenCalledWith(
+			expect.objectContaining({ price: null, officialPrice: null }),
+		);
+	});
+
+	it("locale_priceが配列の場合はオブジェクトへ正規化する", async () => {
+		const result = await savePriceHistory("RJ000001", {
+			...baseApiResponse,
+			locale_price: [{ currency: "USD", price: 9.99 }],
+		} as unknown as DLsiteApiResponse);
+
+		expect(result).toBe(true);
+		expect(mockState.setMock).toHaveBeenCalledWith(
+			expect.objectContaining({ localePrice: { USD: 9.99 } }),
+		);
+	});
+
+	it("Firestoreエラー時はfalseを返す", async () => {
+		mockState.setMock.mockRejectedValueOnce(new Error("Firestore error"));
+
+		const result = await savePriceHistory("RJ000001", baseApiResponse);
+
+		expect(result).toBe(false);
+	});
+});
+
+describe("bulkCheckPriceHistoryExistsToday", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("空配列を渡した場合、Firestoreに問い合わせず空集合を返す", async () => {
+		const result = await bulkCheckPriceHistoryExistsToday([], "2026-07-05");
+
+		expect(result.size).toBe(0);
+		expect(firestoreMock.default.getAll).not.toHaveBeenCalled();
+	});
+
+	it("存在するドキュメントの作品IDのみを集合に含める", async () => {
+		vi.mocked(firestoreMock.default.getAll).mockResolvedValue([
+			{ exists: true, ref: { parent: { parent: { id: "RJ001" } } } },
+			{ exists: false, ref: { parent: { parent: { id: "RJ002" } } } },
+			{ exists: true, ref: { parent: { parent: { id: "RJ003" } } } },
+		] as never);
+
+		const result = await bulkCheckPriceHistoryExistsToday(
+			["RJ001", "RJ002", "RJ003"],
+			"2026-07-05",
+		);
+
+		expect(result).toEqual(new Set(["RJ001", "RJ003"]));
+	});
+
+	it("300件超は複数チャンクに分割してgetAllを呼ぶ", async () => {
+		const workIds = Array.from({ length: 350 }, (_, i) => `RJ${String(i).padStart(6, "0")}`);
+		vi.mocked(firestoreMock.default.getAll).mockImplementation((async (...refs: unknown[]) =>
+			refs.map((ref) => ({ exists: true, ref }))) as never);
+
+		const result = await bulkCheckPriceHistoryExistsToday(workIds, "2026-07-05");
+
+		expect(firestoreMock.default.getAll).toHaveBeenCalledTimes(2);
+		expect(result.size).toBe(350);
+	});
+});

--- a/apps/functions/src/services/price-history/index.ts
+++ b/apps/functions/src/services/price-history/index.ts
@@ -3,4 +3,8 @@
  * DLsite作品の価格履歴データをサブコレクション方式で管理
  */
 
-export { savePriceHistory } from "./price-history-saver";
+export {
+	bulkCheckPriceHistoryExistsToday,
+	getJSTDate,
+	savePriceHistory,
+} from "./price-history-saver";

--- a/apps/functions/src/services/price-history/price-history-saver.ts
+++ b/apps/functions/src/services/price-history/price-history-saver.ts
@@ -1,13 +1,17 @@
 import type { DLsiteApiResponse, PriceHistoryDocument } from "@suzumina.click/shared-types";
 import firestore from "../../infrastructure/database/firestore";
+import { chunkArray } from "../../shared/array-utils";
 import * as logger from "../../shared/logger";
 import { isValidPriceData } from "./price-extractor";
+
+/** priceHistory 存在確認のバルク読み取り（getAll）を分割するチャンクサイズ */
+const PRICE_HISTORY_EXISTS_CHUNK_SIZE = 300;
 
 /**
  * JST（日本標準時）での現在日付を YYYY-MM-DD 形式で取得
  * @returns JST日付文字列
  */
-function getJSTDate(): string {
+export function getJSTDate(): string {
 	// 現在のUTC時刻を取得
 	const now = new Date();
 	// toLocaleStringでJSTの日付を取得
@@ -148,4 +152,48 @@ export async function savePriceHistory(
 		logger.error(`価格履歴保存エラー: ${workId}`, error);
 		return false;
 	}
+}
+
+/**
+ * 指定した作品IDのうち、当日分(`today`)の priceHistory ドキュメントが
+ * 既に存在する作品IDの集合をバルクで確認する（SPR-229 Stage②）。
+ *
+ * `savePriceHistory` 内の重複防止チェック（既存データ確認）と同じ判定を、
+ * DLsite API呼び出しの**前段**でstableティア候補にだけ行うことで、
+ * 変化していないと分かっている作品のAPI呼び出しをスキップできるようにする。
+ * `firestore.getAll()` によるバルク読み取りのため、read総数は個別`get()`と同等
+ * （読み取り箇所を後段から前段に移すだけで、新規readは発生しない）。
+ *
+ * @param workIds 確認対象の作品ID（stable候補のみに絞って渡す想定）
+ * @param today JST暦日文字列（`getJSTDate()`の結果）
+ * @returns 当日分が既に存在する作品IDの集合
+ */
+export async function bulkCheckPriceHistoryExistsToday(
+	workIds: string[],
+	today: string,
+): Promise<Set<string>> {
+	const existsWorkIds = new Set<string>();
+	if (workIds.length === 0) {
+		return existsWorkIds;
+	}
+
+	const refs = workIds.map((workId) =>
+		firestore.collection("works").doc(workId).collection("priceHistory").doc(today),
+	);
+	const chunks = chunkArray(refs, PRICE_HISTORY_EXISTS_CHUNK_SIZE);
+
+	const chunkResults = await Promise.all(chunks.map((chunk) => firestore.getAll(...chunk)));
+
+	for (const docs of chunkResults) {
+		for (const doc of docs) {
+			if (doc.exists) {
+				const workId = doc.ref.parent.parent?.id;
+				if (workId) {
+					existsWorkIds.add(workId);
+				}
+			}
+		}
+	}
+
+	return existsWorkIds;
 }

--- a/apps/functions/src/services/price-history/price-history-saver.ts
+++ b/apps/functions/src/services/price-history/price-history-saver.ts
@@ -161,8 +161,14 @@ export async function savePriceHistory(
  * `savePriceHistory` 内の重複防止チェック（既存データ確認）と同じ判定を、
  * DLsite API呼び出しの**前段**でstableティア候補にだけ行うことで、
  * 変化していないと分かっている作品のAPI呼び出しをスキップできるようにする。
- * `firestore.getAll()` によるバルク読み取りのため、read総数は個別`get()`と同等
- * （読み取り箇所を後段から前段に移すだけで、新規readは発生しない）。
+ *
+ * read総数について（レビュー指摘を受けて明記）: stable-skip判定された作品（多数派）は
+ * このバルク読み取りが`savePriceHistory`内の個別読み取りをまるごと置き換えるため
+ * read総数は実質不変。一方、stable-due判定された作品（当日分が無く実際に取得する少数派）は
+ * このバルク読み取りに加えて`savePriceHistory`内の個別重複チェックも従来通り実行されるため、
+ * その件数分だけreadが純増する（`savePriceHistory`側の重複防止チェックはこの関数からは
+ * 削除していない）。「新規readは発生しない」は無条件には成立しないが、stable-dueは通常
+ * 少数のため実害は小さい。
  *
  * @param workIds 確認対象の作品ID（stable候補のみに絞って渡す想定）
  * @param today JST暦日文字列（`getJSTDate()`の結果）

--- a/packages/shared-types/src/types/firestore/collection-metadata.ts
+++ b/packages/shared-types/src/types/firestore/collection-metadata.ts
@@ -29,6 +29,22 @@ export interface CollectionMetadata {
 	completedBatches?: number[];
 	// Additional fields
 	migrationVersion?: string;
+	/**
+	 * SPR-229: このサイクルのティア別内訳（観測用。バッチ処理ロジックはこれに依存しない）
+	 */
+	tierBreakdown?: {
+		newCount: number;
+		volatileCount: number;
+		stableDueCount: number;
+		stableSkippedCount: number;
+	};
+	/** SPR-229: このサイクルが週次フルスイープ実行かどうか（continuation run でも維持） */
+	isFullSweepCycle?: boolean;
+	/**
+	 * SPR-229: 週次フルスイープ中、通常runならstableとしてスキップされていたはずの作品ID一覧
+	 * （取りこぼし検知用。isFullSweepCycle=trueのサイクルでのみ設定・continuation runで再利用）
+	 */
+	fullSweepWouldSkipWorkIds?: string[];
 }
 
 /**

--- a/packages/shared-types/src/types/firestore/collection-metadata.ts
+++ b/packages/shared-types/src/types/firestore/collection-metadata.ts
@@ -45,6 +45,13 @@ export interface CollectionMetadata {
 	 * （取りこぼし検知用。isFullSweepCycle=trueのサイクルでのみ設定・continuation runで再利用）
 	 */
 	fullSweepWouldSkipWorkIds?: string[];
+	/**
+	 * SPR-229: 週次フルスイープの発火時に前サイクルが継続中で反映できなかった場合にtrue。
+	 * 次の新規サイクル開始時（`prepareNewBatchProcessing`）にこのフラグを見て
+	 * 強制フルスイープとして拾い直し、そのタイミングでクリアする（レビュー指摘対応:
+	 * 継続中サイクルとの衝突で週次フルスイープがその週丸ごと無音で消えるのを防ぐ）。
+	 */
+	pendingFullSweep?: boolean;
 }
 
 /**

--- a/terraform/function_dlsite_individual_info_api.tf
+++ b/terraform/function_dlsite_individual_info_api.tf
@@ -67,6 +67,35 @@ resource "google_cloud_scheduler_job" "fetch_dlsite_individual_api_hourly" {
   ]
 }
 
+# SPR-229 Stage②: ティア差分の取りこぼし検知を兼ねた週次フルスイープ
+# 通常runの2時間おき（0:03, 2:03, ...）・checkDataIntegrityの日曜3:00 JSTと重ならない
+# 土曜4:15 JSTに設定。既存関数・既存トピックを再利用し、mode違いのペイロードで
+# フルスイープ(ティア差分を無視した全件取得)を発火させる（新規関数は増やさない）。
+resource "google_cloud_scheduler_job" "fetch_dlsite_individual_api_weekly_full_sweep" {
+  project = var.gcp_project_id
+  region  = var.region
+  name    = "fetch-dlsite-individual-api-weekly-full-sweep"
+
+  description = "ティア差分の週次フルスイープ（取りこぼし検知・全件強制取得）"
+  schedule    = "15 4 * * 6" # 毎週土曜4:15 JST
+  time_zone   = "Asia/Tokyo"
+  paused      = false
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.dlsite_individual_api_trigger.id
+    data = base64encode(jsonencode({
+      type        = "unified_update"
+      mode        = "weekly_full_sweep"
+      description = "ティア差分の取りこぼし検知を兼ねた週次全件取得"
+    }))
+  }
+
+  depends_on = [
+    google_project_service.cloudscheduler,
+    google_pubsub_topic.dlsite_individual_api_trigger,
+  ]
+}
+
 # Cloud Scheduler から Individual Info API Function を呼び出すための権限
 resource "google_pubsub_topic_iam_member" "scheduler_individual_api_pubsub_publisher" {
   project = var.gcp_project_id


### PR DESCRIPTION
## Summary

- [SPR-229](https://linear.app/nothink/issue/SPR-229) の実装。`fetchDLsiteUnifiedData` が毎run全~2,076作品を無差別にDLsite Individual Info APIから取得している問題（~14,500回/日）を、作品を new/volatile/stable にティア分けしてdue-setを絞ることで削減する。
- **Stage①**: `hasSignificantChanges` を `detectChanges` に分割し、価格/販売状態の変化とメタ情報の変化を区別できるようにした（挙動は不変のリファクタ）。価格のみの変化には割引率(discount)も含む。
- **Stage②**: 新規 `work-tiering.ts` でティア判定を実装。`prepareNewBatchProcessing` にdue-set絞り込みを組み込み、stableティアは `priceHistory/{today_JST}` が既に存在する日はAPI取得をスキップする。
  - read総数について: stable-**skip**作品（多数派）はこの事前バルクチェックが`savePriceHistory`内の個別重複チェックを実質置き換えるため読み取り総数は不変。一方stable-**due**作品（少数派・当日分がまだ無く実際に取得する作品）は、事前バルクチェックに加え`savePriceHistory`内の個別重複チェックも従来通り実行されるため、その件数分だけreadが純増する（レビュー指摘を受けて記述を修正。実害は小さい）。
- 週次フルスイープ（土曜4:15 JST、既存関数・トピックを再利用）で取りこぼしを検知・保険する。stable想定だった作品で実際に変化が検出された件数をバッチ単位でログ出力。
- `DLSITE_TIER_FILTERING_ENABLED` 環境変数で即時ロールバック可能（Firestoreスキーマ変更を伴わないため）。

## 本番同期パイプラインへの影響（One-Way Door）

- `CollectionMetadata` に `tierBreakdown` / `isFullSweepCycle` / `fullSweepWouldSkipWorkIds` / `pendingFullSweep` を追加（観測用、既存ロジックはこれらに依存しない）。
- 新規 Cloud Scheduler job（`fetch-dlsite-individual-api-weekly-full-sweep`）を追加。既存の2時間おきrun・`checkDataIntegrity`（日曜3:00 JST）とは時刻が重ならない。
- 週次フルスイープが継続中の通常サイクルとぶつかった場合は`pendingFullSweep`フラグで次の新規サイクル開始時に拾い直す（無音でその週丸ごと消えない設計）。

## レビュー対応

セルフレビュー（8観点並列調査）とAIレビューの指摘を反映済み。詳細は[コメント参照](https://github.com/nothink-jp/suzumina.click/pull/753#issuecomment-4883171782)。

## Test plan

- [x] `pnpm verify`（lint:docs + lint:tokens + lint + typecheck + test、カバレッジ閾値含む）全通過
- [x] `work-tiering.ts` / `price-history-saver.ts`（`bulkCheckPriceHistoryExistsToday`）の単体テスト追加
- [x] `dlsite-individual-info-api.ts`（`computeDueWorkIds`/`resolveCycleInfo`/`fetchDLsiteUnifiedData`）の単体・統合テスト追加
- [x] `terraform validate` / `terraform fmt -check` で新規Schedulerリソースの構文確認
- [ ] terraform apply（ADR-010のCI経由・plan→承認→apply）とfunctionsデプロイ後、Cloud LoggingでAPI呼び出し数の実測削減を確認
- [ ] デプロイ後1週間、`priceHistory` の暦日連続性（gapなし）と週次フルスイープの取りこぼし検知ログを監視

🤖 Generated with [Claude Code](https://claude.com/claude-code)