### PR TITLE
fix(functions): Pub/Sub envelope不整合で週次フルスイープが本番未発火の回帰を修正 (SPR-229/SPR-230)

### DIFF
--- a/apps/functions/src/endpoints/__tests__/dlsite-individual-info-api.test.ts
+++ b/apps/functions/src/endpoints/__tests__/dlsite-individual-info-api.test.ts
@@ -94,10 +94,15 @@ function makeApiResponse(workno: string): DLsiteApiResponse {
 	return { workno, work_name: `テスト作品${workno}`, price: 1000 } as unknown as DLsiteApiResponse;
 }
 
+// 本番GCFv2（Eventarc経由）と同じMessagePublishedData envelope（message一段ネスト）で
+// 組み立てる。平坦形（event.data.data直下）でモックするとテストだけ通って本番で
+// mode検出が縮退する（SPR-229/230の週次フルスイープ未発火の回帰）。
 function pubsubEvent(payload?: Record<string, unknown>) {
 	return {
 		type: "google.cloud.pubsub.topic.v1.messagePublished",
-		data: payload ? { data: Buffer.from(JSON.stringify(payload)).toString("base64") } : undefined,
+		data: payload
+			? { message: { data: Buffer.from(JSON.stringify(payload)).toString("base64") } }
+			: undefined,
 	} as unknown as Parameters<typeof fetchDLsiteUnifiedData>[0];
 }
 

--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -60,11 +60,16 @@ const getMetadataMock = (firestoreMock as unknown as { __getMock: ReturnType<typ
 
 const dummyClient = {} as youtube_v3.Youtube;
 
+// 本番GCFv2（Eventarc経由）と同じMessagePublishedData envelope（message一段ネスト）で
+// 組み立てる。平坦形（event.data.data直下）でモックするとテストだけ通って本番で
+// mode検出が縮退する（SPR-229/230の週次フルスイープ未発火の回帰）。
 function pubsubEvent(payload?: Record<string, unknown>) {
 	return {
 		type: "google.cloud.pubsub.topic.v1.messagePublished",
 		data: {
-			data: payload ? Buffer.from(JSON.stringify(payload)).toString("base64") : undefined,
+			message: {
+				data: payload ? Buffer.from(JSON.stringify(payload)).toString("base64") : undefined,
+			},
 		},
 	} as unknown as Parameters<typeof fetchYouTubeVideos>[0];
 }

--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -63,12 +63,13 @@ const dummyClient = {} as youtube_v3.Youtube;
 // 本番GCFv2（Eventarc経由）と同じMessagePublishedData envelope（message一段ネスト）で
 // 組み立てる。平坦形（event.data.data直下）でモックするとテストだけ通って本番で
 // mode検出が縮退する（SPR-229/230の週次フルスイープ未発火の回帰）。
-function pubsubEvent(payload?: Record<string, unknown>) {
+// 既定ペイロードは毎時ジョブと同じ `{}`（terraform/scheduler.tf の base64encode("{}")）。
+function pubsubEvent(payload: Record<string, unknown> = {}) {
 	return {
 		type: "google.cloud.pubsub.topic.v1.messagePublished",
 		data: {
 			message: {
-				data: payload ? Buffer.from(JSON.stringify(payload)).toString("base64") : undefined,
+				data: Buffer.from(JSON.stringify(payload)).toString("base64"),
 			},
 		},
 	} as unknown as Parameters<typeof fetchYouTubeVideos>[0];

--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -40,7 +40,7 @@ import { bulkCheckPriceHistoryExistsToday, getJSTDate } from "../services/price-
 import { chunkArray } from "../shared/array-utils";
 import { withClearedUndefined } from "../shared/firestore-write";
 import * as logger from "../shared/logger";
-import { decodePubsubMode, type PubsubMessage } from "../shared/pubsub-utils";
+import { decodePubsubMode, type MessagePublishedData } from "../shared/pubsub-utils";
 
 /**
  * SPR-229 Stage②: ティア差分によるdue-setフィルタの有効/無効フラグ。
@@ -893,7 +893,9 @@ async function executeUnifiedDataCollection(forceFullSweep = false): Promise<Uni
 /**
  * Cloud Functions エントリーポイント
  */
-export async function fetchDLsiteUnifiedData(event: CloudEvent<PubsubMessage>): Promise<void> {
+export async function fetchDLsiteUnifiedData(
+	event: CloudEvent<MessagePublishedData>,
+): Promise<void> {
 	const mode = decodePubsubMode(event.data);
 	const isWeeklyFullSweep = mode === "weekly_full_sweep";
 

--- a/apps/functions/src/endpoints/index.ts
+++ b/apps/functions/src/endpoints/index.ts
@@ -10,6 +10,7 @@
 import * as functions from "@google-cloud/functions-framework";
 // 適切なロギング
 import * as logger from "../shared/logger";
+import type { MessagePublishedData } from "../shared/pubsub-utils";
 // 各モジュールから関数をインポート（統合アーキテクチャ）
 import { checkDataIntegrity } from "./data-integrity-check";
 import { fetchDLsiteUnifiedData } from "./dlsite-individual-info-api";
@@ -40,15 +41,10 @@ export function initializeApplication(): boolean {
 initializeApplication();
 
 // GCFv2用のCloudEventハンドラーを登録（Pub/Subトリガー関数用）
-interface PubsubMessage {
-	data?: string;
-	attributes?: Record<string, string>;
-}
-
 // 統合アーキテクチャによる Cloud Functions 登録
-functions.cloudEvent<PubsubMessage>("fetchYouTubeVideos", fetchYouTubeVideos);
-functions.cloudEvent<PubsubMessage>("fetchDLsiteUnifiedData", fetchDLsiteUnifiedData);
-functions.cloudEvent<PubsubMessage>("checkDataIntegrity", checkDataIntegrity);
+functions.cloudEvent<MessagePublishedData>("fetchYouTubeVideos", fetchYouTubeVideos);
+functions.cloudEvent<MessagePublishedData>("fetchDLsiteUnifiedData", fetchDLsiteUnifiedData);
+functions.cloudEvent<unknown>("checkDataIntegrity", checkDataIntegrity);
 
 /**
  * プロセス終了処理

--- a/apps/functions/src/endpoints/youtube.ts
+++ b/apps/functions/src/endpoints/youtube.ts
@@ -19,7 +19,7 @@ import {
 } from "../services/youtube/youtube-firestore";
 import { SUZUKA_MINASE_CHANNEL_ID } from "../shared/common";
 import * as logger from "../shared/logger";
-import { decodePubsubMode, type PubsubMessage } from "../shared/pubsub-utils";
+import { decodePubsubMode, type MessagePublishedData } from "../shared/pubsub-utils";
 
 // メタデータ保存用のドキュメントID
 const METADATA_DOC_ID = "fetch_metadata";
@@ -717,40 +717,22 @@ async function fetchYouTubeVideosLogic(isWeeklyFullSweep = false): Promise<Fetch
  * @param event - Pub/SubトリガーからのCloudEvent
  * @returns Promise<void> - 非同期処理の完了を表すPromise
  */
-export const fetchYouTubeVideos = async (event: CloudEvent<PubsubMessage>): Promise<void> => {
+export const fetchYouTubeVideos = async (
+	event: CloudEvent<MessagePublishedData>,
+): Promise<void> => {
 	logger.info("fetchYouTubeVideos 関数を開始しました (GCFv2 CloudEvent Handler)");
 
 	try {
 		// CloudEvent（Pub/Sub）の場合
 		logger.info("Pub/Subトリガーからの実行を検出しました");
-		const message = event.data;
 
-		if (!message) {
+		if (!event.data) {
 			logger.error("CloudEventデータが不足しています", { event });
 			return;
 		}
 
-		// 属性情報の処理 - テストに合わせてフォーマットを変更
-		if (message.attributes) {
-			logger.info("受信した属性情報:", message.attributes);
-		}
-
-		// Base64エンコードされたデータがあれば復号 - テストに合わせてフォーマットを変更
-		if (message.data) {
-			try {
-				const decodedData = Buffer.from(message.data, "base64").toString("utf-8");
-				// TypeScriptの型チェックに合格するようオブジェクト形式で渡す
-				logger.info("デコードされたメッセージデータ:", {
-					message: decodedData,
-				});
-			} catch (err) {
-				logger.error("Base64メッセージデータのデコードに失敗しました:", err);
-				return;
-			}
-		}
-
 		// SPR-230: ペイロードのmodeを確認し、週次フルスイープかどうかを判定する
-		const mode = decodePubsubMode(message);
+		const mode = decodePubsubMode(event.data);
 		const isWeeklyFullSweep = mode === "weekly_full_sweep";
 		if (isWeeklyFullSweep) {
 			logger.info("週次フルスイープトリガーを検出しました");

--- a/apps/functions/src/shared/__tests__/pubsub-utils.test.ts
+++ b/apps/functions/src/shared/__tests__/pubsub-utils.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as logger from "../logger";
+import { decodePubsubMode, type MessagePublishedData } from "../pubsub-utils";
+
+vi.mock("../logger", () => ({
+	warn: vi.fn(),
+	info: vi.fn(),
+	error: vi.fn(),
+}));
+
+function envelope(payload: Record<string, unknown>): MessagePublishedData {
+	return {
+		message: { data: Buffer.from(JSON.stringify(payload)).toString("base64") },
+		subscription: "projects/test/subscriptions/test-sub",
+	};
+}
+
+describe("decodePubsubMode", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("本番GCFv2のMessagePublishedData envelope（message一段ネスト）からmodeを取り出す", () => {
+		expect(decodePubsubMode(envelope({ mode: "weekly_full_sweep" }))).toBe("weekly_full_sweep");
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("modeを持たないペイロードはundefined（通常run）", () => {
+		expect(decodePubsubMode(envelope({ type: "unified_update" }))).toBeUndefined();
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("dataがundefinedならundefined（warnなし）", () => {
+		expect(decodePubsubMode(undefined)).toBeUndefined();
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("旧・平坦形（event.data.data直下）はデコードせずwarnを出す（SPR-229/230回帰の文書化）", () => {
+		// かつてのテストモックだけがこの形で、本番では発生しない。silent fallbackで
+		// 週次フルスイープが本番で一度も発火しなかった回帰を、warn必須として固定する。
+		const flat = {
+			data: Buffer.from(JSON.stringify({ mode: "weekly_full_sweep" })).toString("base64"),
+		} as unknown as MessagePublishedData;
+		expect(decodePubsubMode(flat)).toBeUndefined();
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("message.dataが不正なJSONならwarnを出してundefined", () => {
+		const broken: MessagePublishedData = {
+			message: { data: Buffer.from("not-json").toString("base64") },
+		};
+		expect(decodePubsubMode(broken)).toBeUndefined();
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+	});
+
+	it("modeが文字列でなければundefined", () => {
+		expect(decodePubsubMode(envelope({ mode: 123 }))).toBeUndefined();
+	});
+});

--- a/apps/functions/src/shared/pubsub-utils.ts
+++ b/apps/functions/src/shared/pubsub-utils.ts
@@ -10,7 +10,7 @@
 import * as logger from "./logger";
 
 /**
- * Pub/SubメッセージのPubsubMessage型定義
+ * Pub/Subメッセージ本体（base64エンコードされたdataとattributes）
  */
 export interface PubsubMessage {
 	data?: string;
@@ -18,15 +18,38 @@ export interface PubsubMessage {
 }
 
 /**
- * Pub/Subペイロードから`mode`を取り出す。
- * デコード失敗時は安全側（modeなし＝通常run）にフォールバックする。
+ * GCFv2（Eventarc経由Pub/Subトリガー）のCloudEvent `data` フィールドの実形。
+ *
+ * メッセージ本体は `message` に一段ネストされる（google.events.cloud.pubsub.v1
+ * の MessagePublishedData）。`event.data.data` を直接読む平坦形は本番では
+ * 発生しない（SPR-229/230の週次フルスイープが本番で一度も発火しなかった
+ * 回帰の原因。テストモックだけが平坦形で通っていた）。
  */
-export function decodePubsubMode(message: PubsubMessage | undefined): string | undefined {
-	if (!message?.data) {
+export interface MessagePublishedData {
+	message?: PubsubMessage;
+	subscription?: string;
+}
+
+/**
+ * CloudEventの`data`（MessagePublishedData）からペイロードの`mode`を取り出す。
+ * デコード失敗・想定外のenvelope形は安全側（modeなし＝通常run）にフォールバックするが、
+ * silent fallbackはバグを隠すため（本番だけ週次フルスイープが縮退していた実績あり）
+ * 必ずwarnを残す。
+ */
+export function decodePubsubMode(data: MessagePublishedData | undefined): string | undefined {
+	if (!data) {
+		return undefined;
+	}
+	const encoded = data.message?.data;
+	if (!encoded) {
+		logger.warn(
+			"Pub/SubペイロードにMessagePublishedData.message.dataがありません（modeなしとして通常runを続行します）",
+			{ keys: Object.keys(data) },
+		);
 		return undefined;
 	}
 	try {
-		const decoded = Buffer.from(message.data, "base64").toString("utf-8");
+		const decoded = Buffer.from(encoded, "base64").toString("utf-8");
 		const parsed = JSON.parse(decoded) as { mode?: unknown };
 		return typeof parsed.mode === "string" ? parsed.mode : undefined;
 	} catch (err) {


### PR DESCRIPTION
## 概要

SPR-85の再計測（2026-07-12・Cloud Logging本番実測）で発見した回帰の修正。**DLsite・YouTube両方の週次フルスイープが本番で一度も発火していなかった**。

## 原因

GCFv2（Eventarc経由Pub/Subトリガー）のCloudEventでは、メッセージは `event.data.message.data` に一段ネストされる（`MessagePublishedData`）。`decodePubsubMode` は平坦形 `event.data.data` を読んでいたため mode 検出が常に失敗し、安全側フォールバック（通常run）に**警告なしで縮退**していた。

テストの `pubsubEvent()` ヘルパーも同じ誤った平坦形でモックしていたため、テストは通るのに本番だけ壊れる構図だった。

**本番証拠**:
- Cloud Scheduler 側は正常（両ジョブとも `mode="weekly_full_sweep"` を送信済み・lastAttemptTime 確認済み）
- DLsite: スケジューラ発火直後run（07-11T19:15Z）が `週次フルスイープ: false`。通常runでも `mode` 常時null
- YouTube: 「週次フルスイープトリガーを検出しました」が30日間0件

## 変更内容

- `pubsub-utils.ts`: `decodePubsubMode` を `MessagePublishedData`（message一段ネスト）を読む形に修正。envelope形が想定外なら silent fallback せず warn（今回のバグを隠した経路の是正）
- `youtube.ts`: 平坦形を読む重複した手書きデコード/ログブロックを削除し `decodePubsubMode` に一本化
- `index.ts`: 重複 `PubsubMessage` interface を削除し shared から import（正本一元化）
- 両テストの `pubsubEvent()` を本番と同じ envelope 形に是正
- `shared/__tests__/pubsub-utils.test.ts` 新規: 正規envelope／平坦形→undefined+warn（回帰の文書化）／破損data→warn を固定

## 影響・非変更

- ティア差分ロジック本体（正常動作中・API ~70-73%減/quota ~97%減を実測済み）は無変更
- Firestoreスキーマ・Terraform変更なし。ロールバックは前リビジョン再デプロイのみ
- 本番の毎時ジョブは両方とも常に data を送る（YouTube `{}`・DLsite フルJSON）ため、新warnが定常ノイズになることはない

## デプロイ後の検証手順

1. **即時**: 次の2時間runで DLsite「統合データ収集開始」ログに `mode: "individual_info_api_unified"`（現状null）が出ること
2. **07-13(日) 4:00 JST**: YouTube週次フルスイープ自然発火（~11-20 units・軽量）→「週次フルスイープトリガーを検出しました」確認
3. **07-18(土) 4:15 JST**（または手動 `gcloud scheduler jobs run`）: DLsite週次フルスイープ → 「取りこぼし検知」ログ確認

## 検証

- `pnpm verify` 全パス

## セルフマージ区分

本番同期パイプライン変更のため **One-Way Door**（AIレビュー任せにせず自分でレビューしてからマージ）

Linear: [SPR-85](https://linear.app/nothink/issue/SPR-85) / [SPR-229](https://linear.app/nothink/issue/SPR-229) / [SPR-230](https://linear.app/nothink/issue/SPR-230)

🤖 Generated with [Claude Code](https://claude.com/claude-code)