### PR TITLE
fix(web): サムネイル読み込み中のぼかしを弱める

### DIFF
--- a/apps/web/src/components/ui/__tests__/thumbnail-image.test.tsx
+++ b/apps/web/src/components/ui/__tests__/thumbnail-image.test.tsx
@@ -71,14 +71,17 @@ describe("ThumbnailImage", () => {
 	});
 
 	it("プレースホルダー画像が正しく設定される", () => {
+		// next/image 標準の blur placeholder は stdDeviation が固定で調整できないため、
+		// 自前のぼかし背景レイヤー（blur-sm）を敷く方式に変更している
 		render(<ThumbnailImage {...defaultProps} />);
 
 		const image = screen.getByTestId("next-image");
-		expect(image).toHaveAttribute("data-placeholder", "blur");
-		expect(image).toHaveAttribute(
-			"data-blur-data-url",
-			expect.stringContaining("data:image/svg+xml"),
-		);
+		expect(image).toHaveAttribute("data-placeholder", "empty");
+
+		const container = image.parentElement;
+		const backdrop = container?.querySelector('[aria-hidden="true"].blur-sm');
+		expect(backdrop).toBeInTheDocument();
+		expect(backdrop?.getAttribute("style")).toContain("data:image/svg+xml");
 	});
 
 	it("エラー後に再度エラーが発生しても重複して処理されない", async () => {
@@ -119,7 +122,7 @@ describe("ThumbnailImage", () => {
 		expect(image).toHaveAttribute("data-fill", "true");
 		expect(image).toHaveAttribute("data-priority", "true");
 		expect(image).toHaveAttribute("sizes", "100vw");
-		expect(image).toHaveAttribute("data-placeholder", "blur");
+		expect(image).toHaveAttribute("data-placeholder", "empty");
 	});
 
 	it("メモ化により同じpropsでは再レンダリングされない", () => {

--- a/apps/web/src/components/ui/__tests__/thumbnail-image.test.tsx
+++ b/apps/web/src/components/ui/__tests__/thumbnail-image.test.tsx
@@ -84,6 +84,31 @@ describe("ThumbnailImage", () => {
 		expect(backdrop?.getAttribute("style")).toContain("data:image/svg+xml");
 	});
 
+	it("画像の読み込み完了後はぼかし背景レイヤーが外れる", () => {
+		render(<ThumbnailImage {...defaultProps} />);
+
+		const image = screen.getByTestId("next-image");
+		const container = image.parentElement;
+		expect(container?.querySelector('[aria-hidden="true"].blur-sm')).toBeInTheDocument();
+
+		fireEvent.load(image);
+
+		expect(container?.querySelector('[aria-hidden="true"].blur-sm')).not.toBeInTheDocument();
+	});
+
+	it("srcが変更されると読み込み完了状態がリセットされ、ぼかし背景が再表示される", () => {
+		const { rerender } = render(<ThumbnailImage {...defaultProps} />);
+
+		const image = screen.getByTestId("next-image");
+		const container = image.parentElement;
+		fireEvent.load(image);
+		expect(container?.querySelector('[aria-hidden="true"].blur-sm')).not.toBeInTheDocument();
+
+		rerender(<ThumbnailImage {...defaultProps} src="https://example.com/new-image.jpg" />);
+
+		expect(container?.querySelector('[aria-hidden="true"].blur-sm')).toBeInTheDocument();
+	});
+
 	it("エラー後に再度エラーが発生しても重複して処理されない", async () => {
 		render(<ThumbnailImage {...defaultProps} />);
 

--- a/apps/web/src/components/ui/thumbnail-image.tsx
+++ b/apps/web/src/components/ui/thumbnail-image.tsx
@@ -65,6 +65,7 @@ const ThumbnailImage = memo(function ThumbnailImage({
 	});
 	const [hasError, setHasError] = useState(false);
 	const [hasFallbackError, setHasFallbackError] = useState(false);
+	const [isLoaded, setIsLoaded] = useState(false);
 
 	// srcプロップが変更された際に内部状態をリセット
 	useEffect(() => {
@@ -74,6 +75,7 @@ const ThumbnailImage = memo(function ThumbnailImage({
 		setImageSrc(normalizedSrc);
 		setHasError(false);
 		setHasFallbackError(false);
+		setIsLoaded(false);
 	}, [src]);
 
 	const handleError = () => {
@@ -87,6 +89,7 @@ const ThumbnailImage = memo(function ThumbnailImage({
 			const normalizedFallbackSrc = normalizeDLsiteUrl(fallbackSrc);
 			setImageSrc(normalizedFallbackSrc);
 			setHasError(true);
+			setIsLoaded(false);
 		} else if (!hasFallbackError) {
 			// フォールバック画像もエラーの場合、またはフォールバック画像がない場合
 			setImageSrc(PLACEHOLDER_IMAGE);
@@ -112,8 +115,10 @@ const ThumbnailImage = memo(function ThumbnailImage({
 			 * 20 に固定されており props で調整できず、かつ fill + 動的 src では viewBox を
 			 * 正しく計算できないため想定より強くぼける（Next.js 内部実装依存）。
 			 * 自前の背景レイヤーで blur-sm（4px）に固定し、強さを直接制御する。
+			 * 実画像の読み込み完了（onLoad）で外し、blur フィルタの合成コストを
+			 * 常駐させない（一覧ページで多数並ぶ際のパフォーマンス対策）。
 			 */}
-			{!isPlaceholderImage && (
+			{!isPlaceholderImage && !isLoaded && (
 				<div
 					aria-hidden="true"
 					className="absolute inset-0 scale-110 bg-cover bg-center blur-sm"
@@ -132,6 +137,7 @@ const ThumbnailImage = memo(function ThumbnailImage({
 				sizes={sizes}
 				loading={priority ? "eager" : loading}
 				quality={quality}
+				onLoad={() => setIsLoaded(true)}
 				onError={handleError}
 				placeholder="empty"
 				unoptimized={optimized ? undefined : true}

--- a/apps/web/src/components/ui/thumbnail-image.tsx
+++ b/apps/web/src/components/ui/thumbnail-image.tsx
@@ -94,7 +94,7 @@ const ThumbnailImage = memo(function ThumbnailImage({
 		}
 	};
 
-	// プレースホルダー画像の場合はblur効果を無効化
+	// プレースホルダー画像自体を表示している場合は、その下に同じ画像のぼかし背景を重ねない
 	const isPlaceholderImage = imageSrc === PLACEHOLDER_IMAGE;
 
 	return (
@@ -107,6 +107,19 @@ const ThumbnailImage = memo(function ThumbnailImage({
 			}}
 			className={className}
 		>
+			{/*
+			 * next/image 標準の placeholder="blur" は feGaussianBlur の stdDeviation が
+			 * 20 に固定されており props で調整できず、かつ fill + 動的 src では viewBox を
+			 * 正しく計算できないため想定より強くぼける（Next.js 内部実装依存）。
+			 * 自前の背景レイヤーで blur-sm（4px）に固定し、強さを直接制御する。
+			 */}
+			{!isPlaceholderImage && (
+				<div
+					aria-hidden="true"
+					className="absolute inset-0 scale-110 bg-cover bg-center blur-sm"
+					style={{ backgroundImage: `url(${PLACEHOLDER_IMAGE})` }}
+				/>
+			)}
 			<Image
 				src={imageSrc}
 				alt={alt}
@@ -120,8 +133,7 @@ const ThumbnailImage = memo(function ThumbnailImage({
 				loading={priority ? "eager" : loading}
 				quality={quality}
 				onError={handleError}
-				placeholder={isPlaceholderImage ? "empty" : "blur"}
-				blurDataURL={isPlaceholderImage ? undefined : PLACEHOLDER_IMAGE}
+				placeholder="empty"
 				unoptimized={optimized ? undefined : true}
 				style={{
 					// CLS削減: object-fitでレイアウト安定化


### PR DESCRIPTION
## Summary

#794 で桜モチーフに差し替えたプレースホルダーだが、実プレビューで確認したところ blur-up 中のぼかしが強すぎるとのフィードバックを受けて調整。

### 原因
`next/image` の `placeholder="blur"` は内部で SVG filter `feGaussianBlur` の `stdDeviation` を **20固定**で使っており（`next/dist/shared/lib/image-blur-svg.js`）、props からは調整できない。さらに `ThumbnailImage` は `fill` + 動的 `src` の組み合わせのため `blurWidth`/`blurHeight` を渡せず（`fill` と `width`/`height` は Next.js が同時指定をエラーにする）、blur SVG の viewBox を正しく計算できず、想定より強くぼける実装上の制約があった。

### 対応
Next.js 標準の blur-up 機構を使うのをやめ、自前の背景レイヤー（[thumbnail-image.tsx](apps/web/src/components/ui/thumbnail-image.tsx)）に置き換えた:
- 画像コンテナに桜プレースホルダーを `background-image` + Tailwind `blur-sm`（4px固定）で敷く
- `scale-110` で blur によるフチのはみ出し（透明な縁）を吸収
- `<Image>` 側は `placeholder="empty"` にして Next.js の自動ぼかしを無効化

`blur-sm`(4px) は既存の `Next.js std=20` 相当と比べてかなり弱く、花の輪郭が判別できる程度に調整（下記スクリーンショットで比較）。

## Test plan
- [x] `pnpm --filter @suzumina.click/web lint` / `typecheck` — エラーなし（既存の無関係な警告1件のみ）
- [x] `pnpm --filter @suzumina.click/web test` — 107 files / 971 tests 全パス（`thumbnail-image.test.tsx` を新しい DOM 構造・`placeholder="empty"` に合わせて更新）
- [x] ブラウザで新旧のぼかし強度を並べて比較。旧相当(20px)は花の形が完全に潰れて曖昧な塊になるのに対し、新実装(blur-sm/4px)は桜の輪郭がはっきり視認できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)