### PR TITLE
feat(web): /live 下書き一覧を動画単位のキュー表示に (SPR-266 Phase 3)

### DIFF
--- a/apps/web/src/app/live/page.tsx
+++ b/apps/web/src/app/live/page.tsx
@@ -61,7 +61,9 @@ async function findTargetVideo(manualVideoId?: string): Promise<VideoPlainObject
 async function LiveCaptureContent({ manualVideoId }: { manualVideoId?: string }) {
 	const [video, draftsResult] = await Promise.all([
 		findTargetVideo(manualVideoId),
-		getMyButtonDrafts(),
+		// 既定 limit=100 だと下書き多数のユーザーで一覧が黙って欠けるため、保持上限の500で全件取る
+		// （/buttons/create のキュー取得と同じ判断・SPR-266）
+		getMyButtonDrafts(500),
 	]);
 
 	return (

--- a/apps/web/src/components/live/__tests__/draft-groups.test.ts
+++ b/apps/web/src/components/live/__tests__/draft-groups.test.ts
@@ -1,0 +1,51 @@
+import type { AudioButtonDraft } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { groupDraftsByVideo } from "../draft-groups";
+
+function makeDraft(
+	id: string,
+	videoId: string,
+	suggestedStartTime: number,
+	createdAt: string,
+): AudioButtonDraft {
+	return {
+		id,
+		videoId,
+		videoTitle: `動画 ${videoId}`,
+		playerTime: suggestedStartTime + 15,
+		markedAt: createdAt,
+		createdAt,
+		suggestedStartTime,
+	};
+}
+
+describe("groupDraftsByVideo", () => {
+	it("動画単位にグルーピングされ、グループ内は推奨開始秒の昇順になる", () => {
+		const groups = groupDraftsByVideo([
+			makeDraft("a1", "video-a", 300, "2026-07-15T12:10:00.000Z"),
+			makeDraft("a2", "video-a", 100, "2026-07-15T12:05:00.000Z"),
+			makeDraft("b1", "video-b", 50, "2026-07-10T10:00:00.000Z"),
+		]);
+
+		expect(groups).toHaveLength(2);
+		expect(groups[0]?.videoId).toBe("video-a");
+		expect(groups[0]?.drafts.map((d) => d.id)).toEqual(["a2", "a1"]);
+		expect(groups[1]?.videoId).toBe("video-b");
+	});
+
+	it("グループは最新マークを含む順（直近の配信が先頭）", () => {
+		const groups = groupDraftsByVideo([
+			makeDraft("old1", "video-old", 10, "2026-07-01T10:00:00.000Z"),
+			makeDraft("new1", "video-new", 10, "2026-07-15T10:00:00.000Z"),
+			// 古い動画に後からマークが追加された場合はそのグループが繰り上がる
+			makeDraft("old2", "video-old", 20, "2026-07-16T10:00:00.000Z"),
+		]);
+
+		expect(groups.map((g) => g.videoId)).toEqual(["video-old", "video-new"]);
+		expect(groups[0]?.latestCreatedAt).toBe("2026-07-16T10:00:00.000Z");
+	});
+
+	it("空配列は空のグループ一覧", () => {
+		expect(groupDraftsByVideo([])).toEqual([]);
+	});
+});

--- a/apps/web/src/components/live/__tests__/live-capture-view.test.tsx
+++ b/apps/web/src/components/live/__tests__/live-capture-view.test.tsx
@@ -1,0 +1,93 @@
+import type { AudioButtonDraft, VideoPlainObject } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LiveCaptureView } from "../live-capture-view";
+
+vi.mock("@/actions/button-drafts", () => ({
+	createButtonDraft: vi.fn().mockResolvedValue({ success: true, data: {} }),
+	deleteButtonDraft: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("@/lib/analytics/events", () => ({
+	trackMarkDraft: vi.fn(),
+}));
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@suzumina.click/ui/components/custom/youtube-player", () => ({
+	YouTubePlayer: ({ videoId }: { videoId: string }) => (
+		<div data-testid="youtube-player" data-video-id={videoId} />
+	),
+}));
+
+function makeDraft(
+	id: string,
+	videoId: string,
+	videoTitle: string,
+	suggestedStartTime: number,
+	createdAt: string,
+): AudioButtonDraft {
+	return {
+		id,
+		videoId,
+		videoTitle,
+		playerTime: suggestedStartTime + 15,
+		markedAt: createdAt,
+		createdAt,
+		suggestedStartTime,
+	};
+}
+
+describe("LiveCaptureView の下書きキュー表示（SPR-266 第2段）", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("下書きが動画単位にグルーピングされ、件数と「まとめて仕上げる」が表示される", () => {
+		const drafts = [
+			makeDraft("a2", "video-aaaaaaa", "アーカイブ配信A", 300, "2026-07-15T12:10:00.000Z"),
+			makeDraft("a1", "video-aaaaaaa", "アーカイブ配信A", 100, "2026-07-15T12:05:00.000Z"),
+			makeDraft("b1", "video-bbbbbbb", "アーカイブ配信B", 50, "2026-07-10T10:00:00.000Z"),
+		];
+		render(<LiveCaptureView video={null} initialDrafts={drafts} />);
+
+		// グループヘッダ（動画タイトル + 件数）
+		expect(screen.getByText("アーカイブ配信A")).toBeInTheDocument();
+		expect(screen.getByText("2件の下書き")).toBeInTheDocument();
+		expect(screen.getByText("アーカイブ配信B")).toBeInTheDocument();
+		expect(screen.getByText("1件の下書き")).toBeInTheDocument();
+
+		// まとめて仕上げる = グループ先頭（推奨開始秒が最小）の下書きから開く
+		const bulkLinks = screen.getAllByRole("link", { name: /まとめて仕上げる/ });
+		expect(bulkLinks).toHaveLength(2);
+		expect(bulkLinks[0]).toHaveAttribute(
+			"href",
+			"/buttons/create?video_id=video-aaaaaaa&start_time=100&draft_id=a1",
+		);
+	});
+
+	it("配信中の動画グループは仕上げ導線を出さない（アーカイブ公開後に仕上げ）", () => {
+		const liveVideo = {
+			videoId: "video-live11",
+			title: "配信中の動画",
+			_computed: { videoType: "live" },
+		} as unknown as VideoPlainObject;
+		const drafts = [
+			makeDraft("l1", "video-live11", "配信中の動画", 100, "2026-07-18T12:00:00.000Z"),
+		];
+		render(<LiveCaptureView video={liveVideo} initialDrafts={drafts} />);
+
+		expect(screen.getByText("アーカイブ公開後に仕上げ")).toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /まとめて仕上げる/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole("link", { name: /仕上げる/ })).not.toBeInTheDocument();
+	});
+
+	it("下書きゼロなら空状態の案内を出す", () => {
+		render(<LiveCaptureView video={null} initialDrafts={[]} />);
+
+		expect(screen.getByText(/まだ下書きがありません/)).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/components/live/draft-groups.ts
+++ b/apps/web/src/components/live/draft-groups.ts
@@ -1,0 +1,45 @@
+import type { AudioButtonDraft } from "@suzumina.click/shared-types";
+
+/**
+ * /live 下書きキューの動画単位グループ（SPR-266 第2段のキュー画面）。
+ * 「仕上げ済み」の区別は不要（仕上げ＝下書き消化で一覧から消えるため、表示されるのは常に未処理）。
+ */
+export interface DraftVideoGroup {
+	videoId: string;
+	videoTitle: string;
+	/** suggestedStartTime 昇順（仕上げは動画の時系列順が自然なため） */
+	drafts: AudioButtonDraft[];
+	/** グループの並び替えキー: グループ内で最新の createdAt（ISO string） */
+	latestCreatedAt: string;
+}
+
+/**
+ * 下書きを動画単位にグルーピングする。
+ * グループは最新マークを含む順（= 直近の配信が先頭）、グループ内は推奨開始秒の昇順。
+ */
+export function groupDraftsByVideo(drafts: AudioButtonDraft[]): DraftVideoGroup[] {
+	const map = new Map<string, DraftVideoGroup>();
+	for (const draft of drafts) {
+		const group = map.get(draft.videoId);
+		if (group) {
+			group.drafts.push(draft);
+			if (draft.createdAt > group.latestCreatedAt) {
+				group.latestCreatedAt = draft.createdAt;
+			}
+		} else {
+			map.set(draft.videoId, {
+				videoId: draft.videoId,
+				videoTitle: draft.videoTitle,
+				drafts: [draft],
+				latestCreatedAt: draft.createdAt,
+			});
+		}
+	}
+	const groups = [...map.values()];
+	for (const group of groups) {
+		group.drafts.sort((a, b) => a.suggestedStartTime - b.suggestedStartTime);
+	}
+	// ISO 8601 (UTC) は辞書順 = 時刻順
+	groups.sort((a, b) => b.latestCreatedAt.localeCompare(a.latestCreatedAt));
+	return groups;
+}

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -8,11 +8,12 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Input } from "@suzumina.click/ui/components/ui/input";
 import { Bookmark, ExternalLink, Loader2, Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createButtonDraft, deleteButtonDraft } from "@/actions/button-drafts";
 import { trackMarkDraft } from "@/lib/analytics/events";
 import { matchShortcutKey } from "@/lib/keyboard-shortcut";
 import { formatSeconds } from "@/utils/format-seconds";
+import { groupDraftsByVideo } from "./draft-groups";
 
 interface LiveCaptureViewProps {
 	video: VideoPlainObject | null;
@@ -52,6 +53,8 @@ function formatMarkedAt(iso: string): string {
 export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) {
 	const router = useRouter();
 	const [drafts, setDrafts] = useState<AudioButtonDraft[]>(initialDrafts);
+	// 動画単位のキュー表示（SPR-266 第2段）。直近の配信グループが先頭
+	const draftGroups = useMemo(() => groupDraftsByVideo(drafts), [drafts]);
 	const [isMarking, setIsMarking] = useState(false);
 	const [error, setError] = useState("");
 	const [manualInput, setManualInput] = useState("");
@@ -230,50 +233,83 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 						まだ下書きがありません。配信中にマークするとここに溜まります。
 					</p>
 				) : (
-					<ul className="divide-y border rounded-lg">
-						{drafts.map((draft) => {
+					<div className="space-y-4">
+						{draftGroups.map((group) => {
+							// 配信中/配信予定の動画はまだ仕上げられない（判定はグループ単位で足りる）
 							const isCurrentLiveVideo =
-								draft.videoId === video?.videoId && (isLiveNow || isUpcoming);
+								group.videoId === video?.videoId && (isLiveNow || isUpcoming);
+							const firstDraft = group.drafts[0];
 							return (
-								<li key={draft.id} className="flex items-center gap-3 p-3">
-									<div className="min-w-0 flex-1">
-										<p className="text-sm font-medium">
-											{formatSeconds(draft.suggestedStartTime)} から
-											{draft.playerTime == null && (
-												<span className="ml-2 text-xs text-amber-600">壁時計のみ・要頭出し</span>
-											)}
-										</p>
-										<p className="text-xs text-muted-foreground truncate">
-											{draft.videoTitle} ・ {formatMarkedAt(draft.markedAt)}
-										</p>
+								<div key={group.videoId} className="border rounded-lg overflow-hidden">
+									<div className="flex items-center gap-3 p-3 bg-muted/40 border-b">
+										<div className="min-w-0 flex-1">
+											<p className="text-sm font-medium truncate">{group.videoTitle}</p>
+											<p className="text-xs text-muted-foreground">
+												{group.drafts.length}件の下書き
+											</p>
+										</div>
+										{isCurrentLiveVideo ? (
+											<span className="text-xs text-muted-foreground whitespace-nowrap">
+												アーカイブ公開後に仕上げ
+											</span>
+										) : (
+											firstDraft && (
+												<Button asChild size="sm">
+													{/* /buttons ツリーへの遷移はフルロード（intercepting route 回避・SPR-252）。
+													    先頭の下書きから開けば同一動画のキューは create 側が読み込み、
+													    連続仕上げ（SPR-266 第2段）につながる */}
+													<a
+														href={`/buttons/create?video_id=${group.videoId}&start_time=${firstDraft.suggestedStartTime}&draft_id=${firstDraft.id}`}
+													>
+														<ExternalLink className="h-3.5 w-3.5 mr-1" />
+														まとめて仕上げる
+													</a>
+												</Button>
+											)
+										)}
 									</div>
-									{isCurrentLiveVideo ? (
-										<span className="text-xs text-muted-foreground whitespace-nowrap">
-											アーカイブ公開後に仕上げ
-										</span>
-									) : (
-										<Button asChild size="sm" variant="outline">
-											{/* /buttons ツリーへの遷移はフルロード（intercepting route 回避・SPR-252） */}
-											<a
-												href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
-											>
-												<ExternalLink className="h-3.5 w-3.5 mr-1" />
-												仕上げる
-											</a>
-										</Button>
-									)}
-									<Button
-										size="sm"
-										variant="ghost"
-										aria-label="下書きを削除"
-										onClick={() => void handleDelete(draft.id)}
-									>
-										<Trash2 className="h-4 w-4" />
-									</Button>
-								</li>
+									<ul className="divide-y">
+										{group.drafts.map((draft) => (
+											<li key={draft.id} className="flex items-center gap-3 p-3">
+												<div className="min-w-0 flex-1">
+													<p className="text-sm font-medium">
+														{formatSeconds(draft.suggestedStartTime)} から
+														{draft.playerTime == null && (
+															<span className="ml-2 text-xs text-amber-600">
+																壁時計のみ・要頭出し
+															</span>
+														)}
+													</p>
+													<p className="text-xs text-muted-foreground">
+														{formatMarkedAt(draft.markedAt)}
+													</p>
+												</div>
+												{!isCurrentLiveVideo && (
+													<Button asChild size="sm" variant="outline">
+														{/* この1件だけを仕上げたいときの個別導線（フルロード・SPR-252） */}
+														<a
+															href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
+														>
+															<ExternalLink className="h-3.5 w-3.5 mr-1" />
+															仕上げる
+														</a>
+													</Button>
+												)}
+												<Button
+													size="sm"
+													variant="ghost"
+													aria-label="下書きを削除"
+													onClick={() => void handleDelete(draft.id)}
+												>
+													<Trash2 className="h-4 w-4" />
+												</Button>
+											</li>
+										))}
+									</ul>
+								</div>
 							);
 						})}
-					</ul>
+					</div>
 				)}
 			</div>
 		</div>


### PR DESCRIPTION
## 概要

[SPR-266](https://linear.app/nothink/issue/SPR-266) の **Phase 3（最終フェーズ）= /live 下書き一覧のキュー化**。

## 変更内容

- **動画単位のグルーピング**（`draft-groups.ts` の純関数 `groupDraftsByVideo`）: グループは最新マークを含む順（直近の配信が先頭）、グループ内は推奨開始秒の昇順（動画の時系列順で仕上げるのが自然なため）
- **グループヘッダ**: 動画タイトル＋件数＋「**まとめて仕上げる**」。先頭（最も早い秒）の下書きから `/buttons/create` をフルロードで開き、create 側の同一動画キュー読み込み（Phase 2 #801）につながって連続仕上げが始まる
- **配信中/配信予定グループ**は仕上げ導線を出さず「アーカイブ公開後に仕上げ」（従来の行単位判定をグループ単位に昇格）
- 行には個別の「仕上げる」（1件だけ狙う場合）と削除を維持。動画タイトルはヘッダに移動し行から重複を排除
- **`getMyButtonDrafts(500)` に統一**: 前回レビュー指摘（limit=100 の黙った欠け）の /live 側を解消

「仕上げ済み/未処理の区別」は仕上げ＝下書き消化（削除）で一覧から消える設計のため、表示されるものは常に未処理＝追加の状態管理は不要（draft-groups.ts に明記）。

## テスト

- `draft-groups.test.ts`（新規）: グルーピング・両ソート順・空配列
- `live-capture-view.test.tsx`（新規・第1段からの欠落補完）: グループ表示・まとめて仕上げるの href（先頭下書き）・配信中グループの導線抑止・空状態
- `pnpm verify` 全通過

## 備考

本 PR で SPR-266 の3フェーズが完了（Phase 1 #800 / Phase 2 #801 / Phase 3 本PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)