### PR TITLE
feat(web): 配信中/配信予定の VideoCard を「配信中マーク」導線に切り替え（SPR-146 導線）

### DIFF
--- a/apps/web/src/app/live/page.tsx
+++ b/apps/web/src/app/live/page.tsx
@@ -36,13 +36,17 @@ async function findTargetVideo(manualVideoId?: string): Promise<VideoPlainObject
 		filters: { videoType: "live_upcoming" },
 	});
 
-	const live = items.find((v) => v.liveBroadcastContent === "live");
+	// 判定の正本は _computed.videoType（video-card-actions / video-badge と同一。
+	// raw の liveBroadcastContent は stale がありうるため使わない）
+	const live = items.find(
+		(v) => v._computed.videoType === "live" || v._computed.videoType === "possibly_live",
+	);
 	if (live) {
 		return live;
 	}
 
 	const upcoming = items
-		.filter((v) => v.liveBroadcastContent === "upcoming")
+		.filter((v) => v._computed.videoType === "upcoming")
 		.sort((a, b) =>
 			(a.liveStreamingDetails?.scheduledStartTime ?? "9999").localeCompare(
 				b.liveStreamingDetails?.scheduledStartTime ?? "9999",

--- a/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
@@ -89,10 +89,12 @@ describe("VideoCardActions", () => {
 
 		const markLink = screen.getByText("配信中マーク").closest("a");
 		expect(markLink).toHaveAttribute("href", "/live?v=abc123");
+		// live は destructive 赤（「配信中」バッジと同色ペア・赤は live 専用）
+		expect(markLink?.className).toContain("bg-destructive");
 		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
 	});
 
-	it("配信予定の動画も『配信中マーク』リンクを表示する", () => {
+	it("配信予定の動画は『配信待機』リンク（info 青）を表示する", () => {
 		mockUseSession(loggedIn);
 		const video = createMockVideo({
 			liveBroadcastContent: "upcoming",
@@ -106,7 +108,10 @@ describe("VideoCardActions", () => {
 		});
 		render(<VideoCardActions video={video} variant="grid" />);
 
-		expect(screen.getByText("配信中マーク").closest("a")).toHaveAttribute("href", "/live?v=abc123");
+		const waitLink = screen.getByText("配信待機").closest("a");
+		expect(waitLink).toHaveAttribute("href", "/live?v=abc123");
+		// upcoming は info 青（「配信予告」バッジと同色ペア）
+		expect(waitLink?.className).toContain("bg-info");
 	});
 
 	it("未ログインでも配信中はログイン導線でなく『配信中マーク』を表示する（認証は /live 側に委譲）", () => {

--- a/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
@@ -73,7 +73,7 @@ describe("VideoCardActions", () => {
 		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
 	});
 
-	it("ログイン済みでも作成不可なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
+	it("配信中の動画は『配信中マーク』リンク（/live?v=）を表示する（SPR-146）", () => {
 		mockUseSession(loggedIn);
 		const video = createMockVideo({
 			liveBroadcastContent: "live",
@@ -87,11 +87,67 @@ describe("VideoCardActions", () => {
 		});
 		render(<VideoCardActions video={video} variant="grid" />);
 
+		const markLink = screen.getByText("配信中マーク").closest("a");
+		expect(markLink).toHaveAttribute("href", "/live?v=abc123");
+		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
+	});
+
+	it("配信予定の動画も『配信中マーク』リンクを表示する", () => {
+		mockUseSession(loggedIn);
+		const video = createMockVideo({
+			liveBroadcastContent: "upcoming",
+			_computed: {
+				...createMockVideo()._computed,
+				isArchived: false,
+				isUpcoming: true,
+				canCreateButton: false,
+				videoType: "upcoming",
+			},
+		});
+		render(<VideoCardActions video={video} variant="grid" />);
+
+		expect(screen.getByText("配信中マーク").closest("a")).toHaveAttribute("href", "/live?v=abc123");
+	});
+
+	it("未ログインでも配信中はログイン導線でなく『配信中マーク』を表示する（認証は /live 側に委譲）", () => {
+		mockUseSession(loggedOut);
+		const video = createMockVideo({
+			liveBroadcastContent: "live",
+			_computed: {
+				...createMockVideo()._computed,
+				isArchived: false,
+				isLive: true,
+				canCreateButton: false,
+				videoType: "live",
+			},
+		});
+		render(<VideoCardActions video={video} variant="grid" />);
+
+		expect(screen.getByText("配信中マーク")).toBeInTheDocument();
+		expect(screen.queryByText("ログイン")).not.toBeInTheDocument();
+	});
+
+	it("ログイン済みでも作成不可（配信でない動画）なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
+		mockUseSession(loggedIn);
+		const video = createMockVideo({
+			duration: "PT0S",
+			_computed: {
+				...createMockVideo()._computed,
+				isArchived: false,
+				canCreateButton: false,
+				videoType: "normal",
+			},
+		});
+		render(<VideoCardActions video={video} variant="grid" />);
+
 		const createButton = screen.getByText("ボタン作成").closest("button");
 		// native disabled は pointer-events-none で tooltip が出ないため aria-disabled を使う
 		expect(createButton).toHaveAttribute("aria-disabled", "true");
 		expect(createButton).not.toBeDisabled();
-		expect(createButton).toHaveAttribute("title", "ライブ配信中は音声ボタンを作成できません");
+		expect(createButton).toHaveAttribute(
+			"title",
+			"動画の長さが不明なため音声ボタンを作成できません",
+		);
 		// ホバー/フォーカスで理由が届くよう href を持たない（遷移しない）
 		expect(createButton).not.toHaveAttribute("href");
 	});

--- a/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
@@ -132,6 +132,18 @@ describe("VideoCardActions", () => {
 		expect(screen.queryByText("ログイン")).not.toBeInTheDocument();
 	});
 
+	it("stale な liveBroadcastContent=live でも _computed が archived なら通常のボタン作成に進める（正本は videoType）", () => {
+		mockUseSession(loggedIn);
+		// fetchYouTubeVideos の更新遅延で raw フィールドだけ live のまま残るケース。
+		// _computed.videoType は actualEndTime から archived を判定済み＝バッジも「配信アーカイブ」表示
+		const video = createMockVideo({ liveBroadcastContent: "live" });
+		render(<VideoCardActions video={video} variant="grid" />);
+
+		const createLink = screen.getByText("ボタン作成").closest("a");
+		expect(createLink).toHaveAttribute("href", "/buttons/create?video_id=video123");
+		expect(screen.queryByText("配信中マーク")).not.toBeInTheDocument();
+	});
+
 	it("ログイン済みでも作成不可（配信でない動画）なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
 		mockUseSession(loggedIn);
 		const video = createMockVideo({

--- a/apps/web/src/app/videos/components/video-card-actions.tsx
+++ b/apps/web/src/app/videos/components/video-card-actions.tsx
@@ -4,9 +4,11 @@ import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import {
 	canCreateAudioButton,
 	getAudioButtonCreationErrorMessage,
+	isUpcoming,
+	isVideoLive,
 } from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { ExternalLink, Eye, LogIn, Plus } from "lucide-react";
+import { Bookmark, ExternalLink, Eye, LogIn, Plus } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { useSession } from "@/lib/auth/client";
@@ -18,10 +20,17 @@ interface VideoCardActionsProps {
 
 type ButtonGate =
 	| { canCreate: true }
+	| { canCreate: false; liveMarking: true }
 	| { canCreate: false; needsLogin: true }
 	| { canCreate: false; needsLogin: false; reason: string };
 
 function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): ButtonGate {
+	// 配信中/配信予定は「作成不可」ではなく配信中マーキング（/live）への導線に切り替える（SPR-146）。
+	// この時間帯の正しい作成手段はマーク→アーカイブ後の仕上げのため。ログイン判定より先に返すことで
+	// 未ログインでも導線が見え、認証は /live 側の ProtectedRoute（callbackPath 付き）に委ねる
+	if (isVideoLive(video) || isUpcoming(video)) {
+		return { canCreate: false, liveMarking: true };
+	}
 	if (!isLoggedIn) {
 		return { canCreate: false, needsLogin: true };
 	}
@@ -94,6 +103,19 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 				>
 					<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
 					ボタン作成
+				</Link>
+			</Button>
+		);
+	} else if ("liveMarking" in gate) {
+		createAction = (
+			<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
+				<Link
+					href={`/live?v=${video.videoId}`}
+					aria-label={`${video.title}の配信中マーキングを開く`}
+					className="flex items-center whitespace-nowrap"
+				>
+					<Bookmark className="h-4 w-4 mr-1" aria-hidden="true" />
+					配信中マーク
 				</Link>
 			</Button>
 		);

--- a/apps/web/src/app/videos/components/video-card-actions.tsx
+++ b/apps/web/src/app/videos/components/video-card-actions.tsx
@@ -8,7 +8,7 @@ import {
 	isVideoLive,
 } from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Bookmark, ExternalLink, Eye, LogIn, Plus } from "lucide-react";
+import { Bookmark, Clock, ExternalLink, Eye, LogIn, Plus } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { useSession } from "@/lib/auth/client";
@@ -20,7 +20,7 @@ interface VideoCardActionsProps {
 
 type ButtonGate =
 	| { canCreate: true }
-	| { canCreate: false; liveMarking: true }
+	| { canCreate: false; liveMarking: "live" | "upcoming" }
 	| { canCreate: false; needsLogin: true }
 	| { canCreate: false; needsLogin: false; reason: string };
 
@@ -28,8 +28,11 @@ function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): Butto
 	// 配信中/配信予定は「作成不可」ではなく配信中マーキング（/live）への導線に切り替える（SPR-146）。
 	// この時間帯の正しい作成手段はマーク→アーカイブ後の仕上げのため。ログイン判定より先に返すことで
 	// 未ログインでも導線が見え、認証は /live 側の ProtectedRoute（callbackPath 付き）に委ねる
-	if (isVideoLive(video) || isUpcoming(video)) {
-		return { canCreate: false, liveMarking: true };
+	if (isVideoLive(video)) {
+		return { canCreate: false, liveMarking: "live" };
+	}
+	if (isUpcoming(video)) {
+		return { canCreate: false, liveMarking: "upcoming" };
 	}
 	if (!isLoggedIn) {
 		return { canCreate: false, needsLogin: true };
@@ -107,15 +110,35 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 			</Button>
 		);
 	} else if ("liveMarking" in gate) {
+		// バッジと同色ペアで時制を明示する: live = destructive 赤（「配信中」バッジと同色・赤は live 専用）、
+		// upcoming = info 青（「配信予告」バッジと同色）。待機ファンは配信前から /live で M キーを構えられる
+		const isLiveNow = gate.liveMarking === "live";
 		createAction = (
-			<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
+			<Button
+				size="sm"
+				variant={isLiveNow ? "destructive" : "default"}
+				className={
+					isLiveNow
+						? "flex-1 min-h-[44px] text-sm"
+						: "flex-1 min-h-[44px] text-sm bg-info text-info-foreground hover:bg-info/90"
+				}
+				asChild
+			>
 				<Link
 					href={`/live?v=${video.videoId}`}
-					aria-label={`${video.title}の配信中マーキングを開く`}
+					aria-label={
+						isLiveNow
+							? `${video.title}の配信中マーキングを開く`
+							: `${video.title}の配信待機（マーキング）を開く`
+					}
 					className="flex items-center whitespace-nowrap"
 				>
-					<Bookmark className="h-4 w-4 mr-1" aria-hidden="true" />
-					配信中マーク
+					{isLiveNow ? (
+						<Bookmark className="h-4 w-4 mr-1" aria-hidden="true" />
+					) : (
+						<Clock className="h-4 w-4 mr-1" aria-hidden="true" />
+					)}
+					{isLiveNow ? "配信中マーク" : "配信待機"}
 				</Link>
 			</Button>
 		);

--- a/apps/web/src/app/videos/components/video-card-actions.tsx
+++ b/apps/web/src/app/videos/components/video-card-actions.tsx
@@ -4,8 +4,6 @@ import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import {
 	canCreateAudioButton,
 	getAudioButtonCreationErrorMessage,
-	isUpcoming,
-	isVideoLive,
 } from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Bookmark, Clock, ExternalLink, Eye, LogIn, Plus } from "lucide-react";
@@ -27,11 +25,15 @@ type ButtonGate =
 function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): ButtonGate {
 	// 配信中/配信予定は「作成不可」ではなく配信中マーキング（/live）への導線に切り替える（SPR-146）。
 	// この時間帯の正しい作成手段はマーク→アーカイブ後の仕上げのため。ログイン判定より先に返すことで
-	// 未ログインでも導線が見え、認証は /live 側の ProtectedRoute（callbackPath 付き）に委ねる
-	if (isVideoLive(video)) {
+	// 未ログインでも導線が見え、認証は /live 側の ProtectedRoute（callbackPath 付き）に委ねる。
+	// 判定の正本はバッジ（video-badge.ts）と同じ _computed.videoType。raw の liveBroadcastContent は
+	// stale がありうる（アーカイブ済みでも live のまま残る）。operations の isLive や _computed.isLive は
+	// raw を OR しているため使わない — actualEndTime を見て archived を優先する videoType が唯一 stale に強い
+	const { videoType } = video._computed;
+	if (videoType === "live" || videoType === "possibly_live") {
 		return { canCreate: false, liveMarking: "live" };
 	}
-	if (isUpcoming(video)) {
+	if (videoType === "upcoming") {
 		return { canCreate: false, liveMarking: "upcoming" };
 	}
 	if (!isLoggedIn) {

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -65,8 +65,10 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 	const [justMarked, setJustMarked] = useState(false);
 	const playerRef = useRef<YTPlayer | null>(null);
 
-	const isLiveNow = video?.liveBroadcastContent === "live";
-	const isUpcoming = video?.liveBroadcastContent === "upcoming";
+	// 判定の正本は _computed.videoType（video-card-actions / video-badge と同一。raw は stale がありうる）
+	const videoType = video?._computed.videoType;
+	const isLiveNow = videoType === "live" || videoType === "possibly_live";
+	const isUpcoming = videoType === "upcoming";
 
 	const handleMark = useCallback(async () => {
 		// isMarking ガードは M キーの素早い2連打による二重作成防止（ボタンの disabled では keydown を防げない）

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -233,6 +233,7 @@ vi.mock("lucide-react", () => {
 		Eye: createMockIcon("Eye"),
 		Radio: createMockIcon("Radio"),
 		LogIn: createMockIcon("LogIn"),
+		Bookmark: createMockIcon("Bookmark"),
 		// Icons for UserMenu
 		LogOut: createMockIcon("LogOut"),
 		// Icons for tag editors / WorkDetail など


### PR DESCRIPTION
## 目的

[SPR-146](https://linear.app/nothink/issue/SPR-146) 第1段で追加した `/live`（配信中マーキング）への導線を確保する。

方針: **「この動画からボタンを作る」という既存アフォーダンスを、配信の時制に応じて正しい動詞に切り替える**。live/upcoming の動画カードはこれまで「ボタン作成」が aria-disabled（作成不可の理由をツールチップ表示）だったが、この時間帯の正しい作成手段はマーク→アーカイブ後の仕上げなので、その枠を `/live?v=<videoId>` への活性ボタンに差し替える。

## 変更内容

- `video-card-actions.tsx`: ゲート評価に `liveMarking: "live" | "upcoming"` 分岐を追加（最優先で判定）
- **色はバッジと同色ペアで時制を明示**（オーナー決定・2026-07-12）:
  - **live = destructive 赤「配信中マーク」**（「配信中」バッジと同色。赤は live 専用・YouTube 慣習と一致）
  - **upcoming = info 青「配信待機」**（「配信予告」バッジと同色。待機ファンは配信前から /live で M キーを構えられ、埋め込みは配信開始と同時に自動でライブへ切り替わる）
- **トップの動画カルーセルと /videos 一覧は同じ VideoCard を使用**しているため、1箇所の変更で両方の導線をカバー
- 未ログイン時もリンクを表示し、認証は `/live` の ProtectedRoute（callbackPath 付き）に委譲
- アーカイブ（ボタン作成/ログイン導線）・作成不可（配信でない動画の理由表示）の挙動は不変

## 検証

- `pnpm verify` 全パス。テスト8件（live 赤・upcoming 青のクラスコントラクト assert 含む）
- SSR 出力を直接確認: `/live?v=` リンク・「配信中マーク」「配信待機」・`bg-destructive`/`bg-info` の出力を確認済み

## スコープ外

- グローバルナビ/ユーザーメニューへの常設リンク（不採用の判断）
- 全ページ共通の「配信中」バナー（エッジキャッシュと相性が悪く見送り）
- `--live` 専用トークンの新設（live 表現が増えたら昇格を検討）

🤖 Generated with [Claude Code](https://claude.com/claude-code)