### PR TITLE
feat(web): 配信中マーキング /live → 下書き → 仕上げ導線を追加（SPR-146 第1段）

### DIFF
--- a/apps/web/src/actions/__tests__/button-drafts.test.ts
+++ b/apps/web/src/actions/__tests__/button-drafts.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+vi.mock("@/lib/auth/server", () => ({ getCurrentUser: mockGetCurrentUser }));
+
+const mockGetFirestore = vi.fn();
+vi.mock("@/lib/firestore", () => ({ getFirestore: mockGetFirestore }));
+
+vi.mock("@/lib/logger", () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
+const { createButtonDraft, deleteButtonDraft, getMyButtonDrafts } = await import(
+	"../button-drafts"
+);
+
+const VALID_INPUT = {
+	videoId: "9kMBmEvhwUk",
+	videoTitle: "テスト配信",
+	playerTime: 881.037,
+	markedAtMs: Date.now(),
+};
+
+function setupFirestore({ draftCount = 0 }: { draftCount?: number } = {}) {
+	const mockAdd = vi.fn(async (_doc: Record<string, unknown>) => ({ id: "draft-1" }));
+	const mockDelete = vi.fn(async () => undefined);
+	const mockOrderedGet = vi.fn(async () => ({ docs: [] as unknown[] }));
+	const mockLimit = vi.fn(() => ({ get: mockOrderedGet }));
+	const mockOrderBy = vi.fn(() => ({ limit: mockLimit }));
+	const subcollection = {
+		add: mockAdd,
+		count: () => ({ get: async () => ({ data: () => ({ count: draftCount }) }) }),
+		orderBy: mockOrderBy,
+		doc: vi.fn(() => ({ delete: mockDelete })),
+	};
+	const userDoc = vi.fn();
+	mockGetFirestore.mockReturnValue({
+		collection: () => ({ doc: userDoc.mockReturnValue({ collection: () => subcollection }) }),
+	});
+	return { mockAdd, mockDelete, mockOrderBy, mockLimit, mockOrderedGet, userDoc };
+}
+
+describe("createButtonDraft (SPR-146)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: true });
+	});
+
+	it("生の捕捉信号（playerTime + markedAt）を Date として保存し、プレーンを返す", async () => {
+		const { mockAdd } = setupFirestore();
+		const result = await createButtonDraft(VALID_INPUT);
+
+		expect(mockAdd).toHaveBeenCalledOnce();
+		const written = mockAdd.mock.calls[0]?.[0] ?? {};
+		expect(written.videoId).toBe("9kMBmEvhwUk");
+		expect(written.videoTitle).toBe("テスト配信");
+		expect(written.playerTime).toBe(881.037);
+		// Firestore は Date を Timestamp として保存する（新規コレクションの日時規約）
+		expect(written.markedAt).toBeInstanceOf(Date);
+		expect(written.createdAt).toBeInstanceOf(Date);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.id).toBe("draft-1");
+			expect(result.data.suggestedStartTime).toBe(866); // floor(881) - 15
+		}
+	});
+
+	it("playerTime=null（壁時計のみモード）も保存できる", async () => {
+		const { mockAdd } = setupFirestore();
+		const result = await createButtonDraft({ ...VALID_INPUT, playerTime: null });
+		expect(result.success).toBe(true);
+		expect(mockAdd.mock.calls[0]?.[0]?.playerTime).toBeNull();
+		if (result.success) {
+			expect(result.data.suggestedStartTime).toBe(0);
+		}
+	});
+
+	it("未認証は error を返す（redirect しない・SPR-195）", async () => {
+		mockGetCurrentUser.mockResolvedValue(null);
+		const result = await createButtonDraft(VALID_INPUT);
+		expect(result).toEqual({ success: false, error: "ログインが必要です" });
+	});
+
+	it("無効ユーザー（isActive=false）はブロックする", async () => {
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: false });
+		const result = await createButtonDraft(VALID_INPUT);
+		expect(result).toEqual({ success: false, error: "ログインが必要です" });
+	});
+
+	it.each([
+		["videoId 不正", { ...VALID_INPUT, videoId: "bad" }],
+		["playerTime 負値", { ...VALID_INPUT, playerTime: -1 }],
+		["markedAtMs 異常値（24h超のずれ）", { ...VALID_INPUT, markedAtMs: 0 }],
+	])("バリデーション: %s は保存せず error を返す", async (_label, input) => {
+		const { mockAdd } = setupFirestore();
+		const result = await createButtonDraft(input);
+		expect(result.success).toBe(false);
+		expect(mockAdd).not.toHaveBeenCalled();
+	});
+
+	it("下書きが上限件数に達していたら保存を拒否する", async () => {
+		const { mockAdd } = setupFirestore({ draftCount: 500 });
+		const result = await createButtonDraft(VALID_INPUT);
+		expect(result.success).toBe(false);
+		expect(mockAdd).not.toHaveBeenCalled();
+	});
+});
+
+describe("getMyButtonDrafts", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: true });
+	});
+
+	it("createdAt 降順で取得しプレーンへ変換する", async () => {
+		const { mockOrderBy, mockOrderedGet } = setupFirestore();
+		mockOrderedGet.mockResolvedValue({
+			docs: [
+				{
+					id: "d1",
+					data: () => ({
+						videoId: "9kMBmEvhwUk",
+						videoTitle: "t",
+						playerTime: 34.14,
+						markedAt: { toDate: () => new Date("2026-07-10T12:01:26.484Z") },
+						createdAt: { toDate: () => new Date("2026-07-10T12:01:26.500Z") },
+					}),
+				},
+			],
+		});
+		const result = await getMyButtonDrafts();
+		expect(mockOrderBy).toHaveBeenCalledWith("createdAt", "desc");
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data).toHaveLength(1);
+			expect(result.data[0]?.markedAt).toBe("2026-07-10T12:01:26.484Z");
+			expect(result.data[0]?.suggestedStartTime).toBe(19); // floor(34) - 15
+		}
+	});
+
+	it("未認証は error を返す", async () => {
+		mockGetCurrentUser.mockResolvedValue(null);
+		const result = await getMyButtonDrafts();
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("deleteButtonDraft", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: true });
+	});
+
+	it("自分のサブコレクション配下の下書きを削除する", async () => {
+		const { mockDelete } = setupFirestore();
+		const result = await deleteButtonDraft("d1");
+		expect(mockDelete).toHaveBeenCalledOnce();
+		expect(result.success).toBe(true);
+	});
+
+	it("パス操作を含む draftId は拒否する", async () => {
+		const { mockDelete } = setupFirestore();
+		const result = await deleteButtonDraft("../users/other");
+		expect(result.success).toBe(false);
+		expect(mockDelete).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/actions/button-drafts.ts
+++ b/apps/web/src/actions/button-drafts.ts
@@ -1,0 +1,179 @@
+"use server";
+
+import {
+	type AudioButtonDraft,
+	type AudioButtonDraftDocument,
+	audioButtonDraftTransformers,
+	type CreateAudioButtonDraftInput,
+} from "@suzumina.click/shared-types";
+import { getCurrentUser } from "@/lib/auth/server";
+import { getFirestore } from "@/lib/firestore";
+import * as logger from "@/lib/logger";
+
+const SUBCOLLECTION = "buttonDrafts";
+/** 1ユーザーの下書き保持上限（M キー連打・放置による無制限成長の安全弁） */
+const MAX_DRAFTS_PER_USER = 500;
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+/** markedAt の許容ずれ（クライアント時計の異常値を弾く。通常は数秒以内） */
+const MARKED_AT_TOLERANCE_MS = 24 * 60 * 60 * 1000;
+
+export type CreateButtonDraftResult =
+	| { success: true; data: AudioButtonDraft }
+	| { success: false; error: string };
+
+export type ListButtonDraftsResult =
+	| { success: true; data: AudioButtonDraft[] }
+	| { success: false; error: string };
+
+export interface DeleteButtonDraftResult {
+	success: boolean;
+	error?: string;
+}
+
+function draftsRef(discordId: string) {
+	return getFirestore().collection("users").doc(discordId).collection(SUBCOLLECTION);
+}
+
+function validateCreateInput(input: CreateAudioButtonDraftInput): string | null {
+	if (!VIDEO_ID_PATTERN.test(input.videoId)) {
+		return "動画IDが不正です";
+	}
+	if (typeof input.videoTitle !== "string" || input.videoTitle.trim() === "") {
+		return "動画タイトルが不正です";
+	}
+	if (
+		input.playerTime !== null &&
+		(!Number.isFinite(input.playerTime) || input.playerTime < 0 || input.playerTime > 172_800)
+	) {
+		return "再生位置が不正です";
+	}
+	if (
+		!Number.isFinite(input.markedAtMs) ||
+		Math.abs(Date.now() - input.markedAtMs) > MARKED_AT_TOLERANCE_MS
+	) {
+		return "マーク時刻が不正です";
+	}
+	return null;
+}
+
+/**
+ * 配信中マークを下書きとして保存する（SPR-146 第1段）。
+ *
+ * 保存するのは生の捕捉信号のみ（playerTime = 主信号 / markedAt = 壁時計フォールバック。SPR-145）。
+ * 日時は Date で渡し Firestore Timestamp として保存される（新規コレクション規約）。
+ */
+export async function createButtonDraft(
+	input: CreateAudioButtonDraftInput,
+): Promise<CreateButtonDraftResult> {
+	try {
+		// 認可ゲートの正本 = getCurrentUser の null チェック（SPR-195）。
+		// 供給系の書き込みのため無効ユーザーも明示ブロックする。
+		const user = await getCurrentUser();
+		if (!user?.discordId || !user.isActive) {
+			return { success: false, error: "ログインが必要です" };
+		}
+
+		const validationError = validateCreateInput(input);
+		if (validationError) {
+			return { success: false, error: validationError };
+		}
+
+		const ref = draftsRef(user.discordId);
+
+		const countSnapshot = await ref.count().get();
+		if (countSnapshot.data().count >= MAX_DRAFTS_PER_USER) {
+			return {
+				success: false,
+				error: `下書きが上限（${MAX_DRAFTS_PER_USER}件）に達しています。不要な下書きを削除してください`,
+			};
+		}
+
+		const markedAt = new Date(input.markedAtMs);
+		const createdAt = new Date();
+		const doc: Omit<AudioButtonDraftDocument, "markedAt" | "createdAt"> & {
+			markedAt: Date;
+			createdAt: Date;
+		} = {
+			videoId: input.videoId,
+			videoTitle: input.videoTitle.trim().slice(0, 200),
+			playerTime: input.playerTime,
+			markedAt,
+			createdAt,
+		};
+		const added = await ref.add(doc);
+
+		logger.info("音声ボタン下書きを作成", {
+			draftId: added.id,
+			videoId: input.videoId,
+			playerTime: input.playerTime,
+			userId: user.discordId,
+		});
+
+		return {
+			success: true,
+			data: audioButtonDraftTransformers.fromFirestore(added.id, doc),
+		};
+	} catch (error) {
+		logger.error("音声ボタン下書きの作成でエラーが発生", {
+			videoId: input.videoId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { success: false, error: "下書きの保存に失敗しました" };
+	}
+}
+
+/**
+ * 自分の下書き一覧を新しい順で取得する。
+ */
+export async function getMyButtonDrafts(limit = 100): Promise<ListButtonDraftsResult> {
+	try {
+		const user = await getCurrentUser();
+		if (!user?.discordId) {
+			return { success: false, error: "ログインが必要です" };
+		}
+
+		const snapshot = await draftsRef(user.discordId)
+			.orderBy("createdAt", "desc")
+			.limit(Math.min(Math.max(limit, 1), MAX_DRAFTS_PER_USER))
+			.get();
+
+		return {
+			success: true,
+			data: snapshot.docs.map((doc) =>
+				audioButtonDraftTransformers.fromFirestore(doc.id, doc.data() as AudioButtonDraftDocument),
+			),
+		};
+	} catch (error) {
+		logger.error("音声ボタン下書き一覧の取得でエラーが発生", {
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { success: false, error: "下書き一覧の取得に失敗しました" };
+	}
+}
+
+/**
+ * 下書きを削除する（仕上げ完了後の消化・手動削除の両方から使う）。
+ * 自分のサブコレクション配下しか触れないため所有チェックはパスで担保される。
+ */
+export async function deleteButtonDraft(draftId: string): Promise<DeleteButtonDraftResult> {
+	try {
+		const user = await getCurrentUser();
+		if (!user?.discordId) {
+			return { success: false, error: "ログインが必要です" };
+		}
+		if (typeof draftId !== "string" || draftId === "" || draftId.includes("/")) {
+			return { success: false, error: "下書きIDが不正です" };
+		}
+
+		await draftsRef(user.discordId).doc(draftId).delete();
+
+		logger.info("音声ボタン下書きを削除", { draftId, userId: user.discordId });
+		return { success: true };
+	} catch (error) {
+		logger.error("音声ボタン下書きの削除でエラーが発生", {
+			draftId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { success: false, error: "下書きの削除に失敗しました" };
+	}
+}

--- a/apps/web/src/actions/button-drafts.ts
+++ b/apps/web/src/actions/button-drafts.ts
@@ -80,6 +80,8 @@ export async function createButtonDraft(
 
 		const ref = draftsRef(user.discordId);
 
+		// 上限はソフトリミット: count→add 間の TOCTOU で数件超えうるが、個人所有の下書き掃除が目的のため
+		// 許容する（厳密化のトランザクションはコストに見合わない判断）
 		const countSnapshot = await ref.count().get();
 		if (countSnapshot.data().count >= MAX_DRAFTS_PER_USER) {
 			return {

--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -15,6 +15,8 @@ interface CreateAudioButtonPageProps {
 	searchParams: Promise<{
 		video_id?: string;
 		start_time?: string;
+		/** /live の下書きから開いた場合に付与。作成成功時にその下書きを消化する（SPR-146） */
+		draft_id?: string;
 	}>;
 }
 
@@ -153,9 +155,11 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	const videoDuration = videoDurationSeconds > 0 ? videoDurationSeconds : 600;
 
 	const callbackQuery = new URLSearchParams(
-		Object.entries({ video_id: videoId, start_time: resolvedSearchParams.start_time }).filter(
-			(entry): entry is [string, string] => entry[1] !== undefined,
-		),
+		Object.entries({
+			video_id: videoId,
+			start_time: resolvedSearchParams.start_time,
+			draft_id: resolvedSearchParams.draft_id,
+		}).filter((entry): entry is [string, string] => entry[1] !== undefined),
 	).toString();
 	const callbackPath = `/buttons/create?${callbackQuery}`;
 
@@ -171,6 +175,7 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 				videoTitle={videoResult.title}
 				videoDuration={videoDuration}
 				initialStartTime={startTime}
+				draftId={resolvedSearchParams.draft_id}
 			/>
 		</ProtectedRoute>
 	);

--- a/apps/web/src/app/live/page.tsx
+++ b/apps/web/src/app/live/page.tsx
@@ -1,0 +1,73 @@
+import type { VideoPlainObject } from "@suzumina.click/shared-types";
+import type { Metadata } from "next";
+import { getMyButtonDrafts } from "@/actions/button-drafts";
+import { getVideoById, getVideosList } from "@/app/videos/actions";
+import { LiveCaptureView } from "@/components/live/live-capture-view";
+import ProtectedRoute from "@/components/system/protected-route";
+
+export const metadata: Metadata = {
+	title: "配信中マーキング",
+	description: "配信視聴中に「ここ！」をマークして、音声ボタンの下書きを残せます",
+	// ログイン前提の作業用ページのためインデックス不要
+	robots: { index: false, follow: false },
+};
+
+interface LivePageProps {
+	searchParams: Promise<{ v?: string }>;
+}
+
+/**
+ * マーキング対象の動画を選ぶ。
+ * 手動指定（?v=）が最優先。なければ配信中 → 直近の配信予定の順。
+ * liveBroadcastContent の鮮度は fetchYouTubeVideos の更新頻度に依存するため、
+ * 拾えないときの逃げ道として手動指定を残している（SPR-230 の stale 対策と同じ理由）。
+ */
+async function findTargetVideo(manualVideoId?: string): Promise<VideoPlainObject | null> {
+	if (manualVideoId) {
+		return await getVideoById(manualVideoId);
+	}
+
+	const { items } = await getVideosList({
+		page: 1,
+		limit: 12,
+		filters: { videoType: "live_upcoming" },
+	});
+
+	const live = items.find((v) => v.liveBroadcastContent === "live");
+	if (live) {
+		return live;
+	}
+
+	const upcoming = items
+		.filter((v) => v.liveBroadcastContent === "upcoming")
+		.sort((a, b) =>
+			(a.liveStreamingDetails?.scheduledStartTime ?? "9999").localeCompare(
+				b.liveStreamingDetails?.scheduledStartTime ?? "9999",
+			),
+		);
+	return upcoming[0] ?? null;
+}
+
+/**
+ * データ取得は ProtectedRoute の内側で行う（未認証時はリダイレクトされ、ここは実行されない）。
+ */
+async function LiveCaptureContent({ manualVideoId }: { manualVideoId?: string }) {
+	const [video, draftsResult] = await Promise.all([
+		findTargetVideo(manualVideoId),
+		getMyButtonDrafts(),
+	]);
+
+	return (
+		<LiveCaptureView video={video} initialDrafts={draftsResult.success ? draftsResult.data : []} />
+	);
+}
+
+export default async function LivePage({ searchParams }: LivePageProps) {
+	const { v } = await searchParams;
+
+	return (
+		<ProtectedRoute callbackPath={v ? `/live?v=${encodeURIComponent(v)}` : "/live"}>
+			<LiveCaptureContent manualVideoId={v} />
+		</ProtectedRoute>
+	);
+}

--- a/apps/web/src/app/live/page.tsx
+++ b/apps/web/src/app/live/page.tsx
@@ -27,6 +27,9 @@ async function findTargetVideo(manualVideoId?: string): Promise<VideoPlainObject
 		return await getVideoById(manualVideoId);
 	}
 
+	// getVideosList はリポジトリ既定の「全件取得 + in-memory フィルタ」（SPR-213）。videos は数百件規模かつ
+	// /live はログイン者専用の低頻度ページのため許容。レイテンシが実測で問題になったら専用クエリ + 複合
+	// インデックス（terraform 同時追加）を別 Issue で検討する
 	const { items } = await getVideosList({
 		page: 1,
 		limit: 12,

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -6,6 +6,7 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Loader2, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
+import { deleteButtonDraft } from "@/actions/button-drafts";
 import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
 import { useSession } from "@/lib/auth/client";
@@ -19,6 +20,8 @@ interface AudioButtonCreatorProps {
 	videoTitle: string;
 	videoDuration?: number;
 	initialStartTime?: number;
+	/** /live の下書きから開いた場合の下書きID。作成成功時に消化（削除）する（SPR-146） */
+	draftId?: string;
 }
 
 /**
@@ -34,6 +37,7 @@ export function AudioButtonCreator({
 	videoTitle,
 	videoDuration = 600,
 	initialStartTime = 0,
+	draftId,
 }: AudioButtonCreatorProps) {
 	const router = useRouter();
 	const user = useSession();
@@ -78,6 +82,11 @@ export function AudioButtonCreator({
 			const result = await createAudioButton(input);
 
 			if (result.success) {
+				// 下書きから開いた場合は消化（削除）する。ベストエフォート＝失敗してもボタン作成は
+				// 成立しているため遷移を止めない（残った下書きは /live から手動削除できる）。
+				if (draftId) {
+					await deleteButtonDraft(draftId).catch(() => undefined);
+				}
 				// 詳細ページへフルロード遷移（SPR-252）。router.push だと /buttons ツリー内の soft nav が
 				// @modal にインターセプトされ、作成フォームの上にクイックビューが重なってしまう
 				// （フォーム instance も破棄されず「作成中…」が固着する）。フルロードなら
@@ -103,6 +112,7 @@ export function AudioButtonCreator({
 		setIsCreating,
 		setError,
 		videoTitle,
+		draftId,
 	]);
 
 	// 時間調整用のハンドラーは共通フックから取得

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import type { AudioButtonDraft, VideoPlainObject } from "@suzumina.click/shared-types";
+import { YouTubePlayer } from "@suzumina.click/ui/components/custom/youtube-player";
+import type { YTPlayer } from "@suzumina.click/ui/components/custom/youtube-types";
+import { Badge } from "@suzumina.click/ui/components/ui/badge";
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { Input } from "@suzumina.click/ui/components/ui/input";
+import { Bookmark, ExternalLink, Loader2, Trash2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createButtonDraft, deleteButtonDraft } from "@/actions/button-drafts";
+
+interface LiveCaptureViewProps {
+	video: VideoPlainObject | null;
+	initialDrafts: AudioButtonDraft[];
+}
+
+const VIDEO_ID_PATTERN = /(?:v=|youtu\.be\/|\/live\/|\/embed\/|\/shorts\/)([A-Za-z0-9_-]{11})/;
+
+function parseVideoIdInput(value: string): string | null {
+	const trimmed = value.trim();
+	const match = trimmed.match(VIDEO_ID_PATTERN);
+	if (match?.[1]) {
+		return match[1];
+	}
+	return /^[A-Za-z0-9_-]{11}$/.test(trimmed) ? trimmed : null;
+}
+
+function formatSeconds(total: number): string {
+	const s = Math.floor(total % 60);
+	const m = Math.floor((total / 60) % 60);
+	const h = Math.floor(total / 3600);
+	const mm = String(m).padStart(2, "0");
+	const ss = String(s).padStart(2, "0");
+	return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+function formatMarkedAt(iso: string): string {
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) {
+		return "";
+	}
+	return date.toLocaleString("ja-JP", {
+		month: "numeric",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+/**
+ * 配信中マーキング画面（SPR-146 第1段）。
+ *
+ * SPR-145 の計測ハーネスの製品版: マーク時に playerTime（主信号）と壁時計（フォールバック）を
+ * 下書きとして保存する。プレイヤーが使えない場合も壁時計のみで保存を継続する（劣化モード）。
+ */
+export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) {
+	const router = useRouter();
+	const [drafts, setDrafts] = useState<AudioButtonDraft[]>(initialDrafts);
+	const [isMarking, setIsMarking] = useState(false);
+	const [error, setError] = useState("");
+	const [manualInput, setManualInput] = useState("");
+	const [justMarked, setJustMarked] = useState(false);
+	const playerRef = useRef<YTPlayer | null>(null);
+
+	const isLiveNow = video?.liveBroadcastContent === "live";
+	const isUpcoming = video?.liveBroadcastContent === "upcoming";
+
+	const handleMark = useCallback(async () => {
+		if (!video) {
+			return;
+		}
+		setIsMarking(true);
+		setError("");
+
+		// 主信号 = プレイヤー再生位置。取得失敗時は null（壁時計のみモード）で保存を続行する
+		let playerTime: number | null = null;
+		try {
+			const t = playerRef.current?.getCurrentTime?.();
+			if (typeof t === "number" && Number.isFinite(t) && t >= 0) {
+				playerTime = Math.round(t * 1000) / 1000;
+			}
+		} catch {
+			// noop: 劣化モードへ
+		}
+
+		try {
+			const result = await createButtonDraft({
+				videoId: video.videoId,
+				videoTitle: video.title,
+				playerTime,
+				markedAtMs: Date.now(),
+			});
+
+			if (result.success) {
+				setDrafts((prev) => [result.data, ...prev]);
+				setJustMarked(true);
+				setTimeout(() => setJustMarked(false), 600);
+			} else {
+				setError(result.error);
+			}
+		} catch {
+			setError("下書きの保存に失敗しました");
+		} finally {
+			setIsMarking(false);
+		}
+	}, [video]);
+
+	// M キーでマーク（入力欄フォーカス中とキーリピートは無視）
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key.toLowerCase() !== "m" || event.repeat) {
+				return;
+			}
+			const target = event.target as HTMLElement | null;
+			if (
+				target &&
+				(/^(input|textarea|select)$/i.test(target.tagName) || target.isContentEditable)
+			) {
+				return;
+			}
+			event.preventDefault();
+			void handleMark();
+		};
+		document.addEventListener("keydown", onKeyDown);
+		return () => document.removeEventListener("keydown", onKeyDown);
+	}, [handleMark]);
+
+	const handleDelete = useCallback(async (draftId: string) => {
+		const result = await deleteButtonDraft(draftId);
+		if (result.success) {
+			setDrafts((prev) => prev.filter((d) => d.id !== draftId));
+		} else {
+			setError(result.error ?? "下書きの削除に失敗しました");
+		}
+	}, []);
+
+	const handleManualSubmit = useCallback(() => {
+		const videoId = parseVideoIdInput(manualInput);
+		if (!videoId) {
+			setError("動画の URL または ID（11文字）を入力してください");
+			return;
+		}
+		setError("");
+		router.push(`/live?v=${videoId}`);
+	}, [manualInput, router]);
+
+	return (
+		<div className="container mx-auto px-4 py-6 max-w-4xl space-y-6">
+			<div>
+				<h1 className="text-2xl font-bold mb-1">配信中マーキング</h1>
+				<p className="text-sm text-muted-foreground">
+					「ここ！」と思った瞬間にマーク（M
+					キー）。アーカイブ公開後、下書きから音声ボタンに仕上げられます。
+				</p>
+			</div>
+
+			{error && (
+				<div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg">
+					<p className="text-sm text-destructive">{error}</p>
+				</div>
+			)}
+
+			{video ? (
+				<>
+					<div className="space-y-3">
+						<div className="flex items-center gap-2 flex-wrap">
+							{isLiveNow && <Badge variant="destructive">配信中</Badge>}
+							{isUpcoming && <Badge variant="secondary">配信予定</Badge>}
+							{!isLiveNow && !isUpcoming && <Badge variant="outline">アーカイブ</Badge>}
+							<span className="text-sm font-medium truncate">{video.title}</span>
+						</div>
+
+						<div className="aspect-video bg-muted rounded-lg overflow-hidden shadow-lg">
+							<YouTubePlayer
+								videoId={video.videoId}
+								controls={true}
+								onReady={(player) => {
+									playerRef.current = player;
+								}}
+							/>
+						</div>
+
+						<Button
+							onClick={handleMark}
+							disabled={isMarking}
+							size="lg"
+							className={`w-full min-h-[56px] text-lg font-bold transition-colors ${
+								justMarked ? "bg-green-600 hover:bg-green-600" : ""
+							}`}
+						>
+							{isMarking ? (
+								<Loader2 className="h-5 w-5 mr-2 animate-spin" />
+							) : (
+								<Bookmark className="h-5 w-5 mr-2" />
+							)}
+							{justMarked ? "マークしました" : "ここをマーク（M）"}
+						</Button>
+
+						{isUpcoming && (
+							<p className="text-xs text-muted-foreground">
+								配信開始前です。開始後にプレイヤーが再生されてからマークしてください。
+							</p>
+						)}
+					</div>
+				</>
+			) : (
+				<div className="border rounded-lg p-6 space-y-4 text-center">
+					<p className="text-muted-foreground">現在、配信中・配信予定の動画が見つかりません。</p>
+					<div className="flex gap-2 max-w-md mx-auto">
+						<Input
+							value={manualInput}
+							onChange={(e) => setManualInput(e.target.value)}
+							placeholder="動画の URL または ID を直接指定"
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									handleManualSubmit();
+								}
+							}}
+						/>
+						<Button onClick={handleManualSubmit} variant="outline">
+							表示
+						</Button>
+					</div>
+				</div>
+			)}
+
+			<div className="space-y-3">
+				<h2 className="text-lg font-semibold">
+					下書き
+					{drafts.length > 0 && (
+						<span className="ml-2 text-sm font-normal text-muted-foreground">
+							{drafts.length}件
+						</span>
+					)}
+				</h2>
+
+				{drafts.length === 0 ? (
+					<p className="text-sm text-muted-foreground">
+						まだ下書きがありません。配信中にマークするとここに溜まります。
+					</p>
+				) : (
+					<ul className="divide-y border rounded-lg">
+						{drafts.map((draft) => {
+							const isCurrentLiveVideo =
+								draft.videoId === video?.videoId && (isLiveNow || isUpcoming);
+							return (
+								<li key={draft.id} className="flex items-center gap-3 p-3">
+									<div className="min-w-0 flex-1">
+										<p className="text-sm font-medium">
+											{formatSeconds(draft.suggestedStartTime)} から
+											{draft.playerTime == null && (
+												<span className="ml-2 text-xs text-amber-600">壁時計のみ・要頭出し</span>
+											)}
+										</p>
+										<p className="text-xs text-muted-foreground truncate">
+											{draft.videoTitle} ・ {formatMarkedAt(draft.markedAt)}
+										</p>
+									</div>
+									{isCurrentLiveVideo ? (
+										<span className="text-xs text-muted-foreground whitespace-nowrap">
+											アーカイブ公開後に仕上げ
+										</span>
+									) : (
+										<Button asChild size="sm" variant="outline">
+											{/* /buttons ツリーへの遷移はフルロード（intercepting route 回避・SPR-252） */}
+											<a
+												href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
+											>
+												<ExternalLink className="h-3.5 w-3.5 mr-1" />
+												仕上げる
+											</a>
+										</Button>
+									)}
+									<Button
+										size="sm"
+										variant="ghost"
+										aria-label="下書きを削除"
+										onClick={() => void handleDelete(draft.id)}
+									>
+										<Trash2 className="h-4 w-4" />
+									</Button>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -27,6 +27,7 @@ function parseVideoIdInput(value: string): string | null {
 	return /^[A-Za-z0-9_-]{11}$/.test(trimmed) ? trimmed : null;
 }
 
+// shared-types の formatTimestamp は小数第1位付き（"14:26.0"）表示。下書き一覧は整数秒で十分なため独自実装
 function formatSeconds(total: number): string {
 	const s = Math.floor(total % 60);
 	const m = Math.floor((total / 60) % 60);
@@ -68,7 +69,8 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 	const isUpcoming = video?.liveBroadcastContent === "upcoming";
 
 	const handleMark = useCallback(async () => {
-		if (!video) {
+		// isMarking ガードは M キーの素早い2連打による二重作成防止（ボタンの disabled では keydown を防げない）
+		if (!video || isMarking) {
 			return;
 		}
 		setIsMarking(true);
@@ -105,7 +107,7 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 		} finally {
 			setIsMarking(false);
 		}
-	}, [video]);
+	}, [video, isMarking]);
 
 	// M キーでマーク（入力欄フォーカス中とキーリピートは無視）
 	useEffect(() => {

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -163,48 +163,46 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 			)}
 
 			{video ? (
-				<>
-					<div className="space-y-3">
-						<div className="flex items-center gap-2 flex-wrap">
-							{isLiveNow && <Badge variant="destructive">配信中</Badge>}
-							{isUpcoming && <Badge variant="secondary">配信予定</Badge>}
-							{!isLiveNow && !isUpcoming && <Badge variant="outline">アーカイブ</Badge>}
-							<span className="text-sm font-medium truncate">{video.title}</span>
-						</div>
-
-						<div className="aspect-video bg-muted rounded-lg overflow-hidden shadow-lg">
-							<YouTubePlayer
-								videoId={video.videoId}
-								controls={true}
-								onReady={(player) => {
-									playerRef.current = player;
-								}}
-							/>
-						</div>
-
-						<Button
-							onClick={handleMark}
-							disabled={isMarking}
-							size="lg"
-							className={`w-full min-h-[56px] text-lg font-bold transition-colors ${
-								justMarked ? "bg-green-600 hover:bg-green-600" : ""
-							}`}
-						>
-							{isMarking ? (
-								<Loader2 className="h-5 w-5 mr-2 animate-spin" />
-							) : (
-								<Bookmark className="h-5 w-5 mr-2" />
-							)}
-							{justMarked ? "マークしました" : "ここをマーク（M）"}
-						</Button>
-
-						{isUpcoming && (
-							<p className="text-xs text-muted-foreground">
-								配信開始前です。開始後にプレイヤーが再生されてからマークしてください。
-							</p>
-						)}
+				<div className="space-y-3">
+					<div className="flex items-center gap-2 flex-wrap">
+						{isLiveNow && <Badge variant="destructive">配信中</Badge>}
+						{isUpcoming && <Badge variant="secondary">配信予定</Badge>}
+						{!isLiveNow && !isUpcoming && <Badge variant="outline">アーカイブ</Badge>}
+						<span className="text-sm font-medium truncate">{video.title}</span>
 					</div>
-				</>
+
+					<div className="aspect-video bg-muted rounded-lg overflow-hidden shadow-lg">
+						<YouTubePlayer
+							videoId={video.videoId}
+							controls={true}
+							onReady={(player) => {
+								playerRef.current = player;
+							}}
+						/>
+					</div>
+
+					<Button
+						onClick={handleMark}
+						disabled={isMarking}
+						size="lg"
+						className={`w-full min-h-[56px] text-lg font-bold transition-colors ${
+							justMarked ? "bg-green-600 hover:bg-green-600" : ""
+						}`}
+					>
+						{isMarking ? (
+							<Loader2 className="h-5 w-5 mr-2 animate-spin" />
+						) : (
+							<Bookmark className="h-5 w-5 mr-2" />
+						)}
+						{justMarked ? "マークしました" : "ここをマーク（M）"}
+					</Button>
+
+					{isUpcoming && (
+						<p className="text-xs text-muted-foreground">
+							配信開始前です。開始後にプレイヤーが再生されてからマークしてください。
+						</p>
+					)}
+				</div>
 			) : (
 				<div className="border rounded-lg p-6 space-y-4 text-center">
 					<p className="text-muted-foreground">現在、配信中・配信予定の動画が見つかりません。</p>

--- a/packages/shared-types/src/__tests__/audio-button-draft.test.ts
+++ b/packages/shared-types/src/__tests__/audio-button-draft.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { audioButtonDraftTransformers } from "../transformers/audio-button-draft";
+import {
+	AUDIO_BUTTON_DRAFT_PREROLL_SECONDS,
+	calculateDraftSuggestedStartTime,
+} from "../types/audio-button-draft";
+
+describe("calculateDraftSuggestedStartTime", () => {
+	it("playerTime からプリロール分（15秒）巻き戻す（SPR-145 実測由来の定数）", () => {
+		expect(AUDIO_BUTTON_DRAFT_PREROLL_SECONDS).toBe(15);
+		expect(calculateDraftSuggestedStartTime(100.7)).toBe(85);
+	});
+
+	it("配信冒頭のマークは 0 未満にならない（クランプ）", () => {
+		expect(calculateDraftSuggestedStartTime(5.2)).toBe(0);
+		expect(calculateDraftSuggestedStartTime(0)).toBe(0);
+	});
+
+	it("playerTime が無い（壁時計のみモード）場合は 0", () => {
+		expect(calculateDraftSuggestedStartTime(null)).toBe(0);
+		expect(calculateDraftSuggestedStartTime(Number.NaN)).toBe(0);
+	});
+});
+
+describe("audioButtonDraftTransformers.fromFirestore", () => {
+	const base = {
+		videoId: "9kMBmEvhwUk",
+		videoTitle: "テスト配信",
+		playerTime: 881.037,
+	};
+
+	it("Timestamp（toDate を持つオブジェクト）を ISO string へ変換し、推奨開始秒を導出する", () => {
+		const ts = { toDate: () => new Date("2026-07-10T12:15:33.374Z") };
+		const draft = audioButtonDraftTransformers.fromFirestore("d1", {
+			...base,
+			markedAt: ts,
+			createdAt: ts,
+		});
+		expect(draft).toEqual({
+			id: "d1",
+			videoId: "9kMBmEvhwUk",
+			videoTitle: "テスト配信",
+			playerTime: 881.037,
+			markedAt: "2026-07-10T12:15:33.374Z",
+			createdAt: "2026-07-10T12:15:33.374Z",
+			suggestedStartTime: 866,
+		});
+	});
+
+	it("Date / string の日時もそのまま ISO string に正規化する（型混在への防御）", () => {
+		const draft = audioButtonDraftTransformers.fromFirestore("d2", {
+			...base,
+			playerTime: null,
+			markedAt: new Date("2026-07-10T12:00:00.000Z"),
+			createdAt: "2026-07-10T12:00:01.000Z",
+		});
+		expect(draft.markedAt).toBe("2026-07-10T12:00:00.000Z");
+		expect(draft.createdAt).toBe("2026-07-10T12:00:01.000Z");
+		expect(draft.suggestedStartTime).toBe(0);
+	});
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -77,6 +77,7 @@ export * from "./plain-objects/work-plain";
 //   AudioButton → audioButtonTransformers.fromFirestore
 // 旧 utilities/work-conversions.ts（convertToWorkPlainObject 等）は呼び出しゼロの死蔵だったため削除。
 export { audioButtonTransformers } from "./transformers/audio-button";
+export { audioButtonDraftTransformers } from "./transformers/audio-button-draft";
 export {
 	convertToFrontendVideo,
 	fromFirestore as videoFromFirestore,
@@ -97,6 +98,16 @@ export type {
 	FirestoreServerAudioButtonData, // Deprecated alias
 	UpdateAudioButtonInput,
 } from "./types/audio-button";
+export type {
+	AudioButtonDraft,
+	AudioButtonDraftDocument,
+	CreateAudioButtonDraftInput,
+} from "./types/audio-button-draft";
+// AudioButtonDraft（配信中マーキングの下書き・SPR-146。Entity ゲートに従い plain type）
+export {
+	AUDIO_BUTTON_DRAFT_PREROLL_SECONDS,
+	calculateDraftSuggestedStartTime,
+} from "./types/audio-button-draft";
 export type { CircleDocument } from "./types/firestore/circle";
 export { isCircleDocument } from "./types/firestore/circle";
 export type { CollectionMetadata } from "./types/firestore/collection-metadata";

--- a/packages/shared-types/src/transformers/audio-button-draft.ts
+++ b/packages/shared-types/src/transformers/audio-button-draft.ts
@@ -1,0 +1,43 @@
+/**
+ * AudioButtonDraft Transformers
+ *
+ * Firestore document ⇄ プレーンオブジェクトの変換（RSC 境界の誤り訂正符号層）。
+ * shared-types は Firestore SDK 非依存のため、Timestamp は toDate ダックタイピングで扱う。
+ */
+
+import {
+	type AudioButtonDraft,
+	type AudioButtonDraftDocument,
+	calculateDraftSuggestedStartTime,
+} from "../types/audio-button-draft";
+
+/**
+ * Firestore Timestamp / Date / ISO string を ISO string に正規化する。
+ * 不正値は epoch（1970-01-01T00:00:00.000Z）ではなく空文字を避けるため現在時刻でなく
+ * そのまま String() する（沈黙のデータ捏造をしない）。
+ */
+function toIsoString(value: unknown): string {
+	if (value && typeof value === "object" && "toDate" in value) {
+		return (value as { toDate(): Date }).toDate().toISOString();
+	}
+	if (value instanceof Date) {
+		return value.toISOString();
+	}
+	return String(value ?? "");
+}
+
+function fromFirestore(id: string, doc: AudioButtonDraftDocument): AudioButtonDraft {
+	return {
+		id,
+		videoId: doc.videoId,
+		videoTitle: doc.videoTitle,
+		playerTime: doc.playerTime,
+		markedAt: toIsoString(doc.markedAt),
+		createdAt: toIsoString(doc.createdAt),
+		suggestedStartTime: calculateDraftSuggestedStartTime(doc.playerTime),
+	};
+}
+
+export const audioButtonDraftTransformers = {
+	fromFirestore,
+};

--- a/packages/shared-types/src/types/audio-button-draft.ts
+++ b/packages/shared-types/src/types/audio-button-draft.ts
@@ -1,0 +1,71 @@
+/**
+ * AudioButtonDraft Type Definitions（SPR-146 第1段）
+ *
+ * 配信視聴中の「ここ！」マークを保持する下書き。正本は生の捕捉信号
+ * （playerTime / markedAt）であり、開始秒の推奨値は表示時に導出する
+ * （導出値を保存すると生信号との二重管理になるため保存しない）。
+ *
+ * Entity ゲート（CLAUDE.md §0）に従い、Entity 化せず plain type + 純関数に留める。
+ */
+
+/**
+ * プリロール定数（秒）。
+ * SPR-145 実測: 発言を聞いてからマークするまでの人間の反応遅れは 0〜13.8 秒。
+ * 下書きの推奨開始位置はクリック位置からこの秒数だけ巻き戻す（仕上げは前方 trim のみで完結）。
+ */
+export const AUDIO_BUTTON_DRAFT_PREROLL_SECONDS = 15;
+
+/**
+ * Firestore document structure（users/{discordId}/buttonDrafts/{draftId}）
+ *
+ * 日時フィールドは Firestore Timestamp で保存する（CLAUDE.md §1 新規コレクション規約）。
+ * shared-types は Firestore SDK に依存しないため型上は unknown。
+ */
+export interface AudioButtonDraftDocument {
+	videoId: string;
+	/** 表示用に非正規化（audioButtons.videoTitle と同じ前例。タイトル変更の追従はしない） */
+	videoTitle: string;
+	/**
+	 * マーク時のライブプレイヤー再生位置（秒）= VOD 秒の主信号（SPR-145 実測で ±1s 一致）。
+	 * プレイヤーから取得できなかった場合は null（壁時計のみモード）。
+	 */
+	playerTime: number | null;
+	/** マーク時の壁時計（クライアント時刻）。検算・playerTime 欠損時のフォールバック用に常時併記保存 */
+	markedAt: unknown; // Firestore Timestamp
+	createdAt: unknown; // Firestore Timestamp（サーバ時刻）
+}
+
+/**
+ * RSC 境界を越えるプレーンオブジェクト（日時は ISO string）
+ */
+export interface AudioButtonDraft {
+	id: string;
+	videoId: string;
+	videoTitle: string;
+	playerTime: number | null;
+	markedAt: string;
+	createdAt: string;
+	/** 仕上げ画面へ渡す推奨開始秒（playerTime − プリロール、0 未満は 0） */
+	suggestedStartTime: number;
+}
+
+/**
+ * 下書き作成入力（Server Action の引数）
+ */
+export interface CreateAudioButtonDraftInput {
+	videoId: string;
+	videoTitle: string;
+	playerTime: number | null;
+	/** クリック時の壁時計（epoch ms・クライアント時刻） */
+	markedAtMs: number;
+}
+
+/**
+ * 推奨開始秒を導出する。playerTime が無い場合は 0（仕上げ側で頭出し）。
+ */
+export function calculateDraftSuggestedStartTime(playerTime: number | null): number {
+	if (playerTime == null || !Number.isFinite(playerTime)) {
+		return 0;
+	}
+	return Math.max(0, Math.floor(playerTime) - AUDIO_BUTTON_DRAFT_PREROLL_SECONDS);
+}


### PR DESCRIPTION
## 目的

配信視聴中に「ここ！」を1操作（M キー）でマークして音声ボタンの**下書き**として残し、アーカイブ公開後は既存の作成ページで**仕上げるだけ**にする。SPR-137 で確定した唯一の勝ち筋「ボタン作成コストをゼロに近づける」の中核機能・[SPR-146](https://linear.app/nothink/issue/SPR-146) の第1段（最小PoC）。

方式は [SPR-145](https://linear.app/nothink/issue/SPR-145) の実測（2配信・計50マーク・7点耳確認）で決着済み:
- 主信号 = ライブプレイヤーの `getCurrentTime`（playerTime = VOD秒・系統誤差±1s）。壁時計も併記保存
- 下書き開始秒 = クリック位置 − **15s**（プリロール定数 = 実測の反応遅れ 0〜13.8s をカバー）
- ライブ中の `getDuration()` は信用しない

## 変更内容

- **`/live`（新規・noindex・要ログイン）**: 配信中→配信予定の順で対象動画を自動選択（`?v=` で手動指定可）。埋め込みプレイヤー＋マークボタン（M キー）＋下書き一覧（仕上げリンク/削除）。プレイヤー不調時は壁時計のみで保存継続（劣化モード）
- **下書きストレージ（新規 Firestore サブコレクション）**: `users/{discordId}/buttonDrafts`。保存は生の捕捉信号のみ（playerTime + markedAt）、推奨開始秒は読み出し時に導出。日時は Timestamp。単一 orderBy のみ＝**複合インデックス不要（terraform 変更なし）**。上限500件ガード
- **Server Actions**: `src/actions/button-drafts.ts`（作成/一覧/削除）。SPR-195 の null チェック＋作成は `!isActive` 明示ブロック
- **`/buttons/create`**: `draft_id` パラメータ追加。作成成功時に下書きをベストエフォート消化（既存の `start_time` プリフィルはそのまま利用）
- **shared-types**: `AudioButtonDraft` plain type＋純関数（Entity ゲート順守・プリロール定数の正本）
- **ProtectedRoute**: opt-in の `callbackPath` prop 追加（`x-url` ヘッダ未設定によりサインイン後の戻り先が `/buttons/create` 固定になる既知バグの回避。根本修正は別タスク）

## 検証

- `pnpm verify` 全パス（lint:docs/tokens・lint・typecheck・test・カバレッジ閾値）
- テスト追加: shared-types 変換/導出・button-drafts アクション（認可・バリデーション・上限・Timestamp 保存形）
- Emulator 構成でブラウザ確認: `/live` の SSR・未認証時の `/auth/signin?callbackUrl=%2Flive` 誘導を確認済み
- **未検証**: ログイン後の実書き込みフロー（Discord OAuth のため手元確認が必要）。マージ前に `/live` → `?v=` でアーカイブ指定 → M でマーク → 下書き表示 → 仕上げ、の一巡を推奨

## レビュー観点（One-Way Door: 新規 Firestore スキーマ）

1. 下書きの置き場 = users サブコレクション（複合インデックス回避・per-user 所有をパスで担保）で良いか
2. 保存フィールドを生信号のみに絞る設計（suggestedStartTime は導出・非保存）で良いか

第2段（下書きキュー画面・連続仕上げ・SPR-147 合流）は本 PR に含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)