### PR TITLE
test(web): mobile-menu のユニットテストを追加

### DIFF
--- a/apps/web/src/components/layout/__tests__/mobile-menu.test.tsx
+++ b/apps/web/src/components/layout/__tests__/mobile-menu.test.tsx
@@ -1,0 +1,95 @@
+import type { UserSession } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import MobileMenu from "../mobile-menu";
+
+// Next.js Linkコンポーネントのモック
+vi.mock("next/link", () => ({
+	default: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+// AuthButtonのモック（認証UIの詳細は auth-button 側のテストで担保）
+vi.mock("../../user/auth-button", () => ({
+	default: ({ user }: { user?: UserSession | null }) => (
+		<div data-testid="auth-button">{user ? "ログイン中" : "ログイン"}</div>
+	),
+}));
+
+const mockUser: UserSession = {
+	discordId: "123456789",
+	username: "testuser",
+	displayName: "テストユーザー",
+	avatar: "avatar-hash",
+	guildMembership: {
+		guildId: "test-guild",
+		userId: "123456789",
+		isMember: true,
+	},
+	isActive: true,
+};
+
+/** SheetTrigger をクリックしてメニューを開く（Radix Sheet は開くまで中身を描画しない） */
+async function openMenu() {
+	const user = userEvent.setup();
+	await user.click(screen.getByRole("button", { name: "メニューを開く" }));
+}
+
+/** リンクテキストと href の対応を検証する */
+function expectLink(name: RegExp, href: string) {
+	expect(screen.getByRole("link", { name })).toHaveAttribute("href", href);
+}
+
+describe("MobileMenu", () => {
+	describe("未ログイン時", () => {
+		it("公開リンクのみ表示され、ログイン時セクションは表示されない", async () => {
+			render(<MobileMenu user={null} />);
+			await openMenu();
+
+			// 公開リンク
+			expectLink(/動画一覧/, "/videos");
+			expectLink(/ボタン検索/, "/buttons");
+			expectLink(/作品一覧/, "/works");
+
+			// ログイン時セクションは非表示
+			expect(screen.queryByRole("link", { name: /お気に入り/ })).not.toBeInTheDocument();
+			expect(screen.queryByRole("link", { name: /マイページ/ })).not.toBeInTheDocument();
+			expect(screen.queryByRole("link", { name: /配信中マーキング/ })).not.toBeInTheDocument();
+			expect(screen.queryByRole("link", { name: /設定/ })).not.toBeInTheDocument();
+
+			// 認証ボタンは常設
+			expect(screen.getByTestId("auth-button")).toHaveTextContent("ログイン");
+		});
+	});
+
+	describe("ログイン時", () => {
+		it("公開リンクに加えてログイン時セクションの各リンクが正しい href で表示される", async () => {
+			render(<MobileMenu user={mockUser} />);
+			await openMenu();
+
+			// 公開リンク
+			expectLink(/動画一覧/, "/videos");
+			expectLink(/ボタン検索/, "/buttons");
+			expectLink(/作品一覧/, "/works");
+
+			// ログイン時セクション（/live は配信終了後も下書き仕上げに戻れる常設導線）
+			expectLink(/お気に入り/, "/favorites");
+			expectLink(/マイページ/, "/users/me");
+			expectLink(/配信中マーキング/, "/live");
+			expectLink(/設定/, "/settings");
+
+			expect(screen.getByTestId("auth-button")).toHaveTextContent("ログイン中");
+		});
+	});
+
+	it("トリガーを開くまでメニューの中身は描画されない", () => {
+		render(<MobileMenu user={mockUser} />);
+
+		expect(screen.getByRole("button", { name: "メニューを開く" })).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /動画一覧/ })).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/components/layout/__tests__/mobile-menu.test.tsx
+++ b/apps/web/src/components/layout/__tests__/mobile-menu.test.tsx
@@ -86,10 +86,12 @@ describe("MobileMenu", () => {
 		});
 	});
 
-	it("トリガーを開くまでメニューの中身は描画されない", () => {
-		render(<MobileMenu user={mockUser} />);
+	describe("Sheet の遅延描画", () => {
+		it("トリガーを開くまでメニューの中身は描画されない", () => {
+			render(<MobileMenu user={mockUser} />);
 
-		expect(screen.getByRole("button", { name: "メニューを開く" })).toBeInTheDocument();
-		expect(screen.queryByRole("link", { name: /動画一覧/ })).not.toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "メニューを開く" })).toBeInTheDocument();
+			expect(screen.queryByRole("link", { name: /動画一覧/ })).not.toBeInTheDocument();
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- PR #797 の Claude AI Review で nit 指摘された既存の欠落（`apps/web/src/components/layout/mobile-menu.tsx` にテストファイルが存在しない）への対応
- 未ログイン/ログイン時のメニュー構造と各リンクの href を検証するテストを新規作成
- 特に #797 で追加した `/live`（配信終了後の下書き仕上げ導線）リンクをログイン時セクションで検証

## Test plan
- [x] 新規テスト単体実行で 3/3 通過
- [x] `pnpm verify`（lint:docs + lint:tokens + lint + typecheck + test、カバレッジ閾値含む）全通過

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>