### PR TITLE
feat(ui): AudioButtonをフラットデザイン(A案)にリデザイン

### DIFF
--- a/packages/ui/src/components/custom/__tests__/audio-button.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/audio-button.test.tsx
@@ -122,7 +122,7 @@ describe("AudioButton", () => {
 		// メタデータが表示されることを確認
 		expect(screen.getByText("10.0秒")).toBeInTheDocument();
 		expect(screen.getByText("テストユーザー")).toBeInTheDocument();
-		expect(screen.getByText("再生: 5回")).toBeInTheDocument();
+		expect(screen.getByText("再生 5回")).toBeInTheDocument();
 	});
 
 	it("should display tags", async () => {
@@ -227,7 +227,7 @@ describe("AudioButton", () => {
 
 		// 高評価ボタンが liked 状態になっていることを確認
 		const likeButton = screen.getByText("2").closest("button");
-		expect(likeButton).toHaveClass("text-primary");
+		expect(likeButton).toHaveClass("text-suzuka-600");
 	});
 
 	it("should handle detail click", async () => {
@@ -287,7 +287,7 @@ describe("AudioButton", () => {
 		);
 	});
 
-	it("should disable favorite button when not authenticated", async () => {
+	it("should keep favorite button enabled when not authenticated and let the caller decide", async () => {
 		const user = userEvent.setup();
 		const onFavoriteToggleMock = vi.fn();
 
@@ -300,21 +300,19 @@ describe("AudioButton", () => {
 			/>,
 		);
 
-		// 詳細表示ボタン（iアイコン）をクリック
+		// 詳細表示ボタン（⋯アイコン）をクリック
 		const infoButton = screen.getByRole("button", { name: "詳細を表示" });
 		await user.click(infoButton);
 
-		// お気に入りボタンを確認
+		// お気に入りボタンは disabled にしない（クリック可能なまま、呼び出し元がログイン誘導を行う）
 		const favoriteButton = screen.getByRole("button", { name: "お気に入りに追加" });
-		expect(favoriteButton).toBeDisabled();
-		expect(favoriteButton).toHaveClass("opacity-50", "cursor-not-allowed");
+		expect(favoriteButton).not.toBeDisabled();
 
-		// クリックしても何も起こらない
 		await user.click(favoriteButton);
-		expect(onFavoriteToggleMock).not.toHaveBeenCalled();
+		expect(onFavoriteToggleMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("should disable like buttons when not authenticated", async () => {
+	it("should keep like/dislike buttons enabled when not authenticated", async () => {
 		const user = userEvent.setup();
 		const onLikeToggleMock = vi.fn();
 		const onDislikeToggleMock = vi.fn();
@@ -330,31 +328,25 @@ describe("AudioButton", () => {
 			/>,
 		);
 
-		// 詳細表示ボタン（iアイコン）をクリック
+		// 詳細表示ボタン（⋯アイコン）をクリック
 		const infoButton = screen.getByRole("button", { name: "詳細を表示" });
 		await user.click(infoButton);
 
-		// 高評価ボタンを確認
 		const likeButton = screen.getByText("2").closest("button");
-		expect(likeButton).toBeDisabled();
-		expect(likeButton).toHaveClass("opacity-50", "cursor-not-allowed");
+		const dislikeButton = screen.getByRole("button", { name: "低評価する" });
+		expect(likeButton).not.toBeDisabled();
+		expect(dislikeButton).not.toBeDisabled();
 
-		// 低評価ボタンを確認
-		const dislikeButton = screen.getByTitle("低評価するにはログインが必要です");
-		expect(dislikeButton).toBeDisabled();
-		expect(dislikeButton).toHaveClass("opacity-50", "cursor-not-allowed");
-
-		// クリックしても何も起こらない
 		if (likeButton) {
 			await user.click(likeButton);
 		}
 		await user.click(dislikeButton);
 
-		expect(onLikeToggleMock).not.toHaveBeenCalled();
-		expect(onDislikeToggleMock).not.toHaveBeenCalled();
+		expect(onLikeToggleMock).toHaveBeenCalledTimes(1);
+		expect(onDislikeToggleMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("should show authentication required tooltips", async () => {
+	it("should show a login note instead of tooltips when not authenticated", async () => {
 		const user = userEvent.setup();
 
 		render(
@@ -370,13 +362,11 @@ describe("AudioButton", () => {
 			/>,
 		);
 
-		// 詳細表示ボタン（iアイコン）をクリック
+		// 詳細表示ボタン（⋯アイコン）をクリック
 		const infoButton = screen.getByRole("button", { name: "詳細を表示" });
 		await user.click(infoButton);
 
-		// ツールチップメッセージを確認
-		expect(screen.getByTitle("お気に入りするにはログインが必要です")).toBeInTheDocument();
-		expect(screen.getByTitle("高評価するにはログインが必要です")).toBeInTheDocument();
-		expect(screen.getByTitle("低評価するにはログインが必要です")).toBeInTheDocument();
+		// title tooltip ではなく注記行で案内する（スマホで title が出ない問題の回避）
+		expect(screen.getByText("お気に入り・評価にはログインが必要です")).toBeInTheDocument();
 	});
 });

--- a/packages/ui/src/components/custom/audio-button.stories.tsx
+++ b/packages/ui/src/components/custom/audio-button.stories.tsx
@@ -160,7 +160,9 @@ export const UnauthenticatedShowsLoginNote: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button", { name: "詳細を表示" }));
-		await expect(await screen.findByText("お気に入り・評価にはログインが必要です")).toBeVisible();
+		await expect(
+			await screen.findByText("お気に入り・評価にはログインが必要です"),
+		).toBeInTheDocument();
 		const favoriteBtn = await screen.findByRole("button", { name: "お気に入りに追加" });
 		await expect(favoriteBtn).not.toBeDisabled();
 		await userEvent.click(favoriteBtn);

--- a/packages/ui/src/components/custom/audio-button.stories.tsx
+++ b/packages/ui/src/components/custom/audio-button.stories.tsx
@@ -148,8 +148,8 @@ export const FavoriteToggleInteraction: Story = {
 	},
 };
 
-// 同上。未認証時は popover 内の FavoriteButton が disabled になることを確認する。
-export const UnauthenticatedFavoriteDisabled: Story = {
+// 同上。未認証時は disabled にせず注記行を表示し、クリックは呼び出し元（ログイン誘導のtoast等）に委ねる。
+export const UnauthenticatedShowsLoginNote: Story = {
 	args: {
 		audioButton: mockAudioButton,
 		onPlay: fn(),
@@ -160,9 +160,10 @@ export const UnauthenticatedFavoriteDisabled: Story = {
 	play: async ({ canvasElement, args }) => {
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button", { name: "詳細を表示" }));
+		await expect(await screen.findByText("お気に入り・評価にはログインが必要です")).toBeVisible();
 		const favoriteBtn = await screen.findByRole("button", { name: "お気に入りに追加" });
-		await expect(favoriteBtn).toBeDisabled();
+		await expect(favoriteBtn).not.toBeDisabled();
 		await userEvent.click(favoriteBtn);
-		await expect(args.onFavoriteToggle).not.toHaveBeenCalled();
+		await expect(args.onFavoriteToggle).toHaveBeenCalledOnce();
 	},
 };

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -41,12 +41,18 @@ interface AudioButtonProps {
 	onDetailClick?: () => void;
 	// お気に入り関連
 	isFavorite?: boolean;
+	/**
+	 * isAuthenticated=false でも disabled にせず常にクリックで呼び出す（未ログイン注記行は別途表示）。
+	 * 呼び出し元が未ログイン時のガード/ログイン誘導（toast 等）を自前で行うこと。
+	 */
 	onFavoriteToggle?: () => void;
 	// いいね関連
 	isLiked?: boolean;
+	/** onFavoriteToggle と同様、未ログイン時のガードは呼び出し元の責務 */
 	onLikeToggle?: () => void;
 	// 低評価関連
 	isDisliked?: boolean;
+	/** onFavoriteToggle と同様、未ログイン時のガードは呼び出し元の責務 */
 	onDislikeToggle?: () => void;
 	// ハイライト関連
 	searchQuery?: string;

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -26,7 +26,7 @@ import {
 	User,
 	Video,
 } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useId, useRef, useState } from "react";
 import { type AudioControls, AudioPlayer } from "./audio-player";
 import { HighlightText } from "./highlight-text";
 import { TagList } from "./tag-list";
@@ -216,9 +216,11 @@ function PopoverTags({
 function FavoriteButton({
 	isFavorite,
 	onFavoriteToggle,
+	describedBy,
 }: {
 	isFavorite?: boolean;
 	onFavoriteToggle?: () => void;
+	describedBy?: string;
 }) {
 	if (!onFavoriteToggle) return null;
 
@@ -230,6 +232,7 @@ function FavoriteButton({
 				onFavoriteToggle();
 			}}
 			aria-label={isFavorite ? "お気に入りを解除" : "お気に入りに追加"}
+			aria-describedby={describedBy}
 			className={cn(
 				"flex items-center justify-center gap-1.5 h-10 px-2.5 rounded-lg text-xs font-semibold transition-colors hover:bg-accent",
 				isFavorite ? "text-suzuka-600" : "text-muted-foreground hover:text-foreground",
@@ -247,12 +250,14 @@ function LikeDislikeButtons({
 	onLikeToggle,
 	isDisliked,
 	onDislikeToggle,
+	describedBy,
 }: {
 	audioButton: AudioButtonType;
 	isLiked?: boolean;
 	onLikeToggle?: () => void;
 	isDisliked?: boolean;
 	onDislikeToggle?: () => void;
+	describedBy?: string;
 }) {
 	if (!onLikeToggle) return null;
 
@@ -264,6 +269,7 @@ function LikeDislikeButtons({
 					e.stopPropagation();
 					onLikeToggle();
 				}}
+				aria-describedby={describedBy}
 				className={cn(
 					"flex items-center gap-1.5 h-10 px-2.5 rounded-lg text-xs font-semibold transition-colors hover:bg-accent",
 					isLiked ? "text-suzuka-600" : "text-muted-foreground hover:text-foreground",
@@ -272,17 +278,20 @@ function LikeDislikeButtons({
 				<ThumbsUp className={cn("h-4 w-4", isLiked && "fill-current")} />
 				<span>{audioButton.stats.likeCount}</span>
 			</button>
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					onDislikeToggle?.();
-				}}
-				aria-label={isDisliked ? "低評価を取り消す" : "低評価する"}
-				className="flex items-center justify-center h-10 px-2.5 rounded-lg text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-			>
-				<ThumbsDown className={cn("h-4 w-4", isDisliked && "fill-current")} />
-			</button>
+			{onDislikeToggle && (
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						onDislikeToggle();
+					}}
+					aria-label={isDisliked ? "低評価を取り消す" : "低評価する"}
+					aria-describedby={describedBy}
+					className="flex items-center justify-center h-10 px-2.5 rounded-lg text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				>
+					<ThumbsDown className={cn("h-4 w-4", isDisliked && "fill-current")} />
+				</button>
+			)}
 		</div>
 	);
 }
@@ -300,6 +309,7 @@ function PopoverActions({
 	showDetailLink,
 	onDetailClick,
 	onPopoverClose,
+	describedBy,
 }: {
 	audioButton: AudioButtonType;
 	youtubeUrl: string;
@@ -312,10 +322,15 @@ function PopoverActions({
 	showDetailLink?: boolean;
 	onDetailClick?: () => void;
 	onPopoverClose?: () => void;
+	describedBy?: string;
 }) {
 	return (
 		<div className="flex gap-1 items-center flex-wrap">
-			<FavoriteButton isFavorite={isFavorite} onFavoriteToggle={onFavoriteToggle} />
+			<FavoriteButton
+				isFavorite={isFavorite}
+				onFavoriteToggle={onFavoriteToggle}
+				describedBy={describedBy}
+			/>
 
 			<LikeDislikeButtons
 				audioButton={audioButton}
@@ -323,6 +338,7 @@ function PopoverActions({
 				onLikeToggle={onLikeToggle}
 				isDisliked={isDisliked}
 				onDislikeToggle={onDislikeToggle}
+				describedBy={describedBy}
 			/>
 
 			<a
@@ -372,6 +388,8 @@ function AudioButtonPopoverContent({
 	highlightClassName,
 	isAuthenticated,
 }: AudioButtonPopoverContentProps) {
+	const authNoteId = useId();
+
 	return (
 		<div className="p-4 space-y-4">
 			{/* 見出し層: タイトル・秒数/再生数・説明 */}
@@ -395,7 +413,7 @@ function AudioButtonPopoverContent({
 			{/* アクション層 */}
 			<div className="space-y-2 border-t border-border pt-3">
 				{!isAuthenticated && (
-					<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+					<p id={authNoteId} className="flex items-center gap-1.5 text-xs text-muted-foreground">
 						<Lock className="h-3 w-3" />
 						お気に入り・評価にはログインが必要です
 					</p>
@@ -412,6 +430,7 @@ function AudioButtonPopoverContent({
 					showDetailLink={showDetailLink}
 					onDetailClick={onDetailClick}
 					onPopoverClose={onPopoverClose}
+					describedBy={isAuthenticated ? undefined : authNoteId}
 				/>
 			</div>
 		</div>
@@ -441,8 +460,9 @@ export function AudioButton({
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-	const [progress, setProgress] = useState(0);
 	const audioPlayerRef = useRef<AudioControls>(null);
+	// 250ms毎に更新される再生進捗はReact stateにせずDOMへ直接書き込む（コンポーネント全体の再レンダーを避けるため）
+	const progressFillRef = useRef<HTMLSpanElement>(null);
 
 	// 時間の計算
 	const duration = (audioButton.endTime || audioButton.startTime) - audioButton.startTime;
@@ -476,17 +496,29 @@ export function AudioButton({
 		onPlay?.();
 	}, [onPlay]);
 
+	const resetProgressFill = useCallback(() => {
+		if (progressFillRef.current) {
+			progressFillRef.current.style.width = "0%";
+		}
+	}, []);
+
+	const handleProgress = useCallback((progressPercent: number) => {
+		if (progressFillRef.current) {
+			progressFillRef.current.style.width = `${progressPercent}%`;
+		}
+	}, []);
+
 	const handlePlayPause = useCallback(() => {
 		setIsPlaying(false);
 		setIsLoading(false);
-		setProgress(0);
-	}, []);
+		resetProgressFill();
+	}, [resetProgressFill]);
 
 	const handlePlayEnd = useCallback(() => {
 		setIsPlaying(false);
 		setIsLoading(false);
-		setProgress(0);
-	}, []);
+		resetProgressFill();
+	}, [resetProgressFill]);
 
 	return (
 		<>
@@ -497,7 +529,7 @@ export function AudioButton({
 				onPlay={handlePlayStart}
 				onPause={handlePlayPause}
 				onEnd={handlePlayEnd}
-				onProgress={setProgress}
+				onProgress={handleProgress}
 			/>
 
 			{/* UI要素 */}
@@ -512,11 +544,12 @@ export function AudioButton({
 						className,
 					)}
 				>
-					{/* 進捗フィル */}
+					{/* 進捗フィル（DOMへ直接書き込むためReact state化しない） */}
 					<span
+						ref={progressFillRef}
 						aria-hidden="true"
 						className="pointer-events-none absolute inset-0 bg-minase-200 transition-[width] duration-150 ease-linear"
-						style={{ width: `${progress}%` }}
+						style={{ width: "0%" }}
 					/>
 
 					{/* メイン部分 - 再生専用エリア */}

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -16,8 +16,9 @@ import {
 	ArrowRight,
 	Clock,
 	Heart,
-	Info,
 	Loader2,
+	Lock,
+	MoreHorizontal,
 	Pause,
 	Play,
 	ThumbsDown,
@@ -113,46 +114,67 @@ function PopoverDescription({
 	);
 }
 
-// Metadata section component
-function PopoverMetadata({
+// 見出し層: タイトル + 秒数/再生数チップ + 説明
+function PopoverHeader({
 	audioButton,
 	duration,
+	searchQuery,
+	highlightClassName,
 }: {
 	audioButton: AudioButtonType;
 	duration: number;
+	searchQuery?: string;
+	highlightClassName?: string;
 }) {
 	return (
-		<div className="space-y-2 text-sm text-muted-foreground">
-			<div className="flex items-center gap-2">
-				<Clock className="h-4 w-4" />
-				<span>{duration.toFixed(1)}秒</span>
+		<div>
+			<h4 className="font-semibold text-base text-foreground leading-tight">
+				<PopoverTitle
+					text={audioButton.buttonText}
+					searchQuery={searchQuery}
+					highlightClassName={highlightClassName}
+				/>
+			</h4>
+			<div className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+				<span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-semibold text-foreground">
+					<Clock className="h-3 w-3" />
+					{duration.toFixed(1)}秒
+				</span>
+				<span>再生 {audioButton.stats.playCount}回</span>
 			</div>
-			<div className="flex items-center gap-2">
-				<User className="h-4 w-4" />
-				<a
-					href={`/users/${audioButton.creatorId}`}
-					className="text-primary hover:text-primary/90 hover:underline transition-colors"
-					onClick={(e) => e.stopPropagation()}
-				>
-					{audioButton.creatorName}
-				</a>
-			</div>
-			<div className="flex items-center gap-2">
-				<Video className="h-4 w-4" />
-				<span className="text-xs">再生: {audioButton.stats.playCount}回</span>
-			</div>
+			<PopoverDescription
+				description={audioButton.description}
+				searchQuery={searchQuery}
+				highlightClassName={highlightClassName}
+			/>
+		</div>
+	);
+}
+
+// 出典リスト層: 作成者・元動画への導線
+function PopoverMetaList({ audioButton }: { audioButton: AudioButtonType }) {
+	return (
+		<div className="overflow-hidden rounded-lg border border-border">
+			<a
+				href={`/users/${audioButton.creatorId}`}
+				className="flex min-h-[38px] items-center gap-2 px-3 py-2 text-xs hover:bg-accent transition-colors"
+				onClick={(e) => e.stopPropagation()}
+			>
+				<User className="h-3.5 w-3.5 flex-none text-muted-foreground" />
+				<span className="min-w-0 flex-1 truncate">{audioButton.creatorName}</span>
+				<span className="flex-none text-muted-foreground">作成者</span>
+			</a>
 			{audioButton.videoTitle && (
-				<div className="flex items-center gap-2">
-					<Video className="h-4 w-4" />
-					<a
-						href={`/videos/${audioButton.videoId}`}
-						className="text-primary hover:text-primary/90 hover:underline transition-colors text-xs truncate"
-						onClick={(e: React.MouseEvent) => e.stopPropagation()}
-						title={audioButton.videoTitle}
-					>
-						{audioButton.videoTitle}
-					</a>
-				</div>
+				<a
+					href={`/videos/${audioButton.videoId}`}
+					className="flex min-h-[38px] items-center gap-2 border-t border-border px-3 py-2 text-xs hover:bg-accent transition-colors"
+					onClick={(e: React.MouseEvent) => e.stopPropagation()}
+					title={audioButton.videoTitle}
+				>
+					<Video className="h-3.5 w-3.5 flex-none text-muted-foreground" />
+					<span className="min-w-0 flex-1 truncate">{audioButton.videoTitle}</span>
+					<span className="flex-none text-muted-foreground">元動画</span>
+				</a>
 			)}
 		</div>
 	);
@@ -188,11 +210,9 @@ function PopoverTags({
 function FavoriteButton({
 	isFavorite,
 	onFavoriteToggle,
-	isAuthenticated,
 }: {
 	isFavorite?: boolean;
 	onFavoriteToggle?: () => void;
-	isAuthenticated: boolean;
 }) {
 	if (!onFavoriteToggle) return null;
 
@@ -201,17 +221,12 @@ function FavoriteButton({
 			type="button"
 			onClick={(e) => {
 				e.stopPropagation();
-				if (isAuthenticated) onFavoriteToggle();
+				onFavoriteToggle();
 			}}
 			aria-label={isFavorite ? "お気に入りを解除" : "お気に入りに追加"}
-			disabled={!isAuthenticated}
-			title={!isAuthenticated ? "お気に入りするにはログインが必要です" : undefined}
 			className={cn(
-				"flex items-center justify-center w-10 h-10 rounded-md border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors",
-				isFavorite
-					? "text-primary hover:text-primary/90"
-					: "text-muted-foreground hover:text-primary",
-				!isAuthenticated && "opacity-50 cursor-not-allowed hover:bg-background",
+				"flex items-center justify-center gap-1.5 h-10 px-2.5 rounded-lg text-xs font-semibold transition-colors hover:bg-accent",
+				isFavorite ? "text-suzuka-600" : "text-muted-foreground hover:text-foreground",
 			)}
 		>
 			<Heart className={cn("h-4 w-4", isFavorite && "fill-current")} />
@@ -226,33 +241,26 @@ function LikeDislikeButtons({
 	onLikeToggle,
 	isDisliked,
 	onDislikeToggle,
-	isAuthenticated,
 }: {
 	audioButton: AudioButtonType;
 	isLiked?: boolean;
 	onLikeToggle?: () => void;
 	isDisliked?: boolean;
 	onDislikeToggle?: () => void;
-	isAuthenticated: boolean;
 }) {
 	if (!onLikeToggle) return null;
 
 	return (
-		<div className="flex rounded-md border border-input">
+		<div className="flex items-center">
 			<button
 				type="button"
 				onClick={(e) => {
 					e.stopPropagation();
-					if (isAuthenticated) onLikeToggle();
+					onLikeToggle();
 				}}
-				disabled={!isAuthenticated}
-				title={!isAuthenticated ? "高評価するにはログインが必要です" : undefined}
 				className={cn(
-					"flex items-center gap-1 px-3 py-2 text-sm font-medium border-0 rounded-l-md rounded-r-none border-r border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors",
-					isLiked
-						? "text-primary hover:text-primary/90"
-						: "text-muted-foreground hover:text-primary",
-					!isAuthenticated && "opacity-50 cursor-not-allowed hover:bg-background",
+					"flex items-center gap-1.5 h-10 px-2.5 rounded-lg text-xs font-semibold transition-colors hover:bg-accent",
+					isLiked ? "text-suzuka-600" : "text-muted-foreground hover:text-foreground",
 				)}
 			>
 				<ThumbsUp className={cn("h-4 w-4", isLiked && "fill-current")} />
@@ -262,23 +270,10 @@ function LikeDislikeButtons({
 				type="button"
 				onClick={(e) => {
 					e.stopPropagation();
-					if (isAuthenticated && onDislikeToggle) onDislikeToggle();
+					onDislikeToggle?.();
 				}}
-				disabled={!isAuthenticated}
-				title={
-					!isAuthenticated
-						? "低評価するにはログインが必要です"
-						: isDisliked
-							? "低評価を取り消す"
-							: "低評価する"
-				}
-				className={cn(
-					"flex items-center justify-center w-10 h-10 border-0 rounded-r-md rounded-l-none bg-background hover:bg-accent hover:text-accent-foreground transition-colors",
-					isDisliked
-						? "text-muted-foreground hover:text-foreground"
-						: "text-muted-foreground hover:text-foreground",
-					!isAuthenticated && "opacity-50 cursor-not-allowed hover:bg-background",
-				)}
+				aria-label={isDisliked ? "低評価を取り消す" : "低評価する"}
+				className="flex items-center justify-center h-10 px-2.5 rounded-lg text-xs font-semibold text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
 			>
 				<ThumbsDown className={cn("h-4 w-4", isDisliked && "fill-current")} />
 			</button>
@@ -299,7 +294,6 @@ function PopoverActions({
 	showDetailLink,
 	onDetailClick,
 	onPopoverClose,
-	isAuthenticated,
 }: {
 	audioButton: AudioButtonType;
 	youtubeUrl: string;
@@ -312,15 +306,10 @@ function PopoverActions({
 	showDetailLink?: boolean;
 	onDetailClick?: () => void;
 	onPopoverClose?: () => void;
-	isAuthenticated: boolean;
 }) {
 	return (
-		<div className="flex gap-2 pt-2 items-center flex-wrap">
-			<FavoriteButton
-				isFavorite={isFavorite}
-				onFavoriteToggle={onFavoriteToggle}
-				isAuthenticated={isAuthenticated}
-			/>
+		<div className="flex gap-1 items-center flex-wrap">
+			<FavoriteButton isFavorite={isFavorite} onFavoriteToggle={onFavoriteToggle} />
 
 			<LikeDislikeButtons
 				audioButton={audioButton}
@@ -328,14 +317,13 @@ function PopoverActions({
 				onLikeToggle={onLikeToggle}
 				isDisliked={isDisliked}
 				onDislikeToggle={onDislikeToggle}
-				isAuthenticated={isAuthenticated}
 			/>
 
 			<a
 				href={youtubeUrl}
 				target="_blank"
 				rel="noopener noreferrer"
-				className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
+				className="flex items-center gap-1.5 h-10 px-2.5 rounded-lg text-xs font-semibold bg-destructive/10 text-destructive hover:bg-destructive/20 transition-colors"
 				onClick={(e) => e.stopPropagation()}
 			>
 				<YoutubeIcon className="h-4 w-4" />
@@ -351,7 +339,7 @@ function PopoverActions({
 						onPopoverClose?.();
 					}}
 					aria-label="詳細ページを開く"
-					className="flex items-center gap-1 px-3 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
+					className="flex items-center gap-1 h-10 px-2.5 ml-auto rounded-lg text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors whitespace-nowrap"
 				>
 					詳細
 					<ArrowRight className="h-3 w-3" />
@@ -379,48 +367,47 @@ function AudioButtonPopoverContent({
 	isAuthenticated,
 }: AudioButtonPopoverContentProps) {
 	return (
-		<div className="w-96 p-4 space-y-4">
-			{/* タイトル */}
-			<div>
-				<h4 className="font-semibold text-base text-foreground leading-tight">
-					<PopoverTitle
-						text={audioButton.buttonText}
-						searchQuery={searchQuery}
-						highlightClassName={highlightClassName}
-					/>
-				</h4>
-				<PopoverDescription
-					description={audioButton.description}
-					searchQuery={searchQuery}
-					highlightClassName={highlightClassName}
-				/>
-			</div>
+		<div className="p-4 space-y-4">
+			{/* 見出し層: タイトル・秒数/再生数・説明 */}
+			<PopoverHeader
+				audioButton={audioButton}
+				duration={duration}
+				searchQuery={searchQuery}
+				highlightClassName={highlightClassName}
+			/>
 
-			{/* メタデータ */}
-			<PopoverMetadata audioButton={audioButton} duration={duration} />
+			{/* 出典リスト層: 作成者・元動画 */}
+			<PopoverMetaList audioButton={audioButton} />
 
-			{/* タグ */}
+			{/* タグ層 */}
 			<PopoverTags
 				audioButton={audioButton}
 				searchQuery={searchQuery}
 				highlightClassName={highlightClassName}
 			/>
 
-			{/* アクションボタン */}
-			<PopoverActions
-				audioButton={audioButton}
-				youtubeUrl={youtubeUrl}
-				isFavorite={isFavorite}
-				onFavoriteToggle={onFavoriteToggle}
-				isLiked={isLiked}
-				onLikeToggle={onLikeToggle}
-				isDisliked={isDisliked}
-				onDislikeToggle={onDislikeToggle}
-				showDetailLink={showDetailLink}
-				onDetailClick={onDetailClick}
-				onPopoverClose={onPopoverClose}
-				isAuthenticated={isAuthenticated}
-			/>
+			{/* アクション層 */}
+			<div className="space-y-2 border-t border-border pt-3">
+				{!isAuthenticated && (
+					<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+						<Lock className="h-3 w-3" />
+						お気に入り・評価にはログインが必要です
+					</p>
+				)}
+				<PopoverActions
+					audioButton={audioButton}
+					youtubeUrl={youtubeUrl}
+					isFavorite={isFavorite}
+					onFavoriteToggle={onFavoriteToggle}
+					isLiked={isLiked}
+					onLikeToggle={onLikeToggle}
+					isDisliked={isDisliked}
+					onDislikeToggle={onDislikeToggle}
+					showDetailLink={showDetailLink}
+					onDetailClick={onDetailClick}
+					onPopoverClose={onPopoverClose}
+				/>
+			</div>
 		</div>
 	);
 }
@@ -448,6 +435,7 @@ export function AudioButton({
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+	const [progress, setProgress] = useState(0);
 	const audioPlayerRef = useRef<AudioControls>(null);
 
 	// 時間の計算
@@ -485,11 +473,13 @@ export function AudioButton({
 	const handlePlayPause = useCallback(() => {
 		setIsPlaying(false);
 		setIsLoading(false);
+		setProgress(0);
 	}, []);
 
 	const handlePlayEnd = useCallback(() => {
 		setIsPlaying(false);
 		setIsLoading(false);
+		setProgress(0);
 	}, []);
 
 	return (
@@ -501,28 +491,43 @@ export function AudioButton({
 				onPlay={handlePlayStart}
 				onPause={handlePlayPause}
 				onEnd={handlePlayEnd}
+				onProgress={setProgress}
 			/>
 
 			{/* UI要素 */}
 			<Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
 				<div
 					className={cn(
-						"group relative inline-flex items-stretch rounded-lg overflow-hidden shadow-sm",
-						"bg-gradient-to-r from-minase-400 to-minase-500 hover:from-minase-500 hover:to-minase-600",
-						"transition-all duration-200",
+						"group relative inline-flex max-w-full items-stretch overflow-hidden rounded-xl border-[1.5px] border-minase-300 bg-minase-50",
+						"transition-[border-color,background-color,box-shadow,transform] duration-150",
+						"hover:border-minase-500 hover:shadow-[0_2px_8px_hsl(var(--minase-500)/0.18)]",
+						"has-[:active]:scale-[0.98]",
+						isPlaying && "border-minase-600",
 						className,
 					)}
 				>
+					{/* 進捗フィル */}
+					<span
+						aria-hidden="true"
+						className="pointer-events-none absolute inset-0 bg-minase-200 transition-[width] duration-150 ease-linear"
+						style={{ width: `${progress}%` }}
+					/>
+
 					{/* メイン部分 - 再生専用エリア */}
 					<button
 						type="button"
 						onClick={handlePlayClick}
 						disabled={isLoading}
-						className="flex items-center gap-2 px-3 py-2 text-minase-950 dark:text-minase-50 min-h-[44px] flex-1 min-w-0 cursor-pointer hover:bg-black/10 transition-colors"
+						className="relative z-10 flex min-h-[44px] min-w-0 flex-1 cursor-pointer items-center gap-2 px-2.5 py-1.5 hover:bg-minase-100/70 transition-colors"
 						aria-label={isPlaying ? "一時停止" : "再生"}
 					>
 						{/* 再生アイコン */}
-						<div className="flex h-8 w-8 items-center justify-center rounded-full bg-black/10 text-minase-950 dark:text-minase-50 hover:bg-black/20 transition-colors">
+						<div
+							className={cn(
+								"flex h-8 w-8 flex-none items-center justify-center rounded-full bg-minase-500 text-white transition-colors",
+								isPlaying && "bg-minase-600",
+							)}
+						>
 							{isLoading ? (
 								<Loader2 className="h-4 w-4 animate-spin" />
 							) : isPlaying ? (
@@ -533,7 +538,10 @@ export function AudioButton({
 						</div>
 
 						{/* タイトル */}
-						<span className="font-medium text-sm truncate" title={audioButton.buttonText}>
+						<span
+							className="truncate font-bold text-sm text-minase-950"
+							title={audioButton.buttonText}
+						>
 							{searchQuery ? (
 								<HighlightText
 									text={displayTitle}
@@ -552,16 +560,16 @@ export function AudioButton({
 					<PopoverTrigger asChild>
 						<button
 							type="button"
-							className="flex items-center justify-center px-3 py-2 min-h-[44px] min-w-[44px] bg-black/5 text-minase-950 dark:text-minase-50 hover:bg-black/10 transition-colors cursor-pointer"
+							className="relative z-10 flex min-h-[44px] min-w-[44px] flex-none items-center justify-center border-l border-minase-200 text-minase-600 transition-colors hover:bg-minase-100 hover:text-minase-700"
 							aria-label="詳細を表示"
 						>
-							<Info className="h-4 w-4" />
+							<MoreHorizontal className="h-4 w-4" />
 						</button>
 					</PopoverTrigger>
 				</div>
 
 				<PopoverContent
-					className="w-96 p-0 border-border"
+					className="w-[min(320px,calc(100vw-24px))] p-0 border-minase-200"
 					align="start"
 					aria-label={`${audioButton.buttonText} の詳細`}
 				>

--- a/packages/ui/src/components/custom/audio-player.tsx
+++ b/packages/ui/src/components/custom/audio-player.tsx
@@ -22,6 +22,8 @@ export interface AudioPlayerProps {
 	onPause?: () => void;
 	/** 再生終了時のコールバック */
 	onEnd?: () => void;
+	/** 再生進捗（0-100）通知時のコールバック */
+	onProgress?: (progressPercent: number) => void;
 	/** 音量（0-100） */
 	volume?: number;
 	/** 自動再生するかどうか */
@@ -47,7 +49,7 @@ export interface AudioControls {
  * プール化された音声プレイヤーコンポーネント
  */
 export const AudioPlayer = forwardRef<AudioControls, AudioPlayerProps>(
-	({ audioButton, onPlay, onPause, onEnd, volume = 50, autoPlay = false }, ref) => {
+	({ audioButton, onPlay, onPause, onEnd, onProgress, volume = 50, autoPlay = false }, ref) => {
 		const [isPlaying, setIsPlaying] = useState(false);
 		const [isReady, setIsReady] = useState(false);
 		const mountedRef = useRef(true);
@@ -81,6 +83,11 @@ export const AudioPlayer = forwardRef<AudioControls, AudioPlayerProps>(
 							onEnd?.();
 						}
 					},
+					onProgress: (progressPercent) => {
+						if (mountedRef.current) {
+							onProgress?.(progressPercent);
+						}
+					},
 				};
 
 				await pool.playSegment(
@@ -96,7 +103,7 @@ export const AudioPlayer = forwardRef<AudioControls, AudioPlayerProps>(
 					onEnd?.();
 				}
 			}
-		}, [audioButton, onPlay, onPause, onEnd]);
+		}, [audioButton, onPlay, onPause, onEnd, onProgress]);
 
 		/**
 		 * 一時停止処理

--- a/packages/ui/src/lib/__tests__/youtube-player-pool.test.ts
+++ b/packages/ui/src/lib/__tests__/youtube-player-pool.test.ts
@@ -226,4 +226,19 @@ describe("YouTubePlayerPool", () => {
 
 		expect(callbacks.onEnd).toHaveBeenCalled();
 	});
+
+	it("should report playback progress via onProgress callback", async () => {
+		const callbacks = {
+			onProgress: vi.fn(),
+		};
+
+		await pool.playSegment("test-video-id", 10, 20, callbacks);
+
+		// startTime=10, endTime=20 の中間地点(15)を再生中と見なす
+		lastCreatedPlayer?.getCurrentTime.mockReturnValue(15);
+
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		expect(callbacks.onProgress).toHaveBeenCalledWith(50);
+	});
 });

--- a/packages/ui/src/lib/youtube-player-pool.ts
+++ b/packages/ui/src/lib/youtube-player-pool.ts
@@ -21,19 +21,18 @@ interface PlayerData {
 
 interface SegmentPlayback {
 	videoId: string;
+	startTime: number;
 	endTime: number;
 	intervalId: NodeJS.Timeout;
-	callbacks: {
-		onPlay?: () => void;
-		onPause?: () => void;
-		onEnd?: () => void;
-	};
+	callbacks: PlaySegmentCallbacks;
 }
 
 export interface PlaySegmentCallbacks {
 	onPlay?: () => void;
 	onPause?: () => void;
 	onEnd?: () => void;
+	/** 再生進捗（0-100）。監視間隔（250ms）ごとに通知 */
+	onProgress?: (progressPercent: number) => void;
 }
 
 /**
@@ -154,7 +153,7 @@ export class YouTubePlayerPool {
 			player.playVideo();
 
 			// endTime監視を開始
-			this.startEndTimeMonitoring(player, videoId, endTime, callbacks);
+			this.startEndTimeMonitoring(player, videoId, startTime, endTime, callbacks);
 
 			// プレイヤーの状態を更新
 			const playerData = this.players.get(videoId);
@@ -254,15 +253,23 @@ export class YouTubePlayerPool {
 	private startEndTimeMonitoring(
 		player: YTPlayer,
 		videoId: string,
+		startTime: number,
 		endTime: number,
 		callbacks: PlaySegmentCallbacks,
 	): void {
+		const segmentDuration = endTime - startTime;
 		this.activeSegment = {
 			videoId,
+			startTime,
 			endTime,
 			intervalId: setInterval(() => {
 				try {
 					const currentTime = player.getCurrentTime();
+
+					if (segmentDuration > 0) {
+						const progress = ((currentTime - startTime) / segmentDuration) * 100;
+						callbacks.onProgress?.(Math.min(100, Math.max(0, progress)));
+					}
 
 					if (currentTime >= endTime) {
 						this.stopCurrentSegment();


### PR DESCRIPTION
## Summary
- Claude Design提案(A案「みなせ・フラット」)を [AudioButton](packages/ui/src/components/custom/audio-button.tsx) に実装。グラデーション基調→フラット(minase色調)に変更し、再生時は輪郭・アイコンが濃色化する「静→動」の見た目にした
- 再生進捗を背景フィルで可視化するため、YouTubePlayerPoolの既存250ms監視ループに`onProgress`コールバックを追加(新規タイマーは追加していない)。⋯アイコン(旧ⓘ)+区切り線で詳細トリガーを明確化
- Popoverを「見出し(タイトル+秒数/再生数チップ+説明) / 出典リスト(作成者・元動画) / タグ / アクションバー」の4層に再構成し、固定幅`w-96`をレスポンシブ(`min(320px, 100vw-24px)`)に変更
- 未ログイン時のUXを、disabled+titleツールチップ(スマホのタップで出ない既知の問題)から「常時クリック可能+Popover内注記行」に変更。ログイン誘導のトースト表示は既存の呼び出し元([AudioButtonWithFavoriteClient](apps/web/src/components/audio/audio-button-with-favorite-client.tsx))にすでにあるロジックがそのまま働くようになる
- ハードコードされていた色はすべて`suzuka`/`minase`デザイントークン経由に統一(ダークモード対応は今回スコープ外)

B案・C案は不採用のため未実装。

## Test plan
- [x] `pnpm --filter @suzumina.click/ui typecheck` / `lint` / `test` (localで実行、パス)
- [x] `pnpm --filter @suzumina.click/web typecheck` (影響する唯一の呼び出し元を確認、パス)
- [x] `pnpm verify` (プロジェクト全体のlint+typecheck+test、exit 0)
- [x] Storybookでビジュアル確認(通常/認証済み/未認証/長文タイトル/モバイル幅375px)
- [x] disabled前提の既存テストを新仕様(常時有効+注記行)に更新、progress通知の新規テストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)