### PR TITLE
feat(web): 配信中マーキング(/live)への常設導線をユーザーメニューに追加

### DIFF
--- a/apps/web/src/components/layout/mobile-menu.tsx
+++ b/apps/web/src/components/layout/mobile-menu.tsx
@@ -65,6 +65,13 @@ export default function MobileMenu({ user }: MobileMenuProps) {
 							>
 								👤 マイページ
 							</Link>
+							{/* 配信終了後も下書きの仕上げに戻れるよう常設する（動画カード側の導線は live/upcoming 時のみ） */}
+							<Link
+								href="/live"
+								className="text-lg font-medium text-foreground hover:text-foreground/80 hover:bg-accent min-h-[48px] px-4 py-3 rounded-lg transition-colors flex items-center"
+							>
+								🔖 配信中マーキング
+							</Link>
 							<Link
 								href="/settings"
 								className="text-lg font-medium text-foreground hover:text-foreground/80 hover:bg-accent min-h-[48px] px-4 py-3 rounded-lg transition-colors flex items-center"

--- a/apps/web/src/components/user/__tests__/user-menu.test.tsx
+++ b/apps/web/src/components/user/__tests__/user-menu.test.tsx
@@ -99,6 +99,17 @@ describe("UserMenu", () => {
 		expect(myPageLink).toHaveAttribute("href", "/users/me");
 	});
 
+	it("配信中マーキングリンクが常設されている（配信終了後の下書き仕上げ導線）", async () => {
+		const user = userEvent.setup();
+		render(<UserMenu user={mockUser} />);
+
+		const triggerButton = screen.getByRole("button", { name: "ユーザーメニューを開く" });
+		await user.click(triggerButton);
+
+		const liveLink = screen.getByRole("link", { name: /配信中マーキング/i });
+		expect(liveLink).toHaveAttribute("href", "/live");
+	});
+
 	async function clickLogout() {
 		const user = userEvent.setup();
 		render(<UserMenu user={mockUser} />);

--- a/apps/web/src/components/user/user-menu.tsx
+++ b/apps/web/src/components/user/user-menu.tsx
@@ -10,7 +10,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@suzumina.click/ui/components/ui/dropdown-menu";
-import { Heart, LogOut, Settings, User } from "lucide-react";
+import { Bookmark, Heart, LogOut, Settings, User } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { isAuthGatedPath } from "@/lib/auth/auth-redirect";
@@ -83,6 +83,13 @@ export default function UserMenu({ user }: UserMenuProps) {
 					<Link href="/favorites" className="flex items-center gap-2 cursor-pointer">
 						<Heart className="h-4 w-4" />
 						<span>お気に入り</span>
+					</Link>
+				</DropdownMenuItem>
+				{/* 配信終了後も下書きの仕上げに戻れるよう常設する（動画カード側の導線は live/upcoming 時のみ） */}
+				<DropdownMenuItem asChild>
+					<Link href="/live" className="flex items-center gap-2 cursor-pointer">
+						<Bookmark className="h-4 w-4" />
+						<span>配信中マーキング</span>
 					</Link>
 				</DropdownMenuItem>
 				<DropdownMenuItem asChild>

--- a/apps/web/src/lib/auth/__tests__/auth-redirect.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-redirect.test.ts
@@ -10,6 +10,7 @@ describe("isAuthGatedPath", () => {
 		"/users/me/edit",
 		"/buttons/create",
 		"/buttons/RJ123456/edit",
+		"/live",
 	])("認証必須ページ %s は true", (path) => {
 		expect(isAuthGatedPath(path)).toBe(true);
 	});

--- a/apps/web/src/lib/auth/auth-redirect.ts
+++ b/apps/web/src/lib/auth/auth-redirect.ts
@@ -23,6 +23,7 @@ export function isAuthGatedPath(pathname: string): boolean {
 		pathname === "/users/me" ||
 		pathname.startsWith("/users/me/") ||
 		pathname === "/buttons/create" ||
+		pathname === "/live" ||
 		/^\/buttons\/[^/]+\/edit$/.test(pathname)
 	);
 }


### PR DESCRIPTION
## 問題（調査結果）

`/live` への導線は動画カードの「配信中マーク／配信待機」ボタンのみで、`_computed.videoType` が `live` / `possibly_live` / `upcoming` のときにしか表示されない。配信終了（`archived` 化）と同時にサイト上から `/live` へのリンクが消滅する。

一方、下書きの「仕上げる」ボタンは `/live` の下書き一覧にしか存在しないため、**肝心の「配信後に仕上げる」フェーズで URL 直打ち以外の到達手段がなかった**（SPR-146 導線の欠落）。ページ自体は配信なしでも下書き一覧＋手動指定 UI を表示できるため、欠けていたのは導線のみ。

## 変更内容

- **UserMenu（デスクトップ）**: 「配信中マーキング」（Bookmark アイコン → `/live`）をお気に入りと設定の間に常設追加
- **MobileMenu**: ログイン時セクションに「🔖 配信中マーキング」を追加
- **auth-redirect.ts**: `isAuthGatedPath` に `/live` を追記（#784 時点の追記漏れ。`/live` 滞在中ログアウト時の遷移が他の保護ページと揃う）

ラベルは遷移先ページタイトル「配信中マーキング」と完全一致。下書きは per-user のためログイン時メニューへの常設が予測可能性の面でも妥当。

## テスト

- user-menu.test.tsx: リンク常設（href=/live）のテスト追加
- auth-redirect.test.ts: `/live` の gated 判定テスト追加
- `pnpm verify` 全通過

## 備考

下書き件数バッジや連続仕上げキューは SPR-146 第2段の範囲（本PR対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)