### PR TITLE
fix(web): /users/me の callbackUrl 欠落を修正

### DIFF
--- a/apps/web/src/app/users/me/page.tsx
+++ b/apps/web/src/app/users/me/page.tsx
@@ -5,8 +5,8 @@ export default async function MyProfilePage() {
 	const user = await getCurrentUser();
 
 	if (!user) {
-		// 未認証の場合はサインインページへ
-		redirect("/auth/signin");
+		// 未認証の場合はサインインページへ（signin 後に /users/me へ戻れば自分のプロフィールへ再リダイレクトされる）
+		redirect(`/auth/signin?callbackUrl=${encodeURIComponent("/users/me")}`);
 	}
 
 	// 認証済みの場合は自分のプロフィールページへリダイレクト


### PR DESCRIPTION
## Summary
[#782](https://github.com/nothink-jp/suzumina.click/pull/782) で保護ページの `callbackUrl` 欠落（`/favorites`・`/settings`）を修正した際、同じパターンの `redirect("/auth/signin")` が `apps/web/src/app/users/me/page.tsx` にも残っていることを見落としていた。未認証で `/users/me` に来た場合 signin 後は常に `/` に落ち、自分のプロフィールへ戻れなかった。既存パターン（`?callbackUrl=${encodeURIComponent(path)}`）に合わせて修正。

## Test plan
- [x] `pnpm verify`（lint + typecheck + test）が通ることを確認
- [x] `/users/me` は認証後に自身の discordId ページへ再リダイレクトするだけの薄いページのため、callbackUrl=`/users/me` で signin 後に戻れば元のリダイレクトロジックがそのまま動く

🤖 Generated with [Claude Code](https://claude.com/claude-code)