### PR TITLE
fix(ci): claude-review の max-turns 枯渇と失敗の可視化を修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,8 +42,11 @@ jobs:
 
       # advisory（非ブロッキング）なので失敗しても PR を赤くしない。
       # 特に「この workflow 自体を変更した PR」は validation 仕様でハードエラーになるが無害。
-      # 注意: レビュー欠落（コメント未投稿）が失敗のサイン。緑＝必ずレビュー成功、ではない。
+      # 注意: レビュー欠落（コメント未投稿）が失敗のサイン。緑＝必ずレビュー成功、ではない
+      #   （このステップ自体は continue-on-error のため conclusion は常に success になる。
+      #    実際の成否は後続の「Fail job if Claude review errored」ステップの outcome チェックで可視化する）。
       - name: Claude Code Review
+        id: claude-review
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -83,8 +86,22 @@ jobs:
             - 問題が無ければ「重大所見なし」とはっきり書く。
           # モデルは固定しない（版ズレ回避: CLAUDE.md 軸1）。action 既定の最新モデルに任せる。
           # 行内コメント投稿ツールと gh コマンドを明示許可（これが無いと投稿できない）。
+          # git diff / git status: claude-code-action 組み込みシステムプロンプトが PR 差分確認に
+          #   `git diff origin/main...HEAD` / `git status` を使うよう明示的に指示してくる。これを
+          #   allowedTools から漏らすと毎回 permission denied → 再試行のループでターンを空費し、
+          #   「コンテキスト取得」段階のまま max-turns で強制終了する（run 29632314677 で確認・PR #810）。
           # max-turns 40: CLI 更新で既定モデルが変わるとターン消費が増える（sonnet-4-6→5 で 5-15→21+ に増加し
           #   20 では枯渇＝レビュー未投稿。run 28672455307）。モデル非固定の方針を維持するため余裕を持たせる。
           claude_args: |
             --max-turns 40
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git status:*)"
+
+      # continue-on-error でこのステップ自体は success 扱いになるため、レビューが
+      # error_max_turns 等で未完了に終わった場合は job を明示的に fail させて可視化する
+      # （「重大所見なし」で通ったのか「レビューが実行できなかった」のかを gh pr checks で区別するため）。
+      # 必須チェックには設定しない方針（CLAUDE.md §1）なので、この fail は merge をブロックしない。
+      - name: Fail job if Claude review errored
+        if: steps.claude-review.outcome == 'failure'
+        run: |
+          echo "::error::Claude Code Review step failed (outcome=failure). This means the AI review did NOT complete — it is NOT the same as 'reviewed, no findings'. See the Claude Code Review step log above for details."
+          exit 1


### PR DESCRIPTION
## 背景
PR #810 (run [29632314677](https://github.com/nothink-jp/suzumina.click/actions/runs/29632314677)) で `claude-review.yml` の Claude Code Review が `error_max_turns` で強制終了。しかし `continue-on-error: true` によりステップ・job とも `success` 扱いになり、`gh pr checks` では「所見なし・pass」と見分けがつかなかった。

## 根本原因
- `claude-code-action` の組み込みシステムプロンプトは PR 差分確認に `git diff origin/main...HEAD` / `git status` を使うよう明示的に指示する
- しかし `claude_args` の `--allowedTools` にはこれらが含まれておらず、`Bash(gh pr diff:*)` 等の許可はあるが素の `git diff` / `git status` は無い
- そのため Claude が組み込み指示に従って `git diff` を叩くたびに permission denied となり、再試行でターンを浪費（実測 `permission_denials_count: 7`）
- 結果、PR #810 の2回の実行はどちらも進捗チェックリストの「コンテキスト取得・CLAUDE.md 確認」から一歩も進めず、40 ターン上限（実測 `num_turns: 41`）で強制終了していた（実行時間は3分強で job の15分タイムアウトには無関係）

## 変更内容
1. `allowedTools` に `Bash(git diff:*)`, `Bash(git status:*)` を追加し、組み込み指示との矛盾を解消
2. `Claude Code Review` ステップに `id: claude-review` を付与し、後続ステップで `outcome == 'failure'` を検知して job を明示的に fail させる
   - 必須チェックには設定しない方針（CLAUDE.md §1）は変えていないため、この fail は merge をブロックしない
   - `gh pr checks` 上で「レビュー完了・重大所見なし」と「レビューが実行できなかった」を区別できるようにする

## Door 判定
⚠️ One-Way Door（`.github/workflows` の変更）— CLAUDE.md の方針により自己マージせず人間レビューを経ること。

## Test plan
- [ ] YAML 構文チェック済み（ruby -ryaml で validate 済み）
- [ ] main マージ後、複雑な差分を持つ PR（または過去に失敗した PR の再実行）で実際にレビューが完走することを確認
  - 注意: claude-code-action は workflow が main と同一になるまで実レビューをスキップする仕様のため、検証は main マージ後になる
- [ ] 意図的にレビューを失敗させるケース（例: max-turns を極端に低く一時設定）で job が fail 表示になることを確認（任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)