### PR TITLE
fix(ci): Chromaticの無料枠消費を抑制

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,17 +3,17 @@ name: Chromatic
 # packages/ui の Storybook を Chromatic にアップロードし視覚回帰(visual regression)を検出する（SPR-130）。
 # コスト設計: ui 変更時のみ実行 + TurboSnap(--only-changed) で変更 story だけスナップショットし無料枠を節約。
 # - pull_request: マージ前に視覚差分をレビュー（exitZeroOnChanges で GH チェックはブロックしない＝段階的導入）。
-# - push(main): マージ後のベースライン確立。autoAcceptChanges で main の見た目を新ベースラインに自動採用。
+# - push(main) トリガーは廃止（SPR-263）。globals.css 等グローバルファイル変更のたびに TurboSnap が
+#   無効化されフルビルド(678 snapshots)になり無料枠を圧迫したため、main のベースライン確立は
+#   workflow_dispatch の手動実行に切替（autoAcceptChanges: main は手動実行時のみ効く）。
+# - draft PR 中は実行しない（開発中の連続 push でフルビルドを繰り返さないため）。
 # play/a11y は storybook-test.yml、本番ビルド回帰は e2e-smoke.yml が担い、本 workflow は見た目の差分のみ担保する。
 
 on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened]
-  push:
-    branches:
-      - main
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -47,7 +47,11 @@ jobs:
     needs: changes
     # Dependabot run には Actions secrets（CHROMATIC_PROJECT_TOKEN）が注入されず必ず失敗するため除外する。
     # 依存 bump は packages/ui の見た目に影響しない（lock 変更で発火するだけ）ので視覚回帰の対象外でよい。
-    if: needs.changes.outputs.ui == 'true' && github.actor != 'dependabot[bot]'
+    # draft PR は対象外（ready_for_review か workflow_dispatch で改めて実行される）。
+    if: >
+      needs.changes.outputs.ui == 'true' &&
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -55,21 +59,42 @@ jobs:
           # TurboSnap は変更検出に git 履歴を使うため全履歴を取得する
           fetch-depth: 0
 
+      - name: Debounce rapid successive pushes
+        # PR に短時間で複数回 push された場合、古い commit の分は無駄なフルビルド消費になりうるため、
+        # 少し待って PR head が自分自身のままか確認し、既に新しい commit がある（＝後続 run が来る）なら
+        # このジョブは静かにスキップする。concurrency の cancel-in-progress の取りこぼしを補う簡易デバウンス。
+        if: github.event_name == 'pull_request'
+        id: debounce
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 60
+          LATEST_SHA=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq .head.sha)
+          if [ "$LATEST_SHA" != "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup pnpm
+        if: steps.debounce.outputs.stale != 'true'
         uses: pnpm/action-setup@v6
         with:
           run_install: false
 
       - name: Setup Node.js
+        if: steps.debounce.outputs.stale != 'true'
         uses: actions/setup-node@v6
         with:
           node-version: '24.17.0'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.debounce.outputs.stale != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Run Chromatic
+        if: steps.debounce.outputs.stale != 'true'
         uses: chromaui/action@v18
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -79,5 +104,5 @@ jobs:
           onlyChanged: true
           # 視覚差分があっても GH チェックは成功させる（差分は Chromatic 上でレビュー＝段階的導入）
           exitZeroOnChanges: true
-          # main では差分を新ベースラインとして自動採用（PR で既にレビュー済みのため）
+          # main では差分を新ベースラインとして自動採用（push トリガー廃止済みのため workflow_dispatch 時のみ効く）
           autoAcceptChanges: main

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,6 +22,8 @@ concurrency:
 
 permissions:
   contents: read
+  # debounce ステップの `gh api repos/.../pulls/{number}` 呼び出しに必要
+  pull-requests: read
 
 jobs:
   changes:
@@ -48,8 +50,10 @@ jobs:
     # Dependabot run には Actions secrets（CHROMATIC_PROJECT_TOKEN）が注入されず必ず失敗するため除外する。
     # 依存 bump は packages/ui の見た目に影響しない（lock 変更で発火するだけ）ので視覚回帰の対象外でよい。
     # draft PR は対象外（ready_for_review か workflow_dispatch で改めて実行される）。
+    # workflow_dispatch は paths-filter の差分検出（既定 base は直近コミットのみ比較）に関わらず常に実行し、
+    # 手動でのベースライン更新が静かに no-op になることを防ぐ。
     if: >
-      needs.changes.outputs.ui == 'true' &&
+      (needs.changes.outputs.ui == 'true' || github.event_name == 'workflow_dispatch') &&
       github.actor != 'dependabot[bot]' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- globals.css / design-tokens/*.mdx 等グローバルファイルの変更で TurboSnap が自動無効化され、フルビルド(347コンポーネント/678 snapshots)が発生していた。直近のSPR-254だけで2回発生し、無料枠90%消費の主因と特定
- draft PR中はChromaticジョブをスキップ（`github.event.pull_request.draft == false`）
- 連続push時の簡易デバウンス（60秒待ち、PR headが変わっていれば後続ステップをスキップ）を追加
- `push: branches: [main]` トリガーを廃止し `workflow_dispatch` のみに変更。mainマージ毎の自動フルビルド(`autoAcceptChanges: main`)を止め、ベースライン更新は手動実行に切替

## Test plan
- [x] YAML構文チェック（`ruby -ryaml`）
- [x] `pnpm lint:docs` 実行（無関係だが変更PR全体のゲート確認）
- [ ] マージ後、次回UI変更PRで draft/ready_for_review の挙動と debounce ステップの実動作を確認
- [ ] Chromatic側の月間使用量が今後抑制されているか経過観察

🤖 Generated with [Claude Code](https://claude.com/claude-code)