### PR TITLE
fix(web): /videos の total 算出を表示フィルタと一致させ末尾ページの切り捨てを解消

### DIFF
--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -1,11 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	getPopularVideoTags,
-	getTotalVideoCount,
-	getVideoById,
-	getVideosList,
-	getVideoTitles,
-} from "../actions";
+import { getPopularVideoTags, getVideoById, getVideosList, getVideoTitles } from "../actions";
 
 // Mock Firestore
 const mockGet = vi.fn();
@@ -565,42 +559,6 @@ describe("Video Server Actions", () => {
 		it("例外時は null", async () => {
 			mockDoc.mockReturnValue({ get: vi.fn().mockRejectedValue(new Error("fs")) });
 			expect(await getVideoById("video-1")).toBeNull();
-		});
-	});
-
-	describe("getTotalVideoCount", () => {
-		it("フィルタ無しは count() 集計の値を返す（fast path）", async () => {
-			// getVisibleVideoCount は「全件数」→「status ありかつ non-public 件数」の順で
-			// count() を 2 回呼び差分を取る（SPR-246）。
-			mockCount
-				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 42 }) }) })
-				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 0 }) }) });
-			expect(await getTotalVideoCount()).toBe(42);
-		});
-
-		it("フィルタ有りは全件取得しメモリ上でフィルタした件数を返す", async () => {
-			mockGet.mockResolvedValue({
-				docs: [
-					{ id: "video-1", data: () => videoData() },
-					// 非公開は除外される
-					{
-						id: "video-2",
-						data: () =>
-							videoData({
-								id: "video-2",
-								videoId: "video-2",
-								status: { privacyStatus: "private" },
-							}),
-					},
-				],
-			});
-			const n = await getTotalVideoCount({ year: "2024" });
-			expect(n).toBe(1);
-		});
-
-		it("例外時は 0", async () => {
-			mockCount.mockReturnValue({ get: vi.fn().mockRejectedValue(new Error("fs")) });
-			expect(await getTotalVideoCount()).toBe(0);
 		});
 	});
 });

--- a/apps/web/src/app/videos/__tests__/actions.test.ts
+++ b/apps/web/src/app/videos/__tests__/actions.test.ts
@@ -144,10 +144,12 @@ describe("Video Server Actions", () => {
 				docs: mockVideoDocs,
 				size: 2,
 			});
-			// デフォルトパスの総数は count() 集計から取得する（SPR-88）
-			mockCount.mockReturnValue({
-				get: vi.fn().mockResolvedValue({ data: () => ({ count: 2 }) }),
-			});
+			// デフォルトパスの総数は count() 集計から取得する（SPR-88）。
+			// getVisibleVideoCount は「全件数」→「status ありかつ non-public 件数」の順で
+			// count() を 2 回呼び差分を取る（SPR-246）。
+			mockCount
+				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 2 }) }) })
+				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 0 }) }) });
 
 			const result = await getVideoTitles();
 
@@ -308,15 +310,17 @@ describe("Video Server Actions", () => {
 
 		it("フィルタ無しのデフォルトパスは count() 集計で総数を取得する（全件スキャン回避, SPR-88）", async () => {
 			mockGet.mockResolvedValue({ docs: [], size: 0 });
-			mockCount.mockReturnValue({
-				get: vi.fn().mockResolvedValue({ data: () => ({ count: 99 }) }),
-			});
+			// getVisibleVideoCount は「全件数」→「status ありかつ non-public 件数」の順で
+			// count() を 2 回呼び差分を取る（SPR-246: 表示フィルタとの非対称修正）。
+			mockCount
+				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 99 }) }) })
+				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 0 }) }) });
 
 			const result = await getVideosList({ page: 1, limit: 12 });
 
-			// count() + where(public) 集計が使われる
-			expect(mockWhere).toHaveBeenCalledWith("status.privacyStatus", "==", "public");
-			expect(mockCount).toHaveBeenCalled();
+			// count() + where(!=, public) 集計（non-public 件数）が使われる
+			expect(mockWhere).toHaveBeenCalledWith("status.privacyStatus", "!=", "public");
+			expect(mockCount).toHaveBeenCalledTimes(2);
 			expect(result.totalCount).toBe(99);
 		});
 
@@ -566,9 +570,11 @@ describe("Video Server Actions", () => {
 
 	describe("getTotalVideoCount", () => {
 		it("フィルタ無しは count() 集計の値を返す（fast path）", async () => {
-			mockCount.mockReturnValue({
-				get: vi.fn().mockResolvedValue({ data: () => ({ count: 42 }) }),
-			});
+			// getVisibleVideoCount は「全件数」→「status ありかつ non-public 件数」の順で
+			// count() を 2 回呼び差分を取る（SPR-246）。
+			mockCount
+				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 42 }) }) })
+				.mockReturnValueOnce({ get: vi.fn().mockResolvedValue({ data: () => ({ count: 0 }) }) });
 			expect(await getTotalVideoCount()).toBe(42);
 		});
 

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -20,6 +20,27 @@ import * as logger from "@/lib/logger";
 const POPULAR_TAGS_REVALIDATE_SECONDS = 60 * 60;
 
 /**
+ * 表示可能な動画の総数を取得する。
+ *
+ * 一覧の表示フィルタ（`video.status?.privacyStatus === "public" || !video.status`）と
+ * 一致させる必要がある。count() では「status 未設定」を直接問い合わせられないため、
+ * 全件数から「status はあるが public でない」件数を引く方式で算出する
+ * （Firestore の `!=` はフィールド未設定ドキュメントを対象外にする性質を利用）。
+ *
+ * 旧実装は `where("status.privacyStatus","==","public")` のみで数えており、
+ * status 未設定ドキュメント（表示フィルタでは表示される）を total から漏らしていた。
+ * total は ConfigurableList のページ数計算に使われるため、この非対称は
+ * 一覧末尾のページが実在するのに到達できない不具合を生んでいた（SPR-246）。
+ */
+async function getVisibleVideoCount(firestore: FirebaseFirestore.Firestore): Promise<number> {
+	const [totalSnapshot, nonPublicSnapshot] = await Promise.all([
+		firestore.collection("videos").count().get(),
+		firestore.collection("videos").where("status.privacyStatus", "!=", "public").count().get(),
+	]);
+	return totalSnapshot.data().count - nonPublicSnapshot.data().count;
+}
+
+/**
  * ビデオフィルタリングパラメータの型
  */
 interface VideoFilterParams {
@@ -158,7 +179,6 @@ export async function getVideosList(params: {
 	// getVideoTitlesが返すtotalを使用（実際のフィルタリング結果の件数）
 	const filteredCount = data.total;
 
-	// フィルターが適用されていない場合のみ、全件数を取得
 	const hasFilters = !!(
 		videoParams.year ||
 		videoParams.search ||
@@ -168,7 +188,9 @@ export async function getVideosList(params: {
 		videoParams.videoType
 	);
 
-	const totalCount = hasFilters ? filteredCount : await getTotalVideoCount({});
+	// フィルタ無し時、data.total は getVideosWithFiltering 内で既に getVisibleVideoCount により
+	// 算出済み（getTotalVideoCount({}) と同一の計算）なので再計算しない（count() クエリの重複回避）
+	const totalCount = hasFilters ? filteredCount : data.total;
 
 	return {
 		items: data.videos,
@@ -313,17 +335,8 @@ async function getVideosWithFiltering(
 	const plainVideos = videos; // すでにPlainObject
 	const _hasMore = snapshot.size > limit;
 
-	// publicな動画の総数を count() 集計で取得（SPR-88: 毎リクエストの全件 .get()
-	// スキャンを回避。works/actions.ts と同じ count() パターン）。
-	// 注: status 未設定 doc は count() で拾えない。旧 mapper 撤去期の未設定 doc（2026-07 時点 171/554 件）が
-	// 残っていたが、SPR-243 で mapper が status を再写像し毎時 cron の再取得で自然 backfill される。
-	// 表示側の `|| !video.status` フィルタは移行期の安全弁として残している。
-	const countSnapshot = await firestore
-		.collection("videos")
-		.where("status.privacyStatus", "==", "public")
-		.count()
-		.get();
-	const total = countSnapshot.data().count;
+	// 表示可能総数を取得（SPR-88: count() 集計で全件 .get() スキャンを回避、SPR-246: 表示フィルタと非対称だった算出を修正）
+	const total = await getVisibleVideoCount(firestore);
 
 	return {
 		items: plainVideos,
@@ -503,12 +516,7 @@ export async function getTotalVideoCount(params?: {
 			params?.videoType
 		);
 		if (!hasFilters) {
-			const countSnapshot = await firestore
-				.collection("videos")
-				.where("status.privacyStatus", "==", "public")
-				.count()
-				.get();
-			return countSnapshot.data().count;
+			return await getVisibleVideoCount(firestore);
 		}
 
 		// フィルタがある場合は全件取得してメモリ上でフィルタリング（暫定）

--- a/apps/web/src/app/videos/actions.ts
+++ b/apps/web/src/app/videos/actions.ts
@@ -31,6 +31,11 @@ const POPULAR_TAGS_REVALIDATE_SECONDS = 60 * 60;
  * status 未設定ドキュメント（表示フィルタでは表示される）を total から漏らしていた。
  * total は ConfigurableList のページ数計算に使われるため、この非対称は
  * 一覧末尾のページが実在するのに到達できない不具合を生んでいた（SPR-246）。
+ *
+ * 注意: Firestore の `!=` は「フィールド未設定」だけでなく値が `null` のドキュメントも
+ * 対象外にする。そのため status はあるが privacyStatus が欠損/null という中間状態が
+ * 発生すると、表示フィルタでは非表示なのに本関数では visible 側に誤って計上される
+ * （本番データでは 2026-07-05 時点でこのパターンは 0 件を確認済み）。
  */
 async function getVisibleVideoCount(firestore: FirebaseFirestore.Firestore): Promise<number> {
 	const [totalSnapshot, nonPublicSnapshot] = await Promise.all([
@@ -188,8 +193,8 @@ export async function getVideosList(params: {
 		videoParams.videoType
 	);
 
-	// フィルタ無し時、data.total は getVideosWithFiltering 内で既に getVisibleVideoCount により
-	// 算出済み（getTotalVideoCount({}) と同一の計算）なので再計算しない（count() クエリの重複回避）
+	// フィルタ無し時、data.total は getVideosWithFiltering 内で既に getVisibleVideoCount で
+	// 算出済みのため再計算しない（同じ集計を二重に投げる count() クエリの重複回避）
 	const totalCount = hasFilters ? filteredCount : data.total;
 
 	return {
@@ -487,53 +492,5 @@ export async function getVideoById(videoId: string) {
 			stack: error instanceof Error ? error.stack : undefined,
 		});
 		return null;
-	}
-}
-
-/**
- * Entity V2を使用した動画総数の取得
- */
-export async function getTotalVideoCount(params?: {
-	year?: string;
-	search?: string;
-	playlistTags?: string[];
-	userTags?: string[];
-	categoryNames?: string[];
-	videoType?: string;
-}) {
-	try {
-		const firestore = getFirestore();
-
-		// フィルタが無い場合は count() 集計で取得し全件スキャンを回避（SPR-88）。
-		// 現状の唯一の呼び出し元 getVideosList は常にフィルタ無し ({}) で呼ぶため、
-		// この fast path が実質的なホットパス。
-		const hasFilters = !!(
-			params?.year ||
-			params?.search ||
-			params?.playlistTags?.length ||
-			params?.userTags?.length ||
-			params?.categoryNames?.length ||
-			params?.videoType
-		);
-		if (!hasFilters) {
-			return await getVisibleVideoCount(firestore);
-		}
-
-		// フィルタがある場合は全件取得してメモリ上でフィルタリング（暫定）
-		const snapshot = await firestore.collection("videos").get();
-		const videos = snapshot.docs
-			.map((doc) => convertToVideo(doc))
-			.filter((video): video is VideoPlainObject => video !== null)
-			.filter((video) => video.status?.privacyStatus === "public" || !video.status);
-		const filteredVideos = filterVideos(videos, params || {});
-
-		return filteredVideos.length;
-	} catch (error) {
-		logger.error("動画総数V2取得でエラーが発生", {
-			action: "getTotalVideoCount",
-			error: error instanceof Error ? error.message : String(error),
-			stack: error instanceof Error ? error.stack : undefined,
-		});
-		return 0;
 	}
 }


### PR DESCRIPTION
## 概要

SPR-243/245 の本番検証後にユーザー報告された不具合の修正。SPR-75 系列。

## 問題

`/videos` の total 算出と一覧の表示フィルタが非対称だった:

- **total**: `where("status.privacyStatus","==","public")` の count() → status フィールド自体を持たない動画を除外
- **一覧表示フィルタ**: `video.status?.privacyStatus === "public" || !video.status` → status 未設定の動画も表示に含める

この非対称のため、`ConfigurableList` が `total` から算出する `totalPages = Math.ceil(total/itemsPerPage)` が実際に表示可能な件数より少なくなり、**末尾のページに正規の公開動画が存在するのに到達できない**状態だった。

本番実測（2026-07-05）: `videos` 全555件のうち status 未設定は3件（`videos.list` で取得不能・YouTube 側で削除/非公開化済みと SPR-245 で確認済み）。total=552（`Math.ceil(552/12)=46`ページ）だったが、desc順末尾3件（position 553-555）は**正規の公開動画**（2018-2019年公開）で、一覧から完全に隠れていた。

構造自体は SPR-243 以前から存在していたが、旧実装は status 未設定の動画が非常に多く total との差が大きかったため目立たず、SPR-243/245 で差が 171→3件まで縮小したことで初めて「末尾ページの切り捨て」という形で可視化された。

## 対応

`getVisibleVideoCount()` を追加し、表示フィルタと一致する形で total を算出:

```
visible = count(全件) - count(where status.privacyStatus != "public")
```

Firestore の `!=` はフィールド未設定ドキュメントを対象外にする性質があるため、2つの count() 集計の差分で「status 未設定 OR public」を正確に計算できる（フィールド非存在を直接問い合わせる方法が無いため）。単純フィールドの `!=` は複合インデックス不要。

副次的に、`getVideosList` のフィルタ無しパスが `getTotalVideoCount()` を冗長に再計算していた箇所（`getVideoTitles` が既に同じ値を算出済み）を統合し、count() クエリ数の増加（1→2 per 算出）を相殺して既存と同じ2回のまま維持した。

## 検証

- `pnpm verify` 完走（既存テストを新実装の count() 2回呼び出しに合わせて更新）
- **本番 ADC 接続の dev server で再現・修正確認済み**: total が 552→555 に変化、page 47 が新たに出現し、隠れていた3件の正規動画（`謹賀新年＊プチボイスドラマ＊20190101` 等）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)