### PR TITLE
feat(web): ログインファネル(開始/成功/エラー)のGA4計器化 (SPR-267)

### DIFF
--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, Home, RotateCw } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
+import { LoginErrorTracker } from "@/components/analytics/login-error-tracker";
 
 export const metadata: Metadata = {
 	title: "エラー",
@@ -70,6 +71,7 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 
 	return (
 		<div className="min-h-screen flex items-center justify-center bg-background px-4">
+			<LoginErrorTracker error={error} />
 			<Card className="max-w-md w-full shadow-xl animate-in fade-in-0 zoom-in-95 duration-500">
 				<CardContent className="p-8 text-center space-y-6">
 					<div className="mx-auto w-16 h-16 bg-gradient-to-br from-suzuka-100 to-minase-100 rounded-full flex items-center justify-center">

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { signInAction } from "@/app/auth/actions";
-import { DiscordIcon } from "@/components/user/discord-icon";
+import { LoginErrorTracker } from "@/components/analytics/login-error-tracker";
+import { DiscordSignInButton } from "@/components/user/discord-signin-button";
 
 interface SignInPageProps {
 	searchParams: Promise<{ callbackUrl?: string; error?: string }>;
@@ -10,6 +11,7 @@ async function SignInForm({ searchParams }: SignInPageProps) {
 	const { callbackUrl, error } = await searchParams;
 	return (
 		<div className="min-h-screen flex items-center justify-center bg-muted">
+			<LoginErrorTracker error={error} />
 			<div className="max-w-md w-full space-y-8 p-8 bg-card rounded-xl shadow-lg">
 				<div className="text-center">
 					<h2 className="text-3xl font-bold text-foreground mb-2">すずみなくりっく！</h2>
@@ -29,13 +31,11 @@ async function SignInForm({ searchParams }: SignInPageProps) {
 				</div>
 
 				<form action={signInAction.bind(null, callbackUrl ?? "/")} className="space-y-4">
-					<button
-						type="submit"
+					<DiscordSignInButton
 						className="w-full flex items-center justify-center gap-3 bg-primary hover:bg-primary/90 text-primary-foreground font-medium py-3 px-4 rounded-lg transition-colors duration-200"
-					>
-						<DiscordIcon className="w-5 h-5" />
-						Discordでログイン
-					</button>
+						iconClassName="w-5 h-5"
+						label="Discordでログイン"
+					/>
 				</form>
 
 				<div className="text-center text-sm text-muted-foreground space-y-3">

--- a/apps/web/src/components/analytics/__tests__/login-error-tracker.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/login-error-tracker.test.tsx
@@ -33,4 +33,12 @@ describe("LoginErrorTracker", () => {
 
 		expect(spy).not.toHaveBeenCalled();
 	});
+
+	it("pending 印が無ければ error があっても送らない（reload・戻る/進む・URL共有経由の再訪問での水増し防止）", () => {
+		const spy = vi.spyOn(events, "trackLoginError").mockImplementation(() => {});
+
+		render(<LoginErrorTracker error="AccessDenied" />);
+
+		expect(spy).not.toHaveBeenCalled();
+	});
 });

--- a/apps/web/src/components/analytics/__tests__/login-error-tracker.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/login-error-tracker.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as events from "@/lib/analytics/events";
+import { markLoginFlowStarted } from "@/lib/analytics/login-funnel";
+import { LoginErrorTracker } from "../login-error-tracker";
+
+const STORAGE_KEY = "suzumina-login-flow-pending";
+
+beforeEach(() => {
+	sessionStorage.clear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	sessionStorage.clear();
+});
+
+describe("LoginErrorTracker", () => {
+	it("error があれば login_error を送り、pending 印を消費する", () => {
+		const spy = vi.spyOn(events, "trackLoginError").mockImplementation(() => {});
+		markLoginFlowStarted();
+
+		render(<LoginErrorTracker error="AccessDenied" />);
+
+		expect(spy).toHaveBeenCalledWith("AccessDenied");
+		expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+
+	it("error が無ければ何もしない（通常の /auth/signin 訪問を誤発火させない）", () => {
+		const spy = vi.spyOn(events, "trackLoginError").mockImplementation(() => {});
+
+		render(<LoginErrorTracker />);
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/components/analytics/__tests__/login-success-tracker.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/login-success-tracker.test.tsx
@@ -1,0 +1,65 @@
+import type { UserSession } from "@suzumina.click/shared-types";
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as events from "@/lib/analytics/events";
+import { markLoginFlowStarted } from "@/lib/analytics/login-funnel";
+import { useSessionState } from "@/lib/auth/client";
+import { LoginSuccessTracker } from "../login-success-tracker";
+
+vi.mock("@/lib/auth/client");
+
+const mockUser = { discordId: "1", displayName: "テストユーザー" } as UserSession;
+
+function setSessionState(state: { user: UserSession | null; isPending: boolean }) {
+	vi.mocked(useSessionState).mockReturnValue(state);
+}
+
+beforeEach(() => {
+	sessionStorage.clear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	sessionStorage.clear();
+});
+
+describe("LoginSuccessTracker", () => {
+	it("pending 印がある状態でセッション解決＝ログイン成功として login_success を送る", () => {
+		const spy = vi.spyOn(events, "trackLoginSuccess").mockImplementation(() => {});
+		markLoginFlowStarted();
+		setSessionState({ user: mockUser, isPending: false });
+
+		render(<LoginSuccessTracker />);
+
+		expect(spy).toHaveBeenCalledWith("discord");
+	});
+
+	it("pending 印が無ければ、ログイン済みでの通常ページ読み込みでは送らない", () => {
+		const spy = vi.spyOn(events, "trackLoginSuccess").mockImplementation(() => {});
+		setSessionState({ user: mockUser, isPending: false });
+
+		render(<LoginSuccessTracker />);
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("セッション解決前（isPending）では送らない", () => {
+		const spy = vi.spyOn(events, "trackLoginSuccess").mockImplementation(() => {});
+		markLoginFlowStarted();
+		setSessionState({ user: null, isPending: true });
+
+		render(<LoginSuccessTracker />);
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it("未ログイン（解決済み・user=null）では送らない", () => {
+		const spy = vi.spyOn(events, "trackLoginSuccess").mockImplementation(() => {});
+		markLoginFlowStarted();
+		setSessionState({ user: null, isPending: false });
+
+		render(<LoginSuccessTracker />);
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/components/analytics/login-error-tracker.tsx
+++ b/apps/web/src/components/analytics/login-error-tracker.tsx
@@ -12,12 +12,18 @@ interface LoginErrorTrackerProps {
  * ログインファネル: OAuth コールバックが `?error=` 付きで返ってきた場合にエラーイベントを送る
  * 不可視コンポーネント（/auth/signin・/auth/error の両ページで使う）。
  * error が無い（＝通常のログイン要求で /auth/signin に来ただけ）場合は何もしない。
+ *
+ * pending 印（login-funnel.ts）が無い場合も送らない。印が無いのは「このタブが開始した
+ * ログイン試行の結果ではない」ケース（このエラーページの reload・戻る/進むでの再訪問・
+ * URL の直接共有/ブックマーク経由の再訪問）で、login_start と対応しない login_error を
+ * 計上すると SPR-267 の判断材料（開始→エラーの転換率）が水増しされる。
  */
 export function LoginErrorTracker({ error }: LoginErrorTrackerProps) {
 	useEffect(() => {
 		if (!error) return;
-		trackLoginError(error);
-		consumeLoginFlowPending();
+		if (consumeLoginFlowPending()) {
+			trackLoginError(error);
+		}
 	}, [error]);
 
 	return null;

--- a/apps/web/src/components/analytics/login-error-tracker.tsx
+++ b/apps/web/src/components/analytics/login-error-tracker.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackLoginError } from "@/lib/analytics/events";
+import { consumeLoginFlowPending } from "@/lib/analytics/login-funnel";
+
+interface LoginErrorTrackerProps {
+	error?: string;
+}
+
+/**
+ * ログインファネル: OAuth コールバックが `?error=` 付きで返ってきた場合にエラーイベントを送る
+ * 不可視コンポーネント（/auth/signin・/auth/error の両ページで使う）。
+ * error が無い（＝通常のログイン要求で /auth/signin に来ただけ）場合は何もしない。
+ */
+export function LoginErrorTracker({ error }: LoginErrorTrackerProps) {
+	useEffect(() => {
+		if (!error) return;
+		trackLoginError(error);
+		consumeLoginFlowPending();
+	}, [error]);
+
+	return null;
+}

--- a/apps/web/src/components/analytics/login-success-tracker.tsx
+++ b/apps/web/src/components/analytics/login-success-tracker.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackLoginSuccess } from "@/lib/analytics/events";
+import { consumeLoginFlowPending } from "@/lib/analytics/login-funnel";
+import { useSessionState } from "@/lib/auth/client";
+
+/**
+ * ログインファネル: OAuth 完了後、セッションが初めて確立したタイミングを検知して
+ * login_success を送る不可視コンポーネント（全ページ mount・InternalTrafficMarker と同型）。
+ *
+ * login_flow_pending の印（login-funnel.ts）が無い場合は「元々ログイン済みの通常ページ読み込み」
+ * であり誤発火させない。印を消費するのはこの effect が初めて解決したタイミングの一度きり。
+ */
+export function LoginSuccessTracker() {
+	const { user, isPending } = useSessionState();
+
+	useEffect(() => {
+		if (isPending) return;
+		if (user && consumeLoginFlowPending()) {
+			trackLoginSuccess("discord");
+		}
+	}, [isPending, user]);
+
+	return null;
+}

--- a/apps/web/src/components/system/deferred-global-effects.tsx
+++ b/apps/web/src/components/system/deferred-global-effects.tsx
@@ -24,6 +24,12 @@ const PageViewTracker = lazy(() =>
 	import("@/components/analytics/page-view-tracker").then((m) => ({ default: m.PageViewTracker })),
 );
 
+const LoginSuccessTracker = lazy(() =>
+	import("@/components/analytics/login-success-tracker").then((m) => ({
+		default: m.LoginSuccessTracker,
+	})),
+);
+
 const CookieConsentBanner = lazy(() =>
 	import("@/components/consent/cookie-consent-banner").then((m) => ({
 		default: m.CookieConsentBanner,
@@ -47,6 +53,7 @@ export function DeferredGlobalEffects() {
 			<Suspense fallback={null}>
 				<PerformanceMonitor />
 				<PageViewTracker />
+				<LoginSuccessTracker />
 				<CookieConsentBanner />
 			</Suspense>
 		</>

--- a/apps/web/src/components/user/__tests__/discord-signin-button.test.tsx
+++ b/apps/web/src/components/user/__tests__/discord-signin-button.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as events from "@/lib/analytics/events";
+import { DiscordSignInButton } from "../discord-signin-button";
+
+const STORAGE_KEY = "suzumina-login-flow-pending";
+
+beforeEach(() => {
+	sessionStorage.clear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	sessionStorage.clear();
+});
+
+describe("DiscordSignInButton", () => {
+	it("押下時に login_start を送り、login-funnel の印を付ける", () => {
+		const spy = vi.spyOn(events, "trackLoginStart").mockImplementation(() => {});
+		render(<DiscordSignInButton className="" label="Discordでログイン" />);
+
+		fireEvent.click(screen.getByRole("button", { name: /Discordでログイン/i }));
+
+		expect(spy).toHaveBeenCalledWith("discord");
+		expect(sessionStorage.getItem(STORAGE_KEY)).toBe("1");
+	});
+});

--- a/apps/web/src/components/user/auth-button.tsx
+++ b/apps/web/src/components/user/auth-button.tsx
@@ -3,7 +3,7 @@
 import type { UserSession } from "@suzumina.click/shared-types";
 import { usePathname } from "next/navigation";
 import { signInAction } from "@/app/auth/actions";
-import { DiscordIcon } from "./discord-icon";
+import { DiscordSignInButton } from "./discord-signin-button";
 import UserMenu from "./user-menu";
 
 interface AuthButtonProps {
@@ -22,13 +22,10 @@ export default function AuthButton({ user }: AuthButtonProps) {
 
 	return (
 		<form action={signInWithCallback}>
-			<button
-				type="submit"
+			<DiscordSignInButton
 				className="flex items-center gap-2 bg-primary hover:bg-primary/90 text-primary-foreground font-medium py-2 px-4 rounded-lg transition-colors duration-200"
-			>
-				<DiscordIcon className="w-4 h-4" />
-				<span>Discordログイン</span>
-			</button>
+				label="Discordログイン"
+			/>
 		</form>
 	);
 }

--- a/apps/web/src/components/user/discord-signin-button.tsx
+++ b/apps/web/src/components/user/discord-signin-button.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { trackLoginStart } from "@/lib/analytics/events";
+import { markLoginFlowStarted } from "@/lib/analytics/login-funnel";
+import { DiscordIcon } from "./discord-icon";
+
+interface DiscordSignInButtonProps {
+	className: string;
+	iconClassName?: string;
+	label: string;
+}
+
+/**
+ * Discord サインインボタン（ヘッダー / signin ページで共有）。
+ * 遷移自体は親の `<form action={signInAction...}>` が担い、このボタンは押下時に
+ * ログインファネルの起点イベント（login_start）を送るだけの薄い層。
+ */
+export function DiscordSignInButton({
+	className,
+	iconClassName = "w-4 h-4",
+	label,
+}: DiscordSignInButtonProps) {
+	return (
+		<button
+			type="submit"
+			className={className}
+			onClick={() => {
+				trackLoginStart("discord");
+				markLoginFlowStarted();
+			}}
+		>
+			<DiscordIcon className={iconClassName} />
+			<span>{label}</span>
+		</button>
+	);
+}

--- a/apps/web/src/lib/analytics/__tests__/events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/events.test.ts
@@ -4,6 +4,9 @@ import {
 	trackCreateStart,
 	trackCreateSuccess,
 	trackFavoriteToggle,
+	trackLoginError,
+	trackLoginStart,
+	trackLoginSuccess,
 	trackMarkDraft,
 	trackPlayButton,
 } from "../events";
@@ -82,5 +85,23 @@ describe("GA4 カスタムイベント語彙 (SPR-149)", () => {
 			video_id: "vid00000001",
 			has_player_time: false,
 		});
+	});
+
+	it("ログインファネル: start / success / error を送る", () => {
+		grantAnalyticsConsent();
+		trackLoginStart("discord");
+		trackLoginSuccess("discord");
+		trackLoginError("AccessDenied");
+
+		expect(gtag).toHaveBeenCalledWith("event", "login_start", { provider: "discord" });
+		expect(gtag).toHaveBeenCalledWith("event", "login_success", { provider: "discord" });
+		expect(gtag).toHaveBeenCalledWith("event", "login_error", { reason: "AccessDenied" });
+	});
+
+	it("login_error: reason は GA4 のパラメータ上限（100文字）に切り詰める", () => {
+		grantAnalyticsConsent();
+		trackLoginError("x".repeat(150));
+		const call = gtag.mock.calls.find((c) => c[1] === "login_error");
+		expect((call?.[2] as { reason: string } | undefined)?.reason).toHaveLength(100);
 	});
 });

--- a/apps/web/src/lib/analytics/__tests__/login-funnel.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/login-funnel.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { consumeLoginFlowPending, markLoginFlowStarted } from "../login-funnel";
+
+const STORAGE_KEY = "suzumina-login-flow-pending";
+
+beforeEach(() => {
+	sessionStorage.clear();
+});
+
+afterEach(() => {
+	sessionStorage.clear();
+});
+
+describe("ログインファネルの一時マーカー", () => {
+	it("開始の印を付け、結果側で一度だけ消費できる", () => {
+		markLoginFlowStarted();
+		expect(sessionStorage.getItem(STORAGE_KEY)).toBe("1");
+
+		expect(consumeLoginFlowPending()).toBe(true);
+		expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+
+	it("印が無ければ false を返す（通常のログイン済みページ読み込みで誤発火させない）", () => {
+		expect(consumeLoginFlowPending()).toBe(false);
+	});
+
+	it("消費は一度きり（同じ印を二度使えない）", () => {
+		markLoginFlowStarted();
+		expect(consumeLoginFlowPending()).toBe(true);
+		expect(consumeLoginFlowPending()).toBe(false);
+	});
+});

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -61,3 +61,21 @@ export function trackMarkDraft(videoId: string, hasPlayerTime: boolean): void {
 		has_player_time: hasPlayerTime,
 	});
 }
+
+/**
+ * ログインファネル: ボタン押下（OAuth プロバイダへのリダイレクト直前）。
+ * ページ遷移前の最後のタイミングで送るため、他イベントより取りこぼしのリスクが高い点に留意。
+ */
+export function trackLoginStart(provider: string): void {
+	sendGoogleAnalyticsEvent("login_start", { provider });
+}
+
+/** ログインファネル: OAuth コールバック後、セッションが初めて確立した時点（成功） */
+export function trackLoginSuccess(provider: string): void {
+	sendGoogleAnalyticsEvent("login_success", { provider });
+}
+
+/** ログインファネル: OAuth コールバックがエラーで返ってきた場合（reason=better-auth のエラーコード） */
+export function trackLoginError(reason: string): void {
+	sendGoogleAnalyticsEvent("login_error", { reason: reason.slice(0, MAX_PARAM_LENGTH) });
+}

--- a/apps/web/src/lib/analytics/login-funnel.ts
+++ b/apps/web/src/lib/analytics/login-funnel.ts
@@ -1,0 +1,30 @@
+/**
+ * ログインファネルの「開始→結果」を跨いで対応付けるための一時マーカー（sessionStorage）。
+ *
+ * ログイン開始はボタン押下→フォーム送信→OAuth プロバイダへのフルページ遷移のため、
+ * 開始と結果（成功/エラーページ着地）は別ページロードの別 React ツリーで検知する。
+ * このマーカーで「直前に自分が開始したログイン試行の結果である」ことを識別し、
+ * 既にログイン済みユーザーの通常ページ読み込みで login_success を誤発火させない。
+ */
+
+const STORAGE_KEY = "suzumina-login-flow-pending";
+
+/** ログイン開始時（ボタン押下）に呼ぶ */
+export function markLoginFlowStarted(): void {
+	try {
+		window.sessionStorage.setItem(STORAGE_KEY, "1");
+	} catch {
+		// sessionStorage 不可の環境では諦める（login_success の誤発火防止が効かなくなるだけで許容）
+	}
+}
+
+/** 結果側（成功検知 / エラーページ）で一度だけ呼ぶ。印があれば消費して true を返す */
+export function consumeLoginFlowPending(): boolean {
+	try {
+		const pending = window.sessionStorage.getItem(STORAGE_KEY) === "1";
+		window.sessionStorage.removeItem(STORAGE_KEY);
+		return pending;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary
- SPR-108（Discord以外のログイン手段検討）は勘のみでデータ裏付けが無く、SPR-137/SPR-22の「集客は勝利条件から除外」方針となし崩しに矛盾しかねないため、まず計測を追加した
- 本番Firestore実測（登録ユーザー11人）とYouTube登録者(10.6万人)・ci-enフォロワー(13,179人)を比較したところ、ボトルネックは「来訪→登録」ではなく「認知→来訪」側であり、ログイン画面での離脱自体は未計測だった
- `login_start` / `login_success` / `login_error` の3イベントをSPR-149の命名規約に準拠して追加し、ボタン押下とOAuthコールバック結果（別ページロード）をsessionStorageの一時印で対応付け
- 4週間後(2026-08-15)を目安にファネルデータを見てSPR-108着手要否を判断する（[SPR-267](https://linear.app/nothink/issue/SPR-267/ログインファネルlogin-startsuccesserrorのga4計器化-spr-108着手要否の判断材料)にdueDate設定済み）

## Test plan
- [x] `pnpm --filter @suzumina.click/web lint` — pass
- [x] `pnpm --filter @suzumina.click/web typecheck` — pass
- [x] `pnpm --filter @suzumina.click/web test -- --run` — 116 files / 1012 tests pass
- [x] ブラウザ実地確認（Emulator）: ヘッダーのDiscordログインボタン押下でlogin_start発火＋pending印セット、`/auth/error?error=AccessDenied`到達でlogin_error発火＋印消費まで確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)