### PR TITLE
feat(ui): さくら/うさぎブランドマークを packages/ui に組み込み

### DIFF
--- a/packages/ui/src/components/custom/__tests__/brand-mark.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/brand-mark.test.tsx
@@ -1,0 +1,51 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RabbitMark, SakuraMark } from "../brand-mark";
+
+describe("SakuraMark", () => {
+	it("既定サイズ(24)とviewBoxで描画される", () => {
+		const { container } = render(<SakuraMark />);
+		const svg = container.querySelector("svg");
+		expect(svg).toHaveAttribute("viewBox", "0 0 512 512");
+		expect(svg).toHaveAttribute("width", "24");
+		expect(svg).toHaveAttribute("height", "24");
+		expect(svg).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("size / className を反映する", () => {
+		const { container } = render(<SakuraMark size={48} className="text-suzuka-500" />);
+		const svg = container.querySelector("svg");
+		expect(svg).toHaveAttribute("width", "48");
+		expect(svg).toHaveAttribute("height", "48");
+		expect(svg).toHaveClass("text-suzuka-500");
+	});
+
+	it("5枚の花びらパスを持つ", () => {
+		const { container } = render(<SakuraMark />);
+		expect(container.querySelectorAll("path")).toHaveLength(5);
+	});
+});
+
+describe("RabbitMark", () => {
+	it("既定サイズ(24)とviewBoxで描画される", () => {
+		const { container } = render(<RabbitMark />);
+		const svg = container.querySelector("svg");
+		expect(svg).toHaveAttribute("viewBox", "0 0 512 512");
+		expect(svg).toHaveAttribute("width", "24");
+		expect(svg).toHaveAttribute("height", "24");
+		expect(svg).toHaveAttribute("aria-hidden", "true");
+	});
+
+	it("size / className を反映する", () => {
+		const { container } = render(<RabbitMark size={48} className="text-suzuka-500" />);
+		const svg = container.querySelector("svg");
+		expect(svg).toHaveAttribute("width", "48");
+		expect(svg).toHaveAttribute("height", "48");
+		expect(svg).toHaveClass("text-suzuka-500");
+	});
+
+	it("単一パスのシルエットを持つ", () => {
+		const { container } = render(<RabbitMark />);
+		expect(container.querySelectorAll("path")).toHaveLength(1);
+	});
+});

--- a/packages/ui/src/components/custom/brand-mark.stories.tsx
+++ b/packages/ui/src/components/custom/brand-mark.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RabbitMark, SakuraMark } from "./brand-mark";
+
+const meta = {
+	title: "Custom/Brand/BrandMark",
+	component: SakuraMark,
+	parameters: {
+		layout: "centered",
+	},
+	tags: ["autodocs"],
+	argTypes: {
+		size: {
+			control: { type: "range", min: 16, max: 256, step: 8 },
+			description: "表示サイズ（px）。最小 16px",
+		},
+		className: {
+			control: "text",
+			description: "色は text-suzuka-* で指定（currentColor 継承）",
+		},
+	},
+} satisfies Meta<typeof SakuraMark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Sakura: Story = {
+	args: {
+		size: 96,
+		className: "text-suzuka-500 dark:text-suzuka-600",
+	},
+};
+
+export const Rabbit: Story = {
+	args: {
+		size: 96,
+		className: "text-suzuka-500 dark:text-suzuka-600",
+	},
+	render: (args) => <RabbitMark {...args} />,
+};
+
+/** 基本の並び: うさぎ左・さくら右。うさぎ（縦長）基準で高さを揃える */
+export const Pair: Story = {
+	args: {
+		size: 96,
+	},
+	render: (args) => (
+		<div className="flex items-center gap-4">
+			<RabbitMark {...args} className="text-suzuka-500 dark:text-suzuka-600" />
+			<SakuraMark {...args} className="text-suzuka-400 dark:text-suzuka-500" />
+		</div>
+	),
+};
+
+/** 最小サイズ 16px から段階表示（16px 未満では使用しない） */
+export const Sizes: Story = {
+	render: () => (
+		<div className="flex items-end gap-6 text-suzuka-500 dark:text-suzuka-600">
+			{[16, 24, 32, 48, 96].map((size) => (
+				<div key={size} className="flex flex-col items-center gap-2">
+					<div className="flex items-end gap-2">
+						<RabbitMark size={size} />
+						<SakuraMark size={size} />
+					</div>
+					<span className="text-muted-foreground text-xs">{size}px</span>
+				</div>
+			))}
+		</div>
+	),
+};
+
+/** 淡色サブ表示（装飾・背景透かし向け） */
+export const SubtleDecoration: Story = {
+	render: () => (
+		<div className="relative flex h-40 w-80 items-center justify-center overflow-hidden rounded-lg bg-suzuka-50 dark:bg-suzuka-950">
+			<RabbitMark
+				size={160}
+				className="-right-6 absolute top-2 text-suzuka-200 dark:text-suzuka-800"
+			/>
+			<span className="relative font-medium text-suzuka-700 dark:text-suzuka-300">
+				空状態・ヒーロー背景の装飾例
+			</span>
+		</div>
+	),
+};

--- a/packages/ui/src/components/custom/brand-mark.tsx
+++ b/packages/ui/src/components/custom/brand-mark.tsx
@@ -1,0 +1,74 @@
+import type { SVGProps } from "react";
+
+interface BrandMarkProps extends SVGProps<SVGSVGElement> {
+	size?: string | number;
+}
+
+/**
+ * suzumina.click ブランドマーク（さくら / うさぎ）。
+ * パスデータはデザインハンドオフの最終形状（high-fidelity）— 形状・比率は変更しない。
+ *
+ * 色は `currentColor` 継承。既定色は `text-suzuka-500 dark:text-suzuka-600`
+ * （または semantic な `text-primary`）を className で指定する。
+ * heart（機能色）/ minase（面用）をマーク本体色に使わない。
+ * 最小サイズ 16px。装飾利用は aria-hidden のまま、単体でリンク等になる場合は
+ * role="img" + <title> を利用側で付与する。
+ */
+export function SakuraMark({ size = 24, className, ...props }: BrandMarkProps) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 512 512"
+			fill="currentColor"
+			width={size}
+			height={size}
+			className={className}
+			aria-hidden="true"
+			{...props}
+		>
+			<g transform="translate(256 273)">
+				<path d="M0 -28C-74 -54 -88 -148 -50 -198L0 -172L50 -198C88 -148 74 -54 0 -28Z" />
+				<path
+					transform="rotate(72)"
+					d="M0 -28C-74 -54 -88 -148 -50 -198L0 -172L50 -198C88 -148 74 -54 0 -28Z"
+				/>
+				<path
+					transform="rotate(144)"
+					d="M0 -28C-74 -54 -88 -148 -50 -198L0 -172L50 -198C88 -148 74 -54 0 -28Z"
+				/>
+				<path
+					transform="rotate(216)"
+					d="M0 -28C-74 -54 -88 -148 -50 -198L0 -172L50 -198C88 -148 74 -54 0 -28Z"
+				/>
+				<path
+					transform="rotate(288)"
+					d="M0 -28C-74 -54 -88 -148 -50 -198L0 -172L50 -198C88 -148 74 -54 0 -28Z"
+				/>
+			</g>
+		</svg>
+	);
+}
+
+/**
+ * うさぎマーク。図形は縦長（実寸 約304×380）のため、さくらと並べる場合は
+ * うさぎ側を基準に高さを揃える（並び順は「うさぎ左・さくら右」が基本）。
+ */
+export function RabbitMark({ size = 24, className, ...props }: BrandMarkProps) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 512 512"
+			fill="currentColor"
+			width={size}
+			height={size}
+			className={className}
+			aria-hidden="true"
+			{...props}
+		>
+			<path
+				transform="translate(0 -16)"
+				d="M242 242C238 190 224 130 196 96C184 84 166 82 156 96C132 130 128 196 142 246C118 268 104 300 104 336C104 420 172 462 256 462C340 462 408 420 408 336C408 300 394 268 370 246C384 196 380 130 356 96C346 82 328 84 316 96C288 130 274 190 270 242C264 254 248 254 242 242Z"
+			/>
+		</svg>
+	);
+}

--- a/packages/ui/src/components/custom/index.ts
+++ b/packages/ui/src/components/custom/index.ts
@@ -2,6 +2,8 @@
 export { ActionPillRow } from "./action-pill-row";
 export { AudioButton } from "./audio-button";
 export { AudioPlayer } from "./audio-player";
+// Brand marks（さくら / うさぎ）
+export { RabbitMark, SakuraMark } from "./brand-mark";
 export { ConfigurableList } from "./configurable-list";
 // List components
 export type {

--- a/packages/ui/src/components/design-tokens/icons.mdx
+++ b/packages/ui/src/components/design-tokens/icons.mdx
@@ -1,5 +1,6 @@
 import { Meta, IconGallery, IconItem, Title, Subtitle } from "@storybook/addon-docs/blocks";
 import { YoutubeIcon } from "../custom/youtube-icon";
+import { RabbitMark, SakuraMark } from "../custom/brand-mark";
 import {
   AlertCircle,
   ArrowLeft,
@@ -98,6 +99,16 @@ import {
   <IconItem name="User"><User /></IconItem>
   <IconItem name="Users"><Users /></IconItem>
   <IconItem name="LogOut"><LogOut /></IconItem>
+</IconGallery>
+
+## ブランドマーク
+
+サイトのブランドマーク（さくら / うさぎ）。詳細な使い分けは `Custom/Brand/BrandMark` ストーリーを参照。
+色は `text-suzuka-500 dark:text-suzuka-600`（heart / minase は使わない）、最小サイズ 16px。
+
+<IconGallery>
+  <IconItem name="SakuraMark"><SakuraMark className="text-suzuka-500 dark:text-suzuka-600" /></IconItem>
+  <IconItem name="RabbitMark"><RabbitMark className="text-suzuka-500 dark:text-suzuka-600" /></IconItem>
 </IconGallery>
 
 ## サイズスケール


### PR DESCRIPTION
## Summary
- Claude Design のデザインハンドオフ(`design_handoff_brand_marks`)で作成した「さくらマーク」「うさぎマーク」を `SakuraMark` / `RabbitMark` として `packages/ui` の `custom/` に組み込み
- 既存の `XIcon` / `YoutubeIcon` と同じパターン(`fill="currentColor"` + `size` prop + `aria-hidden`)を踏襲。パスデータは形状不変で埋め込み
- Storybook ストーリー(`Custom/Brand/BrandMark`)を追加: Sakura / Rabbit / Pair(うさぎ左・さくら右) / Sizes(16〜96px) / SubtleDecoration
- Design Tokens/Icons ドキュメントページに「ブランドマーク」節を追加

## Test plan
- [x] `pnpm --filter @suzumina.click/ui lint` / `typecheck` / `test` すべて通過
- [x] `pnpm --filter @suzumina.click/ui test:storybook` 46 files / 352 tests 通過
- [x] Storybook 実機確認(Pair・SubtleDecoration の描画、Icons ドキュメントページへの反映)

🤖 Generated with [Claude Code](https://claude.com/claude-code)