### PR TITLE
feat(ci): Artifact Registry イメージGCの実削除を有効化

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -239,11 +239,13 @@ jobs:
       # SPR-220 の再観測で確定した（clean manifest 化後も削除適格な版が10日超残存）。
       # GCP側のpolicy評価に依存せず、ここでdigest単位のGCを自前実行する。
       # ロジックは既存policyのセマンティクスを踏襲: keep-recent-versions(5) / keep latest tag / delete older than 7日。
-      # AR_CLEANUP_DRY_RUN=true の間は削除せずログ出力のみ。初回デプロイでdry-run結果を確認してから false にする。
+      # AR_CLEANUP_DRY_RUN=true の間は削除せずログ出力のみ。初回デプロイ（PR #799マージ直後・
+      # run 29622987957）のdry-run結果で削除候補32版がベースライン調査と完全一致することを確認済みのため、
+      # ここから実削除を有効化する。
       - name: Cleanup old Artifact Registry image versions
         if: always()
         env:
-          AR_CLEANUP_DRY_RUN: 'true'
+          AR_CLEANUP_DRY_RUN: 'false'
         run: |
           echo "🧹 Cleaning up old Artifact Registry image versions (dry_run=${AR_CLEANUP_DRY_RUN})..."
 


### PR DESCRIPTION
## Summary
- PR #799 で追加した Artifact Registry digest単位GCステップの `AR_CLEANUP_DRY_RUN` を `true` → `false` に切り替え、実削除を有効化する
- マージ前ベースライン調査（54版中32版が削除適格）と、PR #799 マージ直後のdeploy（[run 29622987957](https://github.com/nothink-jp/suzumina.click/actions/runs/29622987957)）で得たdry-runログの削除候補32版が完全一致することを確認済み（SPR-247コメント参照）

## Test plan
- [ ] マージ後の初回deployログで実際に32版程度が削除されることを確認
- [ ] `gcloud artifacts versions list` のバージョン数が減少していることを確認
- [ ] 1〜2 deployサイクル後、Cloud Monitoring `artifactregistry.googleapis.com/repository/size` の増加トレンド（07-07〜07-18で+3.5GB相当）が頭打ち/減少に転じることを確認

Closes SPR-247 (Linear)・親: SPR-215

🤖 Generated with [Claude Code](https://claude.com/claude-code)