### PR TITLE
feat(web): 下書きの連続仕上げフロー — 同一動画キューを遷移なしで消化 (SPR-266 Phase 2)

### DIFF
--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -160,7 +160,8 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	// getMyButtonDrafts は未ログイン時に success:false を返すだけなので ProtectedRoute の外で呼んでも安全
 	let videoDrafts: AudioButtonDraft[] | undefined;
 	if (resolvedSearchParams.draft_id) {
-		const draftsResult = await getMyButtonDrafts();
+		// 既定 limit=100 だと下書き多数のユーザーでキューが黙って欠けるため、保持上限の500で全件取る
+		const draftsResult = await getMyButtonDrafts(500);
 		if (draftsResult.success) {
 			videoDrafts = draftsResult.data
 				.filter((draft) => draft.videoId === videoId)

--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -1,4 +1,5 @@
 import {
+	type AudioButtonDraft,
 	canCreateAudioButton,
 	getAudioButtonCreationErrorMessage,
 	parseDurationToSeconds,
@@ -7,6 +8,7 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 import { AlertCircle, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { getMyButtonDrafts } from "@/actions/button-drafts";
 import { getVideoById } from "@/app/videos/actions";
 import { AudioButtonCreator } from "@/components/audio/audio-button-creator";
 import ProtectedRoute from "@/components/system/protected-route";
@@ -154,6 +156,18 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	// フォールバック: 取得失敗時は10分
 	const videoDuration = videoDurationSeconds > 0 ? videoDurationSeconds : 600;
 
+	// 下書き起点のときだけ同一動画の下書きキューを渡す（連続仕上げ・SPR-266）。
+	// getMyButtonDrafts は未ログイン時に success:false を返すだけなので ProtectedRoute の外で呼んでも安全
+	let videoDrafts: AudioButtonDraft[] | undefined;
+	if (resolvedSearchParams.draft_id) {
+		const draftsResult = await getMyButtonDrafts();
+		if (draftsResult.success) {
+			videoDrafts = draftsResult.data
+				.filter((draft) => draft.videoId === videoId)
+				.sort((a, b) => a.suggestedStartTime - b.suggestedStartTime);
+		}
+	}
+
 	const callbackQuery = new URLSearchParams(
 		Object.entries({
 			video_id: videoId,
@@ -176,6 +190,7 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 				videoDuration={videoDuration}
 				initialStartTime={startTime}
 				draftId={resolvedSearchParams.draft_id}
+				videoDrafts={videoDrafts}
 			/>
 		</ProtectedRoute>
 	);

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -13,6 +13,12 @@ vi.mock("@/app/buttons/actions", () => ({
 	}),
 }));
 
+// Mock draft actions（連続仕上げ・SPR-266）
+const mockDeleteButtonDraft = vi.fn().mockResolvedValue({ success: true });
+vi.mock("@/actions/button-drafts", () => ({
+	deleteButtonDraft: (draftId: string) => mockDeleteButtonDraft(draftId),
+}));
+
 // Mock rate limit actions
 vi.mock("@/actions/rate-limit-actions", () => ({
 	getUserRateLimitInfo: vi.fn().mockResolvedValue({
@@ -444,6 +450,112 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			rerender(<AudioButtonCreator key="video-b" {...defaultProps} videoId="other-video" />);
 
 			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
+		});
+	});
+
+	describe("連続仕上げ（下書きキュー・SPR-266 第2段）", () => {
+		const makeDraft = (id: string, suggestedStartTime: number) => ({
+			id,
+			videoId: "test-video-id",
+			videoTitle: "テスト動画タイトル",
+			playerTime: suggestedStartTime + 15,
+			markedAt: "2026-07-15T12:00:00.000Z",
+			createdAt: "2026-07-15T12:00:00.000Z",
+			suggestedStartTime,
+		});
+
+		async function createWithTitle(user: ReturnType<typeof userEvent.setup>, title: string) {
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), title);
+			const createButton = screen.getByRole("button", { name: /音声ボタンを作成/ });
+			await waitFor(() => expect(createButton).toBeEnabled());
+			await user.click(createButton);
+		}
+
+		it("キューに残りがあれば遷移せず次の下書きへ進む（フォームリセット＋プレイヤー維持）", async () => {
+			const user = userEvent.setup();
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					initialStartTime={30}
+					draftId="draft-1"
+					videoDrafts={[makeDraft("draft-1", 30), makeDraft("draft-2", 120)]}
+				/>,
+			);
+
+			// キューパネルに次の下書きが見えている
+			expect(screen.getByText("仕上げキュー")).toBeInTheDocument();
+			expect(screen.getByText(/次: 02:00 付近/)).toBeInTheDocument();
+
+			await createWithTitle(user, "1個目のボタン");
+
+			// 消化（削除）される
+			await waitFor(() => {
+				expect(mockDeleteButtonDraft).toHaveBeenCalledWith("draft-1");
+			});
+			// 遷移せずフォームが次の下書きへ: タイトルはリセット・開始時間は次の下書きの推奨秒
+			expect(mockPush).not.toHaveBeenCalled();
+			expect(screen.getByRole("heading", { name: /音声ボタンを作成/ })).toBeInTheDocument();
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
+			await waitFor(() => {
+				expect(screen.getByDisplayValue("2:00.0")).toBeInTheDocument();
+			});
+			// プレイヤーは遷移せず seek で次の位置へ
+			expect(mockYouTubePlayer.seekTo).toHaveBeenCalledWith(120, true);
+			// 成功バナーが出る（作成したボタンへは新規タブリンク）
+			expect(screen.getByText(/「1個目のボタン」を作成しました/)).toBeInTheDocument();
+			expect(screen.getByRole("link", { name: /開く/ })).toHaveAttribute(
+				"href",
+				"/buttons/new-audio-button-id",
+			);
+		});
+
+		it("最後の下書きなら従来どおり詳細ページへフルロード遷移する", async () => {
+			const user = userEvent.setup();
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					initialStartTime={30}
+					draftId="draft-1"
+					videoDrafts={[makeDraft("draft-1", 30)]}
+				/>,
+			);
+
+			await createWithTitle(user, "最後のボタン");
+
+			await waitFor(() => {
+				expect(mockDeleteButtonDraft).toHaveBeenCalledWith("draft-1");
+			});
+			await waitFor(() => {
+				expect(window.location.href).toContain("/buttons/new-audio-button-id");
+			});
+			expect(mockPush).not.toHaveBeenCalled();
+		});
+
+		it("スキップは下書きを消化せず次へ進む", async () => {
+			const user = userEvent.setup();
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					initialStartTime={30}
+					draftId="draft-1"
+					videoDrafts={[makeDraft("draft-1", 30), makeDraft("draft-2", 120)]}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /スキップして次へ/ }));
+
+			expect(mockDeleteButtonDraft).not.toHaveBeenCalled();
+			await waitFor(() => {
+				expect(screen.getByDisplayValue("2:00.0")).toBeInTheDocument();
+			});
+			// キューが尽きたら「最後の下書き」の案内に変わる
+			expect(screen.getByText(/これが最後の下書きです/)).toBeInTheDocument();
+		});
+
+		it("下書きキューなし（通常作成）ではキューパネルを出さない", () => {
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			expect(screen.queryByText("仕上げキュー")).not.toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -11,6 +11,7 @@ import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
 import { trackCreateError, trackCreateStart, trackCreateSuccess } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
+import { formatSeconds } from "@/utils/format-seconds";
 import { BasicInfoPanel } from "./basic-info-panel";
 import { CreateButtonLimit } from "./create-button-limit";
 import { TimeControlPanel } from "./time-control-panel";
@@ -28,16 +29,6 @@ interface AudioButtonCreatorProps {
 	 * 作成成功後に遷移せず次の下書きへ進む連続仕上げに使う（SPR-266 第2段）
 	 */
 	videoDrafts?: AudioButtonDraft[];
-}
-
-// キュー表示用の整数秒フォーマット（live-capture-view の下書き一覧と同表記）
-function formatQueueTime(total: number): string {
-	const s = Math.floor(total % 60);
-	const m = Math.floor((total / 60) % 60);
-	const h = Math.floor(total / 3600);
-	const mm = String(m).padStart(2, "0");
-	const ss = String(s).padStart(2, "0");
-	return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
 /**
@@ -270,7 +261,7 @@ export function AudioButtonCreator({
 									{remainingDrafts[0] ? (
 										<div className="flex items-center justify-between gap-2">
 											<span className="text-muted-foreground">
-												次: {formatQueueTime(remainingDrafts[0].suggestedStartTime)} 付近
+												次: {formatSeconds(remainingDrafts[0].suggestedStartTime)} 付近
 											</span>
 											<Button
 												size="sm"

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import type { CreateAudioButtonInput } from "@suzumina.click/shared-types";
+import type { AudioButtonDraft, CreateAudioButtonInput } from "@suzumina.click/shared-types";
 import { YouTubePlayer } from "@suzumina.click/ui/components/custom/youtube-player";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Loader2, Plus } from "lucide-react";
+import { ExternalLink, Loader2, Plus, SkipForward } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { deleteButtonDraft } from "@/actions/button-drafts";
 import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
@@ -23,6 +23,21 @@ interface AudioButtonCreatorProps {
 	initialStartTime?: number;
 	/** /live の下書きから開いた場合の下書きID。作成成功時に消化（削除）する（SPR-146） */
 	draftId?: string;
+	/**
+	 * 同一動画の下書きキュー（suggestedStartTime 昇順・現在の下書きを含む）。
+	 * 作成成功後に遷移せず次の下書きへ進む連続仕上げに使う（SPR-266 第2段）
+	 */
+	videoDrafts?: AudioButtonDraft[];
+}
+
+// キュー表示用の整数秒フォーマット（live-capture-view の下書き一覧と同表記）
+function formatQueueTime(total: number): string {
+	const s = Math.floor(total % 60);
+	const m = Math.floor((total / 60) % 60);
+	const h = Math.floor(total / 3600);
+	const mm = String(m).padStart(2, "0");
+	const ss = String(s).padStart(2, "0");
+	return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
 /**
@@ -39,6 +54,7 @@ export function AudioButtonCreator({
 	videoDuration = 600,
 	initialStartTime = 0,
 	draftId,
+	videoDrafts,
 }: AudioButtonCreatorProps) {
 	const router = useRouter();
 	const user = useSession();
@@ -62,13 +78,60 @@ export function AudioButtonCreator({
 	} = setState;
 	const isValid = validation.isValid;
 
+	// 連続仕上げの状態（SPR-266 第2段）。activeDraftId が「今仕上げている下書き」の正本で、
+	// prop の draftId は初期値にすぎない（キューを進むと変わる）
+	const [activeDraftId, setActiveDraftId] = useState(draftId);
+	const [remainingDrafts, setRemainingDrafts] = useState<AudioButtonDraft[]>(() =>
+		(videoDrafts ?? []).filter((draft) => draft.id !== draftId),
+	);
+	const [lastCreated, setLastCreated] = useState<{ id: string; buttonText: string } | null>(null);
+
+	// 次の下書きへフォームとプレイヤーを進める（遷移なし＝プレイヤー維持が連続仕上げの本体）
+	const { setStartTime, setEndTime } = timeAdjustment;
+	const { seekTo, videoDuration: playerDuration } = youtubeManager;
+	const advanceToDraft = useCallback(
+		(next: AudioButtonDraft) => {
+			const duration = playerDuration || videoDuration;
+			// VOD は末尾が最大 ~20s 短くなる場合があるため終端付近はクランプ（SPR-145 実測）
+			const start = Math.min(next.suggestedStartTime, Math.max(0, duration - 1));
+			const end = Math.min(start + 10, duration);
+			setActiveDraftId(next.id);
+			setButtonText("");
+			setDescription("");
+			setTags([]);
+			setError("");
+			setStartTime(start);
+			setEndTime(end);
+			seekTo(start);
+		},
+		[
+			playerDuration,
+			videoDuration,
+			setButtonText,
+			setDescription,
+			setTags,
+			setError,
+			setStartTime,
+			setEndTime,
+			seekTo,
+		],
+	);
+
+	// スキップ: 現在の下書きは消化せず（/live から再度仕上げられる）次へ進む
+	const handleSkip = useCallback(() => {
+		const [next, ...rest] = remainingDrafts;
+		if (!next) return;
+		setRemainingDrafts(rest);
+		advanceToDraft(next);
+	}, [remainingDrafts, advanceToDraft]);
+
 	// 作成処理
 	const handleCreate = useCallback(async () => {
 		if (!isValid) return;
 
 		setIsCreating(true);
 		setError("");
-		trackCreateStart(videoId, Boolean(draftId));
+		trackCreateStart(videoId, Boolean(activeDraftId));
 
 		try {
 			const input: CreateAudioButtonInput = {
@@ -87,12 +150,21 @@ export function AudioButtonCreator({
 				trackCreateSuccess({
 					audioButtonId: result.data.id,
 					videoId,
-					fromDraft: Boolean(draftId),
+					fromDraft: Boolean(activeDraftId),
 				});
 				// 下書きから開いた場合は消化（削除）する。ベストエフォート＝失敗してもボタン作成は
 				// 成立しているため遷移を止めない（残った下書きは /live から手動削除できる）。
-				if (draftId) {
-					await deleteButtonDraft(draftId).catch(() => undefined);
+				if (activeDraftId) {
+					await deleteButtonDraft(activeDraftId).catch(() => undefined);
+				}
+				// 連続仕上げ: 同一動画の下書きが残っていれば遷移せず次へ（プレイヤー維持・SPR-266）
+				const [next, ...rest] = remainingDrafts;
+				if (next) {
+					setLastCreated({ id: result.data.id, buttonText: buttonText.trim() });
+					setRemainingDrafts(rest);
+					advanceToDraft(next);
+					setIsCreating(false);
+					return;
 				}
 				// 詳細ページへフルロード遷移（SPR-252）。router.push だと /buttons ツリー内の soft nav が
 				// @modal にインターセプトされ、作成フォームの上にクイックビューが重なってしまう
@@ -121,7 +193,9 @@ export function AudioButtonCreator({
 		setIsCreating,
 		setError,
 		videoTitle,
-		draftId,
+		activeDraftId,
+		remainingDrafts,
+		advanceToDraft,
 	]);
 
 	// 時間調整用のハンドラーは共通フックから取得
@@ -169,6 +243,54 @@ export function AudioButtonCreator({
 						</div>
 
 						<div className="lg:col-span-1 xl:col-span-1 space-y-4">
+							{lastCreated && (
+								<div className="p-3 bg-primary/10 border border-primary/20 rounded-lg text-sm flex items-center justify-between gap-2">
+									<span className="min-w-0 truncate">
+										「{lastCreated.buttonText}」を作成しました
+									</span>
+									{/* 連続仕上げを中断しないよう新規タブで開く */}
+									<a
+										href={`/buttons/${lastCreated.id}`}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="flex items-center gap-1 text-primary hover:underline whitespace-nowrap"
+									>
+										<ExternalLink className="h-3.5 w-3.5" />
+										開く
+									</a>
+								</div>
+							)}
+
+							{activeDraftId && (videoDrafts?.length ?? 0) > 1 && (
+								<div className="bg-card border rounded-lg p-4 shadow-sm text-sm space-y-2">
+									<div className="flex items-center justify-between">
+										<span className="font-medium">仕上げキュー</span>
+										<span className="text-muted-foreground">残り {remainingDrafts.length} 件</span>
+									</div>
+									{remainingDrafts[0] ? (
+										<div className="flex items-center justify-between gap-2">
+											<span className="text-muted-foreground">
+												次: {formatQueueTime(remainingDrafts[0].suggestedStartTime)} 付近
+											</span>
+											<Button
+												size="sm"
+												variant="ghost"
+												onClick={handleSkip}
+												disabled={isCreating}
+												className="whitespace-nowrap"
+											>
+												<SkipForward className="h-3.5 w-3.5 mr-1" />
+												スキップして次へ
+											</Button>
+										</div>
+									) : (
+										<p className="text-muted-foreground">
+											これが最後の下書きです。作成すると詳細ページへ移動します。
+										</p>
+									)}
+								</div>
+							)}
+
 							<div className="bg-card border rounded-lg p-4 lg:p-6 shadow-sm">
 								<div className="mb-4">
 									<h3 className="text-lg font-semibold">音声操作</h3>

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createButtonDraft, deleteButtonDraft } from "@/actions/button-drafts";
 import { trackMarkDraft } from "@/lib/analytics/events";
 import { matchShortcutKey } from "@/lib/keyboard-shortcut";
+import { formatSeconds } from "@/utils/format-seconds";
 
 interface LiveCaptureViewProps {
 	video: VideoPlainObject | null;
@@ -27,16 +28,6 @@ function parseVideoIdInput(value: string): string | null {
 		return match[1];
 	}
 	return /^[A-Za-z0-9_-]{11}$/.test(trimmed) ? trimmed : null;
-}
-
-// shared-types の formatTimestamp は小数第1位付き（"14:26.0"）表示。下書き一覧は整数秒で十分なため独自実装
-function formatSeconds(total: number): string {
-	const s = Math.floor(total % 60);
-	const m = Math.floor((total / 60) % 60);
-	const h = Math.floor(total / 3600);
-	const mm = String(m).padStart(2, "0");
-	const ss = String(s).padStart(2, "0");
-	return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
 function formatMarkedAt(iso: string): string {

--- a/apps/web/src/utils/format-seconds.ts
+++ b/apps/web/src/utils/format-seconds.ts
@@ -1,0 +1,12 @@
+/**
+ * 秒数を整数秒の h:mm:ss / mm:ss 表記にする（下書き一覧・仕上げキューの表示用）。
+ * shared-types の formatTimestamp は小数第1位付き（"14:26.0"）のため用途が異なる。
+ */
+export function formatSeconds(total: number): string {
+	const s = Math.floor(total % 60);
+	const m = Math.floor((total / 60) % 60);
+	const h = Math.floor(total / 3600);
+	const mm = String(m).padStart(2, "0");
+	const ss = String(s).padStart(2, "0");
+	return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -229,6 +229,7 @@ vi.mock("lucide-react", () => {
 		RotateCcw: createMockIcon("RotateCcw"),
 		// Icons for AudioButtonCreator
 		Plus: createMockIcon("Plus"),
+		SkipForward: createMockIcon("SkipForward"),
 		// Icons for VideoCard
 		Eye: createMockIcon("Eye"),
 		Radio: createMockIcon("Radio"),


### PR DESCRIPTION
## 概要

[SPR-266](https://linear.app/nothink/issue/SPR-266) の **Phase 2 = 連続仕上げフロー**。「1件仕上げたら再ナビゲーションなしで次の下書きへ（1動画内はプレイヤーを維持したまま）」を実装。

## 変更内容

### /buttons/create（server）
- `draft_id` 起点のとき `getMyButtonDrafts` で**同一動画の下書きキュー**（suggestedStartTime 昇順）を取得し creator へ渡す（未ログイン時は action が error を返すだけなので ProtectedRoute 外で安全）

### AudioButtonCreator（client）
- **作成成功時、キューに残りがあれば遷移しない**: フォームをリセットし、次の下書きの推奨秒へ `seekTo`（プレイヤー維持＝連続仕上げの本体）。VOD 末尾は最大 ~20s 短くなる実測（SPR-145）があるため終端クランプを適用
- **成功バナー**: 「〜を作成しました」＋作成ボタンへの**新規タブ**リンク（キューを中断しない）
- **キューパネル**: 残り件数・次の下書きの時刻・「スキップして次へ」（スキップは下書きを消化せず、/live から再仕上げ可能）
- キューが尽きたら（または通常作成なら）**従来どおり詳細ページへフルロード遷移**（SPR-252 の intercepting route 回避を維持）
- 「今仕上げている下書き」の正本は state の `activeDraftId`（prop の draftId は初期値）

## テスト

audio-button-creator.test.tsx に4ケース追加（27件全通過）:
- キュー残ありの作成 → 遷移せず次へ（削除・フォームリセット・seek・バナー・リンク先）
- 最後の下書き → 従来どおりフルロード遷移
- スキップ → 消化せず次へ、キュー枯渇の案内表示
- 通常作成 → キューパネル非表示

`pnpm verify` 全通過。vitest.setup.ts の lucide-react モックに SkipForward を追加。

## 備考

Phase 3（/live 下書き一覧のキュー化: 動画グルーピング・件数表示）は別 PR で継続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)