### PR TITLE
fix(web): 一般公開後も残っていた「プレビュー版」表記を修正

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -129,10 +129,10 @@ export default function AboutPage() {
 							</div>
 							<div className="space-y-2">
 								<h4 className="font-semibold flex items-center gap-2">
-									🔐 Discord認証（すずみなふぁみりー限定）
+									🔐 Discord認証でボタン作成
 								</h4>
 								<p className="text-sm text-muted-foreground">
-									ファンコミュニティメンバー限定でご利用いただけます
+									Discordアカウントでログインすれば、どなたでも音声ボタンを作成できます（すずみなふぁみりーメンバーは1日あたりの作成上限が拡大されます）
 								</p>
 							</div>
 						</div>

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -41,7 +41,7 @@ async function SignInForm({ searchParams }: SignInPageProps) {
 				<div className="text-center text-sm text-muted-foreground space-y-3">
 					<p>Discordアカウントでログインして、音声ボタンを作成・共有しましょう！</p>
 
-					{/* プレビューリリース案内 */}
+					{/* 一般公開のご案内 */}
 					<div className="bg-info/10 border border-info/30 rounded-lg p-4 text-left">
 						<div className="flex items-start gap-2">
 							<span className="text-lg">🎉</span>

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -154,7 +154,7 @@ export default function TermsPage() {
 							<div>
 								<h4 className="font-semibold text-foreground">認証方式</h4>
 								<p className="text-sm text-muted-foreground">
-									本サイトはDiscord認証を使用し、「すずみなふぁみりー」Discordサーバーのメンバーのみ利用可能です。
+									本サイトはDiscord認証を使用しています。閲覧はどなたでも可能で、音声ボタンの作成にはDiscordアカウントでのログインが必要です（「すずみなふぁみりー」Discordサーバーのメンバーは1日あたりの作成上限が拡大されます）。
 								</p>
 							</div>
 							<div>

--- a/apps/web/src/components/layout/site-footer.tsx
+++ b/apps/web/src/components/layout/site-footer.tsx
@@ -43,7 +43,7 @@ export default function SiteFooter() {
 							ファンによる、ファンのためのコミュニティサイト
 						</p>
 						<p className="text-minase-300 text-xs">
-							現在プレビューリリース中 - 閲覧・利用は誰でも、作成はすずみなふぁみりー限定
+							閲覧・利用は誰でも、Discordログインで音声ボタン作成も可能です
 						</p>
 					</div>
 					<div className="border-t border-minase-700 pt-4 text-center text-sm text-minase-200">


### PR DESCRIPTION
## Summary
- footer に残っていた「現在プレビューリリース中 - 作成はすずみなふぁみりー限定」を撤去し、実態（一般公開・誰でもDiscordログインで音声ボタン作成可）に合わせて更新
- about / terms ページの「Discord認証はすずみなふぁみりー限定」という記述も同様に更新（signin ページの案内と矛盾していたため）
- signin ページの古い JSX コメント（`プレビューリリース案内` → `一般公開のご案内`）も併せて修正

いずれもふぁみりーメンバーは1日あたりの作成上限が拡大される点のみ差分として残しています。

## Test plan
- [x] `biome check` 対象4ファイルでエラーなし
- [x] `pnpm --filter @suzumina.click/web typecheck` 通過
- [x] ローカル preview でトップ（footer）・about・terms の表示文言を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)