### PR TITLE
refactor(ui): 再生状態機械を useAudioPlayback hook に一本化 (SPR-258)

### DIFF
--- a/packages/ui/src/components/custom/__tests__/use-audio-playback.test.ts
+++ b/packages/ui/src/components/custom/__tests__/use-audio-playback.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment happy-dom
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AudioControls } from "../audio-player";
+import { useAudioPlayback } from "../use-audio-playback";
+
+/** audioPlayerRef / progressFillRef に実体を注入した hook を用意する */
+function setupPlayback(options?: Parameters<typeof useAudioPlayback>[0]) {
+	const result = renderHook(() => useAudioPlayback(options)).result;
+	const controls = {
+		play: vi.fn(),
+		pause: vi.fn(),
+		stop: vi.fn(),
+		setVolume: vi.fn(),
+		isPlaying: false,
+		isReady: true,
+	} satisfies AudioControls;
+	const fill = document.createElement("span");
+	act(() => {
+		result.current.audioPlayerRef.current = controls;
+		result.current.progressFillRef.current = fill;
+	});
+	return { result, controls, fill };
+}
+
+describe("useAudioPlayback", () => {
+	it("停止中の handleToggle は isLoading にして play を呼ぶ（SPR-200 スピナー経路）", () => {
+		const { result, controls } = setupPlayback();
+
+		act(() => result.current.handleToggle());
+
+		expect(result.current.isLoading).toBe(true);
+		expect(result.current.isPlaying).toBe(false);
+		expect(controls.play).toHaveBeenCalledTimes(1);
+	});
+
+	it("onPlay で再生中になり isLoading が解除され、onPlay/onPlayStateChange(true) を通知する", () => {
+		const onPlay = vi.fn();
+		const onPlayStateChange = vi.fn();
+		const { result } = setupPlayback({ onPlay, onPlayStateChange });
+
+		act(() => result.current.handleToggle());
+		act(() => result.current.playerHandlers.onPlay());
+
+		expect(result.current.isPlaying).toBe(true);
+		expect(result.current.isLoading).toBe(false);
+		expect(onPlay).toHaveBeenCalledTimes(1);
+		expect(onPlayStateChange).toHaveBeenLastCalledWith(true);
+	});
+
+	it("再生中の handleToggle は pause を呼ぶ", () => {
+		const { result, controls } = setupPlayback();
+
+		act(() => result.current.playerHandlers.onPlay());
+		act(() => result.current.handleToggle());
+
+		expect(controls.pause).toHaveBeenCalledTimes(1);
+		expect(controls.play).not.toHaveBeenCalled();
+	});
+
+	it("onProgress は進捗フィルの width を DOM へ直接書き込む", () => {
+		const { result, fill } = setupPlayback();
+
+		act(() => result.current.playerHandlers.onProgress(42));
+
+		expect(fill.style.width).toBe("42%");
+	});
+
+	it("onPause で停止し進捗をリセットし、onPlayStateChange(false) を通知する", () => {
+		const onPlayStateChange = vi.fn();
+		const { result, fill } = setupPlayback({ onPlayStateChange });
+
+		act(() => result.current.playerHandlers.onPlay());
+		act(() => result.current.playerHandlers.onProgress(40));
+		act(() => result.current.playerHandlers.onPause());
+
+		expect(result.current.isPlaying).toBe(false);
+		expect(fill.style.width).toBe("0%");
+		expect(onPlayStateChange).toHaveBeenLastCalledWith(false);
+	});
+
+	it("onEnd でも onPause と同一の停止処理になる", () => {
+		const onPlayStateChange = vi.fn();
+		const { result, fill } = setupPlayback({ onPlayStateChange });
+
+		act(() => result.current.playerHandlers.onPlay());
+		act(() => result.current.playerHandlers.onProgress(80));
+		act(() => result.current.playerHandlers.onEnd());
+
+		expect(result.current.isPlaying).toBe(false);
+		expect(result.current.isLoading).toBe(false);
+		expect(fill.style.width).toBe("0%");
+		expect(onPlayStateChange).toHaveBeenLastCalledWith(false);
+	});
+
+	it("コールバック未指定（AudioButton 相当）でも状態遷移だけで完結する", () => {
+		const { result } = setupPlayback();
+
+		act(() => result.current.playerHandlers.onPlay());
+		expect(result.current.isPlaying).toBe(true);
+
+		act(() => result.current.playerHandlers.onEnd());
+		expect(result.current.isPlaying).toBe(false);
+	});
+});

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -26,10 +26,11 @@ import {
 	User,
 	Video,
 } from "lucide-react";
-import { useCallback, useId, useRef, useState } from "react";
-import { type AudioControls, AudioPlayer } from "./audio-player";
+import { useCallback, useId, useState } from "react";
+import { AudioPlayer } from "./audio-player";
 import { HighlightText } from "./highlight-text";
 import { TagList } from "./tag-list";
+import { useAudioPlayback } from "./use-audio-playback";
 import { XIcon } from "./x-icon";
 import { YoutubeIcon } from "./youtube-icon";
 
@@ -480,12 +481,10 @@ export function AudioButton({
 	isAuthenticated = false,
 	xShareUrl,
 }: AudioButtonProps) {
-	const [isPlaying, setIsPlaying] = useState(false);
-	const [isLoading, setIsLoading] = useState(false);
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-	const audioPlayerRef = useRef<AudioControls>(null);
-	// 250ms毎に更新される再生進捗はReact stateにせずDOMへ直接書き込む（コンポーネント全体の再レンダーを避けるため）
-	const progressFillRef = useRef<HTMLSpanElement>(null);
+	// 再生状態機械は useAudioPlayback に一本化（PlayHero と共有・SPR-258）
+	const { isPlaying, isLoading, audioPlayerRef, progressFillRef, handleToggle, playerHandlers } =
+		useAudioPlayback({ onPlay });
 
 	// 時間の計算
 	const duration = (audioButton.endTime || audioButton.startTime) - audioButton.startTime;
@@ -498,62 +497,17 @@ export function AudioButton({
 			: audioButton.buttonText;
 
 	const handlePlayClick = useCallback(
-		async (e: React.MouseEvent) => {
+		(e: React.MouseEvent) => {
 			e.stopPropagation();
-
-			if (isPlaying) {
-				audioPlayerRef.current?.pause();
-			} else {
-				// 再生開始までの読み込み中はスピナーを出す（onPlay=handlePlayStart で解除）。
-				// 以前は setIsLoading(true) の経路が無くスピナーが不達だった（SPR-200）。
-				setIsLoading(true);
-				audioPlayerRef.current?.play();
-			}
+			handleToggle();
 		},
-		[isPlaying],
+		[handleToggle],
 	);
-
-	const handlePlayStart = useCallback(() => {
-		setIsPlaying(true);
-		setIsLoading(false);
-		onPlay?.();
-	}, [onPlay]);
-
-	const resetProgressFill = useCallback(() => {
-		if (progressFillRef.current) {
-			progressFillRef.current.style.width = "0%";
-		}
-	}, []);
-
-	const handleProgress = useCallback((progressPercent: number) => {
-		if (progressFillRef.current) {
-			progressFillRef.current.style.width = `${progressPercent}%`;
-		}
-	}, []);
-
-	const handlePlayPause = useCallback(() => {
-		setIsPlaying(false);
-		setIsLoading(false);
-		resetProgressFill();
-	}, [resetProgressFill]);
-
-	const handlePlayEnd = useCallback(() => {
-		setIsPlaying(false);
-		setIsLoading(false);
-		resetProgressFill();
-	}, [resetProgressFill]);
 
 	return (
 		<>
 			{/* プール化された音声プレイヤー（DOM要素なし） */}
-			<AudioPlayer
-				ref={audioPlayerRef}
-				audioButton={audioButton}
-				onPlay={handlePlayStart}
-				onPause={handlePlayPause}
-				onEnd={handlePlayEnd}
-				onProgress={handleProgress}
-			/>
+			<AudioPlayer ref={audioPlayerRef} audioButton={audioButton} {...playerHandlers} />
 
 			{/* UI要素 */}
 			<Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>

--- a/packages/ui/src/components/custom/play-hero.tsx
+++ b/packages/ui/src/components/custom/play-hero.tsx
@@ -3,8 +3,8 @@
 import type { AudioButton as AudioButtonType } from "@suzumina.click/shared-types";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { Loader2, Pause, Play } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
-import { type AudioControls, AudioPlayer } from "./audio-player";
+import { AudioPlayer } from "./audio-player";
+import { useAudioPlayback } from "./use-audio-playback";
 
 /**
  * 再生ヒーロー（ボタン画面刷新の中核部品・SPR-254）。
@@ -51,60 +51,16 @@ export function PlayHero({
 	onPlayStateChange,
 	className,
 }: PlayHeroProps) {
-	const [isPlaying, setIsPlaying] = useState(false);
-	const [isLoading, setIsLoading] = useState(false);
-	const audioPlayerRef = useRef<AudioControls>(null);
-	// 進捗はReact stateにせずDOMへ直接書き込む（AudioButton と同じ・再レンダー回避）
-	const progressFillRef = useRef<HTMLSpanElement>(null);
+	// 再生状態機械は useAudioPlayback に一本化（AudioButton と共有・SPR-258）
+	const { isPlaying, isLoading, audioPlayerRef, progressFillRef, handleToggle, playerHandlers } =
+		useAudioPlayback({ onPlay, onPlayStateChange });
 
 	const isL = size === "L";
-
-	const handleToggle = useCallback(() => {
-		if (isPlaying) {
-			audioPlayerRef.current?.pause();
-		} else {
-			setIsLoading(true);
-			audioPlayerRef.current?.play();
-		}
-	}, [isPlaying]);
-
-	const resetProgressFill = useCallback(() => {
-		if (progressFillRef.current) {
-			progressFillRef.current.style.width = "0%";
-		}
-	}, []);
-
-	const handlePlayStart = useCallback(() => {
-		setIsPlaying(true);
-		setIsLoading(false);
-		onPlay?.();
-		onPlayStateChange?.(true);
-	}, [onPlay, onPlayStateChange]);
-
-	const handleStop = useCallback(() => {
-		setIsPlaying(false);
-		setIsLoading(false);
-		resetProgressFill();
-		onPlayStateChange?.(false);
-	}, [resetProgressFill, onPlayStateChange]);
-
-	const handleProgress = useCallback((progressPercent: number) => {
-		if (progressFillRef.current) {
-			progressFillRef.current.style.width = `${progressPercent}%`;
-		}
-	}, []);
 
 	return (
 		<div className={cn("relative inline-block max-w-full", className)}>
 			{/* プール化された音声プレイヤー（DOM要素なし） */}
-			<AudioPlayer
-				ref={audioPlayerRef}
-				audioButton={audioButton}
-				onPlay={handlePlayStart}
-				onPause={handleStop}
-				onEnd={handleStop}
-				onProgress={handleProgress}
-			/>
+			<AudioPlayer ref={audioPlayerRef} audioButton={audioButton} {...playerHandlers} />
 
 			{/* 再生中パルスリング（Lのみ） */}
 			{isL && isPlaying && (

--- a/packages/ui/src/components/custom/use-audio-playback.ts
+++ b/packages/ui/src/components/custom/use-audio-playback.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { AudioControls, AudioPlayerProps } from "./audio-player";
+
+/**
+ * 再生状態機械の正本（SPR-258）。
+ * AudioButton / PlayHero に逐語複製されていた isPlaying/isLoading・進捗フィル・
+ * AudioPlayer ハンドラ群を一本化する。見た目は各コンポーネントの責務のまま。
+ *
+ * 使い方: 返り値の audioPlayerRef と playerHandlers を AudioPlayer に渡し、
+ * progressFillRef を進捗フィル要素に張る。進捗は 250ms 毎の更新のため
+ * React state にせず DOM へ直接書き込む（再レンダー回避）。
+ */
+
+interface UseAudioPlaybackOptions {
+	/** 再生開始時に呼ばれる（再生計上など） */
+	onPlay?: () => void;
+	/** 再生状態の変化を親へ通知する（「再生中」表示の同期など） */
+	onPlayStateChange?: (playing: boolean) => void;
+}
+
+export function useAudioPlayback({ onPlay, onPlayStateChange }: UseAudioPlaybackOptions = {}) {
+	const [isPlaying, setIsPlaying] = useState(false);
+	const [isLoading, setIsLoading] = useState(false);
+	const audioPlayerRef = useRef<AudioControls>(null);
+	const progressFillRef = useRef<HTMLSpanElement>(null);
+
+	const handleToggle = useCallback(() => {
+		if (isPlaying) {
+			audioPlayerRef.current?.pause();
+		} else {
+			// 再生開始までの読み込み中はスピナーを出す（onPlay=handlePlayStart で解除）。
+			// 以前は setIsLoading(true) の経路が無くスピナーが不達だった（SPR-200）。
+			setIsLoading(true);
+			audioPlayerRef.current?.play();
+		}
+	}, [isPlaying]);
+
+	const resetProgressFill = useCallback(() => {
+		if (progressFillRef.current) {
+			progressFillRef.current.style.width = "0%";
+		}
+	}, []);
+
+	const handlePlayStart = useCallback(() => {
+		setIsPlaying(true);
+		setIsLoading(false);
+		onPlay?.();
+		onPlayStateChange?.(true);
+	}, [onPlay, onPlayStateChange]);
+
+	const handleStop = useCallback(() => {
+		setIsPlaying(false);
+		setIsLoading(false);
+		resetProgressFill();
+		onPlayStateChange?.(false);
+	}, [resetProgressFill, onPlayStateChange]);
+
+	const handleProgress = useCallback((progressPercent: number) => {
+		if (progressFillRef.current) {
+			progressFillRef.current.style.width = `${progressPercent}%`;
+		}
+	}, []);
+
+	const playerHandlers = {
+		onPlay: handlePlayStart,
+		onPause: handleStop,
+		onEnd: handleStop,
+		onProgress: handleProgress,
+	} satisfies Pick<AudioPlayerProps, "onPlay" | "onPause" | "onEnd" | "onProgress">;
+
+	return {
+		isPlaying,
+		isLoading,
+		/** AudioPlayer の ref に渡す */
+		audioPlayerRef,
+		/** 進捗フィル要素（width % を DOM 直書き）に張る */
+		progressFillRef,
+		/** 再生/一時停止トグル */
+		handleToggle,
+		/** AudioPlayer にそのまま spread する */
+		playerHandlers,
+	};
+}


### PR DESCRIPTION
## 概要

SPR-254〜256 の UI 部品棚卸しで見つかった唯一の「本物の重複」の解消です。
AudioButton / PlayHero に逐語複製されていた再生状態機械（約60行×2）を `use-audio-playback.ts` へ抽出し、正本を1つにします。

Linear: [SPR-258](https://linear.app/nothink/issue/SPR-258)

## 変更内容

- **新設** `packages/ui/src/components/custom/use-audio-playback.ts`: isPlaying/isLoading state・progressFillRef（DOM 直書き進捗）・AudioPlayer 接続ハンドラ群（onPlay/onPause/onEnd/onProgress）・再生/一時停止トグルを一本化
- **リファクタ** `audio-button.tsx` / `play-hero.tsx`: 同 hook 消費へ（-106行）。**見た目・props 契約は不変更**
- **テスト新設** `use-audio-playback.test.ts`: 状態機械の直接検証（SPR-200 スピナー経路・進捗リセット・onPlayStateChange 通知契約を含む7ケース）

## やらないこと

- PlayHero の AudioButton variant 化（props 契約の交差がほぼなく、統合すると型の約束が崩れるため不採用と判断済み）
- アクション UI の方言統一・per-user 状態 hook 統合（一覧ポップオーバーを触る SPR-257 に畳み込み済み）

## 検証

- `pnpm verify` 通過（lint / typecheck / test / カバレッジ閾値）
- `pnpm --filter @suzumina.click/ui test:storybook` 通過（a11y 含む 347件）
- 既存の play-hero / audio-button コンポーネントテストが無変更でグリーン＝挙動契約が保たれていることの回帰確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)