### PR TITLE
fix(ui): 再生プログレスのカクつきを解消 — transition を進捗更新間隔に同期 (SPR-259)

### DIFF
--- a/packages/ui/src/components/custom/__tests__/audio-button.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/audio-button.test.tsx
@@ -6,6 +6,7 @@ import type { AudioButton as AudioButtonType } from "@suzumina.click/shared-type
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { PROGRESS_TICK_MS } from "../../../lib/playback-constants";
 import { AudioButton } from "../audio-button";
 
 // YouTube Player Pool のモック
@@ -71,6 +72,13 @@ describe("AudioButton", () => {
 
 		const playButton = screen.getByRole("button", { name: "再生" });
 		expect(playButton).toBeInTheDocument();
+	});
+
+	it("進捗フィルの transition は進捗更新間隔と同値（カクつき防止・SPR-259）", () => {
+		const { container } = render(<AudioButton audioButton={mockAudioButton} />);
+
+		const fill = container.querySelector('span[style*="width: 0%"]') as HTMLElement;
+		expect(fill.style.transitionDuration).toBe(`${PROGRESS_TICK_MS}ms`);
 	});
 
 	it("should truncate long titles", () => {

--- a/packages/ui/src/components/custom/__tests__/play-hero.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/play-hero.test.tsx
@@ -6,6 +6,7 @@ import type { AudioButton as AudioButtonType } from "@suzumina.click/shared-type
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { PROGRESS_TICK_MS } from "../../../lib/playback-constants";
 import { PlayHero } from "../play-hero";
 
 // AudioPlayer は props を捕捉するスタブに差し替え、onPlay/onPause/onEnd を任意に発火できるようにする
@@ -118,6 +119,13 @@ describe("PlayHero", () => {
 
 		const fill = container.querySelector('span[style*="width: 0%"]');
 		expect(fill).not.toBeNull();
+	});
+
+	it("進捗フィルの transition は進捗更新間隔と同値（カクつき防止・SPR-259）", () => {
+		const { container } = render(<PlayHero audioButton={mockAudioButton} />);
+
+		const fill = container.querySelector('span[style*="width: 0%"]') as HTMLElement;
+		expect(fill.style.transitionDuration).toBe(`${PROGRESS_TICK_MS}ms`);
 	});
 
 	it("M サイズでも同一の accessibility 構造を保つ", () => {

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -27,6 +27,7 @@ import {
 	Video,
 } from "lucide-react";
 import { useCallback, useId, useState } from "react";
+import { PROGRESS_TICK_MS } from "../../lib/playback-constants";
 import { AudioPlayer } from "./audio-player";
 import { HighlightText } from "./highlight-text";
 import { TagList } from "./tag-list";
@@ -521,12 +522,13 @@ export function AudioButton({
 						className,
 					)}
 				>
-					{/* 進捗フィル（DOMへ直接書き込むためReact state化しない） */}
+					{/* 進捗フィル（DOMへ直接書き込むためReact state化しない）。
+					    transition は進捗更新間隔と同値にして連続移動させる（短いとカクつく・SPR-259） */}
 					<span
 						ref={progressFillRef}
 						aria-hidden="true"
-						className="pointer-events-none absolute inset-0 bg-minase-200 transition-[width] duration-150 ease-linear"
-						style={{ width: "0%" }}
+						className="pointer-events-none absolute inset-0 bg-minase-200 transition-[width] ease-linear"
+						style={{ width: "0%", transitionDuration: `${PROGRESS_TICK_MS}ms` }}
 					/>
 
 					{/* メイン部分 - 再生専用エリア */}

--- a/packages/ui/src/components/custom/play-hero.tsx
+++ b/packages/ui/src/components/custom/play-hero.tsx
@@ -3,6 +3,7 @@
 import type { AudioButton as AudioButtonType } from "@suzumina.click/shared-types";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { Loader2, Pause, Play } from "lucide-react";
+import { PROGRESS_TICK_MS } from "../../lib/playback-constants";
 import { AudioPlayer } from "./audio-player";
 import { useAudioPlayback } from "./use-audio-playback";
 
@@ -84,12 +85,13 @@ export function PlayHero({
 						: "gap-3.5 rounded-2xl border-[1.5px] py-3 pr-[26px] pl-3 shadow-[0_6px_18px_hsl(var(--suzuka-500)/0.12)] hover:shadow-[0_8px_22px_hsl(var(--minase-500)/0.2)]",
 				)}
 			>
-				{/* 進捗フィル（DOMへ直接書き込むためReact state化しない） */}
+				{/* 進捗フィル（DOMへ直接書き込むためReact state化しない）。
+				    transition は進捗更新間隔と同値にして連続移動させる（短いとカクつく・SPR-259） */}
 				<span
 					ref={progressFillRef}
 					aria-hidden="true"
-					className="pointer-events-none absolute inset-0 bg-minase-200 transition-[width] duration-100 ease-linear"
-					style={{ width: "0%" }}
+					className="pointer-events-none absolute inset-0 bg-minase-200 transition-[width] ease-linear"
+					style={{ width: "0%", transitionDuration: `${PROGRESS_TICK_MS}ms` }}
 				/>
 
 				{/* 再生サークル */}

--- a/packages/ui/src/components/custom/use-audio-playback.ts
+++ b/packages/ui/src/components/custom/use-audio-playback.ts
@@ -9,8 +9,9 @@ import type { AudioControls, AudioPlayerProps } from "./audio-player";
  * AudioPlayer ハンドラ群を一本化する。見た目は各コンポーネントの責務のまま。
  *
  * 使い方: 返り値の audioPlayerRef と playerHandlers を AudioPlayer に渡し、
- * progressFillRef を進捗フィル要素に張る。進捗は 250ms 毎の更新のため
- * React state にせず DOM へ直接書き込む（再レンダー回避）。
+ * progressFillRef を進捗フィル要素に張る。進捗は PROGRESS_TICK_MS
+ * （lib/playback-constants.ts）毎の更新のため React state にせず
+ * DOM へ直接書き込む（再レンダー回避）。フィル要素の transition も同定数に揃える（SPR-259）。
  */
 
 interface UseAudioPlaybackOptions {

--- a/packages/ui/src/lib/playback-constants.ts
+++ b/packages/ui/src/lib/playback-constants.ts
@@ -1,0 +1,6 @@
+/**
+ * 再生進捗の監視・通知間隔（ms）の正本。
+ * youtube-player-pool の監視タイマーと、進捗フィルの CSS transition の両方がこの値を参照する。
+ * transition がこの間隔より短いと「動く→止まる」のカクつきになる（SPR-259）。
+ */
+export const PROGRESS_TICK_MS = 250;

--- a/packages/ui/src/lib/youtube-player-pool.ts
+++ b/packages/ui/src/lib/youtube-player-pool.ts
@@ -9,6 +9,7 @@
 
 // 既存のyoutube-typesを再利用
 import type { YTPlayer, YTPlayerConfig } from "../components/custom/youtube-types";
+import { PROGRESS_TICK_MS } from "./playback-constants";
 import { loadYouTubeIframeAPI } from "./youtube-api-loader";
 
 interface PlayerData {
@@ -31,7 +32,7 @@ export interface PlaySegmentCallbacks {
 	onPlay?: () => void;
 	onPause?: () => void;
 	onEnd?: () => void;
-	/** 再生進捗（0-100）。監視間隔（250ms）ごとに通知 */
+	/** 再生進捗（0-100）。PROGRESS_TICK_MS ごとに通知 */
 	onProgress?: (progressPercent: number) => void;
 }
 
@@ -43,7 +44,7 @@ export class YouTubePlayerPool {
 	private players = new Map<string, PlayerData>();
 	private activeSegment: SegmentPlayback | null = null;
 	private readonly maxPoolSize = 5;
-	private readonly monitoringInterval = 250; // 250ms間隔で監視
+	private readonly monitoringInterval = PROGRESS_TICK_MS;
 	private isAPIReady = false;
 	private readyCallbacks: (() => void)[] = [];
 


### PR DESCRIPTION
## 概要

ボタン再生時に進捗フィルがカクつき、再生速度と微妙に合っていないように見える問題（AudioButton / PlayHero 共通）の修正です。

Linear: [SPR-259](https://linear.app/nothink/issue/SPR-259)

## 原因

進捗の**更新間隔**（player pool が 250ms ごとに width % を DOM へ書き込む）に対し、フィルの **CSS transition** が AudioButton 150ms / PlayHero 100ms と短く、各サイクルが「実速度の約1.7〜2.5倍で動く → 100〜150ms 停止」の繰り返しになっていた。カクつきの正体はこの速度ムラ。

## 変更内容

- **新設** `packages/ui/src/lib/playback-constants.ts`: 更新間隔の正本 `PROGRESS_TICK_MS = 250` を定義。pool の `monitoringInterval` と両コンポーネントのフィル `transitionDuration` がこの1定数を参照（値の二重管理を排除）
- **AudioButton / PlayHero**: フィルの `duration-150`/`duration-100` クラスを撤去し、inline style `transitionDuration: ${PROGRESS_TICK_MS}ms` に置換（Tailwind 動的クラス補間の落とし穴を回避）
- **退行防止テスト**: 両コンポーネントで transition-duration = 定数 を検証する2件を追加

## 検証

- `pnpm verify` 通過・Storybook テスト（347件）通過
- **実測（Emulator + 実ブラウザ・MutationObserver 計測）**: 進捗書き込みは 249〜251ms 間隔（平均250ms・ジッタ±1ms）、computed style は `width 0.25s linear`。各 transition がちょうど次の書き込みで終わるため、**停止区間ゼロの連続リニア移動**になることを確認。表示遅延は一定250msとなるが、一定遅延は等速に知覚される

🤖 Generated with [Claude Code](https://claude.com/claude-code)