### PR TITLE
feat(web): 一覧からのボタン詳細をモーダル表示に統合 (SPR-252)

### DIFF
--- a/apps/web/src/app/buttons/@modal/(.)[id]/__tests__/audio-button-detail-modal.test.tsx
+++ b/apps/web/src/app/buttons/@modal/(.)[id]/__tests__/audio-button-detail-modal.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AudioButtonDetailModal } from "../audio-button-detail-modal";
+
+const backMock = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ back: backMock, push: vi.fn(), refresh: vi.fn() }),
+}));
+
+describe("AudioButtonDetailModal", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("children とフル詳細ページへの「ページで開く」リンクを表示する", () => {
+		render(
+			<AudioButtonDetailModal audioButtonId="abc123">
+				<div data-testid="detail-content">詳細コンテンツ</div>
+			</AudioButtonDetailModal>,
+		);
+
+		expect(screen.getByTestId("detail-content")).toBeInTheDocument();
+
+		// soft nav ではモーダルが解除されないため、素の <a>（フルロード）であることが重要
+		const link = screen.getByRole("link", { name: /ページで開く/ });
+		expect(link).toHaveAttribute("href", "/buttons/abc123");
+	});
+
+	it("閉じるボタンで router.back を呼ぶ（履歴で一覧へ戻す）", async () => {
+		const user = userEvent.setup();
+		render(
+			<AudioButtonDetailModal audioButtonId="abc123">
+				<div>詳細</div>
+			</AudioButtonDetailModal>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "Close" }));
+
+		expect(backMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/app/buttons/@modal/(.)[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/buttons/@modal/(.)[id]/__tests__/page.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import InterceptedAudioButtonPage from "../page";
+
+vi.mock("@/app/buttons/actions", () => ({
+	getAudioButtonById: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ back: vi.fn(), push: vi.fn(), refresh: vi.fn() }),
+}));
+
+// 詳細コンテンツ本体（server component ツリー）はモーダル配線の検証には不要
+vi.mock("@/components/audio-button-detail", () => ({
+	AudioButtonDetailMainContent: ({ audioButton }: { audioButton: { buttonText: string } }) => (
+		<div data-testid="main-content">{audioButton.buttonText}</div>
+	),
+}));
+
+import { getAudioButtonById } from "@/app/buttons/actions";
+
+const mockGet = vi.mocked(getAudioButtonById);
+
+describe("InterceptedAudioButtonPage", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("取得成功時はモーダルに詳細コンテンツを描画する", async () => {
+		mockGet.mockResolvedValue({
+			success: true,
+			data: { id: "abc123", buttonText: "テストボタン" },
+		} as Awaited<ReturnType<typeof getAudioButtonById>>);
+
+		render(await InterceptedAudioButtonPage({ params: Promise.resolve({ id: "abc123" }) }));
+
+		expect(screen.getByTestId("main-content")).toHaveTextContent("テストボタン");
+		expect(screen.getByRole("link", { name: /ページで開く/ })).toHaveAttribute(
+			"href",
+			"/buttons/abc123",
+		);
+	});
+
+	it("取得失敗（success=false）時は null を返しモーダルを重ねない", async () => {
+		mockGet.mockResolvedValue({ success: false, error: "not found" } as Awaited<
+			ReturnType<typeof getAudioButtonById>
+		>);
+
+		const element = await InterceptedAudioButtonPage({
+			params: Promise.resolve({ id: "missing" }),
+		});
+		expect(element).toBeNull();
+	});
+
+	it("取得が reject しても throw せず null を返す", async () => {
+		mockGet.mockRejectedValue(new Error("firestore down"));
+
+		const element = await InterceptedAudioButtonPage({
+			params: Promise.resolve({ id: "abc123" }),
+		});
+		expect(element).toBeNull();
+	});
+});

--- a/apps/web/src/app/buttons/@modal/(.)[id]/audio-button-detail-modal.tsx
+++ b/apps/web/src/app/buttons/@modal/(.)[id]/audio-button-detail-modal.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { Dialog, DialogContent, DialogTitle } from "@suzumina.click/ui/components/ui/dialog";
+import { ExternalLink } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 
+interface AudioButtonDetailModalProps {
+	audioButtonId: string;
+	children: ReactNode;
+}
+
 /**
- * 詳細モーダルの殻（SPR-251 spike）。
- * 閉じる操作は router.back() = 履歴を一覧に戻す（スクロール位置・フィルタは App Router が復元する）。
+ * 一覧文脈の上に重ねる詳細モーダルの殻（SPR-252）。
+ * - 閉じる操作は router.back() = 履歴を戻す（一覧のフィルタ・ページネーション・スクロールは App Router が復元）
+ * - モバイルは全画面シート、sm 以上は中央のラージダイアログ
+ * - 「ページで開く」は同一 URL への soft nav ではモーダルが解除されないため、素の <a>（フルロード）で
+ *   フル詳細ページ（関連ボタン・サイドバー付き）へ遷移させる
  */
-export function AudioButtonDetailModal({ children }: { children: ReactNode }) {
+export function AudioButtonDetailModal({ audioButtonId, children }: AudioButtonDetailModalProps) {
 	const router = useRouter();
 	return (
 		<Dialog
@@ -17,8 +26,17 @@ export function AudioButtonDetailModal({ children }: { children: ReactNode }) {
 				if (!open) router.back();
 			}}
 		>
-			<DialogContent className="w-[calc(100vw-1rem)] sm:w-[calc(100vw-2rem)] sm:max-w-4xl max-h-[90vh] overflow-y-auto p-0">
+			<DialogContent className="top-0 left-0 h-full max-h-full w-full max-w-full translate-x-0 translate-y-0 gap-0 overflow-y-auto rounded-none p-0 sm:top-[50%] sm:left-[50%] sm:h-auto sm:max-h-[90vh] sm:w-[calc(100vw-2rem)] sm:max-w-4xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg">
 				<DialogTitle className="sr-only">音声ボタン詳細</DialogTitle>
+				<div className="flex items-center border-b border-border px-4 py-2.5 pr-12">
+					<a
+						href={`/buttons/${audioButtonId}`}
+						className="flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+					>
+						<ExternalLink className="h-4 w-4" />
+						ページで開く
+					</a>
+				</div>
 				{children}
 			</DialogContent>
 		</Dialog>

--- a/apps/web/src/app/buttons/@modal/(.)[id]/audio-button-detail-modal.tsx
+++ b/apps/web/src/app/buttons/@modal/(.)[id]/audio-button-detail-modal.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Dialog, DialogContent, DialogTitle } from "@suzumina.click/ui/components/ui/dialog";
+import { useRouter } from "next/navigation";
+import type { ReactNode } from "react";
+
+/**
+ * 詳細モーダルの殻（SPR-251 spike）。
+ * 閉じる操作は router.back() = 履歴を一覧に戻す（スクロール位置・フィルタは App Router が復元する）。
+ */
+export function AudioButtonDetailModal({ children }: { children: ReactNode }) {
+	const router = useRouter();
+	return (
+		<Dialog
+			open
+			onOpenChange={(open) => {
+				if (!open) router.back();
+			}}
+		>
+			<DialogContent className="w-[calc(100vw-1rem)] sm:w-[calc(100vw-2rem)] sm:max-w-4xl max-h-[90vh] overflow-y-auto p-0">
+				<DialogTitle className="sr-only">音声ボタン詳細</DialogTitle>
+				{children}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/app/buttons/@modal/(.)[id]/page.tsx
+++ b/apps/web/src/app/buttons/@modal/(.)[id]/page.tsx
@@ -1,0 +1,26 @@
+import { getAudioButtonById } from "@/app/buttons/actions";
+import { AudioButtonDetailMainContent } from "@/components/audio-button-detail";
+import { AudioButtonDetailModal } from "./audio-button-detail-modal";
+
+/**
+ * 一覧からのクライアント遷移時のみ発動する intercepting route（SPR-251 spike）。
+ * URL は /buttons/{id} に同期しつつ、一覧の文脈を保ったままモーダルで詳細を出す。
+ * 直接アクセス・リロード時はインターセプトされず、フル詳細ページ（../[id]/page.tsx）が表示される。
+ */
+export default async function InterceptedAudioButtonPage({
+	params,
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	const result = await getAudioButtonById(id).catch(() => null);
+	// 取得できない場合はモーダルを重ねず一覧に留まる
+	if (!result?.success) {
+		return null;
+	}
+	return (
+		<AudioButtonDetailModal>
+			<AudioButtonDetailMainContent audioButton={result.data} />
+		</AudioButtonDetailModal>
+	);
+}

--- a/apps/web/src/app/buttons/@modal/(.)[id]/page.tsx
+++ b/apps/web/src/app/buttons/@modal/(.)[id]/page.tsx
@@ -3,9 +3,10 @@ import { AudioButtonDetailMainContent } from "@/components/audio-button-detail";
 import { AudioButtonDetailModal } from "./audio-button-detail-modal";
 
 /**
- * 一覧からのクライアント遷移時のみ発動する intercepting route（SPR-251 spike）。
+ * 一覧からのクライアント遷移時のみ発動する intercepting route（SPR-251/252）。
  * URL は /buttons/{id} に同期しつつ、一覧の文脈を保ったままモーダルで詳細を出す。
  * 直接アクセス・リロード時はインターセプトされず、フル詳細ページ（../[id]/page.tsx）が表示される。
+ * 関連ボタン群はモーダルには載せない（クイックビューに徹し、ハブ機能はフル詳細ページ=「ページで開く」に委ねる）。
  */
 export default async function InterceptedAudioButtonPage({
 	params,
@@ -19,7 +20,7 @@ export default async function InterceptedAudioButtonPage({
 		return null;
 	}
 	return (
-		<AudioButtonDetailModal>
+		<AudioButtonDetailModal audioButtonId={result.data.id}>
 			<AudioButtonDetailMainContent audioButton={result.data} />
 		</AudioButtonDetailModal>
 	);

--- a/apps/web/src/app/buttons/@modal/default.tsx
+++ b/apps/web/src/app/buttons/@modal/default.tsx
@@ -1,0 +1,4 @@
+/** モーダル非表示時（直接アクセス・リロード・一覧表示中）の @modal スロット */
+export default function Default() {
+	return null;
+}

--- a/apps/web/src/app/buttons/layout.tsx
+++ b/apps/web/src/app/buttons/layout.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+/**
+ * buttons セグメントの layout（SPR-251 spike）。
+ * @modal parallel route を受け、一覧の上に詳細モーダルを重ねる。
+ * 直接アクセス・リロード時は @modal が default.tsx（null）になり、
+ * children（一覧 or フル詳細ページ）のみが表示される＝OGP 受け皿は温存される。
+ */
+export default function ButtonsLayout({
+	children,
+	modal,
+}: {
+	children: ReactNode;
+	modal: ReactNode;
+}) {
+	return (
+		<>
+			{children}
+			{modal}
+		</>
+	);
+}

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -409,10 +409,11 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			await waitFor(() => expect(createButton).toBeEnabled());
 			await user.click(createButton);
 
-			// 詳細ページへ遷移する
+			// 詳細ページへフルロード遷移する（router.push だと @modal にインターセプトされるため。SPR-252）
 			await waitFor(() => {
-				expect(mockPush).toHaveBeenCalledWith("/buttons/new-audio-button-id");
+				expect(window.location.href).toContain("/buttons/new-audio-button-id");
 			});
+			expect(mockPush).not.toHaveBeenCalled();
 
 			// 遷移完了まで「作成中…」を維持し、フォームは空白化しない（ちらつき防止）
 			expect(screen.getByRole("button", { name: /作成中/ })).toBeInTheDocument();

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -78,11 +78,12 @@ export function AudioButtonCreator({
 			const result = await createAudioButton(input);
 
 			if (result.success) {
-				// 詳細ページへ遷移。create セグメントを離れるためこの instance は破棄される。
+				// 詳細ページへフルロード遷移（SPR-252）。router.push だと /buttons ツリー内の soft nav が
+				// @modal にインターセプトされ、作成フォームの上にクイックビューが重なってしまう
+				// （フォーム instance も破棄されず「作成中…」が固着する）。フルロードなら
+				// フル詳細ページ表示と instance 破棄の両方が保証される。
 				// 遷移完了まで「作成中…」を維持し、フォームを空白化しない（ちらつき防止）。
-				// 既知の制約: router.push に完了コールバックが無いため、遷移が完了しない異常時
-				// （ネットワーク断・SSR エラー等）は「作成中…」のまま固着しうる。ちらつき防止を優先。
-				router.push(`/buttons/${result.data.id}`);
+				window.location.href = `/buttons/${result.data.id}`;
 				return;
 			}
 
@@ -99,7 +100,6 @@ export function AudioButtonCreator({
 		tags,
 		timeAdjustment.startTime,
 		timeAdjustment.endTime,
-		router,
 		setIsCreating,
 		setError,
 		videoTitle,

--- a/apps/web/src/components/audio/audio-button-editor.tsx
+++ b/apps/web/src/components/audio/audio-button-editor.tsx
@@ -56,7 +56,9 @@ export function AudioButtonEditor({ audioButton, videoDuration = 600 }: AudioBut
 			const result = await updateAudioButton(audioButton.id, input);
 
 			if (result.success) {
-				router.push(`/buttons/${audioButton.id}`);
+				// フルロード遷移（SPR-252）: router.push だと /buttons ツリー内の soft nav が
+				// @modal にインターセプトされ、編集フォームの上にクイックビューが重なる
+				window.location.href = `/buttons/${audioButton.id}`;
 			} else {
 				setError(result.error || "更新に失敗しました");
 			}
@@ -65,7 +67,7 @@ export function AudioButtonEditor({ audioButton, videoDuration = 600 }: AudioBut
 		} finally {
 			setIsUpdating(false);
 		}
-	}, [isValid, hasChanges, audioButton.id, buttonText, tags, router, setError, setIsUpdating]);
+	}, [isValid, hasChanges, audioButton.id, buttonText, tags, setError, setIsUpdating]);
 
 	// 時間調整用のハンドラーは共通フックから取得
 


### PR DESCRIPTION
## 概要

一覧からボタンの「詳細」をクリックすると、一覧の文脈（フィルタ・ページネーション・スクロール）を保ったまま**モーダルで詳細を表示**し、URL は `/buttons/{id}` に同期します（そのまま共有可能・戻るで一覧復帰）。SPR-251 spike（GO 判定・prod 事前検証済み）の本実装です。Linear: SPR-252

## 挙動マトリクス（spike + 本 PR で実測）

| 経路 | 挙動 |
|---|---|
| 一覧 → 詳細 | モーダル + URL 同期 |
| トップ等 /buttons 外 → 詳細 | インターセプトされず**フル詳細ページ** |
| 詳細 → 詳細（関連ボタン） | 前ページの上にモーダル |
| 直接アクセス / リロード | フル詳細ページ（**OGP 受け皿温存**） |
| 戻る / 閉じる(X) | router.back() で一覧状態復元（Next 16 Activity） |
| create/edit 成功後 | **フルロードでフル詳細ページ**（AIレビュー対応: soft nav だとインターセプトされフォームの上にモーダルが重なるため window.location.href 化） |

## 変更内容

- `app/buttons/layout.tsx`（@modal スロット受け）+ `@modal/default.tsx`（null）+ `@modal/(.)[id]/page.tsx`（intercepting route）
- モーダル殻 `audio-button-detail-modal.tsx`: モバイル**全画面シート** / sm以上は中央ラージダイアログ（calc(100vw-2rem)・max-w-4xl・90vh）
- ヘッダーに**「ページで開く」**: 素の `<a>`（同一 URL への soft nav ではモーダルが解除されないため意図的にフルロード）→ 関連ボタン付きフル詳細ページへ
- 設計判断: モーダルは**クイックビューに徹する**（関連ボタン群は載せない。ハブ機能は SPR-250 のフル詳細ページに委ねる）
- 既存 `AudioButtonDetailMainContent` を server component のまま再利用

## テスト・検証

- [x] テスト5件: モーダル殻（children とページで開くリンク / close→router.back）+ intercepted page（成功時モーダル描画 / success=false で null / reject でも null）
- [x] `pnpm verify` exit 0
- [x] **本番ビルド（next start + 本番 Firestore 読み取り）で実測**: 一覧→モーダル（デスクトップ: 中央・角丸・719px幅）／モバイル 375px: 完全全画面シート（overflow なし）／戻る→一覧復元／ハイドレーションエラー・コンソール警告ゼロ
- [x] Emulator + dev でも一連の挙動確認

## 開発時の既知の癖（dev 限定・prod 無問題）

- Turbopack dev は intercepting route ファイルの HMR 後にルートマニフェストが壊れることがある（`Invalid interception route: /buttons/(.)(.)…` の 500 → フルページにフォールバック）。**dev サーバー再起動 + .next 削除で回復**。本番ビルドでは発生しない（実測済み）
- Tailwind の dev CSS が新規 arbitrary variant（sm:top-[50%] 等）を HMR で再生成しないことがある → 同上

🤖 Generated with [Claude Code](https://claude.com/claude-code)
