### PR TITLE
feat(web): 区間指定UXの軽量化 — 時刻入力の寛容化と I/O キーショートカット (SPR-266 Phase 1)

### DIFF
--- a/apps/web/src/components/audio/time-control-panel.tsx
+++ b/apps/web/src/components/audio/time-control-panel.tsx
@@ -77,8 +77,12 @@ export function TimeControlPanel({
 
 			{/* 範囲選択 */}
 			<div className="space-y-4">
-				<div className="text-sm sm:text-base font-medium">
+				<div className="text-sm sm:text-base font-medium flex items-baseline justify-between gap-2">
 					<span>切り抜き範囲</span>
+					{/* キーボード前提の端末だけに出す（モバイルでは意味を成さないヒント） */}
+					<span className="hidden sm:inline text-xs text-muted-foreground font-normal">
+						I キー = 開始 / O キー = 終了
+					</span>
 				</div>
 
 				{/* 時間設定ボタン: モバイル対応 */}

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createButtonDraft, deleteButtonDraft } from "@/actions/button-drafts";
 import { trackMarkDraft } from "@/lib/analytics/events";
+import { matchShortcutKey } from "@/lib/keyboard-shortcut";
 
 interface LiveCaptureViewProps {
 	video: VideoPlainObject | null;
@@ -113,17 +114,10 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 		}
 	}, [video, isMarking]);
 
-	// M キーでマーク（入力欄フォーカス中とキーリピートは無視）
+	// M キーでマーク。ガードの正本は matchShortcutKey（create/edit の I/O キーと共通・SPR-266）
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
-			if (event.key.toLowerCase() !== "m" || event.repeat) {
-				return;
-			}
-			const target = event.target as HTMLElement | null;
-			if (
-				target &&
-				(/^(input|textarea|select)$/i.test(target.tagName) || target.isContentEditable)
-			) {
+			if (matchShortcutKey(event, ["m"]) === null) {
 				return;
 			}
 			event.preventDefault();

--- a/apps/web/src/hooks/__tests__/use-audio-button-editor.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-audio-button-editor.test.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAudioButtonEditor } from "../use-audio-button-editor";
+
+// I/O ショートカットの検証対象は「現在再生位置を開始/終了に設定する」動作のため、
+// プレイヤー由来の currentTime を固定値で返すモックにする（jsdom に実プレイヤーは無い）
+vi.mock("../use-youtube-player-manager", () => ({
+	useYouTubePlayerManager: () => ({
+		youtubePlayerRef: { current: null },
+		videoId: "dQw4w9WgXcQ",
+		videoDuration: 600,
+		currentTime: 42.5,
+		isPlayerReady: true,
+		isLoading: false,
+		setVideoId: vi.fn(),
+		onPlayerReady: vi.fn(),
+		onPlayerStateChange: vi.fn(),
+		playRange: vi.fn(),
+		seekTo: vi.fn(),
+		getCurrentPlayerTime: vi.fn(),
+	}),
+}));
+
+function pressKey(key: string, options: KeyboardEventInit = {}) {
+	act(() => {
+		document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...options }));
+	});
+}
+
+describe("useAudioButtonEditor の I/O ショートカット（SPR-266）", () => {
+	const config = { videoId: "dQw4w9WgXcQ", videoTitle: "テスト動画", videoDuration: 600 };
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("I キーで現在再生位置が開始時間になる", () => {
+		const { result } = renderHook(() => useAudioButtonEditor(config));
+
+		pressKey("i");
+
+		expect(result.current.timeAdjustment.startTime).toBe(42.5);
+	});
+
+	it("O キーで現在再生位置が終了時間になる（大文字も可）", () => {
+		const { result } = renderHook(() => useAudioButtonEditor(config));
+
+		pressKey("O");
+
+		expect(result.current.timeAdjustment.endTime).toBe(42.5);
+	});
+
+	it("入力欄フォーカス中は無視される", () => {
+		const { result } = renderHook(() => useAudioButtonEditor(config));
+		const input = document.createElement("input");
+		document.body.appendChild(input);
+
+		act(() => {
+			input.dispatchEvent(new KeyboardEvent("keydown", { key: "i", bubbles: true }));
+		});
+
+		expect(result.current.timeAdjustment.startTime).toBe(0);
+		input.remove();
+	});
+
+	it("修飾キー付き・キーリピートは無視される", () => {
+		const { result } = renderHook(() => useAudioButtonEditor(config));
+
+		pressKey("i", { metaKey: true });
+		pressKey("i", { ctrlKey: true });
+		pressKey("o", { repeat: true });
+
+		expect(result.current.timeAdjustment.startTime).toBe(0);
+		// 初期 endTime は initialStartTime + 10 = 10
+		expect(result.current.timeAdjustment.endTime).toBe(10);
+	});
+
+	it("処理中（作成/更新中）は無効化される", () => {
+		const { result } = renderHook(() => useAudioButtonEditor(config));
+
+		act(() => {
+			result.current.setState.setIsProcessing(true);
+		});
+		pressKey("i");
+
+		expect(result.current.timeAdjustment.startTime).toBe(0);
+	});
+});

--- a/apps/web/src/hooks/__tests__/use-time-adjustment.test.ts
+++ b/apps/web/src/hooks/__tests__/use-time-adjustment.test.ts
@@ -258,12 +258,43 @@ describe("useTimeAdjustment", () => {
 			expect(parsed).toBe(12 * 60 + 34 + 0.5);
 		});
 
+		it("小数なしの mm:ss / h:mm:ss をパースできる（SPR-266 寛容化）", () => {
+			const { result } = renderHook(() => useTimeAdjustment(defaultProps));
+
+			expect(result.current.parseTimeString("1:23")).toBe(83);
+			expect(result.current.parseTimeString("1:02:03")).toBe(3723);
+			// 分・秒は1桁も許容（"1:2:3" = 1時間2分3秒）
+			expect(result.current.parseTimeString("1:2:3")).toBe(3723);
+			expect(result.current.parseTimeString("1:5")).toBe(65);
+			// 長時間配信対応: m:ss の分は 60 以上も受ける
+			expect(result.current.parseTimeString("90:00")).toBe(5400);
+		});
+
+		it("素の秒数をパースできる（SPR-266 寛容化）", () => {
+			const { result } = renderHook(() => useTimeAdjustment(defaultProps));
+
+			expect(result.current.parseTimeString("83")).toBe(83);
+			expect(result.current.parseTimeString("83.4")).toBe(83.4);
+			expect(result.current.parseTimeString(" 83 ")).toBe(83);
+		});
+
+		it("小数は複数桁も受ける", () => {
+			const { result } = renderHook(() => useTimeAdjustment(defaultProps));
+
+			expect(result.current.parseTimeString("1:23.45")).toBe(83.45);
+		});
+
 		it("無効な形式は null を返す", () => {
 			const { result } = renderHook(() => useTimeAdjustment(defaultProps));
 
 			expect(result.current.parseTimeString("invalid")).toBe(null);
-			expect(result.current.parseTimeString("1:2:3")).toBe(null);
 			expect(result.current.parseTimeString("")).toBe(null);
+			// 値として 60 以上の分・秒は不正
+			expect(result.current.parseTimeString("1:60")).toBe(null);
+			expect(result.current.parseTimeString("1:2:60")).toBe(null);
+			expect(result.current.parseTimeString("1:60:03")).toBe(null);
+			expect(result.current.parseTimeString("-5")).toBe(null);
+			expect(result.current.parseTimeString("1:23:45:6")).toBe(null);
 		});
 
 		it("境界値が正しく処理される", () => {

--- a/apps/web/src/hooks/use-audio-button-editor.ts
+++ b/apps/web/src/hooks/use-audio-button-editor.ts
@@ -50,6 +50,26 @@ export interface AudioButtonEditorResult {
 }
 
 /**
+ * I/O ショートカットとして処理すべきキー入力なら "in" | "out" を返す。
+ * ガード方針は /live の M キー（live-capture-view）と同一:
+ * 入力欄フォーカス中・キーリピート・修飾キー付きは対象外（null）。
+ */
+function matchInOutHotkey(event: KeyboardEvent): "in" | "out" | null {
+	if (event.repeat || event.ctrlKey || event.metaKey || event.altKey) {
+		return null;
+	}
+	const key = event.key.toLowerCase();
+	if (key !== "i" && key !== "o") {
+		return null;
+	}
+	const target = event.target as HTMLElement | null;
+	if (target && (/^(input|textarea|select)$/i.test(target.tagName) || target.isContentEditable)) {
+		return null;
+	}
+	return key === "i" ? "in" : "out";
+}
+
+/**
  * 音声ボタン作成・編集の共通ロジックを提供するフック
  */
 export function useAudioButtonEditor(config: AudioButtonEditorConfig): AudioButtonEditorResult {
@@ -121,6 +141,29 @@ export function useAudioButtonEditor(config: AudioButtonEditorConfig): AudioButt
 		tags,
 		description,
 	});
+
+	// I/O キーで再生位置を開始/終了時間に設定（SPR-266 区間指定UX）。
+	// 処理中（作成/更新中）はボタン disabled と挙動を揃えて無効化する。
+	const { setCurrentAsStart, setCurrentAsEnd } = timeAdjustment;
+	useEffect(() => {
+		if (isProcessing) {
+			return;
+		}
+		const onKeyDown = (event: KeyboardEvent) => {
+			const hotkey = matchInOutHotkey(event);
+			if (!hotkey) {
+				return;
+			}
+			event.preventDefault();
+			if (hotkey === "in") {
+				setCurrentAsStart();
+			} else {
+				setCurrentAsEnd();
+			}
+		};
+		document.addEventListener("keydown", onKeyDown);
+		return () => document.removeEventListener("keydown", onKeyDown);
+	}, [setCurrentAsStart, setCurrentAsEnd, isProcessing]);
 
 	// 変更があるかチェック（編集モードの場合）
 	const hasChanges = useMemo(() => {

--- a/apps/web/src/hooks/use-audio-button-editor.ts
+++ b/apps/web/src/hooks/use-audio-button-editor.ts
@@ -1,5 +1,6 @@
 import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { matchShortcutKey } from "@/lib/keyboard-shortcut";
 import { useAudioButtonValidation } from "./use-audio-button-validation";
 import { useTimeAdjustment } from "./use-time-adjustment";
 import { useTimeHandlers } from "./use-time-handlers";
@@ -47,26 +48,6 @@ export interface AudioButtonEditorResult {
 
 	// 変更検出（編集モードの場合）
 	hasChanges: boolean;
-}
-
-/**
- * I/O ショートカットとして処理すべきキー入力なら "in" | "out" を返す。
- * ガード方針は /live の M キー（live-capture-view）と同一:
- * 入力欄フォーカス中・キーリピート・修飾キー付きは対象外（null）。
- */
-function matchInOutHotkey(event: KeyboardEvent): "in" | "out" | null {
-	if (event.repeat || event.ctrlKey || event.metaKey || event.altKey) {
-		return null;
-	}
-	const key = event.key.toLowerCase();
-	if (key !== "i" && key !== "o") {
-		return null;
-	}
-	const target = event.target as HTMLElement | null;
-	if (target && (/^(input|textarea|select)$/i.test(target.tagName) || target.isContentEditable)) {
-		return null;
-	}
-	return key === "i" ? "in" : "out";
 }
 
 /**
@@ -142,28 +123,37 @@ export function useAudioButtonEditor(config: AudioButtonEditorConfig): AudioButt
 		description,
 	});
 
-	// I/O キーで再生位置を開始/終了時間に設定（SPR-266 区間指定UX）。
+	// I/O キーで再生位置を開始/終了時間に設定（SPR-266 区間指定UX）。ガードの正本は matchShortcutKey。
 	// 処理中（作成/更新中）はボタン disabled と挙動を揃えて無効化する。
-	const { setCurrentAsStart, setCurrentAsEnd } = timeAdjustment;
+	// setCurrentAsStart/End は currentTime 依存で毎再生ティックに再生成されるため、
+	// ref 経由で最新を呼び、リスナーの張り直しを isProcessing の変化時だけに抑える。
+	const hotkeyActionsRef = useRef({
+		setCurrentAsStart: timeAdjustment.setCurrentAsStart,
+		setCurrentAsEnd: timeAdjustment.setCurrentAsEnd,
+	});
+	hotkeyActionsRef.current = {
+		setCurrentAsStart: timeAdjustment.setCurrentAsStart,
+		setCurrentAsEnd: timeAdjustment.setCurrentAsEnd,
+	};
 	useEffect(() => {
 		if (isProcessing) {
 			return;
 		}
 		const onKeyDown = (event: KeyboardEvent) => {
-			const hotkey = matchInOutHotkey(event);
+			const hotkey = matchShortcutKey(event, ["i", "o"]);
 			if (!hotkey) {
 				return;
 			}
 			event.preventDefault();
-			if (hotkey === "in") {
-				setCurrentAsStart();
+			if (hotkey === "i") {
+				hotkeyActionsRef.current.setCurrentAsStart();
 			} else {
-				setCurrentAsEnd();
+				hotkeyActionsRef.current.setCurrentAsEnd();
 			}
 		};
 		document.addEventListener("keydown", onKeyDown);
 		return () => document.removeEventListener("keydown", onKeyDown);
-	}, [setCurrentAsStart, setCurrentAsEnd, isProcessing]);
+	}, [isProcessing]);
 
 	// 変更があるかチェック（編集モードの場合）
 	const hasChanges = useMemo(() => {

--- a/apps/web/src/hooks/use-time-validation.ts
+++ b/apps/web/src/hooks/use-time-validation.ts
@@ -11,25 +11,42 @@ export interface TimeValidationUtilities {
  * 時間文字列のパース、時間のクランプ、範囲検証を提供
  */
 export function useTimeValidation(): TimeValidationUtilities {
-	// 時間文字列をパースする関数
+	// 時間文字列をパースする関数。
+	// h:mm:ss / m:ss / 素の秒数 の3形式を受け付け、小数は任意（桁数自由）。
+	// 旧実装は「小数1桁必須」の厳格形式のみで "1:23" や "83" が silent に破棄されていた（SPR-266 で寛容化）。
+	// 分・秒の桁は1桁も許容（"1:2:3" = 1時間2分3秒）するが、値としての 60 以上は不正として弾く。
 	const parseTimeString = useCallback((timeStr: string): number | null => {
-		// 時:分:秒.小数 形式 (例: 1:23:45.6)
-		const hourMatch = timeStr.match(/^(\d+):(\d{2}):(\d{2})\.(\d)$/);
-		if (hourMatch?.[1] && hourMatch[2] && hourMatch[3] && hourMatch[4]) {
+		const trimmed = timeStr.trim();
+		const fraction = (digits: string | undefined): number =>
+			digits ? Number.parseFloat(`0.${digits}`) : 0;
+
+		// 時:分:秒 形式 (例: 1:23:45.6 / 1:2:3)
+		const hourMatch = trimmed.match(/^(\d+):(\d{1,2}):(\d{1,2})(?:\.(\d+))?$/);
+		if (hourMatch?.[1] && hourMatch[2] && hourMatch[3]) {
 			const hours = Number.parseInt(hourMatch[1], 10);
 			const minutes = Number.parseInt(hourMatch[2], 10);
 			const seconds = Number.parseInt(hourMatch[3], 10);
-			const decimal = Number.parseInt(hourMatch[4], 10);
-			return hours * 3600 + minutes * 60 + seconds + decimal / 10;
+			if (minutes >= 60 || seconds >= 60) {
+				return null;
+			}
+			return hours * 3600 + minutes * 60 + seconds + fraction(hourMatch[4]);
 		}
 
-		// 分:秒.小数 形式 (例: 50:12.3)
-		const minuteMatch = timeStr.match(/^(\d+):(\d{2})\.(\d)$/);
-		if (minuteMatch?.[1] && minuteMatch[2] && minuteMatch[3]) {
+		// 分:秒 形式 (例: 50:12.3 / 1:23)。長時間配信対応のため分は 60 以上も許容する
+		const minuteMatch = trimmed.match(/^(\d+):(\d{1,2})(?:\.(\d+))?$/);
+		if (minuteMatch?.[1] && minuteMatch[2]) {
 			const minutes = Number.parseInt(minuteMatch[1], 10);
 			const seconds = Number.parseInt(minuteMatch[2], 10);
-			const decimal = Number.parseInt(minuteMatch[3], 10);
-			return minutes * 60 + seconds + decimal / 10;
+			if (seconds >= 60) {
+				return null;
+			}
+			return minutes * 60 + seconds + fraction(minuteMatch[3]);
+		}
+
+		// 素の秒数 (例: 83 / 83.4)
+		const secondsMatch = trimmed.match(/^(\d+)(?:\.(\d+))?$/);
+		if (secondsMatch?.[1]) {
+			return Number.parseInt(secondsMatch[1], 10) + fraction(secondsMatch[2]);
 		}
 
 		return null;

--- a/apps/web/src/lib/__tests__/keyboard-shortcut.test.ts
+++ b/apps/web/src/lib/__tests__/keyboard-shortcut.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { matchShortcutKey } from "../keyboard-shortcut";
+
+function keyEvent(key: string, options: KeyboardEventInit = {}): KeyboardEvent {
+	return new KeyboardEvent("keydown", { key, ...options });
+}
+
+describe("matchShortcutKey", () => {
+	it("対象キーなら小文字で返す（大文字入力も可）", () => {
+		expect(matchShortcutKey(keyEvent("i"), ["i", "o"])).toBe("i");
+		expect(matchShortcutKey(keyEvent("O"), ["i", "o"])).toBe("o");
+		expect(matchShortcutKey(keyEvent("m"), ["m"])).toBe("m");
+	});
+
+	it("対象外キーは null", () => {
+		expect(matchShortcutKey(keyEvent("x"), ["i", "o"])).toBe(null);
+		expect(matchShortcutKey(keyEvent("Enter"), ["m"])).toBe(null);
+	});
+
+	it("キーリピートは null", () => {
+		expect(matchShortcutKey(keyEvent("i", { repeat: true }), ["i"])).toBe(null);
+	});
+
+	it("修飾キー付きはブラウザ/OS に譲る（null）", () => {
+		expect(matchShortcutKey(keyEvent("i", { ctrlKey: true }), ["i"])).toBe(null);
+		expect(matchShortcutKey(keyEvent("i", { metaKey: true }), ["i"])).toBe(null);
+		expect(matchShortcutKey(keyEvent("m", { altKey: true }), ["m"])).toBe(null);
+	});
+
+	it("入力欄フォーカス中（event.target が input 等）は null", () => {
+		for (const tag of ["input", "textarea", "select"]) {
+			const el = document.createElement(tag);
+			document.body.appendChild(el);
+			let result: string | null = "unset";
+			el.addEventListener("keydown", (e) => {
+				result = matchShortcutKey(e, ["i"]);
+			});
+			el.dispatchEvent(keyEvent("i", { bubbles: true }));
+			expect(result).toBe(null);
+			el.remove();
+		}
+	});
+
+	it("contentEditable 要素フォーカス中も null", () => {
+		const el = document.createElement("div");
+		// jsdom では isContentEditable が反映されないため直接定義する
+		Object.defineProperty(el, "isContentEditable", { value: true });
+		document.body.appendChild(el);
+		let result: string | null = "unset";
+		el.addEventListener("keydown", (e) => {
+			result = matchShortcutKey(e, ["i"]);
+		});
+		el.dispatchEvent(keyEvent("i", { bubbles: true }));
+		expect(result).toBe(null);
+		el.remove();
+	});
+});

--- a/apps/web/src/lib/keyboard-shortcut.ts
+++ b/apps/web/src/lib/keyboard-shortcut.ts
@@ -1,0 +1,23 @@
+/**
+ * グローバルなキーボードショートカットとして処理すべきキー入力か判定し、
+ * 該当キー（小文字）を返す。対象外なら null。
+ *
+ * ガードの正本（SPR-266）: /live の M キーと create/edit の I/O キーの両方がこれを使う。
+ * - 入力欄（input/textarea/select/contentEditable）フォーカス中は無視
+ * - キーリピートは無視（押しっぱなしの連発防止）
+ * - 修飾キー付き（Ctrl/Meta/Alt）はブラウザ・OS のショートカットに譲る
+ */
+export function matchShortcutKey(event: KeyboardEvent, keys: readonly string[]): string | null {
+	if (event.repeat || event.ctrlKey || event.metaKey || event.altKey) {
+		return null;
+	}
+	const key = event.key.toLowerCase();
+	if (!keys.includes(key)) {
+		return null;
+	}
+	const target = event.target as HTMLElement | null;
+	if (target && (/^(input|textarea|select)$/i.test(target.tagName) || target.isContentEditable)) {
+		return null;
+	}
+	return key;
+}


### PR DESCRIPTION
## 概要

[SPR-266](https://linear.app/nothink/issue/SPR-266)（下書きキュー＋連続仕上げ）の **Phase 1 = 区間指定UXの軽量化**（旧 SPR-147 分）。フェーズ分割の初弾で、通常作成・編集・下書き仕上げのすべてに効く土台。

## 変更内容

### 1. 時刻入力の寛容化（`parseTimeString`）

旧実装は「小数1桁必須」の厳格形式（`m:ss.d` / `h:mm:ss.d`）のみ受け付け、`1:23` や `83` の入力が **silent に破棄**されていた（SPR-147 の痛み「mm:ss 想定とズレる」の正体）。以下をすべて受け付けるよう変更:

- `h:mm:ss`（分・秒は1桁も可、値60以上は不正として弾く）
- `m:ss`（長時間配信対応のため分は60以上も許容: `90:00` = 90分）
- 素の秒数（`83` / `83.4`）
- 小数は任意・桁数自由（`1:23.45` も可）

### 2. I/O キーショートカット

再生位置を **I キー = 開始時間 / O キー = 終了時間** に設定。create/edit 共通の `useAudioButtonEditor` に実装し両画面で有効。ガード方針は /live の M キーと同一（入力欄フォーカス中・リピート・修飾キー付きは無視、処理中は無効化）。切り抜き範囲ヘッダにデスクトップのみのヒント表示を追加。

## テスト

- `use-time-adjustment.test.ts`: 寛容化の受理/拒否ケースを追加（`1:2:3` は仕様変更で null → 3723 に更新）
- `use-audio-button-editor.test.tsx`: 新規。I/O 設定・入力欄ガード・修飾キー/リピート無視・処理中無効化
- `pnpm verify` 全通過

## 備考

Phase 2（連続仕上げフロー）・Phase 3（/live 下書きキュー画面）は別 PR で継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)