### PR TITLE
fix(ci): AR versions delete に --delete-tags を追加（tagged版が全件削除失敗していた）

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -302,10 +302,15 @@ jobs:
               echo "[dry-run] Would delete: $DIGEST (created $CREATE_TIME)"
             else
               echo "Deleting old version: $DIGEST (created $CREATE_TIME)"
+              # 各版はbuild時に commit-sha タグが必ず付くため（このwhileループの時点で
+              # latestタグの版は既に除外済み）、そのタグ削除も併せて行う --delete-tags が必須。
+              # 無指定だと "Cannot delete version ... because it is tagged" (code 9) で全件失敗する
+              # （2026-07-18 本番実測で確認）。
               gcloud artifacts versions delete "$DIGEST" \
                 --package="${{ env.IMAGE_NAME }}" \
                 --repository="${{ env.REPOSITORY }}" \
                 --location="${{ env.REGION }}" \
+                --delete-tags \
                 --quiet || echo "  ⚠️ Failed to delete $DIGEST"
             fi
             PROCESSED=$((PROCESSED + 1))


### PR DESCRIPTION
## Summary
- PR #802 マージ後の本番デプロイ（[run 29623838014](https://github.com/nothink-jp/suzumina.click/actions/runs/29623838014)）で実削除32件が**全件失敗**していたことが判明
- 実際のエラー: `ERROR: (gcloud.artifacts.versions.delete) { "code": 9, "message": "Cannot delete version ... because it is tagged." }`
- 原因: `deploy-web.yml` は各deployで `:{sha}` タグを必ずpushするため、削除対象の全バージョンに何らかのタグが付いている。`gcloud artifacts versions delete` はデフォルトでタグ付きバージョンの削除を拒否する（`--delete-tags` 指定時のみタグごと削除可能）
- 修正: `--delete-tags` フラグを追加。この分岐に到達する版は事前に `latest` タグの版を除外済みのため、タグごと削除しても安全

## 実害
- 削除はすべて失敗しており、**実際にはまだ1件も削除されていない**（32件のバージョンはそのまま残存）。デプロイ自体は影響を受けていない（cleanup失敗時はログ出力のみでjobは継続する設計・PR #799参照）

## Test plan
- [ ] マージ後の初回deployログで実際に32件（またはその時点の削除適格数）が正常に削除されることを確認
- [ ] `gcloud artifacts versions list` のバージョン数減少を確認
- [ ] Cloud Monitoring のストレージサイズ推移が頭打ち/減少に転じることを確認

親: SPR-215 / SPR-247（Linear）

🤖 Generated with [Claude Code](https://claude.com/claude-code)