### PR TITLE
feat(web): 音声ボタン詳細に動的OG画像を生成 (SPR-249)

### DIFF
--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -6,6 +6,7 @@ import { getAudioButtonById } from "@/app/buttons/actions";
  * X のリンクカードは「画像 + 小タイトル + ドメイン」しか表示しないため（SPR-17 調査）、
  * 「音声ボタンである」こと・ボタン名を画像自体に載せる。
  * og:image / twitter:image はこの規約ファイルから自動出力される（generateMetadata の images 手書きは撤去済み）。
+ * どの失敗経路でも 500 は返さない（ボタン未取得→サイト名版 / フォント取得失敗→ASCII 縮退版）。
  */
 
 export const size = { width: 1200, height: 630 };
@@ -35,7 +36,9 @@ export function buttonTextFontSize(text: string): number {
 
 /**
  * Google Fonts から表示文字だけの Noto Sans JP サブセットを取得する。
- * ブラウザ UA を名乗らない fetch には woff2 でなく TTF が返るため ImageResponse でそのまま使える。
+ * - ブラウザ UA を名乗らない fetch には woff2 でなく TTF が返るため ImageResponse でそのまま使える
+ * - `text=` 付きの css2 は日英混在でも @font-face を1件だけ返す（unicode-range 分割なし。2026-07 実測）。
+ *   万一複数に分割されても、呼び出し側の catch で ASCII 縮退版にフォールバックする
  */
 async function loadNotoSansJpSubset(text: string): Promise<ArrayBuffer> {
 	const uniqueChars = [...new Set(text)].join("");
@@ -68,32 +71,25 @@ function PlayIcon() {
 	);
 }
 
-interface OgImageParams {
-	params: Promise<{ id: string }>;
+interface OgCardProps {
+	headerLabel: string;
+	durationLabel: string;
+	heading: string;
+	headingFontSize: number;
+	footerLeft: string;
+	footerRight: string;
 }
 
-export default async function Image({ params }: OgImageParams) {
-	const { id } = await params;
-
-	let buttonText = "";
-	let durationLabel = "";
-	try {
-		const result = await getAudioButtonById(id);
-		if (result.success) {
-			const button = result.data;
-			buttonText = truncateButtonText(button.buttonText);
-			const duration = (button.endTime || button.startTime) - button.startTime;
-			durationLabel = `${duration.toFixed(1)}秒`;
-		}
-	} catch {
-		// ボタン未取得時はサイト名だけのフォールバック画像を返す（画像 500 でカード無画像になるより良い）
-	}
-
-	const heading = buttonText ? `「${buttonText}」` : "すずみなくりっく！";
-	const fontText = `${heading}${durationLabel}涼花みなせ音声ボタンすずみなくりっく！suzumina.click`;
-	const notoSansJp = await loadNotoSansJpSubset(fontText);
-
-	return new ImageResponse(
+/** カードレイアウト本体（通常版と ASCII 縮退版で共用） */
+function OgCard({
+	headerLabel,
+	durationLabel,
+	heading,
+	headingFontSize,
+	footerLeft,
+	footerRight,
+}: OgCardProps) {
+	return (
 		<div
 			style={{
 				display: "flex",
@@ -111,7 +107,7 @@ export default async function Image({ params }: OgImageParams) {
 			<div style={{ display: "flex", alignItems: "center", gap: 28 }}>
 				<PlayIcon />
 				<div style={{ display: "flex", flexDirection: "column" }}>
-					<span style={{ fontSize: 34, color: SUZUKA_700 }}>涼花みなせ 音声ボタン</span>
+					<span style={{ fontSize: 34, color: SUZUKA_700 }}>{headerLabel}</span>
 					{durationLabel && (
 						<span style={{ fontSize: 28, color: MINASE_600 }}>{durationLabel}</span>
 					)}
@@ -124,7 +120,7 @@ export default async function Image({ params }: OgImageParams) {
 					display: "flex",
 					flexGrow: 1,
 					alignItems: "center",
-					fontSize: buttonText ? buttonTextFontSize(buttonText) : 76,
+					fontSize: headingFontSize,
 					fontWeight: 700,
 					color: MINASE_950,
 					lineHeight: 1.35,
@@ -144,10 +140,62 @@ export default async function Image({ params }: OgImageParams) {
 					paddingTop: 28,
 				}}
 			>
-				<span style={{ fontSize: 36, fontWeight: 700, color: SUZUKA_500 }}>すずみなくりっく！</span>
-				<span style={{ fontSize: 30, color: MINASE_600 }}>suzumina.click</span>
+				<span style={{ fontSize: 36, fontWeight: 700, color: SUZUKA_500 }}>{footerLeft}</span>
+				<span style={{ fontSize: 30, color: MINASE_600 }}>{footerRight}</span>
 			</div>
-		</div>,
+		</div>
+	);
+}
+
+interface OgImageParams {
+	params: Promise<{ id: string }>;
+}
+
+export default async function Image({ params }: OgImageParams) {
+	const { id } = await params;
+
+	// getAudioButtonById は withErrorHandling で例外を握り常に {success} を返すが、
+	// OG 画像はどの経路でも 500 にしないルートなので念のため reject も null に落とす
+	const result = await getAudioButtonById(id).catch(() => null);
+	let buttonText = "";
+	let durationSec: number | null = null;
+	if (result?.success) {
+		buttonText = truncateButtonText(result.data.buttonText);
+		durationSec = (result.data.endTime || result.data.startTime) - result.data.startTime;
+	}
+
+	const heading = buttonText ? `「${buttonText}」` : "すずみなくりっく！";
+	const durationLabel = durationSec != null ? `${durationSec.toFixed(1)}秒` : "";
+	const fontText = `${heading}${durationLabel}涼花みなせ音声ボタンすずみなくりっく！suzumina.click`;
+
+	// フォント取得失敗でも 500 にしない: 内蔵デフォルトフォント（latin のみ）で ASCII 縮退版を描画。
+	// ボタン名が ASCII ならそのまま表示を継続できる
+	const notoSansJp = await loadNotoSansJpSubset(fontText).catch(() => null);
+	if (!notoSansJp) {
+		const asciiButtonText = /^[\x20-\x7E]+$/.test(buttonText) ? buttonText : "";
+		const asciiHeading = asciiButtonText ? `"${asciiButtonText}"` : "suzumina.click";
+		return new ImageResponse(
+			<OgCard
+				headerLabel="SOUND BUTTON"
+				durationLabel={durationSec != null ? `${durationSec.toFixed(1)}s` : ""}
+				heading={asciiHeading}
+				headingFontSize={buttonTextFontSize(asciiHeading)}
+				footerLeft="suzumina.click"
+				footerRight=""
+			/>,
+			{ ...size },
+		);
+	}
+
+	return new ImageResponse(
+		<OgCard
+			headerLabel="涼花みなせ 音声ボタン"
+			durationLabel={durationLabel}
+			heading={heading}
+			headingFontSize={buttonText ? buttonTextFontSize(buttonText) : 76}
+			footerLeft="すずみなくりっく！"
+			footerRight="suzumina.click"
+		/>,
 		{
 			...size,
 			fonts: [{ name: "Noto Sans JP", data: notoSansJp, weight: 700, style: "normal" }],

--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -1,0 +1,156 @@
+import { ImageResponse } from "next/og";
+import { getAudioButtonById } from "@/app/buttons/actions";
+
+/**
+ * 音声ボタン詳細の動的 OG 画像（SPR-249）。
+ * X のリンクカードは「画像 + 小タイトル + ドメイン」しか表示しないため（SPR-17 調査）、
+ * 「音声ボタンである」こと・ボタン名を画像自体に載せる。
+ * og:image / twitter:image はこの規約ファイルから自動出力される（generateMetadata の images 手書きは撤去済み）。
+ */
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "涼花みなせ音声ボタン - すずみなくりっく！";
+
+// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
+// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
+const SUZUKA_500 = "hsl(340, 58%, 46%)";
+const SUZUKA_700 = "hsl(339, 55%, 33%)";
+const MINASE_50 = "hsl(36, 50%, 97%)";
+const MINASE_200 = "hsl(33, 40%, 86%)";
+const MINASE_600 = "hsl(29, 36%, 56%)";
+const MINASE_950 = "hsl(25, 28%, 18%)";
+
+/** ボタン名の表示用整形。長すぎる場合は末尾を省略する */
+export function truncateButtonText(text: string, max = 60): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** ボタン名の長さに応じたフォントサイズ（px） */
+export function buttonTextFontSize(text: string): number {
+	if (text.length <= 15) return 76;
+	if (text.length <= 30) return 60;
+	return 44;
+}
+
+/**
+ * Google Fonts から表示文字だけの Noto Sans JP サブセットを取得する。
+ * ブラウザ UA を名乗らない fetch には woff2 でなく TTF が返るため ImageResponse でそのまま使える。
+ */
+async function loadNotoSansJpSubset(text: string): Promise<ArrayBuffer> {
+	const uniqueChars = [...new Set(text)].join("");
+	const cssUrl = `https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@700&text=${encodeURIComponent(uniqueChars)}`;
+	const css = await (await fetch(cssUrl)).text();
+	const fontUrl = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)?.[1];
+	if (!fontUrl) {
+		throw new Error("OG画像用フォントのサブセット取得に失敗しました");
+	}
+	return (await fetch(fontUrl)).arrayBuffer();
+}
+
+function PlayIcon() {
+	return (
+		<div
+			style={{
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				width: 88,
+				height: 88,
+				borderRadius: 9999,
+				backgroundColor: SUZUKA_500,
+			}}
+		>
+			<svg width="36" height="40" viewBox="0 0 18 20" aria-hidden="true">
+				<path d="M2 1.5 L16.5 10 L2 18.5 Z" fill="white" />
+			</svg>
+		</div>
+	);
+}
+
+interface OgImageParams {
+	params: Promise<{ id: string }>;
+}
+
+export default async function Image({ params }: OgImageParams) {
+	const { id } = await params;
+
+	let buttonText = "";
+	let durationLabel = "";
+	try {
+		const result = await getAudioButtonById(id);
+		if (result.success) {
+			const button = result.data;
+			buttonText = truncateButtonText(button.buttonText);
+			const duration = (button.endTime || button.startTime) - button.startTime;
+			durationLabel = `${duration.toFixed(1)}秒`;
+		}
+	} catch {
+		// ボタン未取得時はサイト名だけのフォールバック画像を返す（画像 500 でカード無画像になるより良い）
+	}
+
+	const heading = buttonText ? `「${buttonText}」` : "すずみなくりっく！";
+	const fontText = `${heading}${durationLabel}涼花みなせ音声ボタンすずみなくりっく！suzumina.click`;
+	const notoSansJp = await loadNotoSansJpSubset(fontText);
+
+	return new ImageResponse(
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				width: "100%",
+				height: "100%",
+				padding: 64,
+				backgroundColor: MINASE_50,
+				borderBottom: `20px solid ${SUZUKA_500}`,
+				fontFamily: "Noto Sans JP",
+			}}
+		>
+			{/* ヘッダー: 再生アイコン + ラベル */}
+			<div style={{ display: "flex", alignItems: "center", gap: 28 }}>
+				<PlayIcon />
+				<div style={{ display: "flex", flexDirection: "column" }}>
+					<span style={{ fontSize: 34, color: SUZUKA_700 }}>涼花みなせ 音声ボタン</span>
+					{durationLabel && (
+						<span style={{ fontSize: 28, color: MINASE_600 }}>{durationLabel}</span>
+					)}
+				</div>
+			</div>
+
+			{/* ボタン名 */}
+			<div
+				style={{
+					display: "flex",
+					flexGrow: 1,
+					alignItems: "center",
+					fontSize: buttonText ? buttonTextFontSize(buttonText) : 76,
+					fontWeight: 700,
+					color: MINASE_950,
+					lineHeight: 1.35,
+					wordBreak: "break-all",
+				}}
+			>
+				{heading}
+			</div>
+
+			{/* フッター: サイトブランド */}
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					borderTop: `2px solid ${MINASE_200}`,
+					paddingTop: 28,
+				}}
+			>
+				<span style={{ fontSize: 36, fontWeight: 700, color: SUZUKA_500 }}>すずみなくりっく！</span>
+				<span style={{ fontSize: 30, color: MINASE_600 }}>suzumina.click</span>
+			</div>
+		</div>,
+		{
+			...size,
+			fonts: [{ name: "Noto Sans JP", data: notoSansJp, weight: 700, style: "normal" }],
+		},
+	);
+}

--- a/apps/web/src/app/buttons/[id]/page.tsx
+++ b/apps/web/src/app/buttons/[id]/page.tsx
@@ -57,19 +57,13 @@ export async function generateMetadata({ params }: AudioButtonDetailPageProps): 
 			"YouTube",
 			"音声切り抜き",
 		],
+		// og:image / twitter:image は手書きしない。同ディレクトリの opengraph-image.tsx
+		// （動的生成・SPR-249）から両タグとも自動出力される
 		openGraph: {
 			title: `${audioButton.buttonText} | すずみなくりっく！`,
 			description: description,
 			type: "article",
 			url: `https://suzumina.click/buttons/${audioButton.id}`,
-			images: [
-				{
-					url: `https://img.youtube.com/vi/${audioButton.videoId}/maxresdefault.jpg`,
-					width: 1280,
-					height: 720,
-					alt: `${audioButton.buttonText} - 涼花みなせ音声ボタン`,
-				},
-			],
 			publishedTime: audioButton.createdAt,
 			authors: [audioButton.creatorName],
 		},
@@ -77,7 +71,6 @@ export async function generateMetadata({ params }: AudioButtonDetailPageProps): 
 			card: "summary_large_image",
 			title: `${audioButton.buttonText} | すずみなくりっく！`,
 			description: description,
-			images: [`https://img.youtube.com/vi/${audioButton.videoId}/maxresdefault.jpg`],
 		},
 		alternates: {
 			canonical: `/buttons/${audioButton.id}`,


### PR DESCRIPTION
## 概要

`/buttons/[id]` の OG 画像を YouTube サムネ流用から動的生成（next/og ImageResponse・1200×630）に置き換えます。X のリンクカードは「画像 + 小タイトルオーバーレイ + ドメイン」しか表示しないため（SPR-17 調査）、「音声ボタンである」こと・ボタン名・再生秒数・サイトブランドを画像自体に載せます。Linear: SPR-249

## 変更内容

- `apps/web/src/app/buttons/[id]/opengraph-image.tsx`（新規・ImageResponse 初導入）
  - ボタン名（60字省略・長さに応じ3段階のフォントサイズ）・再生秒数・桜霞パレット（suzuka/minase、正本 globals.css からライトモード値を転記）・サイト名/ドメイン
  - 日本語フォント: Google Fonts css2 の `text=` パラメータで**表示文字のみサブセット取得**（非ブラウザ UA には TTF が返るため ImageResponse でそのまま使用可。フルフォント同梱 ~5MB を回避）
  - ボタン未取得時はサイト名のみのフォールバック画像（画像 500 でカード無画像になるのを回避）
- `page.tsx`: generateMetadata の `openGraph.images` / `twitter.images` 手書き（YouTube maxresdefault 流用）を撤去。**規約ファイルから og:image / twitter:image 両タグが自動出力される**（dev で実測確認済み）

## 副次効果

- YouTube 側で maxresdefault.jpg が存在しない動画でもカード画像が欠けなくなる

## テスト・検証

- [x] `pnpm verify` 通過（exit 0）
- [x] dev + Emulator で meta 出力実測: og:image / og:image:width/height/alt / twitter:image が生成 URL を指すことを確認
- [x] 画像本体を目視確認: 通常（ベイリース、来い/3.4秒）・最長33字（英文・縮小表示）・存在しない ID（フォールバック）の3パターン、いずれも 200 / image/png
- [ ] **マージ後**: 本番レスポンスで og:image を確認 + X 投稿コンポーザーでカードプレビュー目視（Card Validator は廃止済みのため）

## 留意点

- 画像生成は本番で fonts.googleapis.com への outbound fetch を伴う（1リクエストあたり css + ttf の2フェッチ、サブセットなので数十KB）。X クローラのフェッチ頻度なら問題にならない想定
- twitter:image も規約ファイルから出るため、X 側フォールバック頼みではない

🤖 Generated with [Claude Code](https://claude.com/claude-code)