### PR TITLE
feat(web): ボタン詳細ページを「押すことが主役」のヒーロー構成に刷新 (SPR-255)

### DIFF
--- a/apps/web/src/app/buttons/[id]/page.tsx
+++ b/apps/web/src/app/buttons/[id]/page.tsx
@@ -1,15 +1,14 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
-import { Eye } from "lucide-react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { getAudioButtonById } from "@/app/buttons/actions";
-import {
-	AudioButtonDetailHeader,
-	AudioButtonDetailMainContent,
-	AudioButtonDetailSidebar,
-	RelatedAudioButtons,
-} from "@/components/audio-button-detail";
+import { AudioButtonHero } from "@/components/audio-button-detail/audio-button-hero";
+import { AudioButtonHeroHeader } from "@/components/audio-button-detail/audio-button-hero-header";
+import { CreatorCard } from "@/components/audio-button-detail/creator-card";
+import { DetailTagCard } from "@/components/audio-button-detail/detail-tag-card";
+import { ListCtaCard } from "@/components/audio-button-detail/list-cta-card";
+import { RelatedAudioButtons } from "@/components/audio-button-detail/related-audio-buttons";
+import { SourceVideoCard } from "@/components/audio-button-detail/source-video-card";
 
 interface AudioButtonDetailPageProps {
 	params: Promise<{
@@ -94,51 +93,68 @@ export default async function AudioButtonDetailPage({ params }: AudioButtonDetai
 
 	const audioButton = result.data;
 
-	// per-user 状態（お気に入り/高低評価/編集権限）はここで取得しない。
+	// per-user 状態（お気に入り/高低評価/作成者判定）はここで取得しない。
 	// 純公開 shell として session を読まず、各 client island が自分の状態を解決する（SPR-223）。
-	// これにより詳細ページを共有キャッシュ可（public）へ戻せる（SPR-222/226 の per-user SSR 漏洩を解消）。
+	// これにより詳細ページを共有キャッシュ可（public）のまま保つ（SPR-222/226 の per-user SSR 漏洩対策）。
 
 	return (
 		<div className="min-h-screen">
-			{/* パンくずナビゲーション */}
-			<AudioButtonDetailHeader title={audioButton.buttonText} />
-
-			<div className="container mx-auto px-4 pb-8 max-w-7xl">
-				{/* メインコンテンツ: グリッドレイアウト */}
-				<div className="grid grid-cols-1 lg:grid-cols-3 gap-8 mb-8">
-					{/* 左側: 音声ボタン詳細 */}
-					<AudioButtonDetailMainContent audioButton={audioButton} />
-
-					{/* 右側: 動画カード + ユーザーカード */}
-					<AudioButtonDetailSidebar
-						videoId={audioButton.videoId}
-						videoTitle={audioButton.videoTitle}
+			{/* ヒーロー: 押すことが主役（SPR-255） */}
+			<section className="suzuka-gradient-radial relative px-4 pt-5 pb-8 text-center sm:px-6 sm:pt-11 sm:pb-[52px]">
+				<div className="relative mx-auto max-w-[1240px]">
+					<AudioButtonHeroHeader
+						audioButtonId={audioButton.id}
+						buttonText={audioButton.buttonText}
 						createdBy={audioButton.creatorId}
-						createdByName={audioButton.creatorName}
 					/>
+					<div className="h-[18px] sm:h-[26px]" />
+					<AudioButtonHero audioButton={audioButton} />
+				</div>
+			</section>
+
+			{/* 本文: モバイルは 関連 → 元動画 → タグ → 作成者 → 一覧誘導 の順に積む。
+			    lg 以上は main + 右レール（360px）の2カラム（wrapper を contents 化して order で制御） */}
+			<div className="mx-auto flex max-w-[1240px] flex-col gap-[18px] px-4 pt-6 pb-12 sm:px-8 lg:grid lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start lg:gap-8 lg:pt-9 lg:pb-14">
+				<div className="contents lg:flex lg:min-w-0 lg:flex-col lg:gap-7">
+					<div className="order-1 min-w-0 lg:order-none">
+						<Suspense fallback={null}>
+							<RelatedAudioButtons
+								currentId={audioButton.id}
+								videoId={audioButton.videoId}
+								tags={audioButton.tags || []}
+							/>
+						</Suspense>
+					</div>
+					<div className="order-5 lg:order-none">
+						<Suspense fallback={null}>
+							<ListCtaCard />
+						</Suspense>
+					</div>
 				</div>
 
-				{/* 関連音声ボタン */}
-				<Suspense
-					fallback={
-						<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">
-							<CardHeader>
-								<CardTitle className="text-lg">関連音声ボタン</CardTitle>
-							</CardHeader>
-							<CardContent>
-								<div className="flex items-center justify-center py-8">
-									<Eye className="h-8 w-8 animate-pulse text-muted-foreground" />
-								</div>
-							</CardContent>
-						</Card>
-					}
-				>
-					<RelatedAudioButtons
-						currentId={audioButton.id}
-						videoId={audioButton.videoId}
-						tags={audioButton.tags || []}
-					/>
-				</Suspense>
+				<aside className="contents lg:flex lg:flex-col lg:gap-[18px]">
+					<div className="order-2 lg:order-none">
+						<Suspense fallback={null}>
+							<SourceVideoCard
+								videoId={audioButton.videoId}
+								videoTitle={audioButton.videoTitle}
+								startTime={audioButton.startTime}
+								endTime={audioButton.endTime || audioButton.startTime}
+							/>
+						</Suspense>
+					</div>
+					<div className="order-3 lg:order-none">
+						<DetailTagCard tags={audioButton.tags || []} />
+					</div>
+					<div className="order-4 lg:order-none">
+						<Suspense fallback={null}>
+							<CreatorCard
+								createdBy={audioButton.creatorId}
+								createdByName={audioButton.creatorName}
+							/>
+						</Suspense>
+					</div>
+				</aside>
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/audio-button-detail/__tests__/related-audio-buttons.test.tsx
+++ b/apps/web/src/components/audio-button-detail/__tests__/related-audio-buttons.test.tsx
@@ -58,7 +58,7 @@ describe("RelatedAudioButtons", () => {
 		vi.clearAllMocks();
 	});
 
-	it("同一動画セクションから現在のボタンを除外して表示する", async () => {
+	it("この動画のボタンから現在のボタンを除外して表示する", async () => {
 		mockList.mockImplementation(async (query) => {
 			if (query?.videoId) return successResult([makeButton("current"), makeButton("b1")]);
 			return successResult([]);
@@ -66,7 +66,7 @@ describe("RelatedAudioButtons", () => {
 
 		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: [] }));
 
-		expect(screen.getByText("同じ動画の音声ボタン")).toBeInTheDocument();
+		expect(screen.getByText("この動画のボタン")).toBeInTheDocument();
 		expect(screen.getByText("ボタンb1")).toBeInTheDocument();
 		expect(screen.queryByText("ボタンcurrent")).not.toBeInTheDocument();
 	});
@@ -80,12 +80,12 @@ describe("RelatedAudioButtons", () => {
 
 		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: ["タグA"] }));
 
-		expect(screen.getByText("同じタグの音声ボタン")).toBeInTheDocument();
+		expect(screen.getByText("同じタグのボタン")).toBeInTheDocument();
 		// b1 は同一動画側にのみ表示（重複排除）
 		expect(screen.getAllByText("ボタンb1")).toHaveLength(1);
 		expect(screen.getByText("ボタンb2")).toBeInTheDocument();
 		// もっと見るリンクはタグを | 連結した一覧 URL を指す
-		expect(screen.getByRole("link", { name: "同じタグのボタンをもっと見る" })).toHaveAttribute(
+		expect(screen.getByRole("link", { name: /同じタグのボタンをもっと見る/ })).toHaveAttribute(
 			"href",
 			`/buttons?tags=${encodeURIComponent("タグA")}`,
 		);
@@ -108,9 +108,9 @@ describe("RelatedAudioButtons", () => {
 
 		render(await RelatedAudioButtons({ currentId: "current", videoId: "v1", tags: ["タグA"] }));
 
-		expect(screen.getByText("人気の音声ボタン")).toBeInTheDocument();
+		expect(screen.getByText("人気のボタン")).toBeInTheDocument();
 		expect(screen.getByText("ボタンpop1")).toBeInTheDocument();
-		expect(screen.getByRole("link", { name: "音声ボタン一覧を見る" })).toHaveAttribute(
+		expect(screen.getByRole("link", { name: /音声ボタン一覧を見る/ })).toHaveAttribute(
 			"href",
 			"/buttons",
 		);

--- a/apps/web/src/components/audio-button-detail/__tests__/use-audio-button-hero-state.test.tsx
+++ b/apps/web/src/components/audio-button-detail/__tests__/use-audio-button-hero-state.test.tsx
@@ -1,0 +1,111 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAudioButtonHeroState } from "../use-audio-button-hero-state";
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const mockSession = vi.hoisted(() => ({ current: null as { discordId: string } | null }));
+vi.mock("@/lib/auth/client", () => ({
+	useSession: () => mockSession.current,
+}));
+
+vi.mock("@/hooks/use-play-count", () => ({
+	usePlayCount: () => ({ handlePlay: vi.fn(), cleanup: vi.fn() }),
+}));
+
+vi.mock("@/actions/favorites", () => ({
+	getFavoritesStatusAction: vi.fn().mockResolvedValue(new Map()),
+	toggleFavoriteAction: vi.fn(),
+}));
+vi.mock("@/actions/dislikes", () => ({
+	getLikeDislikeStatusAction: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock("@/actions/likes", () => ({
+	toggleLikeAction: vi.fn(),
+}));
+
+import { toggleFavoriteAction } from "@/actions/favorites";
+import { toggleLikeAction } from "@/actions/likes";
+
+const mockToggleFavorite = vi.mocked(toggleFavoriteAction);
+const mockToggleLike = vi.mocked(toggleLikeAction);
+
+const audioButton = {
+	id: "btn1",
+	buttonText: "テスト",
+	stats: { playCount: 7, likeCount: 2, dislikeCount: 0, favoriteCount: 1, engagementRate: 0 },
+	createdAt: "2026-06-26T00:00:00.000Z",
+	startTime: 0,
+	endTime: 3.4,
+} as AudioButtonPlainObject;
+
+describe("useAudioButtonHeroState", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSession.current = { discordId: "user1" };
+	});
+
+	it("再生開始で playCount が楽観的に +1 される", () => {
+		const { result } = renderHook(() => useAudioButtonHeroState(audioButton));
+
+		expect(result.current.playCount).toBe(7);
+		act(() => result.current.handlePlayStart());
+		expect(result.current.playCount).toBe(8);
+	});
+
+	it("お気に入りトグル失敗時はロールバックされる", async () => {
+		mockToggleFavorite.mockResolvedValue({ success: false, error: "失敗" });
+		const { result } = renderHook(() => useAudioButtonHeroState(audioButton));
+
+		act(() => result.current.toggleFavorite());
+		// 楽観的更新で一旦 true
+		expect(result.current.isFavorited).toBe(true);
+
+		// 失敗後に元へ戻る
+		await waitFor(() => expect(result.current.isFavorited).toBe(false));
+	});
+
+	it("お気に入りトグル成功時はサーバー確定値を反映する", async () => {
+		mockToggleFavorite.mockResolvedValue({ success: true, isFavorited: true });
+		const { result } = renderHook(() => useAudioButtonHeroState(audioButton));
+
+		act(() => result.current.toggleFavorite());
+		await waitFor(() => expect(result.current.isFavorited).toBe(true));
+	});
+
+	it("高評価トグル失敗時は isLiked と likeCount の両方がロールバックされる", async () => {
+		mockToggleLike.mockResolvedValue({ success: false, error: "失敗" });
+		const { result } = renderHook(() => useAudioButtonHeroState(audioButton));
+
+		act(() => result.current.toggleLike());
+		// 楽観的更新
+		expect(result.current.isLiked).toBe(true);
+		expect(result.current.likeCount).toBe(3);
+
+		// ロールバック
+		await waitFor(() => {
+			expect(result.current.isLiked).toBe(false);
+			expect(result.current.likeCount).toBe(2);
+		});
+	});
+
+	it("未認証ではトグルせずアクションも呼ばない", () => {
+		mockSession.current = null;
+		const { result } = renderHook(() => useAudioButtonHeroState(audioButton));
+
+		act(() => result.current.toggleFavorite());
+		act(() => result.current.toggleLike());
+
+		expect(result.current.isFavorited).toBe(false);
+		expect(result.current.isLiked).toBe(false);
+		expect(mockToggleFavorite).not.toHaveBeenCalled();
+		expect(mockToggleLike).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/components/audio-button-detail/audio-button-hero-header.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-hero-header.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@suzumina.click/ui/components/ui/alert-dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@suzumina.click/ui/components/ui/dropdown-menu";
+import { ArrowLeft, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "sonner";
+import { deleteAudioButton } from "@/app/buttons/actions";
+import { useSession } from "@/lib/auth/client";
+
+/**
+ * ヒーロー上部の行（SPR-255）: 一覧への戻りリンク + 作成者専用「…」メニュー。
+ * 作成者判定は client session で行い per-user 状態を SSR に焼かない（表示ゲートのみ・SPR-223）。
+ * メニューは確定済みの2項目（編集ページを開く / 削除…）。
+ */
+
+interface AudioButtonHeroHeaderProps {
+	audioButtonId: string;
+	buttonText: string;
+	createdBy: string;
+}
+
+export function AudioButtonHeroHeader({
+	audioButtonId,
+	buttonText,
+	createdBy,
+}: AudioButtonHeroHeaderProps) {
+	const router = useRouter();
+	const user = useSession();
+	const isCreator = !!user?.discordId && user.discordId === createdBy;
+	const [confirmOpen, setConfirmOpen] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	const handleDelete = async () => {
+		setIsDeleting(true);
+		try {
+			const result = await deleteAudioButton(audioButtonId);
+			if (result.success) {
+				toast.success("音声ボタンを削除しました");
+				router.push("/buttons");
+			} else {
+				toast.error(result.error || "削除に失敗しました");
+				setIsDeleting(false);
+			}
+		} catch {
+			toast.error("削除に失敗しました");
+			setIsDeleting(false);
+		}
+	};
+
+	return (
+		<div className="flex items-center justify-between">
+			<Link
+				href="/buttons"
+				className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-[13px] font-semibold text-muted-foreground transition-colors hover:bg-suzuka-50 hover:text-suzuka-700"
+			>
+				<ArrowLeft className="h-3.5 w-3.5" strokeWidth={2.5} />
+				<span className="hidden sm:inline">音声ボタン一覧</span>
+				<span className="sm:hidden">一覧へ</span>
+			</Link>
+
+			{isCreator ? (
+				<>
+					<DropdownMenu>
+						<DropdownMenuTrigger
+							aria-label="作成者メニュー"
+							className="flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors hover:border-border hover:bg-suzuka-50"
+						>
+							<MoreHorizontal className="h-[18px] w-[18px]" />
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="min-w-[190px]">
+							<DropdownMenuItem asChild>
+								<Link href={`/buttons/${audioButtonId}/edit`}>
+									<Pencil className="h-3.5 w-3.5" />
+									編集ページを開く
+								</Link>
+							</DropdownMenuItem>
+							<DropdownMenuSeparator />
+							<DropdownMenuItem variant="destructive" onSelect={() => setConfirmOpen(true)}>
+								<Trash2 className="h-3.5 w-3.5" />
+								削除…
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+
+					<AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle>音声ボタンを削除しますか？</AlertDialogTitle>
+								<AlertDialogDescription>
+									「{buttonText}」を削除します。この操作は取り消せません。
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel disabled={isDeleting}>キャンセル</AlertDialogCancel>
+								<AlertDialogAction
+									onClick={(e) => {
+										e.preventDefault();
+										void handleDelete();
+									}}
+									disabled={isDeleting}
+									className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+								>
+									{isDeleting ? "削除中…" : "削除する"}
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+				</>
+			) : (
+				/* 戻るリンクの位置を安定させるためのスペーサー */
+				<span className="w-9" aria-hidden="true" />
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/audio-button-detail/audio-button-hero.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-hero.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { ActionPillRow } from "@suzumina.click/ui/components/custom/action-pill-row";
+import { MetaPillRow } from "@suzumina.click/ui/components/custom/meta-pill-row";
+import { PlayHero } from "@suzumina.click/ui/components/custom/play-hero";
+import { buildXShareUrl } from "@/components/audio/share-on-x-button";
+import { useAudioButtonHeroState } from "./use-audio-button-hero-state";
+
+/**
+ * 詳細ページのヒーロー本体（SPR-255）。再生ヒーロー L + メタピル行 + description + アクションピル行。
+ * per-user 状態（お気に入り/高評価）は SSR に焼かず client で自己解決する（純公開 shell・SPR-223）。
+ * 再生回数は再生開始時に楽観的に +1 表示する（デザインの「N 回目の再生中…」）。
+ */
+
+interface AudioButtonHeroProps {
+	audioButton: AudioButtonPlainObject;
+}
+
+/** createdAt(ISO) → "2026/06/26"（JST） */
+export function formatCreatedDate(isoString: string): string {
+	try {
+		return new Date(isoString).toLocaleDateString("ja-JP", {
+			timeZone: "Asia/Tokyo",
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		});
+	} catch {
+		return "";
+	}
+}
+
+export function AudioButtonHero({ audioButton }: AudioButtonHeroProps) {
+	const {
+		isPlaying,
+		playCount,
+		handlePlayStart,
+		handlePlayStateChange,
+		isFavorited,
+		toggleFavorite,
+		isLiked,
+		likeCount,
+		toggleLike,
+	} = useAudioButtonHeroState(audioButton);
+
+	const duration = (audioButton.endTime || audioButton.startTime) - audioButton.startTime;
+	const shareUrl = buildXShareUrl(audioButton.id, audioButton.buttonText);
+
+	const actionPillProps = {
+		isFavorite: isFavorited,
+		onFavoriteToggle: toggleFavorite,
+		isLiked,
+		likeCount,
+		onLikeToggle: toggleLike,
+		shareUrl,
+	};
+
+	return (
+		<div className="text-center">
+			<PlayHero
+				audioButton={audioButton}
+				size="L"
+				onPlay={handlePlayStart}
+				onPlayStateChange={handlePlayStateChange}
+			/>
+
+			<div className="mt-4 sm:mt-5">
+				<MetaPillRow
+					playCount={playCount}
+					durationText={`${duration.toFixed(1)}秒`}
+					dateText={formatCreatedDate(audioButton.createdAt)}
+					favoriteCount={audioButton.stats.favoriteCount || 0}
+					isPlaying={isPlaying}
+				/>
+			</div>
+
+			{audioButton.description?.trim() && (
+				<p className="mx-auto mt-4 max-w-[560px] text-[13.5px] leading-[1.7] text-muted-foreground line-clamp-2">
+					{audioButton.description}
+				</p>
+			)}
+
+			<div className="mt-[18px] sm:mt-[22px]">
+				<div className="hidden sm:block">
+					<ActionPillRow size="default" {...actionPillProps} />
+				</div>
+				<div className="sm:hidden">
+					<ActionPillRow size="sm" {...actionPillProps} />
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/audio-button-detail/audio-button-hero.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-hero.tsx
@@ -5,6 +5,7 @@ import { ActionPillRow } from "@suzumina.click/ui/components/custom/action-pill-
 import { MetaPillRow } from "@suzumina.click/ui/components/custom/meta-pill-row";
 import { PlayHero } from "@suzumina.click/ui/components/custom/play-hero";
 import { buildXShareUrl } from "@/components/audio/share-on-x-button";
+import { formatJSTDateSlash } from "@/utils/date-format";
 import { useAudioButtonHeroState } from "./use-audio-button-hero-state";
 
 /**
@@ -15,20 +16,6 @@ import { useAudioButtonHeroState } from "./use-audio-button-hero-state";
 
 interface AudioButtonHeroProps {
 	audioButton: AudioButtonPlainObject;
-}
-
-/** createdAt(ISO) → "2026/06/26"（JST） */
-export function formatCreatedDate(isoString: string): string {
-	try {
-		return new Date(isoString).toLocaleDateString("ja-JP", {
-			timeZone: "Asia/Tokyo",
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-		});
-	} catch {
-		return "";
-	}
 }
 
 export function AudioButtonHero({ audioButton }: AudioButtonHeroProps) {
@@ -69,7 +56,7 @@ export function AudioButtonHero({ audioButton }: AudioButtonHeroProps) {
 				<MetaPillRow
 					playCount={playCount}
 					durationText={`${duration.toFixed(1)}秒`}
-					dateText={formatCreatedDate(audioButton.createdAt)}
+					dateText={formatJSTDateSlash(audioButton.createdAt)}
 					favoriteCount={audioButton.stats.favoriteCount || 0}
 					isPlaying={isPlaying}
 				/>

--- a/apps/web/src/components/audio-button-detail/creator-card.tsx
+++ b/apps/web/src/components/audio-button-detail/creator-card.tsx
@@ -1,0 +1,50 @@
+import Image from "next/image";
+import Link from "next/link";
+import { getUserByDiscordId } from "@/lib/user-firestore";
+
+/**
+ * 作成者カード（SPR-255）: アバター（無ければイニシャル）+ 名前 + 参加時期 + プロフィール導線。
+ * user が取得できない場合はイニシャルと名前のみで縮退表示する。
+ */
+
+interface CreatorCardProps {
+	createdBy: string;
+	createdByName: string;
+}
+
+export async function CreatorCard({ createdBy, createdByName }: CreatorCardProps) {
+	const user = await getUserByDiscordId(createdBy).catch(() => null);
+	const displayName = user?.displayName || createdByName;
+	const initial = displayName.slice(0, 1) || "?";
+
+	return (
+		<section className="flex items-center gap-3 rounded-[20px] border border-border bg-card px-[18px] py-4">
+			{user?.avatarUrl ? (
+				<Image
+					src={user.avatarUrl}
+					alt={displayName}
+					width={44}
+					height={44}
+					className="h-11 w-11 flex-none rounded-full object-cover"
+					unoptimized
+				/>
+			) : (
+				<div className="flex h-11 w-11 flex-none items-center justify-center rounded-full bg-minase-200 text-lg font-extrabold text-minase-900">
+					{initial}
+				</div>
+			)}
+			<div className="min-w-0 flex-1 text-left">
+				<p className="text-sm font-extrabold">{displayName}</p>
+				{user?.memberSince && (
+					<p className="mt-0.5 text-xs text-muted-foreground">{user.memberSince}から</p>
+				)}
+			</div>
+			<Link
+				href={`/users/${createdBy}`}
+				className="flex-none text-[12.5px] font-bold text-primary hover:text-suzuka-700"
+			>
+				プロフィール
+			</Link>
+		</section>
+	);
+}

--- a/apps/web/src/components/audio-button-detail/detail-tag-card.tsx
+++ b/apps/web/src/components/audio-button-detail/detail-tag-card.tsx
@@ -1,0 +1,37 @@
+import { Tag } from "lucide-react";
+import Link from "next/link";
+
+/**
+ * タグカード（SPR-255）: タグを押すと同タグの一覧フィルタへ遷移する回遊導線。
+ * タグ編集はここでは行わない（作成者は編集ページで行う・確定済み）。
+ */
+
+interface DetailTagCardProps {
+	tags: string[];
+}
+
+export function DetailTagCard({ tags }: DetailTagCardProps) {
+	if (tags.length === 0) {
+		return null;
+	}
+	return (
+		<section className="rounded-[20px] border border-border bg-card px-[18px] py-4">
+			<p className="mb-2.5 text-[11px] font-bold tracking-[0.1em] text-muted-foreground">タグ</p>
+			<div className="flex flex-wrap gap-2">
+				{tags.map((tag) => (
+					<Link
+						key={tag}
+						href={`/buttons?tags=${encodeURIComponent(tag)}`}
+						className="inline-flex items-center gap-1.5 rounded-full border border-suzuka-200 bg-suzuka-50 px-3.5 py-1.5 text-[13px] font-bold text-suzuka-800 transition-colors hover:border-suzuka-500 hover:bg-suzuka-500 hover:text-white"
+					>
+						<Tag className="h-3 w-3" />
+						{tag}
+					</Link>
+				))}
+			</div>
+			<p className="mt-2.5 text-[11.5px] text-muted-foreground">
+				タグを押すと同じタグのボタンを一覧で探せます
+			</p>
+		</section>
+	);
+}

--- a/apps/web/src/components/audio-button-detail/list-cta-card.tsx
+++ b/apps/web/src/components/audio-button-detail/list-cta-card.tsx
@@ -1,0 +1,33 @@
+import { ArrowRight } from "lucide-react";
+import Link from "next/link";
+import { getAudioButtonsList } from "@/app/buttons/actions";
+
+/**
+ * 一覧誘導カード（SPR-255）: 外部流入者を「1ボタン聴いて終わり」にしない受け皿の最終導線。
+ * 総数は limit 1 のクエリ（count 集計 + 1 doc）で取得し、失敗時は数字なしの文言で縮退する。
+ */
+
+export async function ListCtaCard() {
+	const result = await getAudioButtonsList({ limit: 1 }).catch(() => null);
+	const totalCount = result?.success ? result.data.totalCount : null;
+
+	return (
+		<section className="flex flex-wrap items-center justify-between gap-5 rounded-[20px] border-[1.5px] border-minase-200 bg-minase-50 px-6 py-5 max-sm:flex-col max-sm:text-center sm:px-7 sm:py-6">
+			<div>
+				<p className="mb-1 text-base font-extrabold text-minase-950">ほかのボタンも押してみる？</p>
+				<p className="text-[13px] text-minase-800">
+					{totalCount
+						? `みんなが作った音声ボタンが全 ${totalCount} 個、あなたのタップを待ってます`
+						: "みんなが作った音声ボタンが、あなたのタップを待ってます"}
+				</p>
+			</div>
+			<Link
+				href="/buttons"
+				className="inline-flex flex-none items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-extrabold text-primary-foreground shadow-[0_4px_12px_hsl(var(--suzuka-500)/0.3)] transition-opacity hover:opacity-90 max-sm:w-full max-sm:justify-center"
+			>
+				ボタン一覧を見る
+				<ArrowRight className="h-[15px] w-[15px]" strokeWidth={2.5} />
+			</Link>
+		</section>
+	);
+}

--- a/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
+++ b/apps/web/src/components/audio-button-detail/related-audio-buttons.tsx
@@ -1,17 +1,12 @@
 import type { AudioButton } from "@suzumina.click/shared-types";
-import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
-import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
-import { Flame, Tag } from "lucide-react";
 import Link from "next/link";
-import type { ReactNode } from "react";
 import { getAudioButtonsList } from "@/app/buttons/actions";
 import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
 
 /**
- * 詳細ページの関連音声ボタン群（SPR-250 で再生ハブ化）。
+ * 詳細ページの関連音声ボタン群（SPR-250 で再生ハブ化・SPR-255 でヒーロー構成のデザインに刷新）。
  * X共有・検索から着地した訪問者が「1ボタン聴いて終わり」にならないよう、
- * 同じ動画 → 同じタグ → （両方無ければ）人気、の順で必ず次に押せるボタンを出す。
+ * この動画 → 同じタグ → （両方無ければ）人気、の順で必ず次に押せるボタンを出す。
  * 同一動画クエリは既存の videoId+createdAt 複合インデックスを使う（sortBy を変えると新規インデックスが要る点に注意）。
  * タグ・人気は in-memory フィルタ / 単一 orderBy のため複合インデックス不要。
  */
@@ -33,55 +28,43 @@ async function fetchButtons(
 }
 
 function RelatedSection({
-	icon,
 	title,
 	buttons,
 	moreHref,
 	moreLabel,
 }: {
-	icon: ReactNode;
 	title: string;
 	buttons: AudioButton[];
 	moreHref: string;
 	moreLabel: string;
 }) {
 	return (
-		<Card className="bg-card/80 backdrop-blur-sm shadow-lg border-0">
-			<CardHeader>
-				<CardTitle className="flex items-center gap-2 text-lg">
-					{icon}
-					{title}
-				</CardTitle>
-			</CardHeader>
-			<CardContent>
-				<div className="flex flex-wrap gap-3 items-start">
-					{buttons.map((audioButton) => (
-						<AudioButtonWithPlayCount
-							key={audioButton.id}
-							audioButton={audioButton}
-							showFavorite={true}
-							maxTitleLength={50}
-							className="shadow-sm hover:shadow-md transition-all duration-200"
-						/>
-					))}
-				</div>
-				<div className="mt-6 text-center">
-					<Button
-						variant="outline"
-						size="sm"
-						asChild
-						className="border-border text-primary hover:bg-accent"
-					>
-						<Link href={moreHref}>{moreLabel}</Link>
-					</Button>
-				</div>
-			</CardContent>
-		</Card>
+		<section>
+			<div className="mb-3.5 flex items-baseline gap-2.5">
+				<h2 className="text-[19px] font-extrabold">{title}</h2>
+				<span className="text-[13px] font-bold text-suzuka-600">{buttons.length}個</span>
+			</div>
+			<div className="flex flex-wrap items-start gap-3">
+				{buttons.map((audioButton) => (
+					<AudioButtonWithPlayCount
+						key={audioButton.id}
+						audioButton={audioButton}
+						showFavorite={true}
+						maxTitleLength={50}
+						className="shadow-sm hover:shadow-md transition-all duration-200"
+					/>
+				))}
+			</div>
+			<div className="mt-3.5">
+				<Link href={moreHref} className="text-[13px] font-bold text-primary hover:text-suzuka-700">
+					{moreLabel} →
+				</Link>
+			</div>
+		</section>
 	);
 }
 
 export async function RelatedAudioButtons({ currentId, videoId, tags }: RelatedAudioButtonsProps) {
-	// +1 は現在のボタン自身が結果に含まれる分の余裕
 	const [sameVideoAll, sameTagsAll] = await Promise.all([
 		fetchButtons({
 			videoId,
@@ -121,11 +104,10 @@ export async function RelatedAudioButtons({ currentId, videoId, tags }: RelatedA
 	}
 
 	return (
-		<div className="space-y-8">
+		<div className="flex flex-col gap-7">
 			{sameVideo.length > 0 && (
 				<RelatedSection
-					icon={<YoutubeIcon className="h-5 w-5 text-primary" />}
-					title="同じ動画の音声ボタン"
+					title="この動画のボタン"
 					buttons={sameVideo}
 					moreHref={`/buttons?videoId=${encodeURIComponent(videoId)}`}
 					moreLabel="この動画のボタンをもっと見る"
@@ -133,8 +115,7 @@ export async function RelatedAudioButtons({ currentId, videoId, tags }: RelatedA
 			)}
 			{sameTags.length > 0 && (
 				<RelatedSection
-					icon={<Tag className="h-5 w-5 text-primary" />}
-					title="同じタグの音声ボタン"
+					title="同じタグのボタン"
 					buttons={sameTags}
 					moreHref={`/buttons?tags=${encodeURIComponent(tags.join("|"))}`}
 					moreLabel="同じタグのボタンをもっと見る"
@@ -142,8 +123,7 @@ export async function RelatedAudioButtons({ currentId, videoId, tags }: RelatedA
 			)}
 			{popular.length > 0 && (
 				<RelatedSection
-					icon={<Flame className="h-5 w-5 text-primary" />}
-					title="人気の音声ボタン"
+					title="人気のボタン"
 					buttons={popular}
 					moreHref="/buttons"
 					moreLabel="音声ボタン一覧を見る"

--- a/apps/web/src/components/audio-button-detail/source-video-card.tsx
+++ b/apps/web/src/components/audio-button-detail/source-video-card.tsx
@@ -1,0 +1,119 @@
+import { TimeDisplay } from "@suzumina.click/ui/components/custom/time-display";
+import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
+import { Clock } from "lucide-react";
+import { getVideoById } from "@/app/videos/actions";
+import { getVideoBadgeInfo } from "@/components/video/video-badge";
+
+/**
+ * 元動画カード（SPR-255）: サムネイル + 切り抜き位置バー + クリップ範囲 + YouTube リンク。
+ * 切り抜き位置バーは動画総尺（videos ドキュメント・+1 read）から算出する。
+ * 動画が取得できない場合は位置バー・日付・種別バッジなしの縮退表示で継続する。
+ */
+
+interface SourceVideoCardProps {
+	videoId: string;
+	videoTitle: string;
+	startTime: number;
+	endTime: number;
+}
+
+/** ISO8601 duration（PT1H2M3S）→ 秒。パース不能は null */
+export function parseIsoDurationToSeconds(duration: string | undefined): number | null {
+	if (!duration) return null;
+	const match = duration.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$/);
+	if (!match || (!match[1] && !match[2] && !match[3])) return null;
+	const hours = match[1] ? Number.parseInt(match[1], 10) : 0;
+	const minutes = match[2] ? Number.parseInt(match[2], 10) : 0;
+	const seconds = match[3] ? Number.parseFloat(match[3]) : 0;
+	return hours * 3600 + minutes * 60 + seconds;
+}
+
+function formatPublishedDate(isoString: string | undefined): string {
+	if (!isoString) return "";
+	try {
+		return new Date(isoString).toLocaleDateString("ja-JP", {
+			timeZone: "Asia/Tokyo",
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		});
+	} catch {
+		return "";
+	}
+}
+
+export async function SourceVideoCard({
+	videoId,
+	videoTitle,
+	startTime,
+	endTime,
+}: SourceVideoCardProps) {
+	const video = await getVideoById(videoId).catch(() => null);
+
+	const clipDuration = (endTime || startTime) - startTime;
+	const totalSeconds = parseIsoDurationToSeconds(video?.duration);
+	const clipLeftPct = totalSeconds ? Math.min(100, (startTime / totalSeconds) * 100) : null;
+	const clipWidthPct = totalSeconds ? Math.min(100, (clipDuration / totalSeconds) * 100) : null;
+
+	const badge = video ? getVideoBadgeInfo(video) : null;
+	const title = video?.title || videoTitle;
+	const thumbnailUrl = video?.thumbnailUrl || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+	const youtubeUrl = `https://www.youtube.com/watch?v=${videoId}&t=${Math.floor(startTime)}`;
+
+	return (
+		<section className="overflow-hidden rounded-[20px] border border-border bg-card shadow-[0_1px_4px_hsl(var(--suzuka-500)/0.06)]">
+			<div className="relative">
+				<div
+					role="img"
+					aria-label={title}
+					className="aspect-video w-full bg-muted bg-cover bg-center"
+					style={{ backgroundImage: `url(${thumbnailUrl})` }}
+				/>
+				{badge && (
+					<span className="absolute top-2.5 left-2.5 rounded-full bg-foreground/75 px-2.5 py-1 text-[11px] font-bold text-background">
+						{badge.text}
+					</span>
+				)}
+				{/* 切り抜き位置バー（動画総尺が取れたときのみ） */}
+				{clipLeftPct !== null && clipWidthPct !== null && (
+					<div className="absolute right-0 bottom-0 left-0 h-[5px] bg-foreground/35">
+						<span
+							className="absolute top-0 bottom-0 rounded-[2px] bg-heart"
+							style={{
+								left: `${clipLeftPct}%`,
+								width: `${clipWidthPct}%`,
+								minWidth: "6px",
+							}}
+						/>
+					</div>
+				)}
+			</div>
+			<div className="px-[18px] pt-4 pb-[18px]">
+				<p className="mb-1 text-[11px] font-bold tracking-[0.1em] text-muted-foreground">元動画</p>
+				<p className="line-clamp-2 text-sm leading-[1.5] font-bold">{title}</p>
+				{video?.publishedAt && (
+					<p className="mt-2 text-xs text-muted-foreground">
+						{formatPublishedDate(video.publishedAt)}
+					</p>
+				)}
+				<div className="mt-3 flex items-center gap-2 rounded-xl bg-muted px-3.5 py-2.5">
+					<Clock className="h-3.5 w-3.5 flex-none text-muted-foreground" />
+					<span className="text-[12.5px] font-semibold text-foreground">
+						<TimeDisplay time={startTime} format="mm:ss.s" className="inline" /> –{" "}
+						<TimeDisplay time={endTime || startTime} format="mm:ss.s" className="inline" />（
+						{clipDuration.toFixed(1)}秒）
+					</span>
+				</div>
+				<a
+					href={youtubeUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="mt-3 flex items-center justify-center gap-2 rounded-full border border-border px-4 py-[9px] text-[13px] font-bold text-foreground transition-colors hover:bg-accent"
+				>
+					<YoutubeIcon className="h-4 w-4" />
+					この場面をYouTubeで開く
+				</a>
+			</div>
+		</section>
+	);
+}

--- a/apps/web/src/components/audio-button-detail/source-video-card.tsx
+++ b/apps/web/src/components/audio-button-detail/source-video-card.tsx
@@ -3,6 +3,7 @@ import { YoutubeIcon } from "@suzumina.click/ui/components/custom/youtube-icon";
 import { Clock } from "lucide-react";
 import { getVideoById } from "@/app/videos/actions";
 import { getVideoBadgeInfo } from "@/components/video/video-badge";
+import { formatJSTDateSlash } from "@/utils/date-format";
 
 /**
  * 元動画カード（SPR-255）: サムネイル + 切り抜き位置バー + クリップ範囲 + YouTube リンク。
@@ -26,20 +27,6 @@ export function parseIsoDurationToSeconds(duration: string | undefined): number 
 	const minutes = match[2] ? Number.parseInt(match[2], 10) : 0;
 	const seconds = match[3] ? Number.parseFloat(match[3]) : 0;
 	return hours * 3600 + minutes * 60 + seconds;
-}
-
-function formatPublishedDate(isoString: string | undefined): string {
-	if (!isoString) return "";
-	try {
-		return new Date(isoString).toLocaleDateString("ja-JP", {
-			timeZone: "Asia/Tokyo",
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-		});
-	} catch {
-		return "";
-	}
 }
 
 export async function SourceVideoCard({
@@ -93,7 +80,7 @@ export async function SourceVideoCard({
 				<p className="line-clamp-2 text-sm leading-[1.5] font-bold">{title}</p>
 				{video?.publishedAt && (
 					<p className="mt-2 text-xs text-muted-foreground">
-						{formatPublishedDate(video.publishedAt)}
+						{formatJSTDateSlash(video.publishedAt)}
 					</p>
 				)}
 				<div className="mt-3 flex items-center gap-2 rounded-xl bg-muted px-3.5 py-2.5">

--- a/apps/web/src/components/audio-button-detail/use-audio-button-hero-state.ts
+++ b/apps/web/src/components/audio-button-detail/use-audio-button-hero-state.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import { getLikeDislikeStatusAction } from "@/actions/dislikes";
+import { getFavoritesStatusAction, toggleFavoriteAction } from "@/actions/favorites";
+import { toggleLikeAction } from "@/actions/likes";
+import { usePlayCount } from "@/hooks/use-play-count";
+import { useSession } from "@/lib/auth/client";
+
+/**
+ * 詳細ページヒーローの状態管理（SPR-255）。
+ * - 再生: usePlayCount で計上し、表示上は楽観的に +1（「N 回目の再生中…」）
+ * - お気に入り/高評価: SSR に焼かず、認証済みなら client で自己取得（純公開 shell・SPR-223）。
+ *   トグルは favorite-button.tsx / like-dislike-buttons.tsx と同じ楽観的更新 + ロールバック
+ */
+export function useAudioButtonHeroState(audioButton: AudioButtonPlainObject) {
+	const router = useRouter();
+	const user = useSession();
+	const isAuthenticated = !!user;
+
+	// 再生状態と楽観的再生回数
+	const { handlePlay, cleanup } = usePlayCount();
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [playBump, setPlayBump] = useState(0);
+	useEffect(() => cleanup, [cleanup]);
+
+	const handlePlayStart = useCallback(() => {
+		handlePlay(audioButton.id);
+		setPlayBump((n) => n + 1);
+	}, [handlePlay, audioButton.id]);
+
+	// お気に入り / 高評価（client 自己解決）
+	const [isFavorited, setIsFavorited] = useState(false);
+	const [isLiked, setIsLiked] = useState(false);
+	const [likeCount, setLikeCount] = useState(audioButton.stats.likeCount);
+
+	useEffect(() => {
+		if (!isAuthenticated) return;
+		let cancelled = false;
+		void getFavoritesStatusAction([audioButton.id]).then((statusMap) => {
+			if (!cancelled) setIsFavorited(statusMap.get(audioButton.id) ?? false);
+		});
+		void getLikeDislikeStatusAction([audioButton.id]).then((statusMap) => {
+			if (!cancelled) setIsLiked(statusMap.get(audioButton.id)?.isLiked ?? false);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [audioButton.id, isAuthenticated]);
+
+	const toggleFavorite = useCallback(() => {
+		if (!isAuthenticated) {
+			toast.error("お気に入りに追加するにはログインが必要です");
+			router.push("/auth/signin");
+			return;
+		}
+		const previous = isFavorited;
+		setIsFavorited(!previous);
+		void toggleFavoriteAction(audioButton.id).then((result) => {
+			if (result.success && result.isFavorited !== undefined) {
+				setIsFavorited(result.isFavorited);
+				toast.success(
+					result.isFavorited ? "お気に入りに追加しました" : "お気に入りから削除しました",
+				);
+			} else {
+				setIsFavorited(previous);
+				toast.error(result.error || "エラーが発生しました");
+			}
+		});
+	}, [audioButton.id, isAuthenticated, isFavorited, router]);
+
+	const toggleLike = useCallback(() => {
+		if (!isAuthenticated) {
+			toast.error("高評価するにはログインが必要です");
+			return;
+		}
+		const previous = { isLiked, likeCount };
+		setIsLiked(!previous.isLiked);
+		setLikeCount(previous.likeCount + (previous.isLiked ? -1 : 1));
+		void toggleLikeAction(audioButton.id).then((result) => {
+			if (result.success && result.isLiked !== undefined) {
+				setIsLiked(result.isLiked);
+				toast.success(result.isLiked ? "高評価しました" : "高評価を取り消しました");
+			} else {
+				setIsLiked(previous.isLiked);
+				setLikeCount(previous.likeCount);
+				toast.error(result.error || "エラーが発生しました");
+			}
+		});
+	}, [audioButton.id, isAuthenticated, isLiked, likeCount]);
+
+	return {
+		isPlaying,
+		playCount: audioButton.stats.playCount + playBump,
+		handlePlayStart,
+		handlePlayStateChange: setIsPlaying,
+		isFavorited,
+		toggleFavorite,
+		isLiked,
+		likeCount,
+		toggleLike,
+	};
+}

--- a/apps/web/src/utils/date-format.ts
+++ b/apps/web/src/utils/date-format.ts
@@ -116,3 +116,21 @@ export function formatJSTDate(dateString: string | Date): string {
 
 	return `${year}年 ${month}月 ${day}日`;
 }
+
+/**
+ * 日付を日本標準時の "YYYY/MM/DD" でフォーマット（ボタン詳細のメタ表示用）
+ * @param dateString - ISO形式の日付文字列またはDateオブジェクト
+ * @returns 無効な日付は空文字
+ */
+export function formatJSTDateSlash(dateString: string | Date): string {
+	const date = validateAndParseDate(dateString);
+	if (!date) {
+		return "";
+	}
+	return date.toLocaleDateString("ja-JP", {
+		timeZone: "Asia/Tokyo",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	});
+}

--- a/packages/ui/src/components/custom/__tests__/play-hero.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/play-hero.test.tsx
@@ -3,21 +3,26 @@
  */
 
 import type { AudioButton as AudioButtonType } from "@suzumina.click/shared-types";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { PlayHero } from "../play-hero";
 
-// YouTube Player Pool のモック（audio-button.test.tsx と同じ基盤）
-vi.mock("../../lib/youtube-player-pool", () => ({
-	youTubePlayerPool: {
-		onReady: vi.fn((callback) => callback()),
-		playSegment: vi.fn(),
-		stopCurrentSegment: vi.fn(),
-		getOrCreatePlayer: vi.fn(() => Promise.resolve({ setVolume: vi.fn() })),
-		getStats: vi.fn(() => ({ activeSegmentVideoId: null })),
+// AudioPlayer は props を捕捉するスタブに差し替え、onPlay/onPause/onEnd を任意に発火できるようにする
+// （YouTube pool 実体はテスト環境で再生状態まで到達しないため、コールバック契約を直接検証する）
+let capturedPlayerProps: Record<string, unknown> | null = null;
+vi.mock("../audio-player", () => ({
+	AudioPlayer: (props: Record<string, unknown>) => {
+		capturedPlayerProps = props;
+		return null;
 	},
 }));
+
+const firePlayerEvent = (name: "onPlay" | "onPause" | "onEnd" | "onProgress", arg?: number) => {
+	act(() => {
+		(capturedPlayerProps?.[name] as (n?: number) => void)?.(arg);
+	});
+};
 
 const mockAudioButton: AudioButtonType = {
 	id: "hero-test",
@@ -64,10 +69,53 @@ describe("PlayHero", () => {
 		expect(button).toBeDisabled();
 	});
 
-	it("L サイズは進捗フィルとテキストを持つ（既定）", () => {
+	it("再生開始で onPlay と onPlayStateChange(true) が呼ばれ、一時停止表示になる", () => {
+		const onPlay = vi.fn();
+		const onPlayStateChange = vi.fn();
+		render(
+			<PlayHero
+				audioButton={mockAudioButton}
+				onPlay={onPlay}
+				onPlayStateChange={onPlayStateChange}
+			/>,
+		);
+
+		firePlayerEvent("onPlay");
+
+		expect(onPlay).toHaveBeenCalledTimes(1);
+		expect(onPlayStateChange).toHaveBeenLastCalledWith(true);
+		expect(screen.getByRole("button", { name: "一時停止" })).toBeInTheDocument();
+	});
+
+	it("一時停止で onPlayStateChange(false) が呼ばれ、進捗がリセットされる", () => {
+		const onPlayStateChange = vi.fn();
+		const { container } = render(
+			<PlayHero audioButton={mockAudioButton} onPlayStateChange={onPlayStateChange} />,
+		);
+
+		firePlayerEvent("onPlay");
+		firePlayerEvent("onProgress", 40);
+		firePlayerEvent("onPause");
+
+		expect(onPlayStateChange).toHaveBeenLastCalledWith(false);
+		expect(screen.getByRole("button", { name: "再生" })).toBeInTheDocument();
+		const fill = container.querySelector('span[style*="width: 0%"]');
+		expect(fill).not.toBeNull();
+	});
+
+	it("再生終了でも onPlayStateChange(false) が呼ばれる", () => {
+		const onPlayStateChange = vi.fn();
+		render(<PlayHero audioButton={mockAudioButton} onPlayStateChange={onPlayStateChange} />);
+
+		firePlayerEvent("onPlay");
+		firePlayerEvent("onEnd");
+
+		expect(onPlayStateChange).toHaveBeenLastCalledWith(false);
+	});
+
+	it("L サイズは進捗フィルを width 0% で初期化する（既定）", () => {
 		const { container } = render(<PlayHero audioButton={mockAudioButton} size="L" />);
 
-		// 進捗フィルは width 0% で初期化される
 		const fill = container.querySelector('span[style*="width: 0%"]');
 		expect(fill).not.toBeNull();
 	});

--- a/packages/ui/src/components/custom/play-hero.tsx
+++ b/packages/ui/src/components/custom/play-hero.tsx
@@ -18,6 +18,8 @@ interface PlayHeroProps {
 	/** L=詳細ページ用（再生中パルスリング付き）/ M=モーダル用 */
 	size?: "L" | "M";
 	onPlay?: () => void;
+	/** 再生状態の変化を親へ通知する（メタ表示の「再生中」同期用） */
+	onPlayStateChange?: (playing: boolean) => void;
 	className?: string;
 }
 
@@ -42,7 +44,13 @@ function HeroCircleIcon({
 	);
 }
 
-export function PlayHero({ audioButton, size = "L", onPlay, className }: PlayHeroProps) {
+export function PlayHero({
+	audioButton,
+	size = "L",
+	onPlay,
+	onPlayStateChange,
+	className,
+}: PlayHeroProps) {
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
 	const audioPlayerRef = useRef<AudioControls>(null);
@@ -70,13 +78,15 @@ export function PlayHero({ audioButton, size = "L", onPlay, className }: PlayHer
 		setIsPlaying(true);
 		setIsLoading(false);
 		onPlay?.();
-	}, [onPlay]);
+		onPlayStateChange?.(true);
+	}, [onPlay, onPlayStateChange]);
 
 	const handleStop = useCallback(() => {
 		setIsPlaying(false);
 		setIsLoading(false);
 		resetProgressFill();
-	}, [resetProgressFill]);
+		onPlayStateChange?.(false);
+	}, [resetProgressFill, onPlayStateChange]);
 
 	const handleProgress = useCallback((progressPercent: number) => {
 		if (progressFillRef.current) {


### PR DESCRIPTION
## 概要

ボタン画面刷新 Phase 2。詳細ページを「メタデータ表示ページ」から「押すことが主役のヒーロー構成」へ刷新します。SPR-254 の共通部品（PlayHero / MetaPillRow / ActionPillRow）を消費する初のページです。Linear: SPR-255

デザイン正本: [Claude Design「ボタン詳細ページ.dc.html」](https://claude.ai/design/p/c45f5603-8f47-46de-a063-0997bf2ea304?file=%E3%83%9C%E3%82%BF%E3%83%B3%E8%A9%B3%E7%B4%B0%E3%83%9A%E3%83%BC%E3%82%B8.dc.html)

## 変更内容

### ヒーロー（新設）
- suzuka-gradient-radial 背景 + **PlayHero L**（楽観的再生カウント + メタピル行の「再生中」同期は PlayHero に追加した後方互換の `onPlayStateChange` prop で実現）
- メタピル行（これまでに N 回押されました・♥件数・尺・作成日）/ description 2行省略 / アクションピル行（sm/default をブレークポイント切替）
- ヘッダー行: 一覧への戻り + **作成者専用「…」メニュー**（確定済み2項目: 編集ページを開く / 削除…＝AlertDialog 確認付き）
- お気に入り/高評価/作成者判定はすべて client island 自己解決（**per-user 状態を SSR に焼かない原則を維持**）

### 右レール（新設）
- **元動画カード**: サムネ上に**切り抜き位置バー**（videos ドキュメント +1 read で総尺取得。動画未取得時はバー・日付・バッジなしの縮退表示）・種別バッジ・クリップ範囲・「この場面をYouTubeで開く」
- タグカード（→ `/buttons?tags=` フィルタ遷移）/ 作成者カード（アバター・参加時期・プロフィール導線）

### その他
- 一覧誘導カード（総数付き CTA）
- 関連セクションをデザインの見出しスタイルへ（**SPR-250 の3段構成＝この動画/同タグ/人気フォールバックは継承**・退行なし）
- **低評価 UI をページから撤去**（確定済み・データ/action は温存。一覧ポップオーバーは SPR-257 で対応）
- generateMetadata / opengraph-image（SPR-249）は不変
- モバイル375px: **ヒーロー→この動画のボタン→元動画→タグ→作成者→一覧誘導**の積み順（wrapper の `max-lg contents` 化 + order 制御で DOM 重複なし）

## テスト・検証（Emulator + preview 実測）

- [x] デスクトップ: ヒーロー全要素・関連セクション・右レール3カード・CTA の描画確認（スクリーンショット）
- [x] **切り抜き位置バー実測**: 3時間4分の配信アーカイブに対し left 78.17% / width 0.17%（min-width 6px）で正しい位置に描画
- [x] 動画未シードのボタンで縮退表示（バーなし・タイトルは videoTitle フォールバック）を確認
- [x] モバイル375px: 積み順がデザイン通り・sm アクションピル有効を DOM 座標で実測
- [x] コンソールエラーなし・`pnpm verify` exit 0（related テストは新見出しに更新）

## 留意点

- 旧詳細コンポーネント（AudioButtonDetailMainContent 等）はモーダル（SPR-252 実装）が使用中のため残置。**SPR-256（モーダル差し替え）完了時に一括削除**します
- ListCtaCard の総数取得は count 集計 + 1 doc（一覧ページと同経路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)