### PR TITLE
feat(ci): Artifact Registry イメージのdigest単位GCをdeploy後処理で自前実施

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -256,12 +256,18 @@ jobs:
           LATEST_DIGEST=$(gcloud artifacts docker images describe "${IMAGE_PATH}:latest" \
             --format="value(image_summary.digest)" 2>/dev/null || true)
 
-          ALL_VERSIONS=$(gcloud artifacts versions list \
+          # デプロイ自体は既に成功済みのため、一時的なAPIエラーでこのステップ（延いてはjob）を
+          # 失敗扱いにしない。list失敗時はスキップしてexit 0する（削除失敗時の `|| true` と同様の考え方）。
+          if ! ALL_VERSIONS=$(gcloud artifacts versions list \
             --package="${{ env.IMAGE_NAME }}" \
             --repository="${{ env.REPOSITORY }}" \
             --location="${{ env.REGION }}" \
             --sort-by="~createTime" \
-            --format="csv[no-heading](name.basename(),createTime)")
+            --format="csv[no-heading](name.basename(),createTime)" 2>&1); then
+            echo "⚠️ Failed to list Artifact Registry versions (transient API error?), skipping cleanup this run"
+            echo "$ALL_VERSIONS"
+            exit 0
+          fi
 
           if [ -z "$ALL_VERSIONS" ]; then
             echo "No versions found, skipping"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -233,3 +233,74 @@ jobs:
           fi
 
           echo "✅ Revision cleanup completed"
+
+      # Artifact Registry イメージバージョンの掃除
+      # SPR-247: terraform cleanup_policies（artifact_registry.tf）は "web" パッケージで実効性なしと
+      # SPR-220 の再観測で確定した（clean manifest 化後も削除適格な版が10日超残存）。
+      # GCP側のpolicy評価に依存せず、ここでdigest単位のGCを自前実行する。
+      # ロジックは既存policyのセマンティクスを踏襲: keep-recent-versions(5) / keep latest tag / delete older than 7日。
+      # AR_CLEANUP_DRY_RUN=true の間は削除せずログ出力のみ。初回デプロイでdry-run結果を確認してから false にする。
+      - name: Cleanup old Artifact Registry image versions
+        if: always()
+        env:
+          AR_CLEANUP_DRY_RUN: 'true'
+        run: |
+          echo "🧹 Cleaning up old Artifact Registry image versions (dry_run=${AR_CLEANUP_DRY_RUN})..."
+
+          KEEP_COUNT=5
+          CUTOFF_EPOCH=$(date -u -d '7 days ago' +%s)
+
+          IMAGE_PATH="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}"
+
+          # latestタグが指す版のdigest（keep-minimum-versions相当）
+          LATEST_DIGEST=$(gcloud artifacts docker images describe "${IMAGE_PATH}:latest" \
+            --format="value(image_summary.digest)" 2>/dev/null || true)
+
+          ALL_VERSIONS=$(gcloud artifacts versions list \
+            --package="${{ env.IMAGE_NAME }}" \
+            --repository="${{ env.REPOSITORY }}" \
+            --location="${{ env.REGION }}" \
+            --sort-by="~createTime" \
+            --format="csv[no-heading](name.basename(),createTime)")
+
+          if [ -z "$ALL_VERSIONS" ]; then
+            echo "No versions found, skipping"
+            exit 0
+          fi
+
+          INDEX=0
+          PROCESSED=0
+          while IFS=',' read -r DIGEST CREATE_TIME; do
+            [ -z "$DIGEST" ] && continue
+            INDEX=$((INDEX + 1))
+
+            # keep-recent-versions: 直近5版は経過日数に関係なく保持
+            if [ "$INDEX" -le "$KEEP_COUNT" ]; then
+              continue
+            fi
+
+            # keep-minimum-versions: latestタグが指す版は保持
+            if [ -n "$LATEST_DIGEST" ] && [ "$DIGEST" = "$LATEST_DIGEST" ]; then
+              continue
+            fi
+
+            # delete-old: 7日より古い版のみ削除対象
+            CREATE_EPOCH=$(date -u -d "$CREATE_TIME" +%s 2>/dev/null || echo 0)
+            if [ "$CREATE_EPOCH" -eq 0 ] || [ "$CREATE_EPOCH" -ge "$CUTOFF_EPOCH" ]; then
+              continue
+            fi
+
+            if [ "$AR_CLEANUP_DRY_RUN" = "true" ]; then
+              echo "[dry-run] Would delete: $DIGEST (created $CREATE_TIME)"
+            else
+              echo "Deleting old version: $DIGEST (created $CREATE_TIME)"
+              gcloud artifacts versions delete "$DIGEST" \
+                --package="${{ env.IMAGE_NAME }}" \
+                --repository="${{ env.REPOSITORY }}" \
+                --location="${{ env.REGION }}" \
+                --quiet || echo "  ⚠️ Failed to delete $DIGEST"
+            fi
+            PROCESSED=$((PROCESSED + 1))
+          done <<< "$ALL_VERSIONS"
+
+          echo "✅ Processed $PROCESSED old Artifact Registry version(s) (dry_run=${AR_CLEANUP_DRY_RUN})"

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -7,6 +7,14 @@
  * イメージ GC の正本はこのファイルの cleanup_policies（ADR-009 原則3: GC は Terraform ネイティブに一本化）。
  * deploy-web.yml / deploy-functions.yml の手動 image 削除は SPR-96 で撤去し、二重管理を解消した。
  *
+ * 【例外】docker_repo（web パッケージ）の cleanup_policies は SPR-220 の再観測（2026-07-06）で
+ * このリポジトリに対して実効性がないと確定した（clean manifest 化後も delete-old 対象の版が
+ * 10日超残存）。原因不明の GCP 側の挙動のため、policy 定義自体は「宣言的な意図・将来 GCP 側で
+ * 動くようになった場合の保険」として残す（実害はない）。実際の削除実行は SPR-247 により
+ * deploy-web.yml の post-deploy ステップが digest 単位で自前実施する（このファイルの
+ * ポリシーと同じ keep-recent-versions=5 / latest タグ保持 / 7日超削除のロジックを踏襲）。
+ * gcf-artifacts（Cloud Functions）側は cleanup_policies が正常に機能しており対象外。
+ *
  * cleanup_policies のセマンティクス（公式仕様）:
  *   - KEEP は DELETE に優先する（両方に一致する版は「保持」される）
  *   - most_recent_versions(keep_count) は「パッケージ単位」で最新 N 版を保持する


### PR DESCRIPTION
## Summary
- SPR-220 の再観測で、`terraform/artifact_registry.tf` の cleanup_policies が "web" パッケージに対して実効性がないと確定した（clean manifest 化後も delete-old 対象の版が10日超残存）
- GCP側のpolicy評価に依存せず、`deploy-web.yml` のpost-deployステップで既存policyと同じロジック（keep-recent-versions=5 / latestタグ保持 / 7日超削除）をdigest単位で自前実行する
- 既存のterraform cleanup_policiesは実害がないため残す（将来GCP側の挙動が変わった場合の保険として declarative な意図を保持）。実削除責務がworkflow側に移った旨をコメントに明記
- IAM追加変更は不要（SPR-96以前の手動運用時代の`githubActionsArtifactRegistryManager`カスタムロールが`artifactregistry.versions.delete`等を含んだまま残存）

## Safety
- `AR_CLEANUP_DRY_RUN=true` をデフォルトにし、初回はログ出力のみで実削除しない
- マージ後、dry-runログを確認してから別PRで `false` に切り替える運用

Closes SPR-247 (Linear)

## Test plan
- [ ] マージ後、実際のdeployでdry-runログの対象版・削除ロジックが妥当か確認
- [ ] 問題なければ `AR_CLEANUP_DRY_RUN=false` へ切り替えるPRを作成
- [ ] 本番適用後 1〜2 deployサイクルで実際に古いバージョンが削除されることを観測確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)