### PR TITLE
feat(web): OG画像をAudioButton再現デザインにリデザイン (SPR-249)

### DIFF
--- a/apps/web/src/app/buttons/[id]/__tests__/opengraph-image.test.ts
+++ b/apps/web/src/app/buttons/[id]/__tests__/opengraph-image.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+// opengraph-image.tsx は next/og と Firestore 依存の action を import するため、
+// 純関数（truncate / 字幅概算 / タイトル整形）のテストに必要な分だけモックする
+vi.mock("next/og", () => ({ ImageResponse: class {} }));
+vi.mock("@/app/buttons/actions", () => ({ getAudioButtonById: vi.fn() }));
+
+import { estimateTextWidth, formatVideoTitle, truncateButtonText } from "../opengraph-image";
+
+describe("truncateButtonText", () => {
+	it("52字以内はそのまま返す", () => {
+		const text = "あ".repeat(52);
+		expect(truncateButtonText(text)).toBe(text);
+	});
+
+	it("52字を超えると末尾を省略記号にする", () => {
+		const text = "あ".repeat(53);
+		expect(truncateButtonText(text)).toBe(`${"あ".repeat(52)}…`);
+		expect(truncateButtonText(text).length).toBe(53);
+	});
+});
+
+describe("estimateTextWidth", () => {
+	it("全角は 1.0em、半角は 0.6em で概算する", () => {
+		expect(estimateTextWidth("あいう", 56)).toBe(3 * 56);
+		expect(estimateTextWidth("abc", 56)).toBe(Math.round(3 * 0.6 * 56));
+	});
+
+	it("折り返し閾値の境界: 全角13字は 750px 以内・14字で超過（56px時）", () => {
+		expect(estimateTextWidth("あ".repeat(13), 56)).toBeLessThanOrEqual(750);
+		expect(estimateTextWidth("あ".repeat(14), 56)).toBeGreaterThan(750);
+	});
+});
+
+describe("formatVideoTitle", () => {
+	it("絵文字（フォント外グリフ）を除去する", () => {
+		expect(formatVideoTitle("今日はどんなお客さんが来るかな…☕？")).toBe(
+			"今日はどんなお客さんが来るかな…？",
+		);
+	});
+
+	it("ZWJ 合成絵文字・異体字セレクタも除去する", () => {
+		expect(formatVideoTitle("配信👨‍👩‍👧‍👦開始✌️です")).toBe("配信開始です");
+	});
+
+	it("連続空白を1つに畳み、40字を超えると省略する", () => {
+		expect(formatVideoTitle("A  B　 C")).toBe("A B C");
+		const long = "あ".repeat(45);
+		expect(formatVideoTitle(long)).toBe(`${"あ".repeat(40)}…`);
+	});
+
+	it("空文字はそのまま空文字", () => {
+		expect(formatVideoTitle("")).toBe("");
+	});
+});

--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -2,9 +2,9 @@ import { ImageResponse } from "next/og";
 import { getAudioButtonById } from "@/app/buttons/actions";
 
 /**
- * 音声ボタン詳細の動的 OG 画像（SPR-249）。
+ * 音声ボタン詳細の動的 OG 画像（SPR-249 / デザインは Claude Design「音声ボタンOGP」1a 案）。
  * X のリンクカードは「画像 + 小タイトル + ドメイン」しか表示しないため（SPR-17 調査）、
- * 「音声ボタンである」こと・ボタン名を画像自体に載せる。
+ * サイトの AudioButton UI を再現したカードを画像中央に据え、「押せるボタン」であることを伝える。
  * og:image / twitter:image はこの規約ファイルから自動出力される（generateMetadata の images 手書きは撤去済み）。
  * どの失敗経路でも 500 は返さない（ボタン未取得→サイト名版 / フォント取得失敗→ASCII 縮退版）。
  */
@@ -15,34 +15,58 @@ export const alt = "涼花みなせ音声ボタン - すずみなくりっく！
 
 // 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
 // ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
+const BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
+const SUZUKA_100 = "hsl(341, 62%, 94%)";
 const SUZUKA_500 = "hsl(340, 58%, 46%)";
 const SUZUKA_700 = "hsl(339, 55%, 33%)";
 const MINASE_50 = "hsl(36, 50%, 97%)";
+const MINASE_100 = "hsl(34, 44%, 93%)";
 const MINASE_200 = "hsl(33, 40%, 86%)";
+const MINASE_300 = "hsl(32, 38%, 79%)";
+const MINASE_500 = "hsl(30, 38%, 66%)";
 const MINASE_600 = "hsl(29, 36%, 56%)";
+const MINASE_800 = "hsl(27, 32%, 37%)";
 const MINASE_950 = "hsl(25, 28%, 18%)";
+const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 
-/** ボタン名の表示用整形。長すぎる場合は末尾を省略する */
-export function truncateButtonText(text: string, max = 60): string {
+/** ボタン名の表示用整形。折り返し幅 750px × 4行に収まる長さへ末尾省略する */
+export function truncateButtonText(text: string, max = 52): string {
 	return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
-/** ボタン名の長さに応じたフォントサイズ（px） */
-export function buttonTextFontSize(text: string): number {
-	if (text.length <= 15) return 76;
-	if (text.length <= 30) return 60;
-	return 44;
+/**
+ * テキストの概算描画幅（px）。半角 ≈ 0.6em / 全角 ≈ 1.0em の粗い見積もり。
+ * satori(Yoga) は auto 幅 flex の入れ子内でテキスト折り返し幅を解決できないため、
+ * 「1行に収まらない場合だけ明示幅を与えて折り返す」判定に使う（正確な字幅計測は不要）
+ */
+export function estimateTextWidth(text: string, fontSize: number): number {
+	let em = 0;
+	for (const ch of text) {
+		em += (ch.codePointAt(0) ?? 0) <= 0x024f ? 0.6 : 1.0;
+	}
+	return Math.round(em * fontSize);
 }
 
 /**
- * Google Fonts から表示文字だけの Noto Sans JP サブセットを取得する。
+ * 元動画タイトルの表示用整形。フォントに無い絵文字（tofu 化する）を除去し、1行に収まる長さへ省略する
+ */
+export function formatVideoTitle(title: string, max = 40): string {
+	const stripped = title
+		.replace(/\p{Extended_Pictographic}|\u{FE0F}|\u{200D}/gu, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	return stripped.length > max ? `${stripped.slice(0, max)}…` : stripped;
+}
+
+/**
+ * Google Fonts から表示文字だけの M PLUS Rounded 1c（ブランドフォント正）サブセットを取得する。
  * - ブラウザ UA を名乗らない fetch には woff2 でなく TTF が返るため ImageResponse でそのまま使える
  * - `text=` 付きの css2 は日英混在でも @font-face を1件だけ返す（unicode-range 分割なし。2026-07 実測）。
- *   万一複数に分割されても、呼び出し側の catch で ASCII 縮退版にフォールバックする
+ *   万一失敗しても、呼び出し側の catch で ASCII 縮退版にフォールバックする
  */
-async function loadNotoSansJpSubset(text: string): Promise<ArrayBuffer> {
+async function loadMPlusRoundedSubset(weight: 400 | 700, text: string): Promise<ArrayBuffer> {
 	const uniqueChars = [...new Set(text)].join("");
-	const cssUrl = `https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@700&text=${encodeURIComponent(uniqueChars)}`;
+	const cssUrl = `https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@${weight}&text=${encodeURIComponent(uniqueChars)}`;
 	const css = await (await fetch(cssUrl)).text();
 	const fontUrl = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)?.[1];
 	if (!fontUrl) {
@@ -51,98 +75,247 @@ async function loadNotoSansJpSubset(text: string): Promise<ArrayBuffer> {
 	return (await fetch(fontUrl)).arrayBuffer();
 }
 
-function PlayIcon() {
+function PlayCircle() {
 	return (
 		<div
 			style={{
 				display: "flex",
 				alignItems: "center",
 				justifyContent: "center",
-				width: 88,
-				height: 88,
+				width: 92,
+				height: 92,
+				flexShrink: 0,
 				borderRadius: 9999,
-				backgroundColor: SUZUKA_500,
+				backgroundColor: MINASE_500,
 			}}
 		>
-			<svg width="36" height="40" viewBox="0 0 18 20" aria-hidden="true">
-				<path d="M2 1.5 L16.5 10 L2 18.5 Z" fill="white" />
+			<svg
+				width="44"
+				height="44"
+				viewBox="0 0 24 24"
+				fill="white"
+				stroke="white"
+				strokeWidth="2"
+				strokeLinejoin="round"
+				style={{ marginLeft: 6 }}
+				aria-hidden="true"
+			>
+				<path d="m6 3 14 9-14 9V3z" />
 			</svg>
 		</div>
 	);
 }
 
-interface OgCardProps {
-	headerLabel: string;
-	durationLabel: string;
-	heading: string;
-	headingFontSize: number;
-	footerLeft: string;
-	footerRight: string;
+function DotsIcon() {
+	return (
+		<svg width="44" height="44" viewBox="0 0 24 24" fill={MINASE_600} aria-hidden="true">
+			<circle cx="5" cy="12" r="2.2" />
+			<circle cx="12" cy="12" r="2.2" />
+			<circle cx="19" cy="12" r="2.2" />
+		</svg>
+	);
 }
 
-/** カードレイアウト本体（通常版と ASCII 縮退版で共用） */
-function OgCard({
-	headerLabel,
-	durationLabel,
-	heading,
-	headingFontSize,
-	footerLeft,
-	footerRight,
-}: OgCardProps) {
+function ClockIcon() {
+	return (
+		<svg
+			width="26"
+			height="26"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke={MINASE_800}
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<circle cx="12" cy="12" r="10" />
+			<path d="M12 6v6l4 2" />
+		</svg>
+	);
+}
+
+function VideoIcon() {
+	return (
+		<svg
+			width="28"
+			height="28"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke={MUTED_FOREGROUND}
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="m22 8-6 4 6 4V8Z" />
+			<rect x="2" y="6" width="14" height="12" rx="2" />
+		</svg>
+	);
+}
+
+interface OgCardProps {
+	siteName: string;
+	badgeLabel: string;
+	buttonText: string;
+	durationLabel: string;
+	videoTitle: string;
+}
+
+// AudioButton 再現カードの寸法（1200 - 左右 padding 64×2 = カード最大幅 1072。
+// テキスト幅 = 1072 - dots 104 - border 8 - 内 padding 88 - 再生円 92 - gap 30 = 750）
+const CARD_MAX_WIDTH = 1072;
+const BUTTON_TEXT_MAX_WIDTH = 750;
+const BUTTON_TEXT_FONT_SIZE = 56;
+
+/** 1a 案レイアウト: ヘッダー + AudioButton 再現カード + メタ行 + 底部バー（通常版と ASCII 縮退版で共用） */
+function OgCard({ siteName, badgeLabel, buttonText, durationLabel, videoTitle }: OgCardProps) {
+	// 1行に収まらない場合のみ明示幅を与えて折り返す（satori は auto 幅入れ子で折り返せない）
+	const needsWrap = estimateTextWidth(buttonText, BUTTON_TEXT_FONT_SIZE) > BUTTON_TEXT_MAX_WIDTH;
 	return (
 		<div
 			style={{
 				display: "flex",
 				flexDirection: "column",
-				justifyContent: "space-between",
 				width: "100%",
 				height: "100%",
-				padding: 64,
-				backgroundColor: MINASE_50,
-				borderBottom: `20px solid ${SUZUKA_500}`,
-				fontFamily: "Noto Sans JP",
+				backgroundColor: BACKGROUND,
+				fontFamily: "M PLUS Rounded 1c",
 			}}
 		>
-			{/* ヘッダー: 再生アイコン + ラベル */}
-			<div style={{ display: "flex", alignItems: "center", gap: 28 }}>
-				<PlayIcon />
-				<div style={{ display: "flex", flexDirection: "column" }}>
-					<span style={{ fontSize: 34, color: SUZUKA_700 }}>{headerLabel}</span>
-					{durationLabel && (
-						<span style={{ fontSize: 28, color: MINASE_600 }}>{durationLabel}</span>
-					)}
-				</div>
-			</div>
-
-			{/* ボタン名 */}
-			<div
-				style={{
-					display: "flex",
-					flexGrow: 1,
-					alignItems: "center",
-					fontSize: headingFontSize,
-					fontWeight: 700,
-					color: MINASE_950,
-					lineHeight: 1.35,
-					wordBreak: "break-all",
-				}}
-			>
-				{heading}
-			</div>
-
-			{/* フッター: サイトブランド */}
+			{/* ヘッダー: サイト名 + 音声ボタンピル */}
 			<div
 				style={{
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "space-between",
-					borderTop: `2px solid ${MINASE_200}`,
-					paddingTop: 28,
+					padding: "48px 64px 0",
 				}}
 			>
-				<span style={{ fontSize: 36, fontWeight: 700, color: SUZUKA_500 }}>{footerLeft}</span>
-				<span style={{ fontSize: 30, color: MINASE_600 }}>{footerRight}</span>
+				<span style={{ fontWeight: 700, fontSize: 36, color: SUZUKA_500 }}>{siteName}</span>
+				<span
+					style={{
+						backgroundColor: SUZUKA_100,
+						color: SUZUKA_700,
+						fontWeight: 700,
+						fontSize: 25,
+						padding: "10px 30px",
+						borderRadius: 9999,
+					}}
+				>
+					{badgeLabel}
+				</span>
 			</div>
+
+			{/* 中央: サイトの AudioButton を再現したカード */}
+			<div
+				style={{
+					display: "flex",
+					flexGrow: 1,
+					alignItems: "center",
+					justifyContent: "center",
+					padding: "0 64px",
+					minHeight: 0,
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "stretch",
+						...(needsWrap ? { width: CARD_MAX_WIDTH } : {}),
+						backgroundColor: MINASE_50,
+						border: `4px solid ${MINASE_300}`,
+						borderRadius: 32,
+						boxShadow: "0 12px 40px hsl(30, 38%, 66%, 0.35)",
+						overflow: "hidden",
+					}}
+				>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 30,
+							padding: "32px 44px",
+							minWidth: 0,
+						}}
+					>
+						<PlayCircle />
+						<div
+							style={{
+								...(needsWrap ? { width: BUTTON_TEXT_MAX_WIDTH } : {}),
+								fontWeight: 700,
+								fontSize: BUTTON_TEXT_FONT_SIZE,
+								lineHeight: 1.3,
+								color: MINASE_950,
+							}}
+						>
+							{buttonText}
+						</div>
+					</div>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							width: 104,
+							flexShrink: 0,
+							borderLeft: `3px solid ${MINASE_200}`,
+						}}
+					>
+						<DotsIcon />
+					</div>
+				</div>
+			</div>
+
+			{/* メタ行: 再生秒数ピル + 元動画タイトル */}
+			<div style={{ display: "flex", alignItems: "center", gap: 28, padding: "0 64px 44px" }}>
+				{durationLabel && (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 12,
+							flexShrink: 0,
+							backgroundColor: MINASE_100,
+							borderRadius: 9999,
+							padding: "10px 26px",
+							fontWeight: 700,
+							fontSize: 25,
+							color: MINASE_800,
+						}}
+					>
+						<ClockIcon />
+						<span>{durationLabel}</span>
+					</div>
+				)}
+				{videoTitle && (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 14,
+							minWidth: 0,
+							flexGrow: 1,
+							color: MUTED_FOREGROUND,
+							fontSize: 25,
+						}}
+					>
+						<VideoIcon />
+						<span
+							style={{
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+								whiteSpace: "nowrap",
+							}}
+						>
+							{videoTitle}
+						</span>
+					</div>
+				)}
+			</div>
+
+			{/* 底部バー */}
+			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: SUZUKA_500 }} />
 		</div>
 	);
 }
@@ -159,29 +332,33 @@ export default async function Image({ params }: OgImageParams) {
 	const result = await getAudioButtonById(id).catch(() => null);
 	let buttonText = "";
 	let durationSec: number | null = null;
+	let videoTitle = "";
 	if (result?.success) {
 		buttonText = truncateButtonText(result.data.buttonText);
 		durationSec = (result.data.endTime || result.data.startTime) - result.data.startTime;
+		videoTitle = formatVideoTitle(result.data.videoTitle || "");
 	}
 
-	const heading = buttonText ? `「${buttonText}」` : "すずみなくりっく！";
+	const heading = buttonText || "すずみなくりっく！";
 	const durationLabel = durationSec != null ? `${durationSec.toFixed(1)}秒` : "";
-	const fontText = `${heading}${durationLabel}涼花みなせ音声ボタンすずみなくりっく！suzumina.click`;
+	const boldText = `${heading}${durationLabel}すずみなくりっく！音声ボタン`;
 
 	// フォント取得失敗でも 500 にしない: 内蔵デフォルトフォント（latin のみ）で ASCII 縮退版を描画。
-	// ボタン名が ASCII ならそのまま表示を継続できる
-	const notoSansJp = await loadNotoSansJpSubset(fontText).catch(() => null);
-	if (!notoSansJp) {
+	// ボタン名が ASCII ならそのまま表示を継続できる。regular(400) はメタ行専用なので欠けても bold で代替される
+	const [fontBold, fontRegular] = await Promise.all([
+		loadMPlusRoundedSubset(700, boldText).catch(() => null),
+		loadMPlusRoundedSubset(400, videoTitle).catch(() => null),
+	]);
+
+	if (!fontBold) {
 		const asciiButtonText = /^[\x20-\x7E]+$/.test(buttonText) ? buttonText : "";
-		const asciiHeading = asciiButtonText ? `"${asciiButtonText}"` : "suzumina.click";
 		return new ImageResponse(
 			<OgCard
-				headerLabel="SOUND BUTTON"
+				siteName="suzumina.click"
+				badgeLabel="SOUND BUTTON"
+				buttonText={asciiButtonText || "suzumina.click"}
 				durationLabel={durationSec != null ? `${durationSec.toFixed(1)}s` : ""}
-				heading={asciiHeading}
-				headingFontSize={buttonTextFontSize(asciiHeading)}
-				footerLeft="suzumina.click"
-				footerRight=""
+				videoTitle=""
 			/>,
 			{ ...size },
 		);
@@ -189,16 +366,27 @@ export default async function Image({ params }: OgImageParams) {
 
 	return new ImageResponse(
 		<OgCard
-			headerLabel="涼花みなせ 音声ボタン"
+			siteName="すずみなくりっく！"
+			badgeLabel="音声ボタン"
+			buttonText={heading}
 			durationLabel={durationLabel}
-			heading={heading}
-			headingFontSize={buttonText ? buttonTextFontSize(buttonText) : 76}
-			footerLeft="すずみなくりっく！"
-			footerRight="suzumina.click"
+			videoTitle={videoTitle}
 		/>,
 		{
 			...size,
-			fonts: [{ name: "Noto Sans JP", data: notoSansJp, weight: 700, style: "normal" }],
+			fonts: [
+				{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" },
+				...(fontRegular && videoTitle
+					? [
+							{
+								name: "M PLUS Rounded 1c",
+								data: fontRegular,
+								weight: 400 as const,
+								style: "normal" as const,
+							},
+						]
+					: []),
+			],
 		},
 	);
 }

--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -226,7 +226,7 @@ function OgCard({ siteName, badgeLabel, buttonText, durationLabel, videoTitle }:
 						backgroundColor: MINASE_50,
 						border: `4px solid ${MINASE_300}`,
 						borderRadius: 32,
-						boxShadow: "0 12px 40px hsl(30, 38%, 66%, 0.35)",
+						boxShadow: "0 12px 40px hsla(30, 38%, 66%, 0.35)",
 						overflow: "hidden",
 					}}
 				>
@@ -347,7 +347,8 @@ export default async function Image({ params }: OgImageParams) {
 	// ボタン名が ASCII ならそのまま表示を継続できる。regular(400) はメタ行専用なので欠けても bold で代替される
 	const [fontBold, fontRegular] = await Promise.all([
 		loadMPlusRoundedSubset(700, boldText).catch(() => null),
-		loadMPlusRoundedSubset(400, videoTitle).catch(() => null),
+		// videoTitle が空（未設定・ボタン未取得のフォールバック経路）なら 400 のフェッチ自体を省く
+		videoTitle ? loadMPlusRoundedSubset(400, videoTitle).catch(() => null) : Promise.resolve(null),
 	]);
 
 	if (!fontBold) {


### PR DESCRIPTION
## 概要

音声ボタン詳細の OG 画像を、Claude Design で作成した「音声ボタンOGP」**1a 案（サイトそのまま）** に差し替えます。サイトの AudioButton UI を再現したカードを中央に据え、「押せるボタン」であることがカードから一目で伝わるデザインです。Linear: SPR-249

デザインソース: [Claude Design プロジェクト「すずみなくりっくの音声ボタンOG」](https://claude.ai/design/p/bde89fd3-a5b9-43a2-8220-1e4c19697d48?file=%E9%9F%B3%E5%A3%B0%E3%83%9C%E3%82%BF%E3%83%B3OGP.dc.html)（1a/1b/1c の3案からユーザー選定）

## 変更内容

- **レイアウト**: ヘッダー（サイト名 + 「音声ボタン」ピル）/ 中央に AudioButton 再現カード（minase 再生円 + ボタン名 + 「…」区画）/ メタ行（秒数ピル + 元動画タイトル）/ 底部ローズバー
- **フォント**: ブランド正の **M PLUS Rounded 1c** に変更（700/400 の2ウェイトをサブセット取得。400 失敗時は 700 が代替）
- **元動画タイトルを新規表示**: フォント外グリフ（絵文字）を除去し40字省略（☕入りタイトルで除去動作を実測確認）
- **色**: 全てトークン対応値（background/suzuka-100/500/700/minase-50〜950/muted-foreground。正本 globals.css からの転記コメント付き）

## satori の技術的知見（コードコメントに文書化済み）

検証の過程で **satori(Yoga) は auto 幅 flex の入れ子内でテキスト折り返し幅を解決できない**ことを実測で確認（`lineClamp` / `% maxWidth` / px `maxWidth` いずれも無効 — 変更前後でPNGがバイト一致することで裏取り）。対策として、概算字幅（半角0.6em/全角1.0em）で1行超過を判定し、超過時のみカードとテキストに明示 px 幅を与えて折り返す方式を採用。ボタン名は 52 字省略（750px×4行に収まる上限）。

## テスト・検証（dev + Emulator 実測）

- [x] 通常（ベイリース、来い）: デザイン 1a のモック通りに描画
- [x] 長文 ASCII 33字: カード全幅 + 2行折り返し（デザインの長文バリアント通り）
- [x] 存在しない ID: サイト名版フォールバック 200
- [x] 絵文字入り動画タイトル: ☕ 除去を確認（正規表現の lint 対応前後でバイト一致＝回帰なし）
- [x] `pnpm verify` 通過（exit 0）
- [ ] **マージ後**: 本番 og:image 実測 + X コンポーザーでプレビュー目視（X 側は同一URLのOGPキャッシュ注意 — 画像URLの ?hash が変わるため実質新URL）

🤖 Generated with [Claude Code](https://claude.com/claude-code)