### PR TITLE
fix(web): terms/aboutの実態と食い違う記述を修正

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -176,7 +176,7 @@ export default function AboutPage() {
 				{/* フッター */}
 				<div className="text-center pt-8 border-t">
 					<p className="text-sm text-muted-foreground">
-						最終更新: 2025年6月 • 個人運営のファンサイトです
+						最終更新: 2026年7月18日 • 個人運営のファンサイトです
 					</p>
 				</div>
 			</div>

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -164,7 +164,7 @@ export default function TermsPage() {
 								</p>
 								<ul className="text-sm text-muted-foreground mt-2 space-y-1">
 									<li>• 投稿コンテンツの削除</li>
-									<li>• アクセス制限またはアカウント停止</li>
+									<li>• アクセス制限</li>
 									<li>• 必要に応じて関係当局への報告</li>
 								</ul>
 							</div>


### PR DESCRIPTION
## Summary
- `terms`: 利用制限として「アカウント停止」を挙げていたが、`isActive` を無効化する運用・管理ツールは実装されておらず（`protected-route.tsx` のコメント通り、防御的ゲートのみで通常到達しない）、実際に取り得る「アクセス制限」のみ残す
- `about`: 「最終更新: 2025年6月」のまま放置されていたため、実際の最終編集日に更新

#807 のフォローアップとして、実装との突き合わせで見つかったその他の不一致を修正しています。GA4/cookie同意フロー、Discord OAuth収集項目、rate limit数値(10/110)、DLsite連携などは実装と一致していたため対象外です。

## Test plan
- [x] `biome check` 対象2ファイルでエラーなし
- [x] `pnpm --filter @suzumina.click/web typecheck` 通過（pre-push hookで確認）
- [x] ローカル preview で terms（「アカウント停止」非表示）・about（更新日）を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)