### PR TITLE
feat(web): Claude Design案(Home Redesign)に合わせヒーロー/フッターを刷新

### DIFF
--- a/apps/web/src/components/consent/cookie-settings-link.tsx
+++ b/apps/web/src/components/consent/cookie-settings-link.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Settings } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { ConsentState } from "@/lib/consent/google-consent-mode";
 import { updateConsent } from "@/lib/consent/google-consent-mode";
@@ -49,9 +48,8 @@ export function CookieSettingsLink() {
 				variant="ghost"
 				size="sm"
 				onClick={handleOpenSettings}
-				className="text-xs text-muted-foreground hover:text-foreground p-0 h-auto hover:bg-accent transition-colors"
+				className="text-sm text-minase-200 hover:text-minase-50 py-2 px-3.5 h-auto underline underline-offset-4 hover:bg-transparent"
 			>
-				<Settings className="h-3 w-3 mr-1" />
 				クッキー設定
 			</Button>
 

--- a/apps/web/src/components/consent/cookie-settings-link.tsx
+++ b/apps/web/src/components/consent/cookie-settings-link.tsx
@@ -7,8 +7,9 @@ import { updateConsent } from "@/lib/consent/google-consent-mode";
 import { CookiePreferencesPanel } from "./cookie-preferences-panel";
 
 /**
- * Cookie settings link component for footer and other locations
- * Allows users to modify their consent choices at any time
+ * フッターの Cookie 設定リンク。唯一の呼び出し元である SiteFooter の暗色帯
+ * （minase-800）前提の配色にしている（他画面で流用する場合は要調整）。
+ * いつでも同意設定を変更できるようにする。
  */
 export function CookieSettingsLink() {
 	const [showSettings, setShowSettings] = useState(false);
@@ -48,7 +49,7 @@ export function CookieSettingsLink() {
 				variant="ghost"
 				size="sm"
 				onClick={handleOpenSettings}
-				className="text-sm text-minase-200 hover:text-minase-50 py-2 px-3.5 h-auto underline underline-offset-4 hover:bg-transparent"
+				className="text-sm text-minase-200 hover:text-minase-50 py-2 px-3.5 h-auto underline underline-offset-4 hover:bg-transparent focus-visible:border-minase-50 focus-visible:ring-minase-50"
 			>
 				クッキー設定
 			</Button>

--- a/apps/web/src/components/home/hero-section.tsx
+++ b/apps/web/src/components/home/hero-section.tsx
@@ -1,17 +1,48 @@
+import { RabbitMark, SakuraMark } from "@suzumina.click/ui/components/custom/brand-mark";
 import HomeSearch from "@/components/home/home-search";
+
+// Claude Design 案（Home Redesign）の桜吹雪装飾。1枚花びらのパス（sakura.svg の1枚分と同形）を
+// 4枚だけ手書き配置する一回限りの演出のため、共有コンポーネント化はしない。
+const PETAL_PATH = "M0 -20C-62 -42 -74 -128 -46 -178L0 -150L46 -178C74 -128 62 -42 0 -20Z";
+const PETALS = [
+	{ style: { top: "36px", left: "6%" }, size: 34, rotate: -24, className: "text-suzuka-200" },
+	{ style: { bottom: "42px", left: "30%" }, size: 24, rotate: 38, className: "text-suzuka-200" },
+	{ style: { top: "28px", right: "34%" }, size: 26, rotate: 150, className: "text-suzuka-300" },
+	{ style: { bottom: "70px", right: "6%" }, size: 30, rotate: -140, className: "text-suzuka-300" },
+] as const;
 
 /**
  * ホームページのヒーローセクション。
  * PPR の静的シェルに含めるため、データ取得を持たない純粋なサーバーコンポーネント。
  * 検索フォーム（HomeSearch）は client island だが動的データを読まないため静的シェルに含まれる。
+ *
+ * 背景の桜色（suzuka-50）はテーマ非依存の固定ブランド帯として扱う（dark: 反転させない）。
+ * サイト全体はまだダークモード切替 UI を持たないため、現時点では実害はない。
  */
 export function HeroSection() {
 	return (
-		<section className="py-12 sm:py-16 md:py-20 text-center bg-muted critical-above-fold critical-hero">
-			<div className="container mx-auto px-4 sm:px-6 lg:px-8">
-				<div className="max-w-4xl mx-auto">
+		<section className="relative overflow-hidden bg-suzuka-50 py-12 text-center critical-above-fold critical-hero sm:py-16 md:py-20 md:text-left">
+			<div aria-hidden="true" className="pointer-events-none absolute inset-0">
+				{PETALS.map((petal, index) => (
+					<svg
+						// biome-ignore lint/suspicious/noArrayIndexKey: 固定4枚の装飾で並び替えが発生しないため
+						key={index}
+						className={`absolute ${petal.className}`}
+						style={petal.style}
+						width={petal.size}
+						height={petal.size}
+						viewBox="-90 -190 180 180"
+						fill="currentColor"
+						aria-hidden="true"
+					>
+						<path transform={`rotate(${petal.rotate} 0 -100)`} d={PETAL_PATH} />
+					</svg>
+				))}
+			</div>
+			<div className="container relative mx-auto grid gap-10 px-4 sm:px-6 md:grid-cols-[1.15fr_0.85fr] md:items-center lg:px-8">
+				<div className="mx-auto max-w-4xl md:mx-0 md:max-w-none">
 					<h1
-						className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold text-foreground mb-4 sm:mb-6"
+						className="mb-4 font-bold text-2xl text-foreground sm:mb-6 sm:text-3xl md:text-4xl lg:text-5xl"
 						style={{
 							minHeight: "2.5rem",
 							contentVisibility: "visible",
@@ -20,7 +51,7 @@ export function HeroSection() {
 						すずみなくりっく！
 					</h1>
 					<p
-						className="text-base sm:text-lg md:text-xl text-muted-foreground mb-6 sm:mb-8 px-4 sm:px-0"
+						className="mb-6 px-4 text-base text-muted-foreground sm:mb-8 sm:px-0 sm:text-lg md:text-xl"
 						style={{
 							minHeight: "3rem",
 						}}
@@ -30,6 +61,10 @@ export function HeroSection() {
 						あーたたちが集まる、あーたたちのためのファンサイトです
 					</p>
 					<HomeSearch />
+				</div>
+				<div className="relative hidden min-h-[220px] items-center justify-center md:flex">
+					<SakuraMark size={170} className="absolute bottom-2 left-[2%] text-suzuka-300" />
+					<RabbitMark size={230} className="relative text-suzuka-400" />
 				</div>
 			</div>
 		</section>

--- a/apps/web/src/components/home/home-search.tsx
+++ b/apps/web/src/components/home/home-search.tsx
@@ -40,7 +40,7 @@ const HomeSearch = memo(function HomeSearch() {
 	);
 
 	return (
-		<div className="max-w-md mx-auto space-y-3">
+		<div className="max-w-md mx-auto space-y-3 md:mx-0">
 			<ToggleGroup
 				type="single"
 				value={target}

--- a/apps/web/src/components/layout/__tests__/site-footer.test.tsx
+++ b/apps/web/src/components/layout/__tests__/site-footer.test.tsx
@@ -13,26 +13,20 @@ describe("SiteFooter", () => {
 	// 基本的なレンダリングテストは統合テストに移行済み
 	// (src/__tests__/integration/basicComponentRendering.test.tsx)
 
-	it("レスポンシブグリッドレイアウトが適用される", () => {
+	it("リンクが折り返し可能な中央寄せの横並びで配置される", () => {
 		render(<SiteFooter />);
 
-		// リンクコンテナのグリッドレイアウト
+		// リンクコンテナのレイアウト
 		const aboutLink = screen.getByText("このサイトについて");
 		const linkContainer = aboutLink.closest("div");
 
-		// grid-cols-2 md:grid-cols-4 クラスを持つ親要素を探す
-		let gridContainer: HTMLElement | null = linkContainer;
-		while (gridContainer && !gridContainer.className.includes("grid-cols-2")) {
-			gridContainer = gridContainer.parentElement;
+		// flex flex-wrap justify-center クラスを持つ親要素を探す
+		let flexContainer: HTMLElement | null = linkContainer;
+		while (flexContainer && !flexContainer.className.includes("flex-wrap")) {
+			flexContainer = flexContainer.parentElement;
 		}
 
-		expect(gridContainer).toHaveClass(
-			"grid",
-			"grid-cols-2",
-			"md:grid-cols-4",
-			"gap-4",
-			"text-center",
-		);
+		expect(flexContainer).toHaveClass("flex", "flex-wrap", "justify-center");
 	});
 
 	it("ホバー効果とトランジションが設定される", () => {
@@ -85,11 +79,11 @@ describe("SiteFooter", () => {
 
 		// メインタイトル
 		const title = screen.getByText("suzumina.click");
-		expect(title).toHaveClass("font-bold", "text-lg", "mb-2");
+		expect(title).toHaveClass("font-extrabold", "text-lg", "text-minase-50");
 
 		// 説明文
 		const description = screen.getByText("ファンによる、ファンのためのコミュニティサイト");
-		expect(description).toHaveClass("text-muted-foreground", "text-sm");
+		expect(description).toHaveClass("text-minase-200", "text-sm");
 
 		// フッターリンクとコピーライトの存在確認
 		const aboutLink = screen.getByText("このサイトについて");

--- a/apps/web/src/components/layout/site-footer.tsx
+++ b/apps/web/src/components/layout/site-footer.tsx
@@ -1,65 +1,59 @@
+import { RabbitMark } from "@suzumina.click/ui/components/custom/brand-mark";
 import Link from "next/link";
 import { CookieSettingsLink } from "../consent/cookie-settings-link";
 
+const FOOTER_LINKS = [
+	{ href: "/about", label: "このサイトについて" },
+	{ href: "/contact", label: "お問い合わせ" },
+	{ href: "/terms", label: "利用規約" },
+	{ href: "/privacy", label: "プライバシーポリシー" },
+] as const;
+
+/**
+ * サイトフッター。Claude Design 案（Home Redesign）に合わせ、テーマ非依存の
+ * 固定ブランド帯（minase-800 の暖色くすみ茶）として扱う（dark: 反転させない）。
+ * サイト全体はまだダークモード切替 UI を持たないため、現時点では実害はない。
+ */
 export default function SiteFooter() {
 	return (
-		<footer className="bg-muted text-muted-foreground py-12 mt-auto border-t border-border">
+		<footer className="bg-minase-800 text-minase-200 py-12 mt-auto">
 			<div className="max-w-7xl mx-auto px-4">
-				<div className="space-y-8">
-					{/* サポート情報を横一列に */}
-					<div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
-						<Link
-							href="/about"
-							className="text-muted-foreground hover:text-foreground transition-colors text-sm py-2 rounded-md hover:bg-accent focus:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
-						>
-							このサイトについて
-						</Link>
-						<Link
-							href="/contact"
-							className="text-muted-foreground hover:text-foreground transition-colors text-sm py-2 rounded-md hover:bg-accent focus:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
-						>
-							お問い合わせ
-						</Link>
-						<Link
-							href="/terms"
-							className="text-muted-foreground hover:text-foreground transition-colors text-sm py-2 rounded-md hover:bg-accent focus:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
-						>
-							利用規約
-						</Link>
-						<Link
-							href="/privacy"
-							className="text-muted-foreground hover:text-foreground transition-colors text-sm py-2 rounded-md hover:bg-accent focus:bg-accent focus:outline-none focus:ring-2 focus:ring-ring"
-						>
-							プライバシーポリシー
-						</Link>
-					</div>
-
-					{/* クッキー設定リンク */}
-					<div className="text-center">
+				<div className="space-y-7">
+					{/* サポート情報 + クッキー設定を横一列に */}
+					<div className="flex flex-wrap justify-center gap-2">
+						{FOOTER_LINKS.map((link) => (
+							<Link
+								key={link.href}
+								href={link.href}
+								className="text-minase-200 hover:text-minase-50 transition-colors text-sm py-2 px-3.5 rounded-md hover:bg-minase-700 focus:bg-minase-700 focus:outline-none focus:ring-2 focus:ring-ring"
+							>
+								{link.label}
+							</Link>
+						))}
 						<CookieSettingsLink />
 					</div>
 
 					{/* 下段：サイト名と説明文 */}
-					<div className="text-center space-y-4">
-						<div>
-							<h2 className="font-bold text-lg mb-2 text-foreground">suzumina.click</h2>
-							<p className="text-muted-foreground text-sm">
-								ファンによる、ファンのためのコミュニティサイト
-							</p>
-							<p className="text-muted-foreground text-xs mt-1 flex items-center justify-center gap-1">
-								<span>🚀</span>
-								現在プレビューリリース中 - 閲覧・利用は誰でも、作成はすずみなふぁみりー限定
-							</p>
+					<div className="text-center space-y-2">
+						<div className="flex items-center justify-center gap-2">
+							<RabbitMark size={20} className="text-minase-200" />
+							<h2 className="font-extrabold text-lg text-minase-50">suzumina.click</h2>
 						</div>
-						<div className="border-t border-border pt-4 text-sm text-muted-foreground">
-							<p>
-								&copy; 2025{" "}
-								<Link href={"https://www.nothink.jp"} target="_blank">
-									nothink.jp
-								</Link>
-								. このサイトは非公式のファンサイトです。
-							</p>
-						</div>
+						<p className="text-minase-200 text-sm">
+							ファンによる、ファンのためのコミュニティサイト
+						</p>
+						<p className="text-minase-300 text-xs">
+							現在プレビューリリース中 - 閲覧・利用は誰でも、作成はすずみなふぁみりー限定
+						</p>
+					</div>
+					<div className="border-t border-minase-700 pt-4 text-center text-sm text-minase-200">
+						<p>
+							&copy; 2025{" "}
+							<Link href={"https://www.nothink.jp"} target="_blank">
+								nothink.jp
+							</Link>
+							. このサイトは非公式のファンサイトです。
+						</p>
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/components/layout/site-footer.tsx
+++ b/apps/web/src/components/layout/site-footer.tsx
@@ -25,7 +25,7 @@ export default function SiteFooter() {
 							<Link
 								key={link.href}
 								href={link.href}
-								className="text-minase-200 hover:text-minase-50 transition-colors text-sm py-2 px-3.5 rounded-md hover:bg-minase-700 focus:bg-minase-700 focus:outline-none focus:ring-2 focus:ring-ring"
+								className="text-minase-200 hover:text-minase-50 transition-colors text-sm py-2 px-3.5 rounded-md hover:bg-minase-700 focus:bg-minase-700 focus:outline-none focus:ring-2 focus:ring-minase-50"
 							>
 								{link.label}
 							</Link>


### PR DESCRIPTION
## Summary
- #787 で追加した `SakuraMark`/`RabbitMark` を使い、Claude Design の Home Redesign 案（`Home Redesign.dc.html`）にヒーロー・フッターの2箇所を揃える
- トップページ全体をそのまま適用すると既存の一覧セクション等と構造が崩れるため、今回はヒーローとフッターのみに限定

### ヒーロー（`hero-section.tsx`）
- 2カラムレイアウト（左: 見出し+検索フォーム、右: さくら/うさぎマークの装飾イラスト。`md:` 未満では非表示）
- 背景を `suzuka-50` の固定ブランド帯に変更、桜吹雪の装飾（4枚、1回限りの演出のため共有化はせず）を追加
- `HomeSearch` は左寄せに調整（`md:mx-0`）

### フッター（`site-footer.tsx` / `cookie-settings-link.tsx`）
- 背景を `minase-800` の固定暖色帯に変更（デザインの `#7D5B40` = `minase-800` と一致）
- リンク行を `grid-cols-2 md:grid-cols-4` から `flex flex-wrap justify-center` に変更し、クッキー設定リンクも同じ行に統合
- サイト名の横に `RabbitMark` を追加

### 配色トークンの対応関係（デザインの生HEX → 既存トークン）
Claude Design 側のヒーロー/フッターは raw hex 指定だが、実装では既存の `suzuka-*` / `minase-*` semantic トークンに対応づけて使用（HSL変換で数値が完全一致することを確認済み）:
- フッター `#7D5B40`→`minase-800` / `#EADDCD`→`minase-200` / `#9D734D`→`minase-700` / `#FBF8F4`→`minase-50`
- ヒーロー背景 `#FDF2F5`→`suzuka-50`、うさぎイラスト `#D57294`→`suzuka-400`、さくらイラスト `#E4AFC1`→`suzuka-300`

ヒーロー・フッターとも「テーマ非依存の固定ブランド帯」として扱い `dark:` バリアントは付けていない（サイト全体がまだダークモード切替 UI を持たないため現状は実害なし。コード内にコメントで明記）。

## Test plan
- [x] `pnpm --filter @suzumina.click/web lint` / `typecheck` — エラーなし（既存の無関係な警告1件のみ）
- [x] `pnpm --filter @suzumina.click/web test` — 107 files / 971 tests 全パス（`site-footer.test.tsx` はレイアウト変更に合わせて構造アサーションを更新）
- [x] `pnpm dev:local` + ブラウザで実機確認。デスクトップ幅でヒーローの2カラム・桜吹雪・うさぎ&さくらイラスト、フッターの配色（`getComputedStyle` で `#7D5B40`/`#EADDCD`/`#FBF8F4` と厳密一致）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)