### PR TITLE
feat(web): 成功指標の GA4 計器化 — 再生/作成ファネル/お気に入り/マーク + 内部トラフィック分離（SPR-149）

### DIFF
--- a/apps/web/src/components/analytics/internal-traffic-marker.tsx
+++ b/apps/web/src/components/analytics/internal-traffic-marker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+	applyStoredInternalTrafficFlag,
+	syncInternalTrafficFromSession,
+} from "@/lib/analytics/internal-traffic";
+import { useSessionState } from "@/lib/auth/client";
+
+/**
+ * オーナー内部トラフィックのタグ付けを行う不可視コンポーネント（SPR-149）。
+ * PageViewTracker より先に効かせたいため、deferred 層の lazy 群とは別に直接 mount する
+ * （数行のため chunk 分離の価値もない）。
+ */
+export function InternalTrafficMarker() {
+	const { user, isPending } = useSessionState();
+
+	// 再訪時: セッション解決を待たず localStorage の印で即タグ適用（初回 page_view の取りこぼし低減）
+	useEffect(() => {
+		applyStoredInternalTrafficFlag();
+	}, []);
+
+	// セッション解決後: オーナー判定で印を更新
+	useEffect(() => {
+		if (!isPending) {
+			syncInternalTrafficFromSession(user?.discordId);
+		}
+	}, [isPending, user?.discordId]);
+
+	return null;
+}

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -9,6 +9,7 @@ import { useCallback } from "react";
 import { deleteButtonDraft } from "@/actions/button-drafts";
 import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
+import { trackCreateError, trackCreateStart, trackCreateSuccess } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
 import { BasicInfoPanel } from "./basic-info-panel";
 import { CreateButtonLimit } from "./create-button-limit";
@@ -67,6 +68,7 @@ export function AudioButtonCreator({
 
 		setIsCreating(true);
 		setError("");
+		trackCreateStart(videoId, Boolean(draftId));
 
 		try {
 			const input: CreateAudioButtonInput = {
@@ -82,6 +84,11 @@ export function AudioButtonCreator({
 			const result = await createAudioButton(input);
 
 			if (result.success) {
+				trackCreateSuccess({
+					audioButtonId: result.data.id,
+					videoId,
+					fromDraft: Boolean(draftId),
+				});
 				// 下書きから開いた場合は消化（削除）する。ベストエフォート＝失敗してもボタン作成は
 				// 成立しているため遷移を止めない（残った下書きは /live から手動削除できる）。
 				if (draftId) {
@@ -96,9 +103,11 @@ export function AudioButtonCreator({
 				return;
 			}
 
+			trackCreateError(videoId, result.error || "unknown");
 			setError(result.error || "作成に失敗しました");
 			setIsCreating(false);
 		} catch (_error) {
+			trackCreateError(videoId, "unexpected");
 			setError("予期しないエラーが発生しました");
 			setIsCreating(false);
 		}

--- a/apps/web/src/components/audio/audio-button-with-favorite-client.tsx
+++ b/apps/web/src/components/audio/audio-button-with-favorite-client.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { getLikeDislikeStatusAction, toggleDislikeAction } from "@/actions/dislikes";
 import { toggleFavoriteAction } from "@/actions/favorites";
 import { toggleLikeAction } from "@/actions/likes";
+import { trackFavoriteToggle } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
 import { buildXShareUrl } from "@/lib/x-share";
 
@@ -77,6 +78,7 @@ export function AudioButtonWithFavoriteClient({
 				const result = await toggleFavoriteAction(audioButton.id);
 				if (result.success) {
 					setIsFavorited(result.isFavorited ?? false);
+					trackFavoriteToggle(audioButton.id, result.isFavorited ?? false);
 					toast.success(
 						result.isFavorited ? "お気に入りに追加しました" : "お気に入りから削除しました",
 					);

--- a/apps/web/src/components/audio/favorite-button.tsx
+++ b/apps/web/src/components/audio/favorite-button.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { getFavoritesStatusAction, toggleFavoriteAction } from "@/actions/favorites";
+import { trackFavoriteToggle } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
 
 interface FavoriteButtonProps {
@@ -68,6 +69,7 @@ export function FavoriteButton({
 				const result = await toggleFavoriteAction(audioButtonId);
 				if (result.success && result.isFavorited !== undefined) {
 					setIsFavorited(result.isFavorited);
+					trackFavoriteToggle(audioButtonId, result.isFavorited);
 					toast.success(
 						result.isFavorited ? "お気に入りに追加しました" : "お気に入りから削除しました",
 					);

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -10,6 +10,7 @@ import { Bookmark, ExternalLink, Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createButtonDraft, deleteButtonDraft } from "@/actions/button-drafts";
+import { trackMarkDraft } from "@/lib/analytics/events";
 
 interface LiveCaptureViewProps {
 	video: VideoPlainObject | null;
@@ -99,6 +100,7 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 
 			if (result.success) {
 				setDrafts((prev) => [result.data, ...prev]);
+				trackMarkDraft(video.videoId, playerTime != null);
 				setJustMarked(true);
 				setTimeout(() => setJustMarked(false), 600);
 			} else {

--- a/apps/web/src/components/system/deferred-global-effects.tsx
+++ b/apps/web/src/components/system/deferred-global-effects.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { lazy, Suspense, useEffect, useState } from "react";
+import { InternalTrafficMarker } from "@/components/analytics/internal-traffic-marker";
 
 /**
  * 全ページで mount される非クリティカルな client 副作用 / UI を、hydration 後
@@ -39,10 +40,15 @@ export function DeferredGlobalEffects() {
 	if (!mounted) return null;
 
 	return (
-		<Suspense fallback={null}>
-			<PerformanceMonitor />
-			<PageViewTracker />
-			<CookieConsentBanner />
-		</Suspense>
+		<>
+			{/* lazy 群より先に mount し、PageViewTracker の page_view 送信前に内部トラフィックの
+				タグ適用を済ませる（SPR-149。lazy chunk 間では effect 順序が保証されないため直接 import） */}
+			<InternalTrafficMarker />
+			<Suspense fallback={null}>
+				<PerformanceMonitor />
+				<PageViewTracker />
+				<CookieConsentBanner />
+			</Suspense>
+		</>
 	);
 }

--- a/apps/web/src/hooks/use-play-count.ts
+++ b/apps/web/src/hooks/use-play-count.ts
@@ -58,7 +58,9 @@ export function usePlayCount() {
 			// Mark as played in this session
 			playedInSession.current.add(audioButtonId);
 
-			// GA4 再生イベント。デデュープ通過後に送る＝ stats.playCount と同じ意味論（SPR-149）
+			// GA4 再生イベント。デデュープ通過後に送る＝ stats.playCount と同じデデュープ規則（SPR-149）。
+			// 計測対象は「再生した」というクライアント行動の事実のため、後続 incrementPlayCount の
+			// 成否には連動させない（サーバー書き込み失敗時は playCount と僅かに乖離しうる＝既知の許容誤差）
 			trackPlayButton(audioButtonId);
 
 			// Add to pending batch instead of immediate processing

--- a/apps/web/src/hooks/use-play-count.ts
+++ b/apps/web/src/hooks/use-play-count.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { incrementPlayCount } from "@/app/buttons/actions";
+import { trackPlayButton } from "@/lib/analytics/events";
 
 /**
  * Hook to handle play count increments with debouncing
@@ -56,6 +57,9 @@ export function usePlayCount() {
 
 			// Mark as played in this session
 			playedInSession.current.add(audioButtonId);
+
+			// GA4 再生イベント。デデュープ通過後に送る＝ stats.playCount と同じ意味論（SPR-149）
+			trackPlayButton(audioButtonId);
 
 			// Add to pending batch instead of immediate processing
 			pendingIncrements.current.add(audioButtonId);

--- a/apps/web/src/lib/analytics/__tests__/events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/events.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	trackCreateError,
+	trackCreateStart,
+	trackCreateSuccess,
+	trackFavoriteToggle,
+	trackMarkDraft,
+	trackPlayButton,
+} from "../events";
+
+const gtag = vi.fn();
+
+function grantAnalyticsConsent() {
+	localStorage.setItem("consent-state", JSON.stringify({ analytics: true }));
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	(window as unknown as { gtag: typeof gtag }).gtag = gtag;
+	localStorage.clear();
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe("GA4 カスタムイベント語彙 (SPR-149)", () => {
+	it("consent 未取得ならイベントを送らない（sendGoogleAnalyticsEvent のゲートを通る）", () => {
+		trackPlayButton("ab1");
+		trackCreateStart("vid00000001", false);
+		expect(gtag).not.toHaveBeenCalled();
+	});
+
+	it("play_button: audio_button_id を送る", () => {
+		grantAnalyticsConsent();
+		trackPlayButton("ab1");
+		expect(gtag).toHaveBeenCalledWith("event", "play_button", { audio_button_id: "ab1" });
+	});
+
+	it("create ファネル: start / success（from_draft 付き） / error を送る", () => {
+		grantAnalyticsConsent();
+		trackCreateStart("vid00000001", true);
+		trackCreateSuccess({ audioButtonId: "ab1", videoId: "vid00000001", fromDraft: true });
+		trackCreateError("vid00000001", "認証エラー");
+
+		expect(gtag).toHaveBeenCalledWith("event", "create_start", {
+			video_id: "vid00000001",
+			from_draft: true,
+		});
+		expect(gtag).toHaveBeenCalledWith("event", "create_success", {
+			audio_button_id: "ab1",
+			video_id: "vid00000001",
+			from_draft: true,
+		});
+		expect(gtag).toHaveBeenCalledWith("event", "create_error", {
+			video_id: "vid00000001",
+			reason: "認証エラー",
+		});
+	});
+
+	it("create_error: reason は GA4 のパラメータ上限（100文字）に切り詰める", () => {
+		grantAnalyticsConsent();
+		trackCreateError("vid00000001", "x".repeat(150));
+		const call = gtag.mock.calls.find((c) => c[1] === "create_error");
+		expect((call?.[2] as { reason: string }).reason).toHaveLength(100);
+	});
+
+	it("favorite: 追加/削除でイベント名を分ける", () => {
+		grantAnalyticsConsent();
+		trackFavoriteToggle("ab1", true);
+		trackFavoriteToggle("ab1", false);
+		expect(gtag).toHaveBeenCalledWith("event", "add_to_favorite", { audio_button_id: "ab1" });
+		expect(gtag).toHaveBeenCalledWith("event", "remove_from_favorite", {
+			audio_button_id: "ab1",
+		});
+	});
+
+	it("mark_draft: 壁時計のみモードを has_player_time=false で区別する", () => {
+		grantAnalyticsConsent();
+		trackMarkDraft("vid00000001", false);
+		expect(gtag).toHaveBeenCalledWith("event", "mark_draft", {
+			video_id: "vid00000001",
+			has_player_time: false,
+		});
+	});
+});

--- a/apps/web/src/lib/analytics/__tests__/internal-traffic.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/internal-traffic.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	applyStoredInternalTrafficFlag,
+	OWNER_DISCORD_ID,
+	syncInternalTrafficFromSession,
+} from "../internal-traffic";
+
+const gtag = vi.fn();
+const STORAGE_KEY = "suzumina-internal-traffic";
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	(window as unknown as { gtag: typeof gtag }).gtag = gtag;
+	localStorage.clear();
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe("内部トラフィックのタグ付け (SPR-149)", () => {
+	it("オーナーのセッションで traffic_type=internal を適用し、印を永続する", () => {
+		syncInternalTrafficFromSession(OWNER_DISCORD_ID);
+		expect(gtag).toHaveBeenCalledWith("set", { traffic_type: "internal" });
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+	});
+
+	it("別ユーザーのログインで印を外す（gtag set は呼ばない）", () => {
+		localStorage.setItem(STORAGE_KEY, "1");
+		syncInternalTrafficFromSession("999999999999999999");
+		expect(gtag).not.toHaveBeenCalled();
+		expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+
+	it("未ログイン（undefined）では印を保持する＝オーナーのブラウザの匿名アクセスも内部扱い", () => {
+		localStorage.setItem(STORAGE_KEY, "1");
+		syncInternalTrafficFromSession(undefined);
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+	});
+
+	it("印があればセッション解決を待たずにタグを適用する（初回 page_view の取りこぼし低減）", () => {
+		localStorage.setItem(STORAGE_KEY, "1");
+		applyStoredInternalTrafficFlag();
+		expect(gtag).toHaveBeenCalledWith("set", { traffic_type: "internal" });
+	});
+
+	it("印が無ければ何もしない", () => {
+		applyStoredInternalTrafficFlag();
+		expect(gtag).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -1,0 +1,63 @@
+/**
+ * GA4 カスタムイベントの語彙（SPR-149: 成功指標の計器化）。
+ *
+ * 送信は consent ゲート内蔵の sendGoogleAnalyticsEvent（lib/consent/）に一本化し、
+ * イベント名・パラメータ形はこの層でのみ定義する（呼び出し側に文字列を組ませない＝計測語彙のドリフト防止）。
+ *
+ * オーナー除外はイベント抑止ではなく traffic_type=internal のタグ付けで行う（internal-traffic.ts）。
+ * 成功指標「労力あたりの作成ボタン数」はオーナー自身の行動が主データのため、抑止すると測れなくなる。
+ */
+
+import { sendGoogleAnalyticsEvent } from "@/lib/consent/google-consent-mode";
+
+/** GA4 のイベントパラメータ値上限（100文字）に収める */
+const MAX_PARAM_LENGTH = 100;
+
+/**
+ * ボタン再生。呼び出し元は usePlayCount.handlePlay のデデュープ通過後
+ * （30秒デバウンス）＝ stats.playCount のインクリメントと同じ意味論。
+ */
+export function trackPlayButton(audioButtonId: string): void {
+	sendGoogleAnalyticsEvent("play_button", { audio_button_id: audioButtonId });
+}
+
+/** 作成ファネル: 送信開始（バリデーション通過後） */
+export function trackCreateStart(videoId: string, fromDraft: boolean): void {
+	sendGoogleAnalyticsEvent("create_start", { video_id: videoId, from_draft: fromDraft });
+}
+
+/** 作成ファネル: 成功。from_draft は SPR-146 下書きフローの効果測定に使う */
+export function trackCreateSuccess(input: {
+	audioButtonId: string;
+	videoId: string;
+	fromDraft: boolean;
+}): void {
+	sendGoogleAnalyticsEvent("create_success", {
+		audio_button_id: input.audioButtonId,
+		video_id: input.videoId,
+		from_draft: input.fromDraft,
+	});
+}
+
+/** 作成ファネル: 失敗（理由つき。導線・UI の詰まり所を特定する） */
+export function trackCreateError(videoId: string, reason: string): void {
+	sendGoogleAnalyticsEvent("create_error", {
+		video_id: videoId,
+		reason: reason.slice(0, MAX_PARAM_LENGTH),
+	});
+}
+
+/** お気に入りトグル。追加/削除でイベント名を分ける（GA4 上でそのまま数えられるように） */
+export function trackFavoriteToggle(audioButtonId: string, isFavorited: boolean): void {
+	sendGoogleAnalyticsEvent(isFavorited ? "add_to_favorite" : "remove_from_favorite", {
+		audio_button_id: audioButtonId,
+	});
+}
+
+/** 配信中マーキングの下書き作成（SPR-146）。has_player_time=false は壁時計のみの劣化モード */
+export function trackMarkDraft(videoId: string, hasPlayerTime: boolean): void {
+	sendGoogleAnalyticsEvent("mark_draft", {
+		video_id: videoId,
+		has_player_time: hasPlayerTime,
+	});
+}

--- a/apps/web/src/lib/analytics/internal-traffic.ts
+++ b/apps/web/src/lib/analytics/internal-traffic.ts
@@ -15,7 +15,11 @@
 
 const STORAGE_KEY = "suzumina-internal-traffic";
 
-/** オーナーの Discord ID（audioButtons.creatorId として公開済みの値のため秘匿情報ではない） */
+/**
+ * オーナーの Discord ID（audioButtons.creatorId として公開済みの値のため秘匿情報ではない）。
+ * 単一オーナー前提の意図的なハードコード。複数管理者化・オーナー交代が起きたら
+ * env / ロール判定への昇格を検討する（現状その予定はない）。
+ */
 export const OWNER_DISCORD_ID = "570920263135264778";
 
 function setGtagInternalTraffic(): void {

--- a/apps/web/src/lib/analytics/internal-traffic.ts
+++ b/apps/web/src/lib/analytics/internal-traffic.ts
@@ -1,0 +1,53 @@
+/**
+ * オーナー（内部）トラフィックのタグ付け（SPR-149 / SPR-137 議論ログ#6）。
+ *
+ * 目的: GA4 で「常連の継続利用」を見るとき、オーナー自身のアクセスを分離できるようにする。
+ * 6月の PV 急増がオーナーの作成作業由来かファン由来か分離できなかった反省による。
+ *
+ * 方式: gtag('set') で traffic_type=internal を付与する。以降にそのページで送られる
+ * 全イベント（config 経由の page_view 含む）に適用され、GA4 側はセグメント/データフィルタで
+ * 除外できる。イベント自体は送る（オーナーの作成行動は成功指標の主データ）。
+ *
+ * セッション解決は非同期のため、初回 page_view に間に合わない取りこぼしがある。
+ * localStorage に印を永続し、再訪時はセッション解決を待たずマウント直後に適用して塞ぐ
+ * （オーナーの最初の1訪問の page_view のみタグ漏れが残るが許容）。
+ */
+
+const STORAGE_KEY = "suzumina-internal-traffic";
+
+/** オーナーの Discord ID（audioButtons.creatorId として公開済みの値のため秘匿情報ではない） */
+export const OWNER_DISCORD_ID = "570920263135264778";
+
+function setGtagInternalTraffic(): void {
+	if (typeof window === "undefined" || !window.gtag) return;
+	window.gtag("set", { traffic_type: "internal" });
+}
+
+/** localStorage の印に基づき、セッション解決を待たずにタグを適用する（マウント直後に呼ぶ） */
+export function applyStoredInternalTrafficFlag(): void {
+	try {
+		if (localStorage.getItem(STORAGE_KEY) === "1") {
+			setGtagInternalTraffic();
+		}
+	} catch {
+		// localStorage 不可の環境では諦める（タグ漏れは許容）
+	}
+}
+
+/**
+ * セッション解決後に呼ぶ。オーナーなら印を永続してタグ適用。
+ * 別ユーザーのログインを検出したときだけ印を外す（未ログインでは保持＝オーナーのブラウザとみなす）。
+ * 解除は印のみで、適用済みページの gtag 状態はリロードまで残る（許容）。
+ */
+export function syncInternalTrafficFromSession(discordId: string | undefined): void {
+	try {
+		if (discordId === OWNER_DISCORD_ID) {
+			localStorage.setItem(STORAGE_KEY, "1");
+			setGtagInternalTraffic();
+		} else if (discordId) {
+			localStorage.removeItem(STORAGE_KEY);
+		}
+	} catch {
+		// noop
+	}
+}


### PR DESCRIPTION
## 目的

[SPR-149](https://linear.app/nothink/issue/SPR-149)。再定義した成功指標「労力あたりの作成ボタン数」「常連の継続利用」を測る計器。これまで GA4 カスタムイベントは web_vitals / consent_update / page_view のみで、コア行動（再生・作成・お気に入り）が観測不能だった。SPR-22 の方針の賭け「新鮮な供給→常連の再訪」の検証装置でもある。

## イベント設計

語彙は `lib/analytics/events.ts` に一元化（呼び出し側に文字列を組ませない）。送信は既存の consent ゲート内蔵 `sendGoogleAnalyticsEvent`（`lib/consent/google-consent-mode.ts`）経由＝同意なしでは送信されない。

| イベント | 発火点 | 意味論 |
|---|---|---|
| `play_button` | `usePlayCount.handlePlay`（全表面共通のチョークポイント） | 30秒デデュープ後（stats.playCount と同じデデュープ規則）。計測対象はクライアントの再生行動＝サーバー書き込み成否に非連動で、増分失敗時は僅かに乖離しうる（既知の許容誤差） |
| `create_start` / `create_success` / `create_error(reason)` | `audio-button-creator.handleCreate` | 作成ファネル。`from_draft` パラメータで SPR-146 下書きフローの効果を分離 |
| `add_to_favorite` / `remove_from_favorite` | favorite-button / audio-button-with-favorite-client の成功時 | 追加/削除を名前で分離 |
| `mark_draft(has_player_time)` | /live のマーク成功時 | 配信中マーキング。壁時計のみモードを区別 |

編集フロー（audio-button-editor / updateAudioButton）には発火しない（作成のみ）。

## オーナー（内部）トラフィックの分離

SPR-137 議論ログ#6 の反省（6月の PV 急増がオーナーの作成作業由来か分離できなかった）への対応。

- **イベント抑止ではなくタグ付け**: `gtag('set', { traffic_type: 'internal' })`。「労力あたりの作成ボタン数」はオーナー自身の行動が主データのため、抑止すると測れなくなる
- オーナー判定はセッション（discordId）。localStorage に印を永続し、再訪時はセッション解決前にタグ適用（初回 page_view の取りこぼしを低減。ログアウト中もオーナーのブラウザとして内部扱い、別ユーザーのログインで解除）
- `InternalTrafficMarker` は deferred 層の lazy 群より先に直接 mount（lazy chunk 間は effect 順序が保証されないため）
- GA4 側の運用: 探索/レポートで `traffic_type` によるセグメント除外がそのまま可能。恒久除外したい場合は GA4 管理画面のデータフィルタ（内部トラフィック）を有効化（任意・後日でよい）

## 検証

- `pnpm verify` 全パス。新規テスト11件（consent ゲート・各イベントのパラメータ形・reason の100文字切り詰め・内部トラフィックの印の付与/解除/保持）
- 発火点の網羅根拠: 再生は list/detail/modal/carousel/favorites すべてが `usePlayCount.handlePlay` に合流することをコード追跡で確認（レガシー audio-button-card は import 元なしの死コード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
