### PR TITLE
fix(web): 保護ページの callbackUrl 欠落を修正

### DIFF
--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -152,9 +152,12 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	// フォールバック: 取得失敗時は10分
 	const videoDuration = videoDurationSeconds > 0 ? videoDurationSeconds : 600;
 
-	const callbackPath = `/buttons/create?video_id=${videoId}${
-		resolvedSearchParams.start_time ? `&start_time=${resolvedSearchParams.start_time}` : ""
-	}`;
+	const callbackQuery = new URLSearchParams(
+		Object.entries({ video_id: videoId, start_time: resolvedSearchParams.start_time }).filter(
+			(entry): entry is [string, string] => entry[1] !== undefined,
+		),
+	).toString();
+	const callbackPath = `/buttons/create?${callbackQuery}`;
 
 	return (
 		<ProtectedRoute callbackPath={callbackPath}>

--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -152,8 +152,12 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	// フォールバック: 取得失敗時は10分
 	const videoDuration = videoDurationSeconds > 0 ? videoDurationSeconds : 600;
 
+	const callbackPath = `/buttons/create?video_id=${videoId}${
+		resolvedSearchParams.start_time ? `&start_time=${resolvedSearchParams.start_time}` : ""
+	}`;
+
 	return (
-		<ProtectedRoute>
+		<ProtectedRoute callbackPath={callbackPath}>
 			{/*
 			 * key で動画/開始時刻ごとに remount。App Router は同一 /buttons/create セグメントの
 			 * 再訪で page instance を使い回すため、別動画で来たときに前回のフォーム値が残るのを防ぐ。

--- a/apps/web/src/app/favorites/page.tsx
+++ b/apps/web/src/app/favorites/page.tsx
@@ -17,12 +17,17 @@ interface FavoritesPageProps {
 }
 
 export default async function FavoritesPage({ searchParams }: FavoritesPageProps) {
+	const params = await searchParams;
+
 	const user = await getCurrentUser();
 	if (!user?.discordId) {
-		redirect("/auth/signin");
+		const query = new URLSearchParams(
+			Object.entries(params).filter((entry): entry is [string, string] => entry[1] !== undefined),
+		).toString();
+		const callbackPath = query ? `/favorites?${query}` : "/favorites";
+		redirect(`/auth/signin?callbackUrl=${encodeURIComponent(callbackPath)}`);
 	}
 
-	const params = await searchParams;
 	const page = Number(params.page) || 1;
 	const sort = params.sort || "newest";
 

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -21,12 +21,12 @@ export default async function SettingsPage() {
 	const currentUser = await getCurrentUser();
 
 	if (!currentUser?.discordId) {
-		redirect("/auth/signin");
+		redirect("/auth/signin?callbackUrl=%2Fsettings");
 	}
 
 	const user = await getUserByDiscordId(currentUser.discordId);
 	if (!user) {
-		redirect("/auth/signin");
+		redirect("/auth/signin?callbackUrl=%2Fsettings");
 	}
 
 	return <UnifiedSettingsContent user={user} />;

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -21,12 +21,12 @@ export default async function SettingsPage() {
 	const currentUser = await getCurrentUser();
 
 	if (!currentUser?.discordId) {
-		redirect("/auth/signin?callbackUrl=%2Fsettings");
+		redirect(`/auth/signin?callbackUrl=${encodeURIComponent("/settings")}`);
 	}
 
 	const user = await getUserByDiscordId(currentUser.discordId);
 	if (!user) {
-		redirect("/auth/signin?callbackUrl=%2Fsettings");
+		redirect(`/auth/signin?callbackUrl=${encodeURIComponent("/settings")}`);
 	}
 
 	return <UnifiedSettingsContent user={user} />;

--- a/apps/web/src/components/system/__tests__/protected-route.test.tsx
+++ b/apps/web/src/components/system/__tests__/protected-route.test.tsx
@@ -5,16 +5,6 @@ import ProtectedRoute, { requireAuth } from "../protected-route";
 
 vi.mock("@/lib/auth/server");
 
-// next/headers の headers() を制御する
-const { headersStore } = vi.hoisted(() => ({
-	headersStore: { xUrl: null as string | null },
-}));
-vi.mock("next/headers", () => ({
-	headers: vi.fn(async () => ({
-		get: (key: string) => (key === "x-url" ? headersStore.xUrl : null),
-	})),
-}));
-
 // Next の redirect は実装上 throw して以降の処理を止める。テストでも同じ挙動にする。
 vi.mock("next/navigation", () => ({
 	redirect: vi.fn((url: string) => {
@@ -33,7 +23,6 @@ const makeUser = (overrides: Record<string, unknown> = {}) => ({
 describe("ProtectedRoute", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		headersStore.xUrl = null;
 	});
 
 	it("認証済み・アクティブ・権限十分なら children を描画する", async () => {
@@ -46,28 +35,32 @@ describe("ProtectedRoute", () => {
 		expect(redirect).not.toHaveBeenCalled();
 	});
 
-	it("未認証なら fallback へ x-url を callbackUrl 付きでリダイレクトする", async () => {
+	it("未認証なら呼び出し元が渡した callbackPath を callbackUrl に付与してリダイレクトする", async () => {
 		mockCurrentUser(null);
-		headersStore.xUrl = "/works/RJ123456";
 
-		await expect(ProtectedRoute({ children: <div>secret</div> })).rejects.toThrow("REDIRECT:");
+		await expect(
+			ProtectedRoute({ children: <div>secret</div>, callbackPath: "/works/RJ123456" }),
+		).rejects.toThrow("REDIRECT:");
 		expect(redirect).toHaveBeenCalledWith("/auth/signin?callbackUrl=%2Fworks%2FRJ123456");
 	});
 
-	it("未認証かつ x-url ヘッダが無い場合は /buttons/create を callbackUrl に使う", async () => {
+	it("未認証かつ callbackPath 未指定なら callbackUrl 無しでリダイレクトする", async () => {
 		mockCurrentUser(null);
-		headersStore.xUrl = null;
 
 		await expect(ProtectedRoute({ children: <div>x</div> })).rejects.toThrow("REDIRECT:");
-		expect(redirect).toHaveBeenCalledWith("/auth/signin?callbackUrl=%2Fbuttons%2Fcreate");
+		expect(redirect).toHaveBeenCalledWith("/auth/signin");
 	});
 
 	it("fallbackUrl を指定するとその URL にリダイレクトする", async () => {
 		mockCurrentUser(null);
 
-		await expect(ProtectedRoute({ children: <div>x</div>, fallbackUrl: "/login" })).rejects.toThrow(
-			"REDIRECT:",
-		);
+		await expect(
+			ProtectedRoute({
+				children: <div>x</div>,
+				fallbackUrl: "/login",
+				callbackPath: "/buttons/create",
+			}),
+		).rejects.toThrow("REDIRECT:");
 		expect(redirect).toHaveBeenCalledWith("/login?callbackUrl=%2Fbuttons%2Fcreate");
 	});
 

--- a/apps/web/src/components/system/protected-route.tsx
+++ b/apps/web/src/components/system/protected-route.tsx
@@ -1,5 +1,4 @@
 import type { UserSession } from "@suzumina.click/shared-types";
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
 import { getCurrentUser } from "@/lib/auth/server";
@@ -7,12 +6,16 @@ import { getCurrentUser } from "@/lib/auth/server";
 interface ProtectedRouteProps {
 	children: ReactNode;
 	fallbackUrl?: string;
+	/** 未認証時に signin 後の戻り先として使う元ページのパス（クエリ含む）。呼び出し元が明示指定する。 */
+	callbackPath?: string;
 }
 
 /**
  * 認証が必要なページ用のラッパー（Server Component）。
  *
- * - 未認証: サインインページへリダイレクト（元 URL を callbackUrl に付与）。
+ * - 未認証: サインインページへリダイレクト（`callbackPath` があれば callbackUrl に付与）。
+ *   `callbackPath` は呼び出し元の page.tsx が自身の searchParams から明示的に組み立てる
+ *   （x-url ヘッダ等の暗黙経路には頼らない＝呼び出し元を見れば戻り先が分かる状態を優先）。
  * - 認証済みだが無効アカウント（`isActive=false`）: 汎用エラーページ `/auth/error?error=AccountDisabled` へ。
  *   無効化の手段が現状無いため通常は到達しない防御的ゲート。ロールベース認可も無いため
  *   専用の 403 ページは設けず、到達時のみ汎用エラーページで理由を説明する方針（SPR-169）。
@@ -20,15 +23,14 @@ interface ProtectedRouteProps {
 export default async function ProtectedRoute({
 	children,
 	fallbackUrl = "/auth/signin",
+	callbackPath,
 }: ProtectedRouteProps) {
 	const user = await getCurrentUser();
 
 	// 未認証の場合
 	if (!user) {
-		// 現在のURLをコールバックURLとして保存
-		const headersList = await headers();
-		const currentUrl = headersList.get("x-url") || "/buttons/create";
-		redirect(`${fallbackUrl}?callbackUrl=${encodeURIComponent(currentUrl)}`);
+		const query = callbackPath ? `?callbackUrl=${encodeURIComponent(callbackPath)}` : "";
+		redirect(`${fallbackUrl}${query}`);
 	}
 
 	// 無効アカウントの場合（防御的・通常は到達しない）


### PR DESCRIPTION
## Summary
- `ProtectedRoute` は存在しない `x-url` ヘッダに依存しており、未認証時は常に `/buttons/create` にフォールバックしていた。これにより `/buttons/create?video_id=...` へ直接来た未認証ユーザーが signin 後に `video_id` を失い、エラー画面に着地していた。
- 呼び出し元が `callbackPath` を明示的に渡す方式に変更（暗黙のヘッダ経路を廃止）。
- `/favorites`・`/settings` はそもそも `callbackUrl` を一切付けずに `/auth/signin` へリダイレクトしており、signin 後は常に `/` に落ちていた。既存の `/buttons/[id]/edit` と同じ明示的パターンに揃えて修正。

## Test plan
- [x] `apps/web/src/components/system/__tests__/protected-route.test.tsx` を新しい `callbackPath` プロパティに合わせて更新
- [x] `pnpm verify`（lint + typecheck + test、カバレッジ閾値込み）が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)