### PR TITLE
fix(web): guild同期のAPI失敗をisFamilyMember=falseへ誤って確定させない

### DIFF
--- a/apps/web/src/lib/better-auth/guild-sync.ts
+++ b/apps/web/src/lib/better-auth/guild-sync.ts
@@ -49,7 +49,11 @@ export async function refreshGuildStatusIfNeeded(
 	if (!token) return userData;
 	try {
 		const guildMembership = await fetchDiscordGuildMembership(token, discordId);
-		const isFamilyMember = guildMembership ? isValidGuildMember(guildMembership) : false;
+		// null は API 呼び出し自体の失敗（トークン失効・レート制限等）を示す。
+		// 「非メンバー確定」と取り違えて false を書き込むと、以後ずっと復旧できなくなるため
+		// 失敗時は判定を更新せず現状の userData をそのまま維持する。
+		if (!guildMembership) return userData;
+		const isFamilyMember = isValidGuildMember(guildMembership);
 		const today = getJSTDateString();
 		const newLimit = calculateDailyLimit({ isFamilyMember });
 		// 日付が変わっていればカウントをリセット


### PR DESCRIPTION
## Summary
- すずみなふぁみりーに参加済みのユーザーで、1日の音声ボタン作成上限が110個ではなく10個に固定される不具合を修正
- 原因: `refreshGuildStatusIfNeeded()`（`apps/web/src/lib/better-auth/guild-sync.ts`）が、Discord Guild APIの取得失敗（アクセストークン失効・レート制限・Discord障害など）を「非メンバー確定」と取り違え、`flags.isFamilyMember: false` をFirestoreへ書き込んでいた
- 一度誤って書き込まれると `flags.lastGuildCheckDate` も当日日付で更新されるため、日次チェックのゲート（`hasDateChangedJST`）により翌日まで再チェックされず、実質的に復旧不能になっていた
- 修正: `fetchDiscordGuildMembership()` が `null`（=API呼び出し失敗）を返した場合は `flags`/`dailyButtonLimit` を更新せず、受け取った `userData` をそのまま返すようにした（成功時のみ判定を確定させる）

## Test plan
- [x] `biome check` で対象ファイルの静的チェックが通ることを確認
- [x] `tsgo --noEmit`（pre-push hook経由）で型エラーがないことを確認
- [ ] 実際に対象ユーザーが再ログインした際、Discordアクセストークンが有効であれば `flags.isFamilyMember` が `true` に復旧し、UI上で「残り110個」表示になることを確認（本番での自然回復を観察）

🤖 Generated with [Claude Code](https://claude.com/claude-code)