### PR TITLE
feat(web): 音声ボタン詳細を再生ハブ化 — 関連ボタンを同タグ・人気まで拡充 (SPR-250)

### DIFF
--- a/apps/web/src/components/audio-button-detail/__tests__/related-audio-buttons.test.tsx
+++ b/apps/web/src/components/audio-button-detail/__tests__/related-audio-buttons.test.tsx
@@ -1,0 +1,144 @@
+import type { AudioButton } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RelatedAudioButtons } from "../related-audio-buttons";
+
+vi.mock("@/app/buttons/actions", () => ({
+	getAudioButtonsList: vi.fn(),
+}));
+
+// client leaf（session/router 依存）は表示検証に不要なのでボタン名だけ出すスタブに差し替える
+vi.mock("@/components/audio/audio-button-with-play-count", () => ({
+	AudioButtonWithPlayCount: ({ audioButton }: { audioButton: AudioButton }) => (
+		<div data-testid="audio-button">{audioButton.buttonText}</div>
+	),
+}));
+
+import { getAudioButtonsList } from "@/app/buttons/actions";
+
+const mockList = vi.mocked(getAudioButtonsList);
+
+function makeButton(id: string): AudioButton {
+	return {
+		id,
+		buttonText: `ボタン${id}`,
+		tags: [],
+		videoId: "v1",
+		videoTitle: "動画",
+		startTime: 0,
+		endTime: 1,
+		duration: 1,
+		creatorId: "u1",
+		creatorName: "作成者",
+		isPublic: true,
+		stats: { playCount: 0, likeCount: 0, dislikeCount: 0, favoriteCount: 0, engagementRate: 0 },
+		createdAt: "2026-01-01T00:00:00.000Z",
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		_computed: {
+			isPopular: false,
+			engagementRate: 0,
+			engagementRatePercentage: 0,
+			popularityScore: 0,
+			searchableText: "",
+			durationText: "1.0秒",
+			relativeTimeText: "1日前",
+		},
+	} as AudioButton;
+}
+
+function successResult(buttons: AudioButton[]) {
+	return {
+		success: true as const,
+		data: { audioButtons: buttons, totalCount: buttons.length, hasMore: false },
+	};
+}
+
+describe("RelatedAudioButtons", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("同一動画セクションから現在のボタンを除外して表示する", async () => {
+		mockList.mockImplementation(async (query) => {
+			if (query?.videoId) return successResult([makeButton("current"), makeButton("b1")]);
+			return successResult([]);
+		});
+
+		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: [] }));
+
+		expect(screen.getByText("同じ動画の音声ボタン")).toBeInTheDocument();
+		expect(screen.getByText("ボタンb1")).toBeInTheDocument();
+		expect(screen.queryByText("ボタンcurrent")).not.toBeInTheDocument();
+	});
+
+	it("同タグセクションは同一動画セクションと重複するボタンを出さない", async () => {
+		mockList.mockImplementation(async (query) => {
+			if (query?.videoId) return successResult([makeButton("b1")]);
+			if (query?.tags) return successResult([makeButton("b1"), makeButton("b2")]);
+			return successResult([]);
+		});
+
+		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: ["タグA"] }));
+
+		expect(screen.getByText("同じタグの音声ボタン")).toBeInTheDocument();
+		// b1 は同一動画側にのみ表示（重複排除）
+		expect(screen.getAllByText("ボタンb1")).toHaveLength(1);
+		expect(screen.getByText("ボタンb2")).toBeInTheDocument();
+		// もっと見るリンクはタグを | 連結した一覧 URL を指す
+		expect(screen.getByRole("link", { name: "同じタグのボタンをもっと見る" })).toHaveAttribute(
+			"href",
+			`/buttons?tags=${encodeURIComponent("タグA")}`,
+		);
+	});
+
+	it("tags が空なら同タグクエリを発行しない", async () => {
+		mockList.mockResolvedValue(successResult([makeButton("b1")]));
+
+		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: [] }));
+
+		expect(mockList).toHaveBeenCalledTimes(1);
+		expect(mockList).toHaveBeenCalledWith(expect.objectContaining({ videoId: "v1" }));
+	});
+
+	it("同一動画・同タグとも空なら人気ボタンで受ける（行き止まり防止）", async () => {
+		mockList.mockImplementation(async (query) => {
+			if (query?.videoId || query?.tags) return successResult([]);
+			return successResult([makeButton("pop1")]);
+		});
+
+		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: ["タグA"] }));
+
+		expect(screen.getByText("人気の音声ボタン")).toBeInTheDocument();
+		expect(screen.getByText("ボタンpop1")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "音声ボタン一覧を見る" })).toHaveAttribute(
+			"href",
+			"/buttons",
+		);
+	});
+
+	it("全セクション空なら null を返す", async () => {
+		mockList.mockResolvedValue(successResult([]));
+
+		const element = await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: [] });
+		expect(element).toBeNull();
+	});
+
+	it("取得失敗はセクション空として継続する（throw しない）", async () => {
+		mockList.mockRejectedValue(new Error("firestore down"));
+
+		const element = await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: [] });
+		expect(element).toBeNull();
+	});
+
+	it("各セクション最大12件に制限する", async () => {
+		const many = Array.from({ length: 13 }, (_, i) => makeButton(`b${i}`));
+		mockList.mockImplementation(async (query) => {
+			if (query?.videoId) return successResult(many);
+			return successResult([]);
+		});
+
+		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: [] }));
+
+		expect(screen.getAllByTestId("audio-button")).toHaveLength(12);
+	});
+});

--- a/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
+++ b/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
@@ -2,10 +2,19 @@ import type { AudioButton } from "@suzumina.click/shared-types";
 import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
+import { Flame, Tag } from "lucide-react";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { getAudioButtonsList } from "@/app/buttons/actions";
 import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
-import type { AudioButtonQuery } from "@/types/audio-button";
+
+/**
+ * 詳細ページの関連音声ボタン群（SPR-250 で再生ハブ化）。
+ * X共有・検索から着地した訪問者が「1ボタン聴いて終わり」にならないよう、
+ * 同じ動画 → 同じタグ → （両方無ければ）人気、の順で必ず次に押せるボタンを出す。
+ * 同一動画クエリは既存の videoId+createdAt 複合インデックスを使う（sortBy を変えると新規インデックスが要る点に注意）。
+ * タグ・人気は in-memory フィルタ / 単一 orderBy のため複合インデックス不要。
+ */
 
 interface RelatedAudioButtonsProps {
 	currentId: string;
@@ -13,71 +22,131 @@ interface RelatedAudioButtonsProps {
 	tags: string[];
 }
 
-export async function RelatedAudioButtons({
-	currentId,
-	videoId,
-	tags: _tags,
-}: RelatedAudioButtonsProps) {
-	try {
-		// 同じ動画の音声ボタンを取得
-		const sameVideoQuery: AudioButtonQuery = {
-			videoId: videoId,
-			limit: 6,
+const SECTION_LIMIT = 12;
+
+/** 取得失敗はセクション空扱いにしてページ表示を継続する */
+async function fetchButtons(
+	query: Parameters<typeof getAudioButtonsList>[0],
+): Promise<AudioButton[]> {
+	const result = await getAudioButtonsList(query).catch(() => null);
+	return result?.success ? result.data.audioButtons : [];
+}
+
+function RelatedSection({
+	icon,
+	title,
+	buttons,
+	moreHref,
+	moreLabel,
+}: {
+	icon: ReactNode;
+	title: string;
+	buttons: AudioButton[];
+	moreHref: string;
+	moreLabel: string;
+}) {
+	return (
+		<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">
+			<CardHeader>
+				<CardTitle className="flex items-center gap-2 text-lg">
+					{icon}
+					{title}
+				</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="flex flex-wrap gap-3 items-start">
+					{buttons.map((audioButton) => (
+						<AudioButtonWithPlayCount
+							key={audioButton.id}
+							audioButton={audioButton}
+							showFavorite={true}
+							maxTitleLength={50}
+							className="shadow-sm hover:shadow-md transition-all duration-200"
+						/>
+					))}
+				</div>
+				<div className="mt-6 text-center">
+					<Button
+						variant="outline"
+						size="sm"
+						asChild
+						className="border-border text-primary hover:bg-accent"
+					>
+						<Link href={moreHref}>{moreLabel}</Link>
+					</Button>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+export async function RelatedAudioButtons({ currentId, videoId, tags }: RelatedAudioButtonsProps) {
+	// +1 は現在のボタン自身が結果に含まれる分の余裕
+	const [sameVideoAll, sameTagsAll] = await Promise.all([
+		fetchButtons({
+			videoId,
+			limit: SECTION_LIMIT + 1,
 			sortBy: "newest",
 			onlyPublic: true,
-			includeTotalCount: false, // 関連音声ボタンでは総数は不要
-		};
+		}),
+		tags.length > 0
+			? fetchButtons({
+					tags,
+					limit: SECTION_LIMIT + 1,
+					sortBy: "mostPlayed",
+					onlyPublic: true,
+				})
+			: Promise.resolve([]),
+	]);
 
-		const sameVideoResult = await getAudioButtonsList(sameVideoQuery);
+	const sameVideo = sameVideoAll.filter((b) => b.id !== currentId).slice(0, SECTION_LIMIT);
+	const shownIds = new Set([currentId, ...sameVideo.map((b) => b.id)]);
+	const sameTags = sameTagsAll.filter((b) => !shownIds.has(b.id)).slice(0, SECTION_LIMIT);
 
-		if (sameVideoResult.success) {
-			const relatedButtons = sameVideoResult.data.audioButtons.filter(
-				(button: AudioButton) => button.id !== currentId,
-			);
-
-			if (relatedButtons.length > 0) {
-				return (
-					<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">
-						<CardHeader>
-							<CardTitle className="flex items-center gap-2 text-lg">
-								<YoutubeIcon className="h-5 w-5 text-primary" />
-								同じ動画の音声ボタン
-							</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<div className="flex flex-wrap gap-3 items-start">
-								{relatedButtons.slice(0, 6).map((audioButton: AudioButton) => (
-									<AudioButtonWithPlayCount
-										key={audioButton.id}
-										audioButton={audioButton}
-										showFavorite={true}
-										maxTitleLength={50}
-										className="shadow-sm hover:shadow-md transition-all duration-200"
-									/>
-								))}
-							</div>
-							{relatedButtons.length > 6 && (
-								<div className="mt-6 text-center">
-									<Button
-										variant="outline"
-										size="sm"
-										asChild
-										className="border-border text-primary hover:bg-accent"
-									>
-										<Link href={`/buttons?videoId=${videoId}`}>
-											この動画の音声ボタンをもっと見る
-										</Link>
-									</Button>
-								</div>
-							)}
-						</CardContent>
-					</Card>
-				);
-			}
-		}
-	} catch (_error) {
-		// 関連音声ボタン取得エラーは無視してページを継続表示
+	// 両セクションとも空なら人気ボタンで受ける（外部流入の行き止まり防止）
+	let popular: AudioButton[] = [];
+	if (sameVideo.length === 0 && sameTags.length === 0) {
+		const popularAll = await fetchButtons({
+			limit: SECTION_LIMIT + 1,
+			sortBy: "mostPlayed",
+			onlyPublic: true,
+		});
+		popular = popularAll.filter((b) => b.id !== currentId).slice(0, SECTION_LIMIT);
 	}
 
-	return null;
+	if (sameVideo.length === 0 && sameTags.length === 0 && popular.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className="space-y-8">
+			{sameVideo.length > 0 && (
+				<RelatedSection
+					icon={<YoutubeIcon className="h-5 w-5 text-primary" />}
+					title="同じ動画の音声ボタン"
+					buttons={sameVideo}
+					moreHref={`/buttons?videoId=${encodeURIComponent(videoId)}`}
+					moreLabel="この動画のボタンをもっと見る"
+				/>
+			)}
+			{sameTags.length > 0 && (
+				<RelatedSection
+					icon={<Tag className="h-5 w-5 text-primary" />}
+					title="同じタグの音声ボタン"
+					buttons={sameTags}
+					moreHref={`/buttons?tags=${encodeURIComponent(tags.join("|"))}`}
+					moreLabel="同じタグのボタンをもっと見る"
+				/>
+			)}
+			{popular.length > 0 && (
+				<RelatedSection
+					icon={<Flame className="h-5 w-5 text-primary" />}
+					title="人気の音声ボタン"
+					buttons={popular}
+					moreHref="/buttons"
+					moreLabel="音声ボタン一覧を見る"
+				/>
+			)}
+		</div>
+	);
 }

--- a/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
+++ b/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
@@ -92,7 +92,9 @@ export async function RelatedAudioButtons({ currentId, videoId, tags }: RelatedA
 		tags.length > 0
 			? fetchButtons({
 					tags,
-					limit: SECTION_LIMIT + 1,
+					// 同一動画セクションとの重複排除で減る分の余裕。タグ経路は in-memory フィルタ
+					// （全件取得→スライス）のため limit を増やしても Firestore reads は増えない
+					limit: SECTION_LIMIT * 2,
 					sortBy: "mostPlayed",
 					onlyPublic: true,
 				})

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -237,6 +237,7 @@ vi.mock("lucide-react", () => {
 		LogOut: createMockIcon("LogOut"),
 		// Icons for tag editors / WorkDetail など
 		Tag: createMockIcon("Tag"),
+		Flame: createMockIcon("Flame"),
 		FileText: createMockIcon("FileText"),
 		// Icons for VideoDetail
 		Timer: createMockIcon("Timer"),


### PR DESCRIPTION
## 概要

X共有・検索から詳細ページに着地した訪問者が「1ボタン聴いて終わり」にならないよう、関連音声ボタンを**同じ動画 → 同じタグ → （両方無ければ）人気**の3段構成に拡充します。アクセス実態調査（SPR-17 コメント参照）で確定した「ユーザー増は外部→詳細経路のみ」戦略の受け皿です。Linear: SPR-250

## 変更内容

`related-audio-buttons.tsx` を再構成:

- **同じ動画**: 12件に増量（sortBy=newest 維持 = 既存の videoId+createdAt 複合インデックスをそのまま使用。変更すると新規インデックスが必要になるため）
- **同じタグ**（新設）: これまで**受け取るだけで未使用だった `tags` prop を実際に使用**（軸3のズレ解消）。mostPlayed 順 12件・同一動画セクションとの重複排除つき
- **人気**（新設）: 上記2つが空のときのフォールバック。外部流入の行き止まりを防ぐ
- **「もっと見る」を常時表示に修正**: 従来は query limit=6 のまま `length > 6` を判定しており到達不能（dead code）だった。videoId / tags（`|` 連結）付きの一覧 URL へ
- 取得失敗はセクション空扱いでページ表示を継続（従来挙動を維持）

### インデックス影響なし（CLAUDE.md 複合インデックスルール確認済み）

- タグ検索は既存の in-memory フィルタ経路（全件取得→filterByTags）
- 人気ソートは `stats.playCount` 単一 orderBy（自動インデックス）
- 同一動画は既存クエリのまま

## テスト・検証

- [x] 新規テスト7件: currentId 除外 / セクション間の重複排除 / tags 空時のクエリ省略 / 人気フォールバック / 全空で null / 取得失敗の継続 / 12件上限
- [x] `pnpm verify` 通過（exit 0）※ vitest.setup.ts の lucide モックに Flame を追加
- [x] Emulator + preview 実測: 「ベイリース、来い」詳細で同一動画・同タグ両セクションが描画され、「もっと見る」リンク（`?videoId=` / `?tags=ゲーム%7CCOFFEE%20TALK`）が一覧のタグフィルタ（全16件）として機能することを確認。コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)