### PR TITLE
feat(web): 作品詳細ページの動的OG画像生成（SPR-268 段階導入①）

### DIFF
--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -1,6 +1,11 @@
 import { ImageResponse } from "next/og";
 import { getAudioButtonById } from "@/app/buttons/actions";
 import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import {
+	estimateTextWidth as estimateTextWidthShared,
+	formatDisplayTitle,
+	truncateWithEllipsis,
+} from "@/lib/og-text";
 
 /**
  * 音声ボタン詳細の動的 OG 画像（SPR-249 / デザインは Claude Design「音声ボタンOGP」1a 案）。
@@ -32,31 +37,19 @@ const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 
 /** ボタン名の表示用整形。折り返し幅 750px × 4行に収まる長さへ末尾省略する */
 export function truncateButtonText(text: string, max = 52): string {
-	return text.length > max ? `${text.slice(0, max)}…` : text;
+	return truncateWithEllipsis(text, max);
 }
 
-/**
- * テキストの概算描画幅（px）。半角 ≈ 0.6em / 全角 ≈ 1.0em の粗い見積もり。
- * satori(Yoga) は auto 幅 flex の入れ子内でテキスト折り返し幅を解決できないため、
- * 「1行に収まらない場合だけ明示幅を与えて折り返す」判定に使う（正確な字幅計測は不要）
- */
+/** テキストの概算描画幅（px）。lib/og-text の共通実装に委譲（詳細はそちらのコメント参照） */
 export function estimateTextWidth(text: string, fontSize: number): number {
-	let em = 0;
-	for (const ch of text) {
-		em += (ch.codePointAt(0) ?? 0) <= 0x024f ? 0.6 : 1.0;
-	}
-	return Math.round(em * fontSize);
+	return estimateTextWidthShared(text, fontSize);
 }
 
 /**
  * 元動画タイトルの表示用整形。フォントに無い絵文字（tofu 化する）を除去し、1行に収まる長さへ省略する
  */
 export function formatVideoTitle(title: string, max = 40): string {
-	const stripped = title
-		.replace(/\p{Extended_Pictographic}|\u{FE0F}|\u{200D}/gu, "")
-		.replace(/\s+/g, " ")
-		.trim();
-	return stripped.length > max ? `${stripped.slice(0, max)}…` : stripped;
+	return formatDisplayTitle(title, max);
 }
 
 function PlayCircle() {

--- a/apps/web/src/app/works/[workId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/works/[workId]/__tests__/opengraph-image.test.tsx
@@ -94,6 +94,27 @@ describe("作品詳細の OG 画像（app/works/[workId]/opengraph-image.tsx）"
 		vi.unstubAllGlobals();
 	});
 
+	it("許可外ホストのジャケットURLは fetch せず画像無しで描画する", async () => {
+		vi.mocked(getWorkById).mockResolvedValueOnce(
+			makeWork({
+				highResImageUrl: "https://evil.example.com/steal.jpg",
+				thumbnailUrl: "https://evil.example.com/steal-thumb.jpg",
+			}) as never,
+		);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = (await Image({
+			params: Promise.resolve({ workId: "RJ00000001" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(response.element.props.jacketDataUri).toBeNull();
+
+		vi.unstubAllGlobals();
+	});
+
 	it("フォント取得失敗でも 500 にせず ASCII 縮退版を描画する", async () => {
 		vi.mocked(getWorkById).mockResolvedValueOnce(makeWork({ title: "Ascii Title" }) as never);
 		vi.mocked(loadMPlusRoundedSubset).mockRejectedValue(new Error("font error"));

--- a/apps/web/src/app/works/[workId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/works/[workId]/__tests__/opengraph-image.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ImageResponse は実描画せず、渡された element / options を検証できる形で捕捉する
+vi.mock("next/og", () => ({
+	ImageResponse: class {
+		element: React.ReactElement;
+		options: { fonts?: unknown[] } | undefined;
+		constructor(element: React.ReactElement, options?: { fonts?: unknown[] }) {
+			this.element = element;
+			this.options = options;
+		}
+	},
+}));
+vi.mock("@/app/works/actions", () => ({ getWorkById: vi.fn() }));
+vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+
+import { getWorkById } from "@/app/works/actions";
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import Image, { alt, contentType, size } from "../opengraph-image";
+
+type OgCardProps = {
+	title: string;
+	circle: string;
+	price: string;
+	jacketDataUri: string | null;
+};
+
+function makeWork(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		title: "テスト作品タイトル",
+		circle: "テストサークル",
+		price: { formattedPrice: "1,320円" },
+		highResImageUrl: "https://img.dlsite.jp/example_main.jpg",
+		thumbnailUrl: "https://img.dlsite.jp/example_sam.jpg",
+		...overrides,
+	};
+}
+
+describe("作品詳細の OG 画像（app/works/[workId]/opengraph-image.tsx）", () => {
+	it("1200×630 の PNG を宣言している", () => {
+		expect(size).toEqual({ width: 1200, height: 630 });
+		expect(contentType).toBe("image/png");
+		expect(alt).toContain("DLsite作品情報");
+	});
+
+	it("作品取得成功時はタイトル・サークル・価格・ジャケットを描画する", async () => {
+		vi.mocked(getWorkById).mockResolvedValueOnce(makeWork() as never);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(4),
+				headers: new Headers({ "content-type": "image/jpeg" }),
+			}),
+		);
+
+		const response = (await Image({
+			params: Promise.resolve({ workId: "RJ00000001" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(response.element.props.title).toBe("テスト作品タイトル");
+		expect(response.element.props.circle).toBe("テストサークル");
+		expect(response.element.props.price).toBe("1,320円");
+		expect(response.element.props.jacketDataUri).toMatch(/^data:image\/jpeg;base64,/);
+
+		vi.unstubAllGlobals();
+	});
+
+	it("作品が見つからない場合はサイト名版にフォールバックする", async () => {
+		vi.mocked(getWorkById).mockResolvedValueOnce(null);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ workId: "unknown" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(response.element.props.title).toBe("すずみなくりっく！");
+		expect(response.element.props.jacketDataUri).toBeNull();
+	});
+
+	it("ジャケット取得失敗でも 500 にせず画像無しで描画を継続する", async () => {
+		vi.mocked(getWorkById).mockResolvedValueOnce(makeWork() as never);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
+
+		const response = (await Image({
+			params: Promise.resolve({ workId: "RJ00000001" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(response.element.props.jacketDataUri).toBeNull();
+		expect(response.element.props.title).toBe("テスト作品タイトル");
+
+		vi.unstubAllGlobals();
+	});
+
+	it("フォント取得失敗でも 500 にせず ASCII 縮退版を描画する", async () => {
+		vi.mocked(getWorkById).mockResolvedValueOnce(makeWork({ title: "Ascii Title" }) as never);
+		vi.mocked(loadMPlusRoundedSubset).mockRejectedValue(new Error("font error"));
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(4),
+				headers: new Headers({ "content-type": "image/jpeg" }),
+			}),
+		);
+
+		const response = (await Image({
+			params: Promise.resolve({ workId: "RJ00000001" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps>; options: { fonts?: unknown[] } };
+
+		expect(response.element.props.title).toBe("Ascii Title");
+		expect(response.options.fonts).toBeUndefined();
+
+		vi.unstubAllGlobals();
+	});
+});

--- a/apps/web/src/app/works/[workId]/opengraph-image.tsx
+++ b/apps/web/src/app/works/[workId]/opengraph-image.tsx
@@ -29,12 +29,18 @@ const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 const TITLE_MAX_WIDTH = 620;
 const TITLE_FONT_SIZE = 48;
 
+// next.config.mjs の images.remotePatterns と同じ許可ホスト（DLsite CDN限定）。
+// work.highResImageUrl/thumbnailUrl はスクレイパー由来でユーザー入力ではないが、
+// fetch する経路である以上 next/image と同じ制約を明示しておく
+const ALLOWED_JACKET_HOSTNAME = "img.dlsite.jp";
+
 /**
  * ジャケット画像を data URI として取得する。取得・変換に失敗しても null を返すのみで例外を投げない
  * （satori はネットワーク不安定な remote src の直接指定より、埋め込み済み data URI の方が安定するため事前取得する）
  */
 async function loadJacketDataUri(url: string): Promise<string | null> {
 	try {
+		if (new URL(url).hostname !== ALLOWED_JACKET_HOSTNAME) return null;
 		const res = await fetch(url);
 		if (!res.ok) return null;
 		const buffer = await res.arrayBuffer();

--- a/apps/web/src/app/works/[workId]/opengraph-image.tsx
+++ b/apps/web/src/app/works/[workId]/opengraph-image.tsx
@@ -1,0 +1,204 @@
+import { ImageResponse } from "next/og";
+import { getWorkById } from "@/app/works/actions";
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import { estimateTextWidth, formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
+
+/**
+ * DLsite作品詳細の動的 OG 画像（SPR-268 / /buttons/[id] の opengraph-image と同じ file-convention パターン）。
+ * X のリンクカードは「画像 + 小タイトル + ドメイン」しか表示しないため（SPR-17 調査）、
+ * 作品ジャケット + タイトル + サークル名 + 価格を画像内に構成し、カード単体で内容が伝わるようにする。
+ * og:image / twitter:image はこの規約ファイルから自動出力される（generateMetadata の images 手書きはしない）。
+ * どの失敗経路でも 500 は返さない（作品未取得→サイト名版 / ジャケット取得失敗→ジャケット無し版 / フォント取得失敗→ASCII 縮退版）。
+ */
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "DLsite作品情報 - すずみなくりっく！";
+
+// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
+// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
+const BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
+const SUZUKA_100 = "hsl(341, 62%, 94%)";
+const SUZUKA_500 = "hsl(340, 58%, 46%)";
+const SUZUKA_700 = "hsl(339, 55%, 33%)";
+const MINASE_300 = "hsl(32, 38%, 79%)";
+const MINASE_800 = "hsl(27, 32%, 37%)";
+const MINASE_950 = "hsl(25, 28%, 18%)";
+const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
+
+const TITLE_MAX_WIDTH = 620;
+const TITLE_FONT_SIZE = 48;
+
+/**
+ * ジャケット画像を data URI として取得する。取得・変換に失敗しても null を返すのみで例外を投げない
+ * （satori はネットワーク不安定な remote src の直接指定より、埋め込み済み data URI の方が安定するため事前取得する）
+ */
+async function loadJacketDataUri(url: string): Promise<string | null> {
+	try {
+		const res = await fetch(url);
+		if (!res.ok) return null;
+		const buffer = await res.arrayBuffer();
+		const base64 = Buffer.from(buffer).toString("base64");
+		const contentType = res.headers.get("content-type") || "image/jpeg";
+		return `data:${contentType};base64,${base64}`;
+	} catch {
+		return null;
+	}
+}
+
+interface OgCardProps {
+	badgeLabel: string;
+	title: string;
+	circle: string;
+	price: string;
+	jacketDataUri: string | null;
+}
+
+/** ジャケット + タイトル/サークル/価格の2カラムレイアウト（通常版と縮退版で共用） */
+function OgCard({ badgeLabel, title, circle, price, jacketDataUri }: OgCardProps) {
+	const needsWrap = estimateTextWidth(title, TITLE_FONT_SIZE) > TITLE_MAX_WIDTH;
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				width: "100%",
+				height: "100%",
+				backgroundColor: BACKGROUND,
+				fontFamily: "M PLUS Rounded 1c",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: 56,
+					flexGrow: 1,
+					padding: "56px 64px 0",
+				}}
+			>
+				{jacketDataUri && (
+					// biome-ignore lint/performance/noImgElement: ImageResponse(satori) は next/image を使えないため生 img 必須
+					<img
+						src={jacketDataUri}
+						alt=""
+						width={420}
+						height={315}
+						style={{
+							borderRadius: 24,
+							border: `4px solid ${MINASE_300}`,
+							boxShadow: "0 12px 40px hsla(30, 38%, 66%, 0.35)",
+							objectFit: "cover",
+							flexShrink: 0,
+						}}
+					/>
+				)}
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						gap: 22,
+						minWidth: 0,
+					}}
+				>
+					<span
+						style={{
+							alignSelf: "flex-start",
+							backgroundColor: SUZUKA_100,
+							color: SUZUKA_700,
+							fontWeight: 700,
+							fontSize: 25,
+							padding: "10px 30px",
+							borderRadius: 9999,
+						}}
+					>
+						{badgeLabel}
+					</span>
+					<div
+						style={{
+							...(needsWrap ? { width: TITLE_MAX_WIDTH } : {}),
+							fontWeight: 700,
+							fontSize: TITLE_FONT_SIZE,
+							lineHeight: 1.35,
+							color: MINASE_950,
+						}}
+					>
+						{title}
+					</div>
+					<span style={{ fontSize: 28, color: MUTED_FOREGROUND }}>{circle}</span>
+					<span style={{ fontWeight: 700, fontSize: 34, color: SUZUKA_500 }}>{price}</span>
+				</div>
+			</div>
+
+			<div style={{ display: "flex", alignItems: "center", gap: 14, padding: "0 64px 40px" }}>
+				<span style={{ fontWeight: 700, fontSize: 30, color: SUZUKA_500 }}>すずみなくりっく！</span>
+				<span style={{ fontSize: 22, color: MINASE_800 }}>suzumina.click</span>
+			</div>
+
+			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: SUZUKA_500 }} />
+		</div>
+	);
+}
+
+interface OgImageParams {
+	params: Promise<{ workId: string }>;
+}
+
+export default async function Image({ params }: OgImageParams) {
+	const { workId } = await params;
+
+	const work = await getWorkById(workId).catch(() => null);
+
+	const title = work ? formatDisplayTitle(work.title, 44) : "すずみなくりっく！";
+	const circle = work ? truncateWithEllipsis(work.circle, 30) : "";
+	const price = work ? work.price.formattedPrice : "";
+	const jacketUrl = work?.highResImageUrl || work?.thumbnailUrl || null;
+	const jacketDataUri = jacketUrl ? await loadJacketDataUri(jacketUrl) : null;
+
+	const fontBold = await loadMPlusRoundedSubset(700, `${title}DLsite作品すずみなくりっく！`).catch(
+		() => null,
+	);
+	const fontRegular = await loadMPlusRoundedSubset(400, `${circle}${price}suzumina.click`).catch(
+		() => null,
+	);
+
+	if (!fontBold) {
+		const asciiTitle = /^[\x20-\x7E]+$/.test(title) ? title : "";
+		return new ImageResponse(
+			<OgCard
+				badgeLabel="DLSITE WORK"
+				title={asciiTitle || "suzumina.click"}
+				circle=""
+				price=""
+				jacketDataUri={jacketDataUri}
+			/>,
+			{ ...size },
+		);
+	}
+
+	return new ImageResponse(
+		<OgCard
+			badgeLabel="DLsite作品"
+			title={title}
+			circle={circle}
+			price={price}
+			jacketDataUri={jacketDataUri}
+		/>,
+		{
+			...size,
+			fonts: [
+				{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" },
+				...(fontRegular
+					? [
+							{
+								name: "M PLUS Rounded 1c",
+								data: fontRegular,
+								weight: 400 as const,
+								style: "normal" as const,
+							},
+						]
+					: []),
+			],
+		},
+	);
+}

--- a/apps/web/src/lib/__tests__/og-text.test.ts
+++ b/apps/web/src/lib/__tests__/og-text.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	estimateTextWidth,
+	formatDisplayTitle,
+	stripUnsupportedGlyphs,
+	truncateWithEllipsis,
+} from "../og-text";
+
+describe("truncateWithEllipsis", () => {
+	it("max文字以内はそのまま返す", () => {
+		const text = "あ".repeat(10);
+		expect(truncateWithEllipsis(text, 10)).toBe(text);
+	});
+
+	it("maxを超えると末尾を省略記号にする", () => {
+		const text = "あ".repeat(11);
+		expect(truncateWithEllipsis(text, 10)).toBe(`${"あ".repeat(10)}…`);
+	});
+});
+
+describe("estimateTextWidth", () => {
+	it("全角は 1.0em、半角は 0.6em で概算する", () => {
+		expect(estimateTextWidth("あいう", 56)).toBe(3 * 56);
+		expect(estimateTextWidth("abc", 56)).toBe(Math.round(3 * 0.6 * 56));
+	});
+});
+
+describe("stripUnsupportedGlyphs", () => {
+	it("絵文字・異体字セレクタ・ZWJ合成絵文字を除去する", () => {
+		expect(stripUnsupportedGlyphs("今日はどんなお客さんが来るかな…☕？")).toBe(
+			"今日はどんなお客さんが来るかな…？",
+		);
+		expect(stripUnsupportedGlyphs("配信👨‍👩‍👧‍👦開始✌️です")).toBe("配信開始です");
+	});
+
+	it("連続空白を1つに畳む", () => {
+		expect(stripUnsupportedGlyphs("A  B　 C")).toBe("A B C");
+	});
+});
+
+describe("formatDisplayTitle", () => {
+	it("絵文字除去と省略を両方適用する", () => {
+		const long = `${"あ".repeat(45)}☕`;
+		expect(formatDisplayTitle(long, 40)).toBe(`${"あ".repeat(40)}…`);
+	});
+
+	it("空文字はそのまま空文字", () => {
+		expect(formatDisplayTitle("", 40)).toBe("");
+	});
+});

--- a/apps/web/src/lib/og-text.ts
+++ b/apps/web/src/lib/og-text.ts
@@ -1,0 +1,35 @@
+/**
+ * OG 画像（ImageResponse / satori）向けのテキスト整形ヘルパ。
+ * app/buttons/[id]/opengraph-image.tsx（SPR-249）・app/works/[workId]/opengraph-image.tsx（SPR-268）等で共用する。
+ */
+
+/** 末尾を省略記号にして max 文字に収める */
+export function truncateWithEllipsis(text: string, max: number): string {
+	return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * テキストの概算描画幅（px）。半角 ≈ 0.6em / 全角 ≈ 1.0em の粗い見積もり。
+ * satori(Yoga) は auto 幅 flex の入れ子内でテキスト折り返し幅を解決できないため、
+ * 「1行に収まらない場合だけ明示幅を与えて折り返す」判定に使う（正確な字幅計測は不要）
+ */
+export function estimateTextWidth(text: string, fontSize: number): number {
+	let em = 0;
+	for (const ch of text) {
+		em += (ch.codePointAt(0) ?? 0) <= 0x024f ? 0.6 : 1.0;
+	}
+	return Math.round(em * fontSize);
+}
+
+/** フォントに無い絵文字（tofu 化する）・異体字セレクタ・ZWJ を除去し、連続空白を1つに畳む */
+export function stripUnsupportedGlyphs(text: string): string {
+	return text
+		.replace(/\p{Extended_Pictographic}|\u{FE0F}|\u{200D}/gu, "")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/** 絵文字除去 + 空白畳み込み + 省略の一括整形（動画タイトル・作品タイトル等の表示用） */
+export function formatDisplayTitle(text: string, max: number): string {
+	return truncateWithEllipsis(stripUnsupportedGlyphs(text), max);
+}


### PR DESCRIPTION
## 概要（SPR-268 段階導入①）

`/works/[workId]` にジャケット画像＋タイトル＋サークル名＋価格を構成した動的OG画像を追加する。`/buttons/[id]`（SPR-249）と同じ file-convention パターン。X等のリンクカードは「画像＋小タイトル＋ドメイン」のみで description は出ないため（SPR-17 調査）、カード単体で作品内容が伝わるようにする。

SPR-171（サイト共通のデフォルトOGP画像404修正）で全ページに汎用フォールバック画像を用意済み。本PRはそのうち `/works/[workId]` をコンテンツ固有の動的画像へアップグレードする。段階導入②③（videos/circles/creators）は別PRで対応する。

## 変更内容

- **`app/works/[workId]/opengraph-image.tsx` 新設**: DLsiteジャケット画像（`highResImageUrl` → `thumbnailUrl` の順でフォールバック）を fetch して data URI に変換し埋め込み、タイトル・サークル名・価格・バッジを2カラムで構成。satori の remote src 直指定より、事前フェッチ済み data URI の方が安定するため採用
- **フェイルセーフ**: 作品未取得（404相当）→サイト名版、ジャケット取得失敗（ネットワークエラー等）→画像無し版、フォント取得失敗→ASCII縮退版。いずれの経路でも500は返さない
- **`lib/og-text.ts` 新設**: テキスト整形ヘルパ（省略・字幅概算・絵文字除去）を切り出し、`/buttons/[id]` 側もこれに委譲するようリファクタ（重複排除）。既存テストが検証する公開API（`truncateButtonText`/`estimateTextWidth`/`formatVideoTitle`）は維持
- テスト追加: `og-text.test.ts`（共通ヘルパ）、`works/[workId]/__tests__/opengraph-image.test.tsx`（成功系・作品未取得・ジャケット取得失敗・フォント取得失敗の4パターン）

## 検討した論点: R18作品のジャケット表示

実装中、R18作品でジャケット画像がそのままOG画像に埋め込まれ、Xやチャットアプリのリンクプレビューに**クリック無しで自動表示される**ことを確認した。調査の結果、`/works`（一覧）には年齢確認ゲート（`showR18Content`）があるが、**`/works/[workId]`（詳細ページ）自体には年齢確認ゲートが無く**、既存挙動として直リンクがあれば誰でも閲覧可能な状態だった。

ユーザーと協議の上、既存のサイト方針（詳細ページは年齢確認なしで閲覧可能）と一貫させ、**ジャケット画像はR18作品も含めそのまま表示する**方針で実装した。年齢確認ゲート自体の見直しはこのPRのスコープ外（別途検討）。

## 検証（ローカル dev + emulator 実測）

- `/works/RJ01000639`（サンプル作品）で og:image が `works/[workId]/opengraph-image` を指すこと・画像が200で描画されることをスクリーンショットで確認（ジャケット・タイトル・サークル名・価格・底部バーとも正しく表示）
- `/works`（一覧）は従来どおり汎用フォールバック画像を維持（意図的にスコープ外）
- `/buttons/[id]`（リファクタ後）は従来どおり自前の動的OG画像を維持し、既存テストも変更なく通過
- `pnpm verify` 全パス

## デプロイ後の確認

- [ ] 本番の `/works/[id]` og:image が 200 を返し、ジャケット画像を含むこと
- [ ] カードプレビューで表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)