### PR TITLE
feat(web,ui): 一覧のAudioButtonポップオーバーに「Xで共有」を追加 (SPR-248拡張)

### DIFF
--- a/apps/web/src/components/audio/__tests__/share-on-x-button.test.tsx
+++ b/apps/web/src/components/audio/__tests__/share-on-x-button.test.tsx
@@ -9,8 +9,18 @@ describe("buildXShareUrl", () => {
 		expect(url.origin).toBe("https://x.com");
 		expect(url.pathname).toBe("/intent/post");
 		expect(url.searchParams.get("text")).toBe("「ベイリース、来い」");
-		expect(url.searchParams.get("url")).toBe("https://suzumina.click/buttons/abc123");
+		expect(url.searchParams.get("url")).toBe(
+			"https://suzumina.click/buttons/abc123?utm_source=x&utm_medium=social",
+		);
 		expect(url.searchParams.get("hashtags")).toBe("涼花みなせ");
+	});
+
+	it("共有先 URL に X 流入判別用の utm が付与される", () => {
+		const shared = new URL(new URL(buildXShareUrl("abc123", "テスト")).searchParams.get("url")!);
+
+		expect(shared.pathname).toBe("/buttons/abc123");
+		expect(shared.searchParams.get("utm_source")).toBe("x");
+		expect(shared.searchParams.get("utm_medium")).toBe("social");
 	});
 
 	it("URL に影響する記号（& # ? =）を含むボタン名も壊れずエンコードされる", () => {
@@ -18,7 +28,9 @@ describe("buildXShareUrl", () => {
 
 		expect(url.searchParams.get("text")).toBe("「A&B #tag ?= 100%」");
 		// 他のパラメータが記号に侵食されないこと
-		expect(url.searchParams.get("url")).toBe("https://suzumina.click/buttons/id1");
+		expect(url.searchParams.get("url")).toBe(
+			"https://suzumina.click/buttons/id1?utm_source=x&utm_medium=social",
+		);
 		expect(url.searchParams.get("hashtags")).toBe("涼花みなせ");
 	});
 });

--- a/apps/web/src/components/audio/audio-button-with-favorite-client.tsx
+++ b/apps/web/src/components/audio/audio-button-with-favorite-client.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { getLikeDislikeStatusAction, toggleDislikeAction } from "@/actions/dislikes";
 import { toggleFavoriteAction } from "@/actions/favorites";
 import { toggleLikeAction } from "@/actions/likes";
+import { buildXShareUrl } from "@/components/audio/share-on-x-button";
 import { useSession } from "@/lib/auth/client";
 
 interface AudioButtonWithFavoriteClientProps {
@@ -220,6 +221,7 @@ export function AudioButtonWithFavoriteClient({
 			searchQuery={searchQuery}
 			highlightClassName={highlightClassName}
 			isAuthenticated={isAuthenticated}
+			xShareUrl={buildXShareUrl(audioButton.id, audioButton.buttonText)}
 		/>
 	);
 }

--- a/apps/web/src/components/audio/share-on-x-button.tsx
+++ b/apps/web/src/components/audio/share-on-x-button.tsx
@@ -9,7 +9,8 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 export function buildXShareUrl(audioButtonId: string, buttonText: string): string {
 	const params = new URLSearchParams({
 		text: `「${buttonText}」`,
-		url: `https://suzumina.click/buttons/${audioButtonId}`,
+		// utm は X 共有経由の流入を GA4 / サーバーログで判別するため（canonical は utm なしのまま）
+		url: `https://suzumina.click/buttons/${audioButtonId}?utm_source=x&utm_medium=social`,
 		hashtags: "涼花みなせ",
 	});
 	return `https://x.com/intent/post?${params.toString()}`;

--- a/packages/ui/src/components/custom/__tests__/audio-button.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/audio-button.test.tsx
@@ -287,6 +287,30 @@ describe("AudioButton", () => {
 		);
 	});
 
+	it("xShareUrl 指定時のみポップオーバーに共有リンクを表示する", async () => {
+		const user = userEvent.setup();
+		const shareUrl = "https://x.com/intent/post?text=test";
+
+		render(<AudioButton audioButton={mockAudioButton} xShareUrl={shareUrl} />);
+
+		await user.click(screen.getByRole("button", { name: "詳細を表示" }));
+
+		const shareLink = screen.getByRole("link", { name: "「テスト音声ボタン」をXで共有" });
+		expect(shareLink).toHaveAttribute("href", shareUrl);
+		expect(shareLink).toHaveAttribute("target", "_blank");
+		expect(shareLink).toHaveAttribute("rel", "noopener noreferrer");
+	});
+
+	it("xShareUrl 未指定なら共有リンクを表示しない", async () => {
+		const user = userEvent.setup();
+
+		render(<AudioButton audioButton={mockAudioButton} />);
+
+		await user.click(screen.getByRole("button", { name: "詳細を表示" }));
+
+		expect(screen.queryByRole("link", { name: /をXで共有/ })).not.toBeInTheDocument();
+	});
+
 	it("should keep favorite button enabled when not authenticated and let the caller decide", async () => {
 		const user = userEvent.setup();
 		const onFavoriteToggleMock = vi.fn();

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -30,6 +30,7 @@ import { useCallback, useId, useRef, useState } from "react";
 import { type AudioControls, AudioPlayer } from "./audio-player";
 import { HighlightText } from "./highlight-text";
 import { TagList } from "./tag-list";
+import { XIcon } from "./x-icon";
 import { YoutubeIcon } from "./youtube-icon";
 
 interface AudioButtonProps {
@@ -59,6 +60,8 @@ interface AudioButtonProps {
 	highlightClassName?: string;
 	// 認証関連
 	isAuthenticated?: boolean;
+	/** X共有の intent URL。指定時のみポップオーバーに「共有」アクションを表示（組み立ては呼び出し元の責務） */
+	xShareUrl?: string;
 }
 
 interface AudioButtonPopoverContentProps {
@@ -77,6 +80,7 @@ interface AudioButtonPopoverContentProps {
 	searchQuery?: string;
 	highlightClassName?: string;
 	isAuthenticated: boolean;
+	xShareUrl?: string;
 }
 
 // Extracted components for reducing complexity
@@ -310,6 +314,7 @@ function PopoverActions({
 	onDetailClick,
 	onPopoverClose,
 	describedBy,
+	xShareUrl,
 }: {
 	audioButton: AudioButtonType;
 	youtubeUrl: string;
@@ -323,6 +328,7 @@ function PopoverActions({
 	onDetailClick?: () => void;
 	onPopoverClose?: () => void;
 	describedBy?: string;
+	xShareUrl?: string;
 }) {
 	return (
 		<div className="flex gap-1 items-center flex-wrap">
@@ -351,6 +357,20 @@ function PopoverActions({
 				<YoutubeIcon className="h-4 w-4" />
 				YouTube
 			</a>
+
+			{xShareUrl && (
+				<a
+					href={xShareUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="flex items-center gap-1.5 h-10 px-2.5 rounded-lg text-xs font-semibold bg-foreground/5 text-foreground hover:bg-foreground/10 transition-colors"
+					onClick={(e) => e.stopPropagation()}
+					aria-label={`「${audioButton.buttonText}」をXで共有`}
+				>
+					<XIcon className="h-3.5 w-3.5" />
+					共有
+				</a>
+			)}
 
 			{showDetailLink && onDetailClick && (
 				<button
@@ -387,6 +407,7 @@ function AudioButtonPopoverContent({
 	searchQuery,
 	highlightClassName,
 	isAuthenticated,
+	xShareUrl,
 }: AudioButtonPopoverContentProps) {
 	const authNoteId = useId();
 
@@ -431,6 +452,7 @@ function AudioButtonPopoverContent({
 					onDetailClick={onDetailClick}
 					onPopoverClose={onPopoverClose}
 					describedBy={isAuthenticated ? undefined : authNoteId}
+					xShareUrl={xShareUrl}
 				/>
 			</div>
 		</div>
@@ -456,6 +478,7 @@ export function AudioButton({
 	searchQuery,
 	highlightClassName,
 	isAuthenticated = false,
+	xShareUrl,
 }: AudioButtonProps) {
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
@@ -627,6 +650,7 @@ export function AudioButton({
 						onPopoverClose={() => setIsPopoverOpen(false)}
 						searchQuery={searchQuery}
 						highlightClassName={highlightClassName}
+						xShareUrl={xShareUrl}
 						isAuthenticated={isAuthenticated}
 					/>
 				</PopoverContent>


### PR DESCRIPTION
## 概要

一覧・トップ等の AudioButton ポップオーバー（「…」メニュー）のアクション行に「共有」（X intent リンク）を追加します。あわせて共有先 URL に UTM パラメータを付与し、X 経由流入を計測可能にします。Linear: SPR-248

## 背景（アクセス実態調査の結論）

Cloud Run リクエストログ30日分・GA4・Firestore playCount の突合により:
- 詳細ページの人間アクセスは約3.5件/日（うち72%は単発スイープ、平常時は約1件/日）
- 再生（累計3,462回）はほぼすべて一覧/トップで完結
- → 共有ボタンが詳細ページ（PR #769）にしかないと共有機会がほぼ発生しない。**共有の起点は再生の現場＝一覧の AudioButton に置く必要がある**

## 変更内容

- `packages/ui` AudioButton: `xShareUrl?: string` prop を追加。指定時のみポップオーバーのアクション行（YouTube リンクの隣）に共有リンクを表示。intent URL の組み立ては呼び出し元の責務（packages/ui は表示のみ）
- `apps/web` audio-button-with-favorite-client: `buildXShareUrl` で xShareUrl を注入（AudioButton の全利用箇所はこの1箇所に集約されているため、一覧・トップ・詳細の再生エリアすべてで有効化）
- `buildXShareUrl`: 共有先 URL に `?utm_source=x&utm_medium=social` を付与（canonical / og:url は utm なしのまま）。共有効果の検証手段の確保が目的

## テスト

- [x] `pnpm verify` 通過（exit 0）
- [x] packages/ui: xShareUrl 指定時のみ共有リンクが表示されること・href/target/rel を検証（userEvent でポップオーバーを開くテスト）
- [x] apps/web: utm 付与を含む intent URL 組み立てを検証
- [x] Firestore Emulator + ブラウザ preview で一覧ページのポップオーバーを実際に開き、共有リンクのパラメータ（text/url+utm/hashtags）・target/rel を確認。リロード後のコンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)