### PR TITLE
feat(functions): fetchYouTubeVideosをplaylistモードへ本切替え (SPR-230)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -205,7 +205,7 @@ jobs:
             --trigger-topic youtube-video-fetch-trigger \
             --region asia-northeast1 \
             --project ${{ secrets.GCP_PROJECT_ID }} \
-            --set-env-vars NODE_ENV=production,FUNCTION_SIGNATURE_TYPE=cloudevent,FUNCTION_TARGET=fetchYouTubeVideos,YOUTUBE_DISCOVERY_MODE=shadow \
+            --set-env-vars NODE_ENV=production,FUNCTION_SIGNATURE_TYPE=cloudevent,FUNCTION_TARGET=fetchYouTubeVideos,YOUTUBE_DISCOVERY_MODE=playlist \
             --memory 256Mi \
             --timeout 540s \
             --max-instances 3 \


### PR DESCRIPTION
## Summary
- shadowモード(#758)での実測検証を踏まえ、discoveryの主経路を`search.list`(100 units/回)から`playlistItems.list`ベースのincremental走査(1 unit/ページ)へ本切替えする
- `YOUTUBE_DISCOVERY_MODE`を`shadow`→`playlist`に変更する1行差分

## Shadow検証で得た知見（2026-07-05T07:30 UTC run実測）
発見集合に8件missing・5件extraの差分があったが、両方とも切替えに支障ない性質と判明:

- **missing 8件**（Firestoreにあるがuploads playlistに無い）: oEmbed APIで全件403(非公開)/404(削除済み)を確認。旧search.list方式でも現在は再発見不能な既存データで、方式変更起因の退行ではない。
- **extra 5件**（uploads playlistにあるがFirestoreに無い）: YouTube Data APIで全件`privacyStatus: public`を確認（公開日は2021〜2025年に分散）。`search.list`の「チャンネル全動画列挙を保証しない」という既知の制約による取りこぼしで、uploads playlist方式はこれを解消する（Googleが公式にuploads playlist方式を推奨する理由そのもの）。

## 既知の制約（フォローアップ）
- incremental discovery（early-stop）は「新着のみ」検出が目的のため、上記extra 5件のような**過去の取りこぼしは自動バックフィルされない**（既知IDに当たった時点で打ち切るため）。週次フルスイープも検知ログのみで保存は行わない。
- 一括バックフィルが必要な場合は別途スクリプトでの対応を検討（本PRのスコープ外）。

## Test plan
- [ ] マージ後、次回run以降でCloud Loggingの`operation: 'search'`ログが出なくなること
- [ ] `operation: 'channels'`(初回のみ)・`playlistItems`(discovery用、`uploadsPlaylistId`付き)のログが出ること
- [ ] 日次units合計が数百程度に落ちることを実測
- [ ] 新着動画が引き続き毎時検出されることを1-2日確認
- [ ] 次の日曜4:00 JSTの週次フルスイープが初回正常に起動・完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)