### PR TITLE
feat(functions): YouTube discoveryをsearch.listからuploads playlist経由へ段階移行 (SPR-230)

### DIFF
--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -235,6 +235,35 @@ describe("fetchYouTubeVideos: playlistモード（incremental discovery）", () 
 		expect(youtubeApi.fetchUploadsPlaylistPage).toHaveBeenCalledTimes(2);
 		expect(youtubeApi.fetchVideoDetails).toHaveBeenCalledWith(dummyClient, ["a", "b", "c"]);
 	});
+
+	it("ページ上限に達しても後続ページが残っている場合はisComplete扱いにせず警告する（レビュー指摘対応）", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "playlist";
+		getMetadataMock.mockResolvedValue({
+			exists: true,
+			data: () => ({ isInProgress: false, uploadsPlaylistId: "UUcached" }),
+		});
+		// 全ページが未知IDのみ・かつ常にnextPageTokenありを返し続ける（ページ上限で強制打ち切りされる状況）
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockImplementation(async () => ({
+			videoIds: ["x"],
+			nextPageToken: "more",
+		}));
+		vi.mocked(youtubeFirestore.getKnownVideoIdsSet).mockResolvedValue(new Set());
+		vi.mocked(youtubeApi.fetchVideoDetails).mockResolvedValue([
+			{ id: "x" } as youtube_v3.Schema$Video,
+		]);
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		// ページ上限到達の警告ログが出る
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("ページ上限"),
+			expect.anything(),
+		);
+		// isComplete扱いにならないため lastSuccessfulCompleteFetch は更新されない
+		expect(updateMock).not.toHaveBeenCalledWith(
+			expect.objectContaining({ lastSuccessfulCompleteFetch: expect.anything() }),
+		);
+	});
 });
 
 describe("fetchYouTubeVideos: 週次フルスイープ（mode=weekly_full_sweep）", () => {

--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -1,54 +1,296 @@
-import { describe, expect, it, vi } from "vitest";
+/**
+ * youtube.ts のテスト（SPR-230: discoveryモード切替・early-stop・週次フルスイープ 中心）
+ *
+ * サービス層（youtube-api.ts / youtube-firestore.ts）はモックし、
+ * dlsite-individual-info-api.test.tsと同様のパターンでエンドポイントの分岐を検証する。
+ */
 
-// Mocks
-vi.mock("../../../shared/logger", () => ({
+import type { youtube_v3 } from "googleapis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infrastructure/database/firestore", () => {
+	const updateMock = vi.fn().mockResolvedValue(undefined);
+	const getMock = vi.fn().mockResolvedValue({ exists: false });
+	const docRef = { update: updateMock, get: getMock, set: vi.fn() };
+	const collection = vi.fn(() => ({ doc: vi.fn(() => docRef) }));
+
+	return {
+		default: { collection, getAll: vi.fn() },
+		Timestamp: { now: vi.fn(() => ({ seconds: 0, nanoseconds: 0 })) },
+		__updateMock: updateMock,
+		__getMock: getMock,
+	};
+});
+
+vi.mock("../../services/youtube/youtube-api", () => ({
+	initializeYouTubeClient: vi.fn(),
+	searchVideos: vi.fn(),
+	extractVideoIds: vi.fn(),
+	fetchVideoDetails: vi.fn(),
+	fetchChannelPlaylists: vi.fn(),
+	fetchPlaylistItems: vi.fn(),
+	fetchUploadsPlaylistId: vi.fn(),
+	fetchUploadsPlaylistPage: vi.fn(),
+}));
+
+vi.mock("../../services/youtube/youtube-firestore", () => ({
+	saveVideosToFirestore: vi.fn(),
+	getKnownVideoIdsSet: vi.fn(),
+	getAllVideoIds: vi.fn(),
+}));
+
+vi.mock("../../shared/logger", () => ({
+	debug: vi.fn(),
 	info: vi.fn(),
 	warn: vi.fn(),
 	error: vi.fn(),
-	debug: vi.fn(),
 }));
 
-vi.mock("../../config/feature-flags", () => ({
-	isEntityEnabled: vi.fn(() => false), // デフォルトは無効
-}));
+const { fetchYouTubeVideos } = await import("../youtube");
+const youtubeApi = await import("../../services/youtube/youtube-api");
+const youtubeFirestore = await import("../../services/youtube/youtube-firestore");
+const logger = await import("../../shared/logger");
+const firestoreMock = vi.mocked(await import("../../infrastructure/database/firestore"));
+const updateMock = (firestoreMock as unknown as { __updateMock: ReturnType<typeof vi.fn> })
+	.__updateMock;
+const getMetadataMock = (firestoreMock as unknown as { __getMock: ReturnType<typeof vi.fn> })
+	.__getMock;
 
-vi.mock("../../../infrastructure/database/firestore", () => ({
-	default: {
-		collection: vi.fn(() => ({
-			doc: vi.fn(() => ({
-				get: vi.fn().mockResolvedValue({ exists: false }),
-				set: vi.fn().mockResolvedValue(undefined),
-				update: vi.fn().mockResolvedValue(undefined),
-			})),
-		})),
-		batch: vi.fn(() => ({
-			set: vi.fn(),
-			commit: vi.fn().mockResolvedValue(undefined),
-		})),
-	},
-	Timestamp: {
-		now: vi.fn().mockReturnValue({ seconds: 1234567890, nanoseconds: 0 }),
-	},
-}));
+const dummyClient = {} as youtube_v3.Youtube;
 
-vi.mock("googleapis", () => ({
-	google: {
-		youtube: vi.fn(() => ({
-			search: {
-				list: vi.fn().mockResolvedValue({ data: { items: [] } }),
-			},
-			videos: {
-				list: vi.fn().mockResolvedValue({ data: { items: [] } }),
-			},
-		})),
-	},
-}));
+function pubsubEvent(payload?: Record<string, unknown>) {
+	return {
+		type: "google.cloud.pubsub.topic.v1.messagePublished",
+		data: {
+			data: payload ? Buffer.from(JSON.stringify(payload)).toString("base64") : undefined,
+		},
+	} as unknown as Parameters<typeof fetchYouTubeVideos>[0];
+}
 
-import { fetchYouTubeVideos } from "../youtube";
+beforeEach(() => {
+	vi.clearAllMocks();
+	delete process.env.YOUTUBE_DISCOVERY_MODE;
 
-describe("fetchYouTubeVideos", () => {
-	it("should be exported as a function", () => {
-		expect(fetchYouTubeVideos).toBeDefined();
-		expect(typeof fetchYouTubeVideos).toBe("function");
+	getMetadataMock.mockResolvedValue({ exists: false });
+	vi.mocked(youtubeApi.initializeYouTubeClient).mockReturnValue([dummyClient, undefined]);
+	vi.mocked(youtubeApi.fetchChannelPlaylists).mockResolvedValue([]);
+	vi.mocked(youtubeApi.fetchPlaylistItems).mockResolvedValue([]);
+	vi.mocked(youtubeApi.fetchVideoDetails).mockResolvedValue([]);
+	vi.mocked(youtubeFirestore.saveVideosToFirestore).mockResolvedValue(0);
+	vi.mocked(youtubeFirestore.getKnownVideoIdsSet).mockResolvedValue(new Set());
+	vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set());
+});
+
+describe("fetchYouTubeVideos: 通常run（既定=searchモード）", () => {
+	it("search.listベースの経路で動画を取得・保存する", async () => {
+		vi.mocked(youtubeApi.searchVideos).mockResolvedValue({ items: [], nextPageToken: undefined });
+		vi.mocked(youtubeApi.extractVideoIds).mockReturnValue(["v1", "v2"]);
+		vi.mocked(youtubeApi.fetchVideoDetails).mockResolvedValue([
+			{ id: "v1" } as youtube_v3.Schema$Video,
+			{ id: "v2" } as youtube_v3.Schema$Video,
+		]);
+		vi.mocked(youtubeFirestore.saveVideosToFirestore).mockResolvedValue(2);
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		expect(youtubeApi.searchVideos).toHaveBeenCalled();
+		expect(youtubeApi.fetchUploadsPlaylistId).not.toHaveBeenCalled();
+		expect(youtubeFirestore.saveVideosToFirestore).toHaveBeenCalled();
+	});
+});
+
+describe("fetchYouTubeVideos: shadowモード", () => {
+	it("既存経路の保存は維持しつつ、uploads playlist全走査との比較ログを追加で出す", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "shadow";
+		vi.mocked(youtubeApi.searchVideos).mockResolvedValue({ items: [], nextPageToken: undefined });
+		vi.mocked(youtubeApi.extractVideoIds).mockReturnValue(["v1"]);
+		vi.mocked(youtubeApi.fetchVideoDetails).mockResolvedValue([
+			{ id: "v1" } as youtube_v3.Schema$Video,
+		]);
+		vi.mocked(youtubeApi.fetchUploadsPlaylistId).mockResolvedValue("UUxxxx");
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: ["v1"],
+			nextPageToken: undefined,
+		});
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v1"]));
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		// 既存経路（search.list）は維持される
+		expect(youtubeApi.searchVideos).toHaveBeenCalled();
+		// 追加で比較用にuploads playlist側も呼ばれる
+		expect(youtubeApi.fetchUploadsPlaylistId).toHaveBeenCalled();
+		expect(youtubeApi.fetchUploadsPlaylistPage).toHaveBeenCalled();
+		expect(youtubeFirestore.getAllVideoIds).toHaveBeenCalled();
+		// 発見集合が一致しているのでinfoログ（警告ではない）
+		expect(logger.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("差分があります"),
+			expect.anything(),
+		);
+	});
+
+	it("発見集合に差分がある場合はwarnログを出す（保存フロー自体は継続する）", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "shadow";
+		vi.mocked(youtubeApi.searchVideos).mockResolvedValue({ items: [], nextPageToken: undefined });
+		vi.mocked(youtubeApi.extractVideoIds).mockReturnValue([]);
+		vi.mocked(youtubeApi.fetchUploadsPlaylistId).mockResolvedValue("UUxxxx");
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: ["v1"],
+			nextPageToken: undefined,
+		});
+		// Firestoreにはv2があるが、uploads playlist走査では見つからない → 差分あり
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v2"]));
+
+		const result = await fetchYouTubeVideos(pubsubEvent());
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("差分があります"),
+			expect.anything(),
+		);
+		// 比較の失敗/差分検出自体は本処理の完了を妨げない
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("fetchYouTubeVideos: playlistモード（incremental discovery）", () => {
+	it("uploads playlist IDが未キャッシュなら取得してメタデータに保存する", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "playlist";
+		vi.mocked(youtubeApi.fetchUploadsPlaylistId).mockResolvedValue("UUxxxx");
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: [],
+			nextPageToken: undefined,
+		});
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		expect(youtubeApi.fetchUploadsPlaylistId).toHaveBeenCalledTimes(1);
+		expect(updateMock).toHaveBeenCalledWith(
+			expect.objectContaining({ uploadsPlaylistId: "UUxxxx" }),
+		);
+	});
+
+	it("キャッシュ済みのuploads playlist IDがあれば再取得しない", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "playlist";
+		getMetadataMock.mockResolvedValue({
+			exists: true,
+			data: () => ({ isInProgress: false, uploadsPlaylistId: "UUcached" }),
+		});
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: [],
+			nextPageToken: undefined,
+		});
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		expect(youtubeApi.fetchUploadsPlaylistId).not.toHaveBeenCalled();
+		expect(youtubeApi.fetchUploadsPlaylistPage).toHaveBeenCalledWith(
+			dummyClient,
+			"UUcached",
+			undefined,
+		);
+	});
+
+	it("ページ内に既知IDが混ざったら、それより前の未知IDだけ採用してページングを打ち切る", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "playlist";
+		getMetadataMock.mockResolvedValue({
+			exists: true,
+			data: () => ({ isInProgress: false, uploadsPlaylistId: "UUcached" }),
+		});
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: ["new1", "known1", "known2"],
+			nextPageToken: "next-page",
+		});
+		vi.mocked(youtubeFirestore.getKnownVideoIdsSet).mockResolvedValue(
+			new Set(["known1", "known2"]),
+		);
+		vi.mocked(youtubeApi.fetchVideoDetails).mockResolvedValue([
+			{ id: "new1" } as youtube_v3.Schema$Video,
+		]);
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		// 既知IDに当たった時点で打ち切るため、1ページ分しか呼ばれない
+		expect(youtubeApi.fetchUploadsPlaylistPage).toHaveBeenCalledTimes(1);
+		expect(youtubeApi.fetchVideoDetails).toHaveBeenCalledWith(dummyClient, ["new1"]);
+	});
+
+	it("全件が未知（初回バックフィル相当）の場合は次ページまで継続する", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "playlist";
+		getMetadataMock.mockResolvedValue({
+			exists: true,
+			data: () => ({ isInProgress: false, uploadsPlaylistId: "UUcached" }),
+		});
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage)
+			.mockResolvedValueOnce({ videoIds: ["a", "b"], nextPageToken: "p2" })
+			.mockResolvedValueOnce({ videoIds: ["c"], nextPageToken: undefined });
+		vi.mocked(youtubeFirestore.getKnownVideoIdsSet).mockResolvedValue(new Set());
+		vi.mocked(youtubeApi.fetchVideoDetails).mockResolvedValue([
+			{ id: "a" } as youtube_v3.Schema$Video,
+			{ id: "b" } as youtube_v3.Schema$Video,
+			{ id: "c" } as youtube_v3.Schema$Video,
+		]);
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		expect(youtubeApi.fetchUploadsPlaylistPage).toHaveBeenCalledTimes(2);
+		expect(youtubeApi.fetchVideoDetails).toHaveBeenCalledWith(dummyClient, ["a", "b", "c"]);
+	});
+});
+
+describe("fetchYouTubeVideos: 週次フルスイープ（mode=weekly_full_sweep）", () => {
+	it("通常の詳細取得・保存フローは実行せず、discovery取りこぼし検知のみ行う", async () => {
+		vi.mocked(youtubeApi.fetchUploadsPlaylistId).mockResolvedValue("UUxxxx");
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: ["v1"],
+			nextPageToken: undefined,
+		});
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v1"]));
+
+		await fetchYouTubeVideos(pubsubEvent({ mode: "weekly_full_sweep" }));
+
+		expect(youtubeApi.searchVideos).not.toHaveBeenCalled();
+		expect(youtubeApi.fetchVideoDetails).not.toHaveBeenCalled();
+		expect(youtubeFirestore.saveVideosToFirestore).not.toHaveBeenCalled();
+		expect(youtubeApi.fetchUploadsPlaylistId).toHaveBeenCalled();
+		expect(youtubeFirestore.getAllVideoIds).toHaveBeenCalled();
+	});
+
+	it("週次フルスイープでも通常runと同じ二重実行ロックに従う", async () => {
+		getMetadataMock.mockResolvedValue({
+			exists: true,
+			data: () => ({
+				isInProgress: true,
+				lastFetchedAt: { toMillis: () => Date.now() },
+			}),
+		});
+
+		await fetchYouTubeVideos(pubsubEvent({ mode: "weekly_full_sweep" }));
+
+		expect(youtubeApi.fetchUploadsPlaylistId).not.toHaveBeenCalled();
+	});
+});
+
+describe("fetchYouTubeVideos: Pub/Subペイロードのデコード", () => {
+	it("dataが空でも通常runとして処理を続行する", async () => {
+		vi.mocked(youtubeApi.searchVideos).mockResolvedValue({ items: [], nextPageToken: undefined });
+		vi.mocked(youtubeApi.extractVideoIds).mockReturnValue([]);
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		expect(youtubeApi.searchVideos).toHaveBeenCalled();
+	});
+
+	it("不正なJSONペイロードは安全側（通常run）にフォールバックする", async () => {
+		vi.mocked(youtubeApi.searchVideos).mockResolvedValue({ items: [], nextPageToken: undefined });
+		vi.mocked(youtubeApi.extractVideoIds).mockReturnValue([]);
+
+		const event = {
+			type: "test",
+			data: { data: Buffer.from("not-json").toString("base64") },
+		} as unknown as Parameters<typeof fetchYouTubeVideos>[0];
+
+		await fetchYouTubeVideos(event);
+
+		expect(youtubeApi.searchVideos).toHaveBeenCalled();
 	});
 });

--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -150,6 +150,38 @@ describe("fetchYouTubeVideos: shadowモード", () => {
 		// 比較の失敗/差分検出自体は本処理の完了を妨げない
 		expect(result).toBeUndefined();
 	});
+
+	it("全走査がページ上限で打ち切られた場合はmissing判定をスキップして警告する（レビュー指摘対応）", async () => {
+		process.env.YOUTUBE_DISCOVERY_MODE = "shadow";
+		vi.mocked(youtubeApi.searchVideos).mockResolvedValue({ items: [], nextPageToken: undefined });
+		vi.mocked(youtubeApi.extractVideoIds).mockReturnValue([]);
+		vi.mocked(youtubeApi.fetchUploadsPlaylistId).mockResolvedValue("UUxxxx");
+		// 常にnextPageTokenありを返し続ける → fetchVideoIdsViaPlaylistFullがページ上限で打ち切られる
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockImplementation(async () => ({
+			videoIds: ["v1"],
+			nextPageToken: "more",
+		}));
+		// Firestoreには走査未到達分のv2がある想定（打ち切られなければmissing判定される状況）
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v1", "v2"]));
+
+		await fetchYouTubeVideos(pubsubEvent());
+
+		// ページ上限打ち切りの警告が出る
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("ページ上限で打ち切られたため、今回はmissing判定をスキップします"),
+			expect.anything(),
+		);
+		// missing判定はスキップされるため「差分があります」ログは出ない
+		expect(logger.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("差分があります"),
+			expect.anything(),
+		);
+		// 一致ログも出ない（判定自体をスキップしているため）
+		expect(logger.info).not.toHaveBeenCalledWith(
+			expect.stringContaining("発見集合が一致しました"),
+			expect.anything(),
+		);
+	});
 });
 
 describe("fetchYouTubeVideos: playlistモード（incremental discovery）", () => {

--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -40,6 +40,7 @@ import { bulkCheckPriceHistoryExistsToday, getJSTDate } from "../services/price-
 import { chunkArray } from "../shared/array-utils";
 import { withClearedUndefined } from "../shared/firestore-write";
 import * as logger from "../shared/logger";
+import { decodePubsubMode, type PubsubMessage } from "../shared/pubsub-utils";
 
 /**
  * SPR-229 Stage②: ティア差分によるdue-setフィルタの有効/無効フラグ。
@@ -50,35 +51,6 @@ import * as logger from "../shared/logger";
  */
 function isTierFilteringEnabled(): boolean {
 	return process.env.DLSITE_TIER_FILTERING_ENABLED !== "false";
-}
-
-/**
- * Pub/SubメッセージのPubsubMessage型定義（youtube.tsと同型）
- */
-interface PubsubMessage {
-	data?: string;
-	attributes?: Record<string, string>;
-}
-
-/**
- * SPR-229 Stage②: Pub/Subペイロードから`mode`を取り出す。
- * 週次フルスイープ（`mode==="weekly_full_sweep"`）かどうかの判定に使う。
- * デコード失敗時は安全側（通常のティア差分run）にフォールバックする。
- */
-function decodePubsubMode(message: PubsubMessage | undefined): string | undefined {
-	if (!message?.data) {
-		return undefined;
-	}
-	try {
-		const decoded = Buffer.from(message.data, "base64").toString("utf-8");
-		const parsed = JSON.parse(decoded) as { mode?: unknown };
-		return typeof parsed.mode === "string" ? parsed.mode : undefined;
-	} catch (err) {
-		logger.warn("Pub/Subペイロードのデコードに失敗（modeなしとして通常runを続行します）", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-		return undefined;
-	}
 }
 
 // 統合メタデータ保存用の定数

--- a/apps/functions/src/endpoints/youtube.ts
+++ b/apps/functions/src/endpoints/youtube.ts
@@ -299,11 +299,17 @@ async function resolveUploadsPlaylistId(
  * 既知のはずと判断してそのページで打ち切る（early-stop）。Firestoreが空の場合
  * （初回バックフィル）は全ページが「既知IDなし」と判定され続けるため、
  * 特別分岐なしで自然に全件取得になる。
+ *
+ * @returns `videoIds`（新着の動画ID）と、`MAX_DISCOVERY_PAGES`到達により本来まだ
+ *   後続ページが残っていた状態で打ち切られたかどうか（`truncated`）。レビュー指摘対応:
+ *   early-stop（既知IDに当たって正常に打ち切り）とページ上限による強制打ち切りを
+ *   区別しないと、チャンネル動画数が上限（20ページ=1,000件）を超えた際に
+ *   超過分の旧動画が「発見完了」扱いのまま恒久的に見つからなくなる。
  */
 async function fetchVideoIdsViaPlaylistIncremental(
 	youtube: youtube_v3.Youtube,
 	uploadsPlaylistId: string,
-): Promise<string[]> {
+): Promise<{ videoIds: string[]; truncated: boolean }> {
 	const newVideoIds: string[] = [];
 	let pageToken: string | undefined;
 	let page = 0;
@@ -311,7 +317,7 @@ async function fetchVideoIdsViaPlaylistIncremental(
 	do {
 		const page_ = await fetchUploadsPlaylistPage(youtube, uploadsPlaylistId, pageToken);
 		if (page_.videoIds.length === 0) {
-			break;
+			return { videoIds: newVideoIds, truncated: false };
 		}
 
 		const knownIds = await getKnownVideoIdsSet(page_.videoIds);
@@ -319,15 +325,23 @@ async function fetchVideoIdsViaPlaylistIncremental(
 		newVideoIds.push(...unknownInPage);
 
 		if (unknownInPage.length < page_.videoIds.length) {
-			// このページ内に既知IDが混ざっていた＝新着はここまで
-			break;
+			// このページ内に既知IDが混ざっていた＝新着はここまで（正常なearly-stop）
+			return { videoIds: newVideoIds, truncated: false };
 		}
 
 		pageToken = page_.nextPageToken;
 		page++;
 	} while (pageToken && page < MAX_DISCOVERY_PAGES);
 
-	return newVideoIds;
+	// ループを抜けた時点でpageTokenが残っている＝ページ上限による強制打ち切り
+	const truncated = Boolean(pageToken);
+	if (truncated) {
+		logger.warn(
+			`uploads playlistのページ上限(${MAX_DISCOVERY_PAGES})に達したため打ち切りました。後続ページが未処理のまま残っています`,
+			{ processedPages: page, newVideoIdsCount: newVideoIds.length },
+		);
+	}
+	return { videoIds: newVideoIds, truncated };
 }
 
 /**
@@ -409,8 +423,13 @@ async function fetchVideoIds(
 
 	if (mode === "playlist") {
 		const uploadsPlaylistId = await resolveUploadsPlaylistId(youtube, metadata);
-		const videoIds = await fetchVideoIdsViaPlaylistIncremental(youtube, uploadsPlaylistId);
-		return { videoIds, nextPageToken: undefined, isComplete: true };
+		const { videoIds, truncated } = await fetchVideoIdsViaPlaylistIncremental(
+			youtube,
+			uploadsPlaylistId,
+		);
+		// truncated=true（ページ上限による強制打ち切り）の場合はisComplete:falseとし、
+		// lastSuccessfulCompleteFetchを誤って更新しないようにする（レビュー指摘対応）。
+		return { videoIds, nextPageToken: undefined, isComplete: !truncated };
 	}
 
 	return fetchVideoIdsViaSearch(youtube, metadata);

--- a/apps/functions/src/endpoints/youtube.ts
+++ b/apps/functions/src/endpoints/youtube.ts
@@ -18,6 +18,7 @@ import {
 } from "../services/youtube/youtube-firestore";
 import { SUZUKA_MINASE_CHANNEL_ID } from "../shared/common";
 import * as logger from "../shared/logger";
+import { decodePubsubMode, type PubsubMessage } from "../shared/pubsub-utils";
 
 // メタデータ保存用のドキュメントID
 const METADATA_DOC_ID = "fetch_metadata";
@@ -39,6 +40,15 @@ interface FetchMetadata {
 	nextPageToken?: string;
 	isInProgress: boolean;
 	lastError?: string;
+	/**
+	 * 直近で「打ち切りなく完了した」run の時刻。
+	 * SPR-230レビュー指摘: discoveryモードによって保証の強さが異なる点に注意。
+	 * search経路（既定）ではチャンネル全カタログを最後まで走査できたことを意味するが、
+	 * playlist経路ではその run のincremental走査が`MAX_DISCOVERY_PAGES`上限に達さず
+	 * 終えられたこと（＝early-stopで正常終了、または上限に達さず全件終了）を意味するに
+	 * 留まる。定常運用では早期にearly-stopするため、「全カタログを検証済み」という
+	 * 意味では読めない（そこまでの保証が要る場合は週次フルスイープの`truncated`判定を見る）。
+	 */
 	lastSuccessfulCompleteFetch?: Timestamp;
 	/** SPR-230: uploads playlist ID（チャンネル固定のため一度取得したらキャッシュする） */
 	uploadsPlaylistId?: string;
@@ -67,35 +77,6 @@ function getDiscoveryMode(): "search" | "shadow" | "playlist" {
 interface FetchResult {
 	videoCount: number;
 	error?: string;
-}
-
-/**
- * Pub/SubメッセージのPubsubMessage型定義
- */
-interface PubsubMessage {
-	data?: string;
-	attributes?: Record<string, string>;
-}
-
-/**
- * SPR-230: Pub/Subペイロードから`mode`を取り出す（DLsite側`decodePubsubMode`と同型）。
- * 週次フルスイープ（`mode==="weekly_full_sweep"`）かどうかの判定に使う。
- * デコード失敗時は安全側（通常run）にフォールバックする。
- */
-function decodePubsubMode(message: PubsubMessage | undefined): string | undefined {
-	if (!message?.data) {
-		return undefined;
-	}
-	try {
-		const decoded = Buffer.from(message.data, "base64").toString("utf-8");
-		const parsed = JSON.parse(decoded) as { mode?: unknown };
-		return typeof parsed.mode === "string" ? parsed.mode : undefined;
-	} catch (err) {
-		logger.warn("Pub/Subペイロードのデコードに失敗（modeなしとして通常runを続行します）", {
-			error: err instanceof Error ? err.message : String(err),
-		});
-		return undefined;
-	}
 }
 
 /**
@@ -348,11 +329,16 @@ async function fetchVideoIdsViaPlaylistIncremental(
  * uploads playlistを（early-stopせず）全件ページングして動画IDを取得する
  *
  * SPR-230: shadowモードでの発見集合突合、および週次フルスイープの取りこぼし検知に使う。
+ *
+ * @returns `videoIds`と、`MAX_DISCOVERY_PAGES`到達により打ち切られたかどうか（`truncated`）。
+ *   レビュー指摘対応: `fetchVideoIdsViaPlaylistIncremental`と同じ理由で、打ち切りを
+ *   検知しないと、チャンネル動画数が上限を超えた際にこの関数を使う取りこぼし検知
+ *   （shadow比較・週次フルスイープ）自体が「未走査分をすべて取りこぼし」と誤検知し続ける。
  */
 async function fetchVideoIdsViaPlaylistFull(
 	youtube: youtube_v3.Youtube,
 	uploadsPlaylistId: string,
-): Promise<string[]> {
+): Promise<{ videoIds: string[]; truncated: boolean }> {
 	const allVideoIds: string[] = [];
 	let pageToken: string | undefined;
 	let page = 0;
@@ -364,25 +350,49 @@ async function fetchVideoIdsViaPlaylistFull(
 		page++;
 	} while (pageToken && page < MAX_DISCOVERY_PAGES);
 
-	return allVideoIds;
+	const truncated = Boolean(pageToken);
+	if (truncated) {
+		logger.warn(
+			`uploads playlist全件走査がページ上限(${MAX_DISCOVERY_PAGES})に達したため打ち切りました。取りこぼし検知の比較は不完全です`,
+			{ processedPages: page, videoIdsCount: allVideoIds.length },
+		);
+	}
+	return { videoIds: allVideoIds, truncated };
 }
 
 /**
  * SPR-230 shadowモード: uploads playlist全走査の発見集合とFirestoreの既知集合を比較し、
  * 対称差をログ出力する。比較自体が失敗しても本処理には影響させない（ログのみ・例外を投げない）。
+ *
+ * ページ上限で全走査自体が打ち切られた場合（`truncated`）、未走査分は「Firestoreにあるが
+ * playlist走査で見つからない」＝missing判定に必ず引っかかってしまい偽陽性になるため、
+ * その回はmissing判定をスキップする（レビュー指摘対応）。
  */
 async function logDiscoveryShadowComparison(
 	youtube: youtube_v3.Youtube,
 	uploadsPlaylistId: string,
 ): Promise<void> {
 	try {
-		const [playlistVideoIds, knownIds] = await Promise.all([
+		const [{ videoIds: playlistVideoIds, truncated }, knownIds] = await Promise.all([
 			fetchVideoIdsViaPlaylistFull(youtube, uploadsPlaylistId),
 			getAllVideoIds(),
 		]);
 		const playlistIdSet = new Set(playlistVideoIds);
-		const missingInPlaylist = [...knownIds].filter((id) => !playlistIdSet.has(id));
 		const extraInPlaylist = playlistVideoIds.filter((id) => !knownIds.has(id));
+
+		if (truncated) {
+			logger.warn(
+				"SPR-230 shadow: uploads playlist全走査がページ上限で打ち切られたため、今回はmissing判定をスキップします",
+				{
+					uploadsPlaylist走査件数: playlistVideoIds.length,
+					Firestore既知件数: knownIds.size,
+					uploadsPlaylistのみに存在する件数: extraInPlaylist.length,
+				},
+			);
+			return;
+		}
+
+		const missingInPlaylist = [...knownIds].filter((id) => !playlistIdSet.has(id));
 
 		if (missingInPlaylist.length === 0 && extraInPlaylist.length === 0) {
 			logger.info("SPR-230 shadow: discovery方式の発見集合が一致しました", {
@@ -514,7 +524,8 @@ function mapPlaylistTagsToVideos(
  *
  * discovery方式（uploads playlist経由）の取りこぼし検知のみが目的で、通常の動画詳細取得・
  * 保存フローは実行しない（統計取得のティア化はPhase③のスコープ外）。コストは
- * uploads playlist全走査（~11ページ=11 units）程度と軽量。
+ * uploads playlist全走査（現在の動画数~550件なら~11ページ=11 units、上限
+ * `MAX_DISCOVERY_PAGES`=20ページ=20 unitsまで）程度と軽量。
  */
 async function runWeeklyFullSweep(
 	youtube: youtube_v3.Youtube,

--- a/apps/functions/src/endpoints/youtube.ts
+++ b/apps/functions/src/endpoints/youtube.ts
@@ -5,11 +5,17 @@ import {
 	extractVideoIds,
 	fetchChannelPlaylists,
 	fetchPlaylistItems,
+	fetchUploadsPlaylistId,
+	fetchUploadsPlaylistPage,
 	fetchVideoDetails,
 	initializeYouTubeClient,
 	searchVideos,
 } from "../services/youtube/youtube-api";
-import { saveVideosToFirestore } from "../services/youtube/youtube-firestore";
+import {
+	getAllVideoIds,
+	getKnownVideoIdsSet,
+	saveVideosToFirestore,
+} from "../services/youtube/youtube-firestore";
 import { SUZUKA_MINASE_CHANNEL_ID } from "../shared/common";
 import * as logger from "../shared/logger";
 
@@ -20,8 +26,12 @@ const METADATA_DOC_ID = "fetch_metadata";
 const METADATA_COLLECTION = "youtubeMetadata";
 
 // 実行制限関連の定数
-const MAX_PAGES_PER_EXECUTION = 3; // 1回の実行での最大ページ数
+const MAX_PAGES_PER_EXECUTION = 3; // 1回の実行での最大ページ数（search.listベース経路用）
 const LOCK_TIMEOUT_MS = 30 * 60 * 1000; // ロックのタイムアウト（30分）
+
+// SPR-230: uploads playlistベースdiscoveryのページ数上限（1 unit/ページと安価なため緩め。
+// 初回バックフィル(~550件≈11ページ)を1runで完了できる余裕を持たせる）
+const MAX_DISCOVERY_PAGES = 20;
 
 // メタデータの型定義
 interface FetchMetadata {
@@ -30,6 +40,21 @@ interface FetchMetadata {
 	isInProgress: boolean;
 	lastError?: string;
 	lastSuccessfulCompleteFetch?: Timestamp;
+	/** SPR-230: uploads playlist ID（チャンネル固定のため一度取得したらキャッシュする） */
+	uploadsPlaylistId?: string;
+}
+
+/**
+ * SPR-230: discovery方式の切り替えフラグ。呼び出し時に都度`process.env`を読む
+ * （DLsiteの`isTierFilteringEnabled()`パターン踏襲・テストで環境変数を切り替えられるように）。
+ *
+ * - "search"（既定）: 現行のsearch.listベース（変更なし）
+ * - "shadow": search.list経路は維持しつつ、uploads playlist全走査との差分をログ出力のみ行う
+ * - "playlist": uploads playlistベースのincremental discoveryに完全移行
+ */
+function getDiscoveryMode(): "search" | "shadow" | "playlist" {
+	const raw = process.env.YOUTUBE_DISCOVERY_MODE;
+	return raw === "shadow" || raw === "playlist" ? raw : "search";
 }
 
 /**
@@ -50,6 +75,27 @@ interface FetchResult {
 interface PubsubMessage {
 	data?: string;
 	attributes?: Record<string, string>;
+}
+
+/**
+ * SPR-230: Pub/Subペイロードから`mode`を取り出す（DLsite側`decodePubsubMode`と同型）。
+ * 週次フルスイープ（`mode==="weekly_full_sweep"`）かどうかの判定に使う。
+ * デコード失敗時は安全側（通常run）にフォールバックする。
+ */
+function decodePubsubMode(message: PubsubMessage | undefined): string | undefined {
+	if (!message?.data) {
+		return undefined;
+	}
+	try {
+		const decoded = Buffer.from(message.data, "base64").toString("utf-8");
+		const parsed = JSON.parse(decoded) as { mode?: unknown };
+		return typeof parsed.mode === "string" ? parsed.mode : undefined;
+	} catch (err) {
+		logger.warn("Pub/Subペイロードのデコードに失敗（modeなしとして通常runを続行します）", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return undefined;
+	}
 }
 
 /**
@@ -143,13 +189,13 @@ async function prepareExecution(): Promise<[FetchMetadata | undefined, FetchResu
 }
 
 /**
- * YouTube動画IDを検索して取得
+ * YouTube動画IDをsearch.list経由で検索して取得（現行方式・SPR-230移行前の既存ロジック）
  *
  * @param youtube - YouTube APIクライアント
  * @param metadata - 取得済みのメタデータ
  * @returns Promise<{videoIds: string[], nextPageToken: string | undefined, isComplete: boolean}> - 取得した動画IDと関連情報
  */
-async function fetchVideoIds(
+async function fetchVideoIdsViaSearch(
 	youtube: youtube_v3.Youtube,
 	metadata: FetchMetadata,
 ): Promise<{
@@ -220,6 +266,154 @@ async function fetchVideoIds(
 	}
 
 	return { videoIds: allVideoIds, nextPageToken, isComplete };
+}
+
+/**
+ * uploads playlist IDを解決する（メタデータにキャッシュ済みならそれを使い、無ければ取得して保存）
+ *
+ * SPR-230: 対象は`SUZUKA_MINASE_CHANNEL_ID`固定チャンネルで、uploads playlist IDは
+ * 実質不変のため、一度取得すればメタデータ経由で以後の呼び出しコストはゼロになる。
+ */
+async function resolveUploadsPlaylistId(
+	youtube: youtube_v3.Youtube,
+	metadata: FetchMetadata,
+): Promise<string> {
+	if (metadata.uploadsPlaylistId) {
+		return metadata.uploadsPlaylistId;
+	}
+
+	const uploadsPlaylistId = await fetchUploadsPlaylistId(youtube, SUZUKA_MINASE_CHANNEL_ID);
+	if (!uploadsPlaylistId) {
+		throw new Error("uploads playlist IDの取得に失敗しました");
+	}
+
+	await updateMetadata({ uploadsPlaylistId });
+	return uploadsPlaylistId;
+}
+
+/**
+ * uploads playlistを新着順にページングし、Firestoreに未登録の（＝新着の）動画IDだけを返す
+ *
+ * SPR-230 Phase②: uploads playlistは新着順（reverse-chronological）なので、
+ * ページ内に1件でも既知IDがあれば、それより後ろ（時系列的に古い動画）はすべて
+ * 既知のはずと判断してそのページで打ち切る（early-stop）。Firestoreが空の場合
+ * （初回バックフィル）は全ページが「既知IDなし」と判定され続けるため、
+ * 特別分岐なしで自然に全件取得になる。
+ */
+async function fetchVideoIdsViaPlaylistIncremental(
+	youtube: youtube_v3.Youtube,
+	uploadsPlaylistId: string,
+): Promise<string[]> {
+	const newVideoIds: string[] = [];
+	let pageToken: string | undefined;
+	let page = 0;
+
+	do {
+		const page_ = await fetchUploadsPlaylistPage(youtube, uploadsPlaylistId, pageToken);
+		if (page_.videoIds.length === 0) {
+			break;
+		}
+
+		const knownIds = await getKnownVideoIdsSet(page_.videoIds);
+		const unknownInPage = page_.videoIds.filter((id) => !knownIds.has(id));
+		newVideoIds.push(...unknownInPage);
+
+		if (unknownInPage.length < page_.videoIds.length) {
+			// このページ内に既知IDが混ざっていた＝新着はここまで
+			break;
+		}
+
+		pageToken = page_.nextPageToken;
+		page++;
+	} while (pageToken && page < MAX_DISCOVERY_PAGES);
+
+	return newVideoIds;
+}
+
+/**
+ * uploads playlistを（early-stopせず）全件ページングして動画IDを取得する
+ *
+ * SPR-230: shadowモードでの発見集合突合、および週次フルスイープの取りこぼし検知に使う。
+ */
+async function fetchVideoIdsViaPlaylistFull(
+	youtube: youtube_v3.Youtube,
+	uploadsPlaylistId: string,
+): Promise<string[]> {
+	const allVideoIds: string[] = [];
+	let pageToken: string | undefined;
+	let page = 0;
+
+	do {
+		const result = await fetchUploadsPlaylistPage(youtube, uploadsPlaylistId, pageToken);
+		allVideoIds.push(...result.videoIds);
+		pageToken = result.nextPageToken;
+		page++;
+	} while (pageToken && page < MAX_DISCOVERY_PAGES);
+
+	return allVideoIds;
+}
+
+/**
+ * SPR-230 shadowモード: uploads playlist全走査の発見集合とFirestoreの既知集合を比較し、
+ * 対称差をログ出力する。比較自体が失敗しても本処理には影響させない（ログのみ・例外を投げない）。
+ */
+async function logDiscoveryShadowComparison(
+	youtube: youtube_v3.Youtube,
+	uploadsPlaylistId: string,
+): Promise<void> {
+	try {
+		const [playlistVideoIds, knownIds] = await Promise.all([
+			fetchVideoIdsViaPlaylistFull(youtube, uploadsPlaylistId),
+			getAllVideoIds(),
+		]);
+		const playlistIdSet = new Set(playlistVideoIds);
+		const missingInPlaylist = [...knownIds].filter((id) => !playlistIdSet.has(id));
+		const extraInPlaylist = playlistVideoIds.filter((id) => !knownIds.has(id));
+
+		if (missingInPlaylist.length === 0 && extraInPlaylist.length === 0) {
+			logger.info("SPR-230 shadow: discovery方式の発見集合が一致しました", {
+				uploadsPlaylist件数: playlistVideoIds.length,
+				Firestore既知件数: knownIds.size,
+			});
+		} else {
+			logger.warn("SPR-230 shadow: discovery方式の発見集合に差分があります", {
+				uploadsPlaylistに無いFirestore既知件数: missingInPlaylist.length,
+				uploadsPlaylistのみに存在する件数: extraInPlaylist.length,
+				missingSample: missingInPlaylist.slice(0, 10),
+				extraSample: extraInPlaylist.slice(0, 10),
+			});
+		}
+	} catch (error) {
+		logger.warn("SPR-230 shadow: discovery方式の比較に失敗しました（本処理には影響しません）", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+/**
+ * YouTube動画IDを取得する（discoveryモードに応じて経路を切り替える）
+ *
+ * - "search"/"shadow": 既存のsearch.listベース経路（挙動を変えない）。"shadow"のみ
+ *   後続で`logDiscoveryShadowComparison`による比較ログを追加で行う。
+ * - "playlist": uploads playlistベースのincremental discoveryに完全移行
+ */
+async function fetchVideoIds(
+	youtube: youtube_v3.Youtube,
+	metadata: FetchMetadata,
+): Promise<{
+	videoIds: string[];
+	nextPageToken: string | undefined;
+	isComplete: boolean;
+}> {
+	const mode = getDiscoveryMode();
+
+	if (mode === "playlist") {
+		const uploadsPlaylistId = await resolveUploadsPlaylistId(youtube, metadata);
+		const videoIds = await fetchVideoIdsViaPlaylistIncremental(youtube, uploadsPlaylistId);
+		return { videoIds, nextPageToken: undefined, isComplete: true };
+	}
+
+	return fetchVideoIdsViaSearch(youtube, metadata);
 }
 
 // 注：動画詳細取得機能はutils/youtube-apiから利用
@@ -297,11 +491,111 @@ function mapPlaylistTagsToVideos(
 }
 
 /**
+ * SPR-230: 週次フルスイープ（early-stopなし全ページ走査＋Firestore既知IDとの突合）
+ *
+ * discovery方式（uploads playlist経由）の取りこぼし検知のみが目的で、通常の動画詳細取得・
+ * 保存フローは実行しない（統計取得のティア化はPhase③のスコープ外）。コストは
+ * uploads playlist全走査（~11ページ=11 units）程度と軽量。
+ */
+async function runWeeklyFullSweep(
+	youtube: youtube_v3.Youtube,
+	metadata: FetchMetadata,
+): Promise<FetchResult> {
+	try {
+		logger.info(
+			"週次フルスイープを開始します（discovery取りこぼし検知のみ、動画詳細取得は行いません）",
+		);
+		const uploadsPlaylistId = await resolveUploadsPlaylistId(youtube, metadata);
+		await logDiscoveryShadowComparison(youtube, uploadsPlaylistId);
+		await updateMetadata({ isInProgress: false, lastError: undefined });
+		logger.info("週次フルスイープが完了しました");
+		return { videoCount: 0 };
+	} catch (error: unknown) {
+		logger.error("週次フルスイープでエラーが発生しました:", error);
+		await updateMetadata({
+			isInProgress: false,
+			lastError: error instanceof Error ? error.message : String(error),
+		});
+		return {
+			videoCount: 0,
+			error: error instanceof Error ? error.message : "不明なエラーが発生しました",
+		};
+	}
+}
+
+/**
+ * 通常の動画ID取得〜詳細取得〜Firestore保存フロー（旧`fetchYouTubeVideosLogic`本体・SPR-230で分離）
+ */
+async function runNormalFetchAndSave(
+	youtube: youtube_v3.Youtube,
+	metadata: FetchMetadata,
+): Promise<FetchResult> {
+	// 3. 動画IDの取得
+	logger.info(`チャンネル ${SUZUKA_MINASE_CHANNEL_ID} の動画情報取得を開始します`);
+	const { videoIds, nextPageToken, isComplete } = await fetchVideoIds(youtube, metadata);
+
+	// SPR-230: shadowモードは発見結果に関わらず毎run比較する（0件run＝定常状態こそ
+	// 両方式が一致すべき基準ケースのため、videoIds空チェックの前に実行する）。
+	// search.list経路の挙動・保存結果には影響させない、比較専用。
+	if (getDiscoveryMode() === "shadow") {
+		try {
+			const uploadsPlaylistId = await resolveUploadsPlaylistId(youtube, metadata);
+			await logDiscoveryShadowComparison(youtube, uploadsPlaylistId);
+		} catch (error) {
+			logger.warn(
+				"SPR-230 shadow: uploads playlist ID解決に失敗しました（本処理には影響しません）",
+				{ error: error instanceof Error ? error.message : String(error) },
+			);
+		}
+	}
+
+	logger.info(`取得した動画ID合計: ${videoIds.length}件`);
+	if (videoIds.length === 0) {
+		logger.info("チャンネルに動画が見つかりませんでした");
+		await updateMetadata({ isInProgress: false });
+		return { videoCount: 0 };
+	}
+
+	// 4. プレイリスト情報の取得
+	logger.info("プレイリスト情報を取得中...");
+	const playlistVideoMap = await buildPlaylistVideoMapping(youtube, SUZUKA_MINASE_CHANNEL_ID);
+
+	// 5. 動画の詳細情報取得
+	const videoDetails = await fetchVideoDetails(youtube, videoIds);
+
+	// 6. プレイリストタグを動画にマッピング
+	const videosWithPlaylistTags = mapPlaylistTagsToVideos(videoDetails, playlistVideoMap);
+
+	// 7. Firestoreにデータ保存
+	const savedCount = await saveVideosToFirestore(videosWithPlaylistTags);
+
+	// 8. メタデータを更新
+	if (isComplete) {
+		await updateMetadata({
+			nextPageToken: undefined,
+			lastSuccessfulCompleteFetch: Timestamp.now(),
+		});
+	} else if (nextPageToken) {
+		// 明示的にnextPageTokenを使用（既にfetchVideoIds内で保存されているが、変数使用のため記述）
+		logger.debug(`次回の実行のためにページトークンを保存: ${nextPageToken}`);
+	}
+
+	// 9. 処理完了を記録
+	await updateMetadata({
+		isInProgress: false,
+		lastError: undefined,
+	});
+
+	return { videoCount: savedCount };
+}
+
+/**
  * YouTube動画情報取得の共通処理
  *
+ * @param isWeeklyFullSweep SPR-230: 週次フルスイープ実行時true（discovery取りこぼし検知のみ行う）
  * @returns Promise<FetchResult> - 処理結果
  */
-async function fetchYouTubeVideosLogic(): Promise<FetchResult> {
+async function fetchYouTubeVideosLogic(isWeeklyFullSweep = false): Promise<FetchResult> {
 	try {
 		// 1. YouTube APIクライアントの初期化
 		const [youtube, initError] = initializeYouTubeClient();
@@ -324,48 +618,11 @@ async function fetchYouTubeVideosLogic(): Promise<FetchResult> {
 			return { videoCount: 0, error: "メタデータの準備に失敗しました" };
 		}
 
-		// 3. 動画IDの取得
-		logger.info(`チャンネル ${SUZUKA_MINASE_CHANNEL_ID} の動画情報取得を開始します`);
-		const { videoIds, nextPageToken, isComplete } = await fetchVideoIds(youtube, metadata);
-
-		logger.info(`取得した動画ID合計: ${videoIds.length}件`);
-		if (videoIds.length === 0) {
-			logger.info("チャンネルに動画が見つかりませんでした");
-			await updateMetadata({ isInProgress: false });
-			return { videoCount: 0 };
+		if (isWeeklyFullSweep) {
+			return await runWeeklyFullSweep(youtube, metadata);
 		}
 
-		// 4. プレイリスト情報の取得
-		logger.info("プレイリスト情報を取得中...");
-		const playlistVideoMap = await buildPlaylistVideoMapping(youtube, SUZUKA_MINASE_CHANNEL_ID);
-
-		// 5. 動画の詳細情報取得
-		const videoDetails = await fetchVideoDetails(youtube, videoIds);
-
-		// 6. プレイリストタグを動画にマッピング
-		const videosWithPlaylistTags = mapPlaylistTagsToVideos(videoDetails, playlistVideoMap);
-
-		// 7. Firestoreにデータ保存
-		const savedCount = await saveVideosToFirestore(videosWithPlaylistTags);
-
-		// 8. メタデータを更新
-		if (isComplete) {
-			await updateMetadata({
-				nextPageToken: undefined,
-				lastSuccessfulCompleteFetch: Timestamp.now(),
-			});
-		} else if (nextPageToken) {
-			// 明示的にnextPageTokenを使用（既にfetchVideoIds内で保存されているが、変数使用のため記述）
-			logger.debug(`次回の実行のためにページトークンを保存: ${nextPageToken}`);
-		}
-
-		// 9. 処理完了を記録
-		await updateMetadata({
-			isInProgress: false,
-			lastError: undefined,
-		});
-
-		return { videoCount: savedCount };
+		return await runNormalFetchAndSave(youtube, metadata);
 	} catch (error: unknown) {
 		// エラー発生時はログ出力して処理終了
 		logger.error("YouTube動画情報取得中にエラーが発生しました:", error);
@@ -425,8 +682,15 @@ export const fetchYouTubeVideos = async (event: CloudEvent<PubsubMessage>): Prom
 			}
 		}
 
+		// SPR-230: ペイロードのmodeを確認し、週次フルスイープかどうかを判定する
+		const mode = decodePubsubMode(message);
+		const isWeeklyFullSweep = mode === "weekly_full_sweep";
+		if (isWeeklyFullSweep) {
+			logger.info("週次フルスイープトリガーを検出しました");
+		}
+
 		// 共通のロジックを実行
-		const result = await fetchYouTubeVideosLogic();
+		const result = await fetchYouTubeVideosLogic(isWeeklyFullSweep);
 
 		if (result.error) {
 			logger.warn(`YouTube動画取得処理でエラーが発生しました: ${result.error}`);

--- a/apps/functions/src/infrastructure/monitoring/youtube-quota-monitor.ts
+++ b/apps/functions/src/infrastructure/monitoring/youtube-quota-monitor.ts
@@ -32,6 +32,9 @@ export const QUOTA_COSTS = {
 	// プレイリスト関連（3層タグシステム用）
 	playlists: 1, // playlists.list API
 	playlistItems: 1, // playlistItems.list API
+
+	// チャンネル情報取得（SPR-230: uploads playlist ID解決用）
+	channels: 1, // channels.list API
 } as const;
 
 /**

--- a/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
@@ -22,6 +22,8 @@ vi.mock("../../../shared/logger", () => ({
 import {
 	fetchChannelPlaylists,
 	fetchPlaylistItems,
+	fetchUploadsPlaylistId,
+	fetchUploadsPlaylistPage,
 	fetchVideoDetails,
 	searchVideos,
 } from "../youtube-api";
@@ -31,6 +33,7 @@ const makeClient = () => ({
 	videos: { list: vi.fn() },
 	playlists: { list: vi.fn() },
 	playlistItems: { list: vi.fn() },
+	channels: { list: vi.fn() },
 });
 const asYoutube = (c: ReturnType<typeof makeClient>) => c as unknown as youtube_v3.Youtube;
 
@@ -136,5 +139,74 @@ describe("fetchPlaylistItems", () => {
 		const c = makeClient();
 		c.playlistItems.list.mockRejectedValue(new Error("items fail"));
 		expect(await fetchPlaylistItems(asYoutube(c), "pl")).toEqual([]);
+	});
+});
+
+describe("fetchUploadsPlaylistId", () => {
+	it("クォータ不足は例外", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		await expect(fetchUploadsPlaylistId(asYoutube(makeClient()), "ch")).rejects.toThrow("クォータ");
+	});
+
+	it("uploads playlist IDを返す", async () => {
+		const c = makeClient();
+		c.channels.list.mockResolvedValue({
+			data: { items: [{ contentDetails: { relatedPlaylists: { uploads: "UUxxxx" } } }] },
+		});
+		const r = await fetchUploadsPlaylistId(asYoutube(c), "ch");
+		expect(r).toBe("UUxxxx");
+		expect(recordQuotaUsage).toHaveBeenCalledWith("channels");
+	});
+
+	it("items無し・uploads無しはundefined", async () => {
+		const c = makeClient();
+		c.channels.list.mockResolvedValue({ data: {} });
+		expect(await fetchUploadsPlaylistId(asYoutube(c), "ch")).toBeUndefined();
+	});
+
+	it("API エラーは再throw", async () => {
+		const c = makeClient();
+		c.channels.list.mockRejectedValue(new Error("channels fail"));
+		await expect(fetchUploadsPlaylistId(asYoutube(c), "ch")).rejects.toThrow("channels fail");
+	});
+});
+
+describe("fetchUploadsPlaylistPage", () => {
+	it("クォータ不足は例外", async () => {
+		canExecuteOperation.mockReturnValue(false);
+		await expect(fetchUploadsPlaylistPage(asYoutube(makeClient()), "UUxxxx")).rejects.toThrow(
+			"クォータ",
+		);
+	});
+
+	it("1ページ分のvideoIdとnextPageTokenを返す（空videoIdは除外）", async () => {
+		const c = makeClient();
+		c.playlistItems.list.mockResolvedValue({
+			data: {
+				items: [{ contentDetails: { videoId: "a" } }, { contentDetails: {} }],
+				nextPageToken: "n1",
+			},
+		});
+		const r = await fetchUploadsPlaylistPage(asYoutube(c), "UUxxxx");
+		expect(r).toEqual({ videoIds: ["a"], nextPageToken: "n1" });
+		expect(c.playlistItems.list).toHaveBeenCalledWith(
+			expect.objectContaining({ playlistId: "UUxxxx", pageToken: undefined }),
+		);
+		expect(recordQuotaUsage).toHaveBeenCalledWith("playlistItems");
+	});
+
+	it("items無しは空配列", async () => {
+		const c = makeClient();
+		c.playlistItems.list.mockResolvedValue({ data: {} });
+		expect(await fetchUploadsPlaylistPage(asYoutube(c), "UUxxxx")).toEqual({
+			videoIds: [],
+			nextPageToken: undefined,
+		});
+	});
+
+	it("API エラーは再throw", async () => {
+		const c = makeClient();
+		c.playlistItems.list.mockRejectedValue(new Error("page fail"));
+		await expect(fetchUploadsPlaylistPage(asYoutube(c), "UUxxxx")).rejects.toThrow("page fail");
 	});
 });

--- a/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
@@ -9,10 +9,12 @@ import { SUZUKA_MINASE_CHANNEL_ID } from "../../../shared/common";
 const mockBatchSet = vi.fn();
 const mockBatchCommit = vi.fn().mockResolvedValue(undefined);
 const mockDoc = vi.fn((id: string) => ({ id }));
+const mockGetAll = vi.fn();
 vi.mock("../../../infrastructure/database/firestore", () => ({
 	default: {
 		collection: vi.fn(() => ({ doc: mockDoc })),
 		batch: vi.fn(() => ({ set: mockBatchSet, commit: mockBatchCommit })),
+		getAll: (...refs: unknown[]) => mockGetAll(...refs),
 	},
 }));
 
@@ -32,7 +34,7 @@ vi.mock("../../mappers/video-mapper", () => ({
 	},
 }));
 
-import { saveVideosToFirestore } from "../youtube-firestore";
+import { getKnownVideoIdsSet, saveVideosToFirestore } from "../youtube-firestore";
 
 // videoToFirestore（実物）が受け付ける最小の VideoPlainObject
 const plainObject = (id = "v1") =>
@@ -94,5 +96,37 @@ describe("saveVideosToFirestore", () => {
 		mockBatchCommit.mockRejectedValue(new Error("commit fail"));
 		const result = await saveVideosToFirestore([ytVideo({ id: "v1" })]);
 		expect(result).toBe(0);
+	});
+});
+
+describe("getKnownVideoIdsSet", () => {
+	it("空配列はgetAllを呼ばず空集合を返す", async () => {
+		const result = await getKnownVideoIdsSet([]);
+		expect(result.size).toBe(0);
+		expect(mockGetAll).not.toHaveBeenCalled();
+	});
+
+	it("既存ドキュメントのIDのみを集合に含める", async () => {
+		mockGetAll.mockResolvedValue([
+			{ id: "v1", exists: true },
+			{ id: "v2", exists: false },
+			{ id: "v3", exists: true },
+		]);
+
+		const result = await getKnownVideoIdsSet(["v1", "v2", "v3"]);
+
+		expect(result).toEqual(new Set(["v1", "v3"]));
+	});
+
+	it("300件超は複数チャンクに分割してgetAllを呼ぶ", async () => {
+		const videoIds = Array.from({ length: 350 }, (_, i) => `v${i}`);
+		mockGetAll.mockImplementation(async (...refs: { id: string }[]) =>
+			refs.map((ref) => ({ id: ref.id, exists: true })),
+		);
+
+		const result = await getKnownVideoIdsSet(videoIds);
+
+		expect(mockGetAll).toHaveBeenCalledTimes(2);
+		expect(result.size).toBe(350);
 	});
 });

--- a/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
@@ -10,9 +10,13 @@ const mockBatchSet = vi.fn();
 const mockBatchCommit = vi.fn().mockResolvedValue(undefined);
 const mockDoc = vi.fn((id: string) => ({ id }));
 const mockGetAll = vi.fn();
+const mockSelectGet = vi.fn();
 vi.mock("../../../infrastructure/database/firestore", () => ({
 	default: {
-		collection: vi.fn(() => ({ doc: mockDoc })),
+		collection: vi.fn(() => ({
+			doc: mockDoc,
+			select: vi.fn(() => ({ get: mockSelectGet })),
+		})),
 		batch: vi.fn(() => ({ set: mockBatchSet, commit: mockBatchCommit })),
 		getAll: (...refs: unknown[]) => mockGetAll(...refs),
 	},
@@ -34,7 +38,7 @@ vi.mock("../../mappers/video-mapper", () => ({
 	},
 }));
 
-import { getKnownVideoIdsSet, saveVideosToFirestore } from "../youtube-firestore";
+import { getAllVideoIds, getKnownVideoIdsSet, saveVideosToFirestore } from "../youtube-firestore";
 
 // videoToFirestore（実物）が受け付ける最小の VideoPlainObject
 const plainObject = (id = "v1") =>
@@ -128,5 +132,25 @@ describe("getKnownVideoIdsSet", () => {
 
 		expect(mockGetAll).toHaveBeenCalledTimes(2);
 		expect(result.size).toBe(350);
+	});
+});
+
+describe("getAllVideoIds", () => {
+	it("videosコレクション全件のIDを集合として返す", async () => {
+		mockSelectGet.mockResolvedValue({
+			docs: [{ id: "v1" }, { id: "v2" }, { id: "v3" }],
+		});
+
+		const result = await getAllVideoIds();
+
+		expect(result).toEqual(new Set(["v1", "v2", "v3"]));
+	});
+
+	it("コレクションが空の場合は空集合を返す", async () => {
+		mockSelectGet.mockResolvedValue({ docs: [] });
+
+		const result = await getAllVideoIds();
+
+		expect(result.size).toBe(0);
 	});
 });

--- a/apps/functions/src/services/youtube/youtube-api.ts
+++ b/apps/functions/src/services/youtube/youtube-api.ts
@@ -248,6 +248,99 @@ export async function fetchChannelPlaylists(
 }
 
 /**
+ * チャンネルのuploads playlist ID（アップロード済み動画を新着順に並べたプレイリスト）を取得する
+ *
+ * SPR-230: discoveryを`search.list`(100 units)から`playlistItems.list`(1 unit)へ
+ * 置換するための前段。`UC…`→`UU…`という非公式な文字列変換には頼らず、
+ * `channels.list`で正規に取得する（One-Way Door変更のため検証可能性を優先）。
+ *
+ * @param youtube - YouTube APIクライアント
+ * @param channelId - チャンネルID
+ * @returns uploads playlist ID（取得できなければundefined）
+ */
+export async function fetchUploadsPlaylistId(
+	youtube: youtube_v3.Youtube,
+	channelId: string,
+): Promise<string | undefined> {
+	if (!canExecuteOperation("channels")) {
+		throw new Error("YouTube APIクォータが不足しています");
+	}
+
+	try {
+		const response = await youtube.channels.list({
+			part: ["contentDetails"],
+			id: [channelId],
+		});
+
+		recordQuotaUsage("channels");
+		getYouTubeQuotaMonitor().logQuotaUsage("channels", 1, { channelId });
+
+		const uploadsPlaylistId =
+			response.data.items?.[0]?.contentDetails?.relatedPlaylists?.uploads ?? undefined;
+
+		if (!uploadsPlaylistId) {
+			logger.warn("uploads playlist IDの取得に失敗しました", { channelId });
+		}
+
+		return uploadsPlaylistId;
+	} catch (error: unknown) {
+		logger.error("チャンネル情報取得エラー:", error);
+		throw error;
+	}
+}
+
+/**
+ * uploads playlistの動画IDを1ページ分取得する（discovery専用）
+ *
+ * uploads playlistは新着順（reverse-chronological）に並んでいるため、
+ * 呼び出し側でこれをページングして「既知videoIdに当たったら停止」する
+ * incremental discoveryに使う。プレイリストタグ付け用の`fetchPlaylistItems`
+ * （全件走査・タグ付け目的）とは責務が異なるため専用関数として分離している。
+ *
+ * @param youtube - YouTube APIクライアント
+ * @param uploadsPlaylistId - uploads playlist ID
+ * @param pageToken - 継続ページトークン
+ * @returns このページの動画ID（新着順）と次ページトークン
+ */
+export async function fetchUploadsPlaylistPage(
+	youtube: youtube_v3.Youtube,
+	uploadsPlaylistId: string,
+	pageToken?: string,
+): Promise<{ videoIds: string[]; nextPageToken?: string }> {
+	if (!canExecuteOperation("playlistItems")) {
+		throw new Error("YouTube APIクォータが不足しています");
+	}
+
+	try {
+		const response = await youtube.playlistItems.list({
+			part: ["contentDetails"],
+			playlistId: uploadsPlaylistId,
+			maxResults: MAX_VIDEOS_PER_BATCH,
+			pageToken,
+		});
+
+		recordQuotaUsage("playlistItems");
+		getYouTubeQuotaMonitor().logQuotaUsage("playlistItems", 1, {
+			uploadsPlaylistId,
+			pageToken: pageToken || "none",
+			resultCount: response.data.items?.length || 0,
+		});
+
+		const videoIds = (response.data.items || [])
+			.map((item) => item.contentDetails?.videoId)
+			.filter((id): id is string => typeof id === "string" && id.length > 0);
+
+		return {
+			videoIds,
+			nextPageToken: response.data.nextPageToken ?? undefined,
+		};
+	} catch (error: unknown) {
+		logger.error("uploads playlistアイテム取得エラー:", error);
+		throw error;
+	}
+}
+
+/**
  * プレイリストの動画一覧を取得
  * 既存のページネーション処理パターンを活用
  *

--- a/apps/functions/src/services/youtube/youtube-firestore.ts
+++ b/apps/functions/src/services/youtube/youtube-firestore.ts
@@ -16,6 +16,60 @@ import { VideoMapper } from "../mappers/video-mapper";
 const VIDEOS_COLLECTION = "videos";
 const MAX_FIRESTORE_BATCH_SIZE = 500; // Firestoreのバッチ書き込み上限
 
+/** videoIdバルク存在確認（getAll）を分割するチャンクサイズ */
+const KNOWN_VIDEO_IDS_CHUNK_SIZE = 300;
+
+/**
+ * 指定した動画IDのうち、Firestoreに既に存在する（=既知の）IDの集合を返す
+ *
+ * SPR-230: uploads playlistは新着順なので、ページ内の動画IDがこの集合に
+ * 含まれていれば「既に発見済みの旧動画」と判定できる（incremental discoveryの
+ * early-stop判定に使う）。`videos`コレクションはdoc ID=video.idのため、
+ * DLsiteの`getExistingWorksMap`（productIdフィールドでの`in`クエリ）と違い
+ * `firestore.getAll(...refs)`によるバルク直接取得がそのまま使える。
+ *
+ * @param videoIds 確認対象の動画ID
+ * @returns 既にFirestoreに存在する動画IDの集合
+ */
+export async function getKnownVideoIdsSet(videoIds: string[]): Promise<Set<string>> {
+	const knownIds = new Set<string>();
+	if (videoIds.length === 0) {
+		return knownIds;
+	}
+
+	const refs = videoIds.map((id) => firestore.collection(VIDEOS_COLLECTION).doc(id));
+	const chunks: FirebaseFirestore.DocumentReference[][] = [];
+	for (let i = 0; i < refs.length; i += KNOWN_VIDEO_IDS_CHUNK_SIZE) {
+		chunks.push(refs.slice(i, i + KNOWN_VIDEO_IDS_CHUNK_SIZE));
+	}
+
+	const chunkResults = await Promise.all(chunks.map((chunk) => firestore.getAll(...chunk)));
+
+	for (const docs of chunkResults) {
+		for (const doc of docs) {
+			if (doc.exists) {
+				knownIds.add(doc.id);
+			}
+		}
+	}
+
+	return knownIds;
+}
+
+/**
+ * Firestoreに保存されている全動画IDの集合を返す（`videos`コレクション全件のID一覧）
+ *
+ * SPR-230: 週次フルスイープでの取りこぼし検知（uploads playlist全走査で見つからなかった
+ * 既知動画IDが無いか）に使う。`select()`でフィールド取得を省きID一覧のみを取得することで
+ * 読み取りコストを抑える。対象は~550件程度の小規模コレクションのため全件取得で十分。
+ *
+ * @returns Firestoreに存在する全動画IDの集合
+ */
+export async function getAllVideoIds(): Promise<Set<string>> {
+	const snapshot = await firestore.collection(VIDEOS_COLLECTION).select().get();
+	return new Set(snapshot.docs.map((doc) => doc.id));
+}
+
 /**
  * Entity 形式でYouTube動画をFirestoreに保存
  *

--- a/apps/functions/src/services/youtube/youtube-firestore.ts
+++ b/apps/functions/src/services/youtube/youtube-firestore.ts
@@ -8,6 +8,7 @@
 import { videoToFirestore } from "@suzumina.click/shared-types";
 import type { youtube_v3 } from "googleapis";
 import firestore from "../../infrastructure/database/firestore";
+import { chunkArray } from "../../shared/array-utils";
 import { SUZUKA_MINASE_CHANNEL_ID } from "../../shared/common";
 import * as logger from "../../shared/logger";
 import { VideoMapper } from "../mappers/video-mapper";
@@ -38,10 +39,7 @@ export async function getKnownVideoIdsSet(videoIds: string[]): Promise<Set<strin
 	}
 
 	const refs = videoIds.map((id) => firestore.collection(VIDEOS_COLLECTION).doc(id));
-	const chunks: FirebaseFirestore.DocumentReference[][] = [];
-	for (let i = 0; i < refs.length; i += KNOWN_VIDEO_IDS_CHUNK_SIZE) {
-		chunks.push(refs.slice(i, i + KNOWN_VIDEO_IDS_CHUNK_SIZE));
-	}
+	const chunks = chunkArray(refs, KNOWN_VIDEO_IDS_CHUNK_SIZE);
 
 	const chunkResults = await Promise.all(chunks.map((chunk) => firestore.getAll(...chunk)));
 

--- a/apps/functions/src/shared/pubsub-utils.ts
+++ b/apps/functions/src/shared/pubsub-utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Pub/Subペイロードの`mode`デコードユーティリティ
+ *
+ * DLsite（`fetchDLsiteUnifiedData`）とYouTube（`fetchYouTubeVideos`）双方の
+ * Cloud Schedulerトリガーが、同一関数・同一トピックを週次フルスイープ等の
+ * 別モードで起動するために使う共通パターン（レビュー指摘: 元は2ファイルに
+ * 同一実装が複製されていた）。
+ */
+
+import * as logger from "./logger";
+
+/**
+ * Pub/SubメッセージのPubsubMessage型定義
+ */
+export interface PubsubMessage {
+	data?: string;
+	attributes?: Record<string, string>;
+}
+
+/**
+ * Pub/Subペイロードから`mode`を取り出す。
+ * デコード失敗時は安全側（modeなし＝通常run）にフォールバックする。
+ */
+export function decodePubsubMode(message: PubsubMessage | undefined): string | undefined {
+	if (!message?.data) {
+		return undefined;
+	}
+	try {
+		const decoded = Buffer.from(message.data, "base64").toString("utf-8");
+		const parsed = JSON.parse(decoded) as { mode?: unknown };
+		return typeof parsed.mode === "string" ? parsed.mode : undefined;
+	} catch (err) {
+		logger.warn("Pub/Subペイロードのデコードに失敗（modeなしとして通常runを続行します）", {
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return undefined;
+	}
+}

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -27,6 +27,34 @@ resource "google_cloud_scheduler_job" "fetch_youtube_videos_hourly" {
   ]
 }
 
+# SPR-230: discovery方式（uploads playlist経由）の取りこぼし検知を兼ねた週次フルスイープ
+# 通常runの毎時30分・DLsiteの週次フルスイープ（土曜4:15 JST）と重ならない
+# 日曜4:00 JSTに設定。既存関数・既存topicを再利用し、mode違いのペイロードで
+# early-stopなしの全ページ走査＋Firestore既知IDとの突合を発火させる（新規関数は増やさない）。
+resource "google_cloud_scheduler_job" "fetch_youtube_videos_weekly_full_sweep" {
+  project     = var.gcp_project_id
+  region      = var.region
+  name        = "fetch-youtube-videos-weekly-full-sweep"
+  schedule    = "0 4 * * 0" # 毎週日曜4:00 JST
+  time_zone   = "Asia/Tokyo"
+  description = "YouTube discovery方式の取りこぼし検知（uploads playlist全走査）を週次で実行します"
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.youtube_video_fetch_trigger.id
+    data = base64encode(jsonencode({
+      mode        = "weekly_full_sweep"
+      description = "discovery方式の取りこぼし検知を兼ねた週次全件走査"
+    }))
+  }
+
+  depends_on = [
+    google_project_service.cloudscheduler,
+    google_pubsub_topic.youtube_video_fetch_trigger,
+    google_pubsub_topic_iam_member.scheduler_pubsub_publisher,
+    google_service_account.fetch_youtube_videos_sa,
+  ]
+}
+
 
 # 旧 collectDLsiteTimeseries 関連スケジューラーは統合アーキテクチャにより削除済み
 #


### PR DESCRIPTION
## Summary

- [SPR-230](https://linear.app/nothink/issue/SPR-230) の実装（Phase①②）。DLsite側（SPR-229、#753）で確立したティア差分削減パターンをYouTube側に横展開する。
- discoveryが`search.list`（100 units/回）を使い日次クォータ（既定10,000）の~72%を消費している問題に対し、uploads playlist経由の`playlistItems.list`（1 unit/ページ）へ置換する。
- **Phase①（discovery置換）**: `fetchUploadsPlaylistId`/`fetchUploadsPlaylistPage`（`youtube-api.ts`）を新設。uploads playlist ID（`UC→UU`の非公式変換ではなく`channels.list`で正規取得）は`FetchMetadata`にキャッシュし、以後の取得コストを実質ゼロにする。
- **One-Way Doorのため一発切替えはしない**: `YOUTUBE_DISCOVERY_MODE`環境変数（`search`既定/`shadow`/`playlist`）でシャドーモードを設ける。`shadow`中は既存`search.list`経路を維持しつつ、uploads playlist全走査との発見集合差分をログ出力のみで検証する。ロールバックは環境変数のみで即時可能。
- **Phase②（incremental discovery）**: uploads playlistは新着順のため、ページ内に既知videoIdが1件でもあればそのページで打ち切る（early-stop）。`videos`コレクションはdoc ID=videoIdのため`firestore.getAll`によるバルク確認がそのまま使える（`getKnownVideoIdsSet`）。初回バックフィルは全件未知のため特別分岐なしで自然に全件取得になる。
- 週次フルスイープ（日曜4:00 JST、DLsite週次(土曜4:15 JST)と時間帯分散）を追加。early-stopなし全走査＋Firestore既知IDとの突合をログ出力するのみで、通常の動画詳細取得・保存フローは実行しない（コストは~11 units/週と軽量）。

Phase③（統計取得のティア化・`buildPlaylistVideoMapping`のキャッシュ化）はPhase①②の本番実測（新着検出漏れの有無）を見てから別PRで着手する。

## 本番同期パイプラインへの影響（One-Way Door）

- `FetchMetadata`に`uploadsPlaylistId`を追加（additive、既存フィールドへの影響なし）
- 新規Cloud Scheduler job（`fetch-youtube-videos-weekly-full-sweep`）を追加。既存の毎時30分run・DLsite週次フルスイープとは時刻が重ならない
- `youtube-quota-monitor.ts`の`QUOTA_COSTS`に`channels: 1`を追加

## Test plan

- [x] `pnpm verify`（lint:docs + lint:tokens + lint + typecheck + test、カバレッジ閾値含む）全通過
- [x] `youtube-api.ts`（`fetchUploadsPlaylistId`/`fetchUploadsPlaylistPage`）の単体テスト追加
- [x] `youtube-firestore.ts`（`getKnownVideoIdsSet`/`getAllVideoIds`）の単体テスト追加
- [x] `youtube.ts`（discoveryモード切替・early-stop・週次フルスイープ・Pub/Subペイロードデコード）の統合テスト追加
- [x] `terraform validate` / `terraform fmt -check` で新規Schedulerリソースの構文確認
- [ ] terraform apply（ADR-010のCI経由・plan→承認→apply）とfunctionsデプロイ後、`YOUTUBE_DISCOVERY_MODE=shadow`で1-2日運用し、Cloud Loggingで発見集合の対称差ログが常に0件であることを確認
- [ ] 差分ゼロを確認後、`YOUTUBE_DISCOVERY_MODE=playlist`へ切替え、`search.list`のquota消費が無くなり日次unitsが数百程度に落ちることを実測

🤖 Generated with [Claude Code](https://claude.com/claude-code)