### PR TITLE
refactor(web): 動画カードの作成導線を session 非依存に統一（ログイン分岐撤去）

### DIFF
--- a/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card-actions.test.tsx
@@ -1,10 +1,7 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mockUseSession } from "@/test-utils/auth";
 import VideoCardActions from "../video-card-actions";
-
-vi.mock("@/lib/auth/client");
 
 function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 	const base = {
@@ -35,16 +32,12 @@ function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 	return { ...base, ...overrides } as unknown as VideoPlainObject;
 }
 
-const loggedIn = { discordId: "user123", displayName: "テストユーザー" };
-const loggedOut = null;
-
 describe("VideoCardActions", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
 	it("sidebar variant では『動画を見る』リンクのみ表示する", () => {
-		mockUseSession(loggedOut);
 		render(<VideoCardActions video={createMockVideo()} variant="sidebar" />);
 
 		const link = screen.getByText("動画を見る").closest("a");
@@ -52,29 +45,17 @@ describe("VideoCardActions", () => {
 		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
 	});
 
-	it("ログイン済み・作成可能ならボタン作成リンクを表示する", () => {
-		mockUseSession(loggedIn);
+	it("作成可能ならボタン作成リンクを表示する（ログイン状態に依存しない・認証は /buttons/create 側に委譲）", () => {
 		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
 
 		const createLink = screen.getByText("ボタン作成").closest("a");
 		expect(createLink).toHaveAttribute("href", "/buttons/create?video_id=video123");
 		expect(screen.getByText("詳細を見る")).toBeInTheDocument();
-	});
-
-	it("未ログインならログイン導線を表示する（callbackUrl 付き）", () => {
-		mockUseSession(loggedOut);
-		render(<VideoCardActions video={createMockVideo()} variant="grid" />);
-
-		const loginLink = screen.getByText("ログイン").closest("a");
-		expect(loginLink).toHaveAttribute(
-			"href",
-			"/auth/signin?callbackUrl=%2Fbuttons%2Fcreate%3Fvideo_id%3Dvideo123",
-		);
-		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
+		// ログイン分岐は撤去済み（/live 導線と同じく目的地の ProtectedRoute が認証の正本）
+		expect(screen.queryByText("ログイン")).not.toBeInTheDocument();
 	});
 
 	it("配信中の動画は『配信中マーク』リンク（/live?v=）を表示する（SPR-146）", () => {
-		mockUseSession(loggedIn);
 		const video = createMockVideo({
 			liveBroadcastContent: "live",
 			_computed: {
@@ -92,10 +73,11 @@ describe("VideoCardActions", () => {
 		// live は destructive 赤（「配信中」バッジと同色ペア・赤は live 専用）
 		expect(markLink?.className).toContain("bg-destructive");
 		expect(screen.queryByText("ボタン作成")).not.toBeInTheDocument();
+		// 認証は /live 側の ProtectedRoute に委譲（カードは session 非依存でログイン導線を出さない）
+		expect(screen.queryByText("ログイン")).not.toBeInTheDocument();
 	});
 
 	it("配信予定の動画は『配信待機』リンク（info 青）を表示する", () => {
-		mockUseSession(loggedIn);
 		const video = createMockVideo({
 			liveBroadcastContent: "upcoming",
 			_computed: {
@@ -114,26 +96,7 @@ describe("VideoCardActions", () => {
 		expect(waitLink?.className).toContain("bg-info");
 	});
 
-	it("未ログインでも配信中はログイン導線でなく『配信中マーク』を表示する（認証は /live 側に委譲）", () => {
-		mockUseSession(loggedOut);
-		const video = createMockVideo({
-			liveBroadcastContent: "live",
-			_computed: {
-				...createMockVideo()._computed,
-				isArchived: false,
-				isLive: true,
-				canCreateButton: false,
-				videoType: "live",
-			},
-		});
-		render(<VideoCardActions video={video} variant="grid" />);
-
-		expect(screen.getByText("配信中マーク")).toBeInTheDocument();
-		expect(screen.queryByText("ログイン")).not.toBeInTheDocument();
-	});
-
 	it("stale な liveBroadcastContent=live でも _computed が archived なら通常のボタン作成に進める（正本は videoType）", () => {
-		mockUseSession(loggedIn);
 		// fetchYouTubeVideos の更新遅延で raw フィールドだけ live のまま残るケース。
 		// _computed.videoType は actualEndTime から archived を判定済み＝バッジも「配信アーカイブ」表示
 		const video = createMockVideo({ liveBroadcastContent: "live" });
@@ -144,8 +107,7 @@ describe("VideoCardActions", () => {
 		expect(screen.queryByText("配信中マーク")).not.toBeInTheDocument();
 	});
 
-	it("ログイン済みでも作成不可（配信でない動画）なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
-		mockUseSession(loggedIn);
+	it("作成不可（配信でない動画）なら理由を tooltip に持つ aria-disabled ボタンを表示する", () => {
 		const video = createMockVideo({
 			duration: "PT0S",
 			_computed: {
@@ -170,7 +132,6 @@ describe("VideoCardActions", () => {
 	});
 
 	it("埋め込み制限がある場合は理由として埋め込み制限を表示する", () => {
-		mockUseSession(loggedIn);
 		const video = createMockVideo({ status: { embeddable: false } });
 		render(<VideoCardActions video={video} variant="grid" />);
 

--- a/apps/web/src/app/videos/components/__tests__/video-card.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-card.test.tsx
@@ -1,11 +1,7 @@
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mockUseSession } from "@/test-utils/auth";
 import VideoCard from "../video-card";
-
-// モックの設定（認証ゲートは VideoCardActions client island が useSession を使う）
-vi.mock("@/lib/auth/client");
 
 vi.mock("@/components/ui/thumbnail-image", () => ({
 	// biome-ignore lint/performance/noImgElement: モックコンポーネントでは<img>の使用を許可
@@ -67,7 +63,6 @@ function createMockVideo(overrides?: Partial<any>): VideoPlainObject {
 describe("VideoCard", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mockUseSession(null);
 	});
 
 	it("動画の基本情報が表示される", () => {

--- a/apps/web/src/app/videos/components/video-card-actions.tsx
+++ b/apps/web/src/app/videos/components/video-card-actions.tsx
@@ -1,15 +1,12 @@
-"use client";
-
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import {
 	canCreateAudioButton,
 	getAudioButtonCreationErrorMessage,
 } from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Bookmark, Clock, ExternalLink, Eye, LogIn, Plus } from "lucide-react";
+import { Bookmark, Clock, ExternalLink, Eye, Plus } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { useSession } from "@/lib/auth/client";
 
 interface VideoCardActionsProps {
 	video: VideoPlainObject;
@@ -19,13 +16,11 @@ interface VideoCardActionsProps {
 type ButtonGate =
 	| { canCreate: true }
 	| { canCreate: false; liveMarking: "live" | "upcoming" }
-	| { canCreate: false; needsLogin: true }
-	| { canCreate: false; needsLogin: false; reason: string };
+	| { canCreate: false; reason: string };
 
-function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): ButtonGate {
+function evaluateButtonGate(video: VideoPlainObject): ButtonGate {
 	// 配信中/配信予定は「作成不可」ではなく配信中マーキング（/live）への導線に切り替える（SPR-146）。
-	// この時間帯の正しい作成手段はマーク→アーカイブ後の仕上げのため。ログイン判定より先に返すことで
-	// 未ログインでも導線が見え、認証は /live 側の ProtectedRoute（callbackPath 付き）に委ねる。
+	// この時間帯の正しい作成手段はマーク→アーカイブ後の仕上げのため。
 	// 判定の正本はバッジ（video-badge.ts）と同じ _computed.videoType。raw の liveBroadcastContent は
 	// stale がありうる（アーカイブ済みでも live のまま残る）。operations の isLive や _computed.isLive は
 	// raw を OR しているため使わない — actualEndTime を見て archived を優先する videoType が唯一 stale に強い
@@ -36,20 +31,15 @@ function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): Butto
 	if (videoType === "upcoming") {
 		return { canCreate: false, liveMarking: "upcoming" };
 	}
-	if (!isLoggedIn) {
-		return { canCreate: false, needsLogin: true };
-	}
 	if (video.status?.embeddable === false) {
 		return {
 			canCreate: false,
-			needsLogin: false,
 			reason: "この動画は埋め込みが制限されているため、音声ボタンを作成できません",
 		};
 	}
 	if (!canCreateAudioButton(video)) {
 		return {
 			canCreate: false,
-			needsLogin: false,
 			reason:
 				getAudioButtonCreationErrorMessage(video) ||
 				"音声ボタンを作成できるのは配信アーカイブのみです",
@@ -59,12 +49,12 @@ function evaluateButtonGate(video: VideoPlainObject, isLoggedIn: boolean): Butto
 }
 
 /**
- * VideoCard のアクション領域（client island）。
- * 認証ゲート（useSession）をカード本体から隔離するための最小 client コンポーネント。
+ * VideoCard のアクション領域。
+ * ログイン状態は見ない（session 非依存）: 認証は各目的地（/live・/buttons/create）の
+ * ProtectedRoute（callbackPath 付き）が正本で、カードはポインタに徹する。
+ * これにより per-user 状態を SSR に焼かず、セッション解決待ちのラベルちらつきも起きない。
  */
 export default function VideoCardActions({ video, variant }: VideoCardActionsProps) {
-	const user = useSession();
-
 	const detailLink = (
 		<Button
 			size="sm"
@@ -95,7 +85,7 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 		);
 	}
 
-	const gate = evaluateButtonGate(video, Boolean(user));
+	const gate = evaluateButtonGate(video);
 
 	let createAction: ReactNode;
 	if (gate.canCreate) {
@@ -141,20 +131,6 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 						<Clock className="h-4 w-4 mr-1" aria-hidden="true" />
 					)}
 					{isLiveNow ? "配信中マーク" : "配信待機"}
-				</Link>
-			</Button>
-		);
-	} else if (gate.needsLogin) {
-		// 未ログイン: ログイン導線を出す
-		createAction = (
-			<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
-				<Link
-					href={`/auth/signin?callbackUrl=${encodeURIComponent(`/buttons/create?video_id=${video.id}`)}`}
-					aria-label="ログインして音声ボタンを作成"
-					className="flex items-center whitespace-nowrap"
-				>
-					<LogIn className="h-4 w-4 mr-1" aria-hidden="true" />
-					ログイン
 				</Link>
 			</Button>
 		);

--- a/apps/web/src/app/videos/components/video-card.tsx
+++ b/apps/web/src/app/videos/components/video-card.tsx
@@ -56,9 +56,9 @@ interface VideoCardProps {
 }
 
 /**
- * 動画カード（server shell）。
- * 認証ゲートを伴うアクションは {@link VideoCardActions}（client island）に隔離し、
- * 本体は純表示に徹する。WorkCard と同じ「shell + island」構造。
+ * 動画カード（server component）。
+ * アクション領域は {@link VideoCardActions} に分離。session 非依存のポインタ集
+ * （認証は各目的地の ProtectedRoute に委譲）のため、カード全体が server 描画で完結する。
  */
 function VideoCard({ video, variant = "grid", priority = false, searchQuery }: VideoCardProps) {
 	const actualButtonCount = video.audioButtonCount ?? 0;


### PR DESCRIPTION
## 背景

動画カードのアクションで、live/upcoming（/live 導線＝未ログインでも表示・認証は目的地に委譲）と archived（未ログイン時は「ログイン」ボタンに変化）の**認証の扱いが非対称**だった。`/buttons/create` 自身が ProtectedRoute（callbackPath 付き）を持つため、カード側のログイン分岐は機能的に冗長。

## 変更内容

**/live 型に統一**（目的地ページの ProtectedRoute が認証の正本・カードはポインタに徹する）:

- `needsLogin` 分岐と `useSession` を撤去。未ログインでも「ボタン作成」を表示し、クリック → signin → callbackPath で作成画面へ（従来の「ログイン」ボタンと同じ着地）
- 副次効果1: **セッション解決待ちのラベルちらつき解消** — 従来はログイン済みユーザーにも毎カードで「ログイン」→「ボタン作成」のフリップが起きていた
- 副次効果2: hooks もイベントハンドラも無くなったため **"use client" を撤去し server 描画に**。per-user 状態を一切持たないため SSR/エッジキャッシュとも整合（client island ぶんのバンドルも削減）
- 作成不可の理由表示（aria-disabled + title）は未ログインにも見えるようになるが、動画自体の制約（埋め込み制限等）は誰にとっても不可なので正しい情報

トレードオフ: クリック前の「ログインが必要」の予告は無くなる（signin 画面で即分かるため実害は小さいと判断）。

## テスト

- video-card-actions.test.tsx を session 非依存に書き換え（auth モック撤去・未ログイン variant テストは重複化したため統合）
- video-card.test.tsx の不要になった auth モックを掃除
- `pnpm verify` 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)