### PR TITLE
fix(ci,infra): DLsite Run Absent 偽陽性の再発防止

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -16,8 +16,10 @@ permissions:
 
 # 短時間に複数PRがmainへ連続マージされると、前のデプロイが進行中のまま次のrunが
 # gcloud functions deploy を叩き、GCP側が "unable to queue the operation" (409) で
-# 全関数デプロイを拒否する（2026-07-04 実測）。cancel-in-progress ではなく直列化する
-# （進行中のデプロイを打ち切ると部分適用のまま終わるため、待たせて完走させる）。
+# 全関数デプロイを拒否する（2026-07-04 実測）。cancel-in-progress: false は「実行中の run」
+# を打ち切らないという意味（待たせて完走させる＝進行中のデプロイが部分適用のまま終わるのを防ぐ）。
+# 待機中(pending)の run は仕様上、後続pushで古い方が置き換わり得るが、最終的にmainの
+# 最新状態がデプロイされればよいユースケースなので問題ない。
 concurrency:
   group: deploy-functions-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -14,6 +14,14 @@ permissions:
   contents: read
   id-token: write
 
+# 短時間に複数PRがmainへ連続マージされると、前のデプロイが進行中のまま次のrunが
+# gcloud functions deploy を叩き、GCP側が "unable to queue the operation" (409) で
+# 全関数デプロイを拒否する（2026-07-04 実測）。cancel-in-progress ではなく直列化する
+# （進行中のデプロイを打ち切ると部分適用のまま終わるため、待たせて完走させる）。
+concurrency:
+  group: deploy-functions-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-pr-status:
     name: Check PR Status

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -307,6 +307,13 @@ resource "google_monitoring_alert_policy" "dlsite_api_batch_all_failed" {
 # Scheduler 停止 / Pub/Sub subscription・Eventarc trigger の破壊 / 関数消失では
 # 「ログが出ない」ため、ログ内容ベースのアラートは全て沈黙する（SPR-234 分類 B1）。
 # run 開始ログ（2h 毎・12回/日）を metric 化し、absence 条件で run 途絶そのものを検知する。
+#
+# 注意（2026-07-04 実測の偽陽性）: 同日に fetchdlsiteunifieddata への実デプロイが
+# 34分間に4回集中（うち1回はCI側の409衝突で失敗）した際、実行ログ自体は1件も
+# 欠けていなかった（gcloud logging read で確認済み）にも関わらず、本アラートが
+# 2回誤発火した。revision churn が激しい時間帯に log-based metric の反映が
+# 遅延した可能性が高い。duration を3h→4hに拡げて余裕を持たせている
+# （deploy-functions.yml 側の同時実行制御と合わせて二段構え）。
 resource "google_logging_metric" "dlsite_run_started" {
   name    = "dlsite_run_started"
   project = var.gcp_project_id
@@ -331,12 +338,14 @@ resource "google_monitoring_alert_policy" "dlsite_run_absent" {
   combiner     = "OR"
 
   conditions {
-    display_name = "定期runが3時間以上観測されない"
+    display_name = "定期runが4時間以上観測されない"
 
-    # 2h 周期 + 1h マージン。1 run 欠けの時点で異常（過去ログでは欠けゼロ）。
+    # 2h 周期 + 2h マージン（旧: 1hマージン=3h）。2026-07-04 に revision churn 集中時の
+    # metric 反映遅延で3hマージンでは偽陽性が2回発生したため拡大。1 run 欠けただけでは
+    # 発火せず、2 run 連続欠けで異常とみなす。
     condition_absent {
       filter   = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.dlsite_run_started.id}\" resource.type=\"cloud_run_revision\""
-      duration = "10800s"
+      duration = "14400s"
 
       aggregations {
         alignment_period   = "300s"
@@ -355,12 +364,20 @@ resource "google_monitoring_alert_policy" "dlsite_run_absent" {
 
   documentation {
     content   = <<-EOT
-    # DLsite 定期 run の途絶（3時間以上）
+    # DLsite 定期 run の途絶（4時間以上）
 
-    fetchDLsiteUnifiedData の run 開始ログが3時間以上観測されていません（正常時は
+    fetchDLsiteUnifiedData の run 開始ログが4時間以上観測されていません（正常時は
     2時間毎・12回/日）。ログ自体が出ない障害のため、他の DLsite アラートは沈黙します。
 
-    ## 考えられる原因と確認手順
+    ## まず確認すること（2026-07-04 に偽陽性実績あり）
+    実際に run が欠けているかを最優先で確認する。過去に revision churn 集中時の
+    metric 反映遅延で、実行ログは正常に出ているのにこのアラートだけ誤発火した例がある：
+    ```bash
+    gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="fetchdlsiteunifieddata" AND (jsonPayload.message:"統合データ収集開始" OR textPayload:"統合データ収集開始")' --freshness=1d --format="value(timestamp)" --order=asc
+    ```
+    直近の2時間おきの時刻が全て埋まっていれば偽陽性（対応不要）。
+
+    ## 実際に欠けていた場合の原因と確認手順
     1. Cloud Scheduler 停止/削除: gcloud scheduler jobs describe fetch-dlsite-individual-api-hourly --location=asia-northeast1
     2. Pub/Sub topic/subscription・Eventarc trigger の破壊: gcloud eventarc triggers list --location=asia-northeast1
     3. サービス消失/起動不能: gcloud run services describe fetchdlsiteunifieddata --region=asia-northeast1


### PR DESCRIPTION
## Summary

2026-07-04 に GCP アラート「Cloud Run Revision - DLsite Run Started is absent for more than 180 mins」が2回届いた（14:13 UTC・20:13 UTC）ことを受けた調査と対応。

- `gcloud logging read` で該当期間の `統合データ収集開始` ログを全件確認したところ、予定run（2h毎）は1件も欠けておらず、**両方とも偽陽性**だった。
- 同日 11:46〜12:20 UTC の34分間に `fetchdlsiteunifieddata` への実デプロイが4回集中しており（SPR-240/239/243/241）、うち SPR-239 のデプロイは CI 側の同時実行制御が無かったために `gcloud functions deploy` が競合し `409 unable to queue the operation` で全関数デプロイ失敗という実バグも見つかった。
- 実行ログの欠測はゼロだったため、アラート誤発火は revision churn 集中時の metric 反映遅延が濃厚（内部挙動のため断定はできず）。

## Changes

- `.github/workflows/deploy-functions.yml`: `concurrency` グループを追加し、連続マージ時に deploy が競合して 409 で失敗する既知バグを解消（`cancel-in-progress: false` で直列化・打ち切りはしない）
- `terraform/monitoring_dlsite.tf`: `dlsite_run_absent` の `condition_absent.duration` を `10800s`(3h) → `14400s`(4h) に緩和。1 run 欠けただけでは発火せず、2 run 連続欠けで異常とみなすようにして偽陽性を抑制。ドキュメントに「まず実ログの欠測有無を確認する」手順も追記

## Test plan

- [x] `terraform fmt -check` で構文差分なしを確認
- [x] terraform 変更は ADR-010 の CI（plan→承認→apply）で本番反映（本PRのマージ後、通常のterraform applyフローに乗る想定）
- [ ] マージ後、次に functions への連続マージが発生した際に 409 が再発しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)