### PR TITLE
feat(web): 音声ボタン詳細に「Xで共有」ボタンを追加 (SPR-248)

### DIFF
--- a/apps/web/src/components/audio-button-detail/audio-button-detail-actions.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-actions.tsx
@@ -1,14 +1,17 @@
 import { FavoriteButton } from "@/components/audio/favorite-button";
 import { LikeDislikeButtons } from "@/components/audio/like-dislike-buttons";
+import { ShareOnXButton } from "@/components/audio/share-on-x-button";
 
 interface AudioButtonDetailActionsProps {
 	audioButtonId: string;
+	buttonText: string;
 	favoriteCount: number;
 	likeCount: number;
 }
 
 export function AudioButtonDetailActions({
 	audioButtonId,
+	buttonText,
 	favoriteCount,
 	likeCount,
 }: AudioButtonDetailActionsProps) {
@@ -33,6 +36,9 @@ export function AudioButtonDetailActions({
 					variant="outline"
 					size="sm"
 				/>
+
+				{/* Xで共有（静的 intent リンク・SPR-248） */}
+				<ShareOnXButton audioButtonId={audioButtonId} buttonText={buttonText} />
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-detail-main-content.tsx
@@ -121,6 +121,7 @@ export function AudioButtonDetailMainContent({ audioButton }: AudioButtonDetailM
 					{/* アクションボタン */}
 					<AudioButtonDetailActions
 						audioButtonId={audioButton.id}
+						buttonText={audioButton.buttonText}
 						favoriteCount={audioButton.stats.favoriteCount || 0}
 						likeCount={audioButton.stats.likeCount}
 					/>

--- a/apps/web/src/components/audio/__tests__/share-on-x-button.test.tsx
+++ b/apps/web/src/components/audio/__tests__/share-on-x-button.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { buildXShareUrl, ShareOnXButton } from "../share-on-x-button";
+
+describe("buildXShareUrl", () => {
+	it("x.com の intent URL を生成し、text/url/hashtags を含む", () => {
+		const url = new URL(buildXShareUrl("abc123", "ベイリース、来い"));
+
+		expect(url.origin).toBe("https://x.com");
+		expect(url.pathname).toBe("/intent/post");
+		expect(url.searchParams.get("text")).toBe("「ベイリース、来い」");
+		expect(url.searchParams.get("url")).toBe("https://suzumina.click/buttons/abc123");
+		expect(url.searchParams.get("hashtags")).toBe("涼花みなせ");
+	});
+
+	it("URL に影響する記号（& # ? =）を含むボタン名も壊れずエンコードされる", () => {
+		const url = new URL(buildXShareUrl("id1", "A&B #tag ?= 100%"));
+
+		expect(url.searchParams.get("text")).toBe("「A&B #tag ?= 100%」");
+		// 他のパラメータが記号に侵食されないこと
+		expect(url.searchParams.get("url")).toBe("https://suzumina.click/buttons/id1");
+		expect(url.searchParams.get("hashtags")).toBe("涼花みなせ");
+	});
+});
+
+describe("ShareOnXButton", () => {
+	it("intent URL への新規タブリンクとして描画される", () => {
+		render(<ShareOnXButton audioButtonId="abc123" buttonText="テストボタン" />);
+
+		const link = screen.getByRole("link", { name: "「テストボタン」をXで共有" });
+		expect(link).toHaveAttribute("href", buildXShareUrl("abc123", "テストボタン"));
+		expect(link).toHaveAttribute("target", "_blank");
+		expect(link).toHaveAttribute("rel", "noopener noreferrer");
+		expect(link).toHaveTextContent("Xで共有");
+	});
+});

--- a/apps/web/src/components/audio/share-on-x-button.tsx
+++ b/apps/web/src/components/audio/share-on-x-button.tsx
@@ -1,0 +1,41 @@
+import { XIcon } from "@suzumina.click/ui/components/custom/x-icon";
+import { Button } from "@suzumina.click/ui/components/ui/button";
+
+/**
+ * X 共有 intent URL の組み立て正本（SPR-248）。
+ * Player Card は承認制で使えないため、共有はカード（OGP）+ Web Intent で行う（SPR-17 の結論）。
+ * URL は共有先で意味を持つよう本番の canonical URL に固定する（generateMetadata の og:url と同じ方針）。
+ */
+export function buildXShareUrl(audioButtonId: string, buttonText: string): string {
+	const params = new URLSearchParams({
+		text: `「${buttonText}」`,
+		url: `https://suzumina.click/buttons/${audioButtonId}`,
+		hashtags: "涼花みなせ",
+	});
+	return `https://x.com/intent/post?${params.toString()}`;
+}
+
+interface ShareOnXButtonProps {
+	audioButtonId: string;
+	buttonText: string;
+}
+
+/**
+ * 「Xで共有」ボタン。per-user 状態を持たないため静的な intent リンクで完結する
+ * （client island 不要・SSR そのまま）。
+ */
+export function ShareOnXButton({ audioButtonId, buttonText }: ShareOnXButtonProps) {
+	return (
+		<Button variant="outline" size="sm" asChild className="flex items-center gap-1">
+			<a
+				href={buildXShareUrl(audioButtonId, buttonText)}
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={`「${buttonText}」をXで共有`}
+			>
+				<XIcon className="h-4 w-4" />
+				Xで共有
+			</a>
+		</Button>
+	);
+}

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -50,6 +50,7 @@ export { TimeDisplay } from "./time-display";
 export type { ValidationMessageProps } from "./validation-message";
 export { ValidationMessage, ValidationMessages } from "./validation-message";
 
+export { XIcon } from "./x-icon";
 export { YoutubeIcon } from "./youtube-icon";
 // YouTube components
 export { YouTubePlayer } from "./youtube-player";

--- a/packages/ui/src/components/custom/x-icon.tsx
+++ b/packages/ui/src/components/custom/x-icon.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+interface XIconProps extends SVGProps<SVGSVGElement> {
+	size?: string | number;
+}
+
+/**
+ * X（旧Twitter）ロゴアイコン。lucide-react 1.x はブランドアイコンを持たないため自前で保持する
+ * （YoutubeIcon と同じパターン）。塗りつぶしグリフのため stroke ではなく fill を使う。
+ */
+export function XIcon({ size = 24, className, ...props }: XIconProps) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			width={size}
+			height={size}
+			className={className}
+			aria-hidden="true"
+			{...props}
+		>
+			<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+		</svg>
+	);
+}


### PR DESCRIPTION
## 概要

音声ボタン詳細ページのアクション行（お気に入り・高評価の並び）に「Xで共有」ボタンを追加します。

SPR-17 スパイクの結論（X内インライン再生は Player Card 承認制のため不可能 → X は入口と割り切り共有導線を整備）に基づく実装です。Linear: SPR-248

## 変更内容

- `apps/web/src/components/audio/share-on-x-button.tsx`（新規）: `x.com/intent/post` への静的リンク。intent URL の組み立ては純関数 `buildXShareUrl` に分離（text=「ボタン名」/ hashtags=涼花みなせ / canonical URL）。per-user 状態を持たないため client island 不要
- `packages/ui/src/components/custom/x-icon.tsx`（新規）: X ロゴアイコン。lucide-react 1.x はブランドアイコン非搭載のため YoutubeIcon と同パターンで自前保持
- `audio-button-detail-actions.tsx` / `audio-button-detail-main-content.tsx`: `buttonText` prop を追加し ShareOnXButton を組み込み

### 設計判断

Issue の実装メモには「navigator.share 優先」とあったが、「Xで共有」という明示ラベルのボタンが OS 共有シートを開くのはラベルと挙動の不一致（軸3）になるため、X intent への直接リンクに単純化した。汎用共有（Web Share API）が欲しくなったら別ボタンとして追加する。

## テスト

- [x] `pnpm verify` 通過（exit 0）
- [x] 新規テスト: intent URL の組み立て（日本語・`& # ? =` 記号のエンコード検証）+ リンク描画（href/target/rel/aria-label）
- [x] Firestore Emulator + ブラウザ preview で実表示を検証: アクション行に表示され、intent URL のパラメータが正しくデコードされること・コンソールエラーなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)