### PR TITLE
fix(terraform): github-actions-sa に artifactregistry.tags.delete を追加

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -206,7 +206,8 @@ resource "google_project_iam_custom_role" "github_actions_artifact_registry_role
     "artifactregistry.tags.create",
     "artifactregistry.tags.update",
     "artifactregistry.tags.get",
-    "artifactregistry.tags.list"
+    "artifactregistry.tags.list",
+    "artifactregistry.tags.delete" # SPR-247: versions delete --delete-tags に必要（tags.delete不足でPERMISSION_DENIED実測）
   ]
 }
 


### PR DESCRIPTION
## Summary
- PR #804（`--delete-tags` フラグ追加）マージ後の本番デプロイ（[run 29624213666](https://github.com/nothink-jp/suzumina.click/actions/runs/29624213666)）で削除が再び全件失敗
- 今回のエラー: `PERMISSION_DENIED: Permission 'artifactregistry.tags.delete' denied`
- `terraform/iam.tf` の `githubActionsArtifactRegistryManager` カスタムロールに `tags.create` / `tags.update` / `tags.get` / `tags.list` はあったが、`--delete-tags` に必要な **`tags.delete` が抜けていた**
- `artifactregistry.tags.delete` を追加

## 実害
- なし。削除は全件失敗＝まだ1件も削除されていない（本PRで3回連続のno-op）

## Test plan
- [ ] terraform plan で `githubActionsArtifactRegistryManager` の権限追加のみが差分として出ることを確認（ADR-010: CI の plan→承認→apply）
- [ ] apply後、次のdeployログで実際に削除が成功することを確認
- [ ] `gcloud artifacts versions list` のバージョン数減少を確認

親: SPR-215 / SPR-247（Linear）／直前: #804（`--delete-tags` 追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)