### PR TITLE
feat(web): サークル・クリエイター詳細ページの動的OG画像生成（SPR-268 段階導入③・最終）

### DIFF
--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -1,7 +1,22 @@
-import { ImageResponse } from "next/og";
 import { getAudioButtonById } from "@/app/buttons/actions";
-import { loadMPlusRoundedSubset } from "@/lib/og-font";
 import {
+	OG_BACKGROUND as BACKGROUND,
+	OG_MINASE_50 as MINASE_50,
+	OG_MINASE_100 as MINASE_100,
+	OG_MINASE_200 as MINASE_200,
+	OG_MINASE_300 as MINASE_300,
+	OG_MINASE_500 as MINASE_500,
+	OG_MINASE_600 as MINASE_600,
+	OG_MINASE_800 as MINASE_800,
+	OG_MINASE_950 as MINASE_950,
+	OG_MUTED_FOREGROUND as MUTED_FOREGROUND,
+	OG_SUZUKA_100 as SUZUKA_100,
+	OG_SUZUKA_500 as SUZUKA_500,
+	OG_SUZUKA_700 as SUZUKA_700,
+} from "@/lib/og-palette";
+import { buildOgImageResponse } from "@/lib/og-response";
+import {
+	asciiOrEmpty,
 	estimateTextWidth as estimateTextWidthShared,
 	formatDisplayTitle,
 	truncateWithEllipsis,
@@ -18,22 +33,6 @@ import {
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const alt = "涼花みなせ音声ボタン - すずみなくりっく！";
-
-// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
-// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
-const BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
-const SUZUKA_100 = "hsl(341, 62%, 94%)";
-const SUZUKA_500 = "hsl(340, 58%, 46%)";
-const SUZUKA_700 = "hsl(339, 55%, 33%)";
-const MINASE_50 = "hsl(36, 50%, 97%)";
-const MINASE_100 = "hsl(34, 44%, 93%)";
-const MINASE_200 = "hsl(33, 40%, 86%)";
-const MINASE_300 = "hsl(32, 38%, 79%)";
-const MINASE_500 = "hsl(30, 38%, 66%)";
-const MINASE_600 = "hsl(29, 36%, 56%)";
-const MINASE_800 = "hsl(27, 32%, 37%)";
-const MINASE_950 = "hsl(25, 28%, 18%)";
-const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 
 /** ボタン名の表示用整形。折り返し幅 750px × 4行に収まる長さへ末尾省略する */
 export function truncateButtonText(text: string, max = 52): string {
@@ -318,53 +317,29 @@ export default async function Image({ params }: OgImageParams) {
 
 	const heading = buttonText || "すずみなくりっく！";
 	const durationLabel = durationSec != null ? `${durationSec.toFixed(1)}秒` : "";
-	const boldText = `${heading}${durationLabel}すずみなくりっく！音声ボタン`;
 
-	// フォント取得失敗でも 500 にしない: 内蔵デフォルトフォント（latin のみ）で ASCII 縮退版を描画。
-	// ボタン名が ASCII ならそのまま表示を継続できる。regular(400) はメタ行専用なので欠けても bold で代替される
-	const [fontBold, fontRegular] = await Promise.all([
-		loadMPlusRoundedSubset(700, boldText).catch(() => null),
-		// videoTitle が空（未設定・ボタン未取得のフォールバック経路）なら 400 のフェッチ自体を省く
-		videoTitle ? loadMPlusRoundedSubset(400, videoTitle).catch(() => null) : Promise.resolve(null),
-	]);
-
-	if (!fontBold) {
-		const asciiButtonText = /^[\x20-\x7E]+$/.test(buttonText) ? buttonText : "";
-		return new ImageResponse(
+	return buildOgImageResponse({
+		size,
+		boldText: `${heading}${durationLabel}すずみなくりっく！音声ボタン`,
+		// videoTitle が空（未設定・ボタン未取得のフォールバック経路）なら regular(400) のフェッチ自体を省く
+		regularText: videoTitle || undefined,
+		renderFallback: () => (
 			<OgCard
 				siteName="suzumina.click"
 				badgeLabel="SOUND BUTTON"
-				buttonText={asciiButtonText || "suzumina.click"}
+				buttonText={asciiOrEmpty(buttonText) || "suzumina.click"}
 				durationLabel={durationSec != null ? `${durationSec.toFixed(1)}s` : ""}
 				videoTitle=""
-			/>,
-			{ ...size },
-		);
-	}
-
-	return new ImageResponse(
-		<OgCard
-			siteName="すずみなくりっく！"
-			badgeLabel="音声ボタン"
-			buttonText={heading}
-			durationLabel={durationLabel}
-			videoTitle={videoTitle}
-		/>,
-		{
-			...size,
-			fonts: [
-				{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" },
-				...(fontRegular && videoTitle
-					? [
-							{
-								name: "M PLUS Rounded 1c",
-								data: fontRegular,
-								weight: 400 as const,
-								style: "normal" as const,
-							},
-						]
-					: []),
-			],
-		},
-	);
+			/>
+		),
+		renderFull: () => (
+			<OgCard
+				siteName="すずみなくりっく！"
+				badgeLabel="音声ボタン"
+				buttonText={heading}
+				durationLabel={durationLabel}
+				videoTitle={videoTitle}
+			/>
+		),
+	});
 }

--- a/apps/web/src/app/circles/[circleId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/circles/[circleId]/__tests__/opengraph-image.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ImageResponse は実描画せず、渡された element / options を検証できる形で捕捉する
+vi.mock("next/og", () => ({
+	ImageResponse: class {
+		element: React.ReactElement;
+		options: { fonts?: unknown[] } | undefined;
+		constructor(element: React.ReactElement, options?: { fonts?: unknown[] }) {
+			this.element = element;
+			this.options = options;
+		}
+	},
+}));
+vi.mock("../actions", () => ({ getCircleInfo: vi.fn() }));
+vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import type { TextOgCardProps } from "@/lib/og-text-card";
+import { getCircleInfo } from "../actions";
+import Image, { alt, contentType, size } from "../opengraph-image";
+
+describe("サークル詳細の OG 画像（app/circles/[circleId]/opengraph-image.tsx）", () => {
+	it("1200×630 の PNG を宣言している", () => {
+		expect(size).toEqual({ width: 1200, height: 630 });
+		expect(contentType).toBe("image/png");
+		expect(alt).toContain("サークル情報");
+	});
+
+	it("サークル取得成功時は名称・作品数を描画する", async () => {
+		vi.mocked(getCircleInfo).mockResolvedValueOnce({
+			circleId: "RG00001",
+			name: "テストサークル",
+			workCount: 12,
+			createdAt: null,
+		} as never);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ circleId: "RG00001" }),
+		})) as unknown as { element: React.ReactElement<TextOgCardProps> };
+
+		expect(response.element.props.name).toBe("テストサークル");
+		expect(response.element.props.statLabel).toBe("12作品");
+	});
+
+	it("サークルが見つからない場合はサイト名版にフォールバックする", async () => {
+		vi.mocked(getCircleInfo).mockResolvedValueOnce(null);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ circleId: "unknown" }),
+		})) as unknown as { element: React.ReactElement<TextOgCardProps> };
+
+		expect(response.element.props.name).toBe("すずみなくりっく！");
+		expect(response.element.props.statLabel).toBe("");
+	});
+
+	it("フォント取得失敗でも 500 にせず ASCII 縮退版を描画する", async () => {
+		vi.mocked(getCircleInfo).mockResolvedValueOnce({
+			circleId: "RG00001",
+			name: "Ascii Circle",
+			workCount: 3,
+			createdAt: null,
+		} as never);
+		vi.mocked(loadMPlusRoundedSubset).mockRejectedValue(new Error("font error"));
+
+		const response = (await Image({
+			params: Promise.resolve({ circleId: "RG00001" }),
+		})) as unknown as {
+			element: React.ReactElement<TextOgCardProps>;
+			options: { fonts?: unknown[] };
+		};
+
+		expect(response.element.props.name).toBe("Ascii Circle");
+		expect(response.options.fonts).toBeUndefined();
+	});
+});

--- a/apps/web/src/app/circles/[circleId]/opengraph-image.tsx
+++ b/apps/web/src/app/circles/[circleId]/opengraph-image.tsx
@@ -1,7 +1,56 @@
+import { ImageResponse } from "next/og";
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import { formatDisplayTitle } from "@/lib/og-text";
+import { TextOgCard } from "@/lib/og-text-card";
+import { getCircleInfo } from "./actions";
+
 /**
- * サイト既定 OG 画像の再輸出（SPR-171）。
- * このセグメントの page.tsx は openGraph を上書き定義しており、Next.js の metadata 解決は
- * openGraph フィールド単位の置換のため root の file-convention 画像が落ちる。
- * 同一セグメントの file-convention は metadata より優先されるため、ここで再輸出して補う。
+ * DLsiteサークル詳細の動的 OG 画像（SPR-268 段階導入③）。
+ * サークルは画像素材を持たないため、works/videos のジャケット/サムネイル付きカードとは異なり
+ * タイポグラフィ主体のカード（lib/og-text-card.tsx 共通コンポーネント）で構成する。
+ * og:image / twitter:image はこの規約ファイルから自動出力される（generateMetadata の images 手書きはしない）。
+ * どの失敗経路でも 500 は返さない（サークル未取得→サイト名版 / フォント取得失敗→ASCII 縮退版）。
  */
-export { alt, contentType, default, size } from "@/app/opengraph-image";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "サークル情報 - すずみなくりっく！";
+
+interface OgImageParams {
+	params: Promise<{ circleId: string }>;
+}
+
+export default async function Image({ params }: OgImageParams) {
+	const { circleId } = await params;
+
+	const circle = await getCircleInfo(circleId).catch(() => null);
+
+	const name = circle ? formatDisplayTitle(circle.name, 30) : "すずみなくりっく！";
+	const statLabel = circle ? `${circle.workCount}作品` : "";
+
+	const fontBold = await loadMPlusRoundedSubset(
+		700,
+		`${name}DLsiteサークルすずみなくりっく！${statLabel}`,
+	).catch(() => null);
+
+	if (!fontBold) {
+		const asciiName = /^[\x20-\x7E]+$/.test(name) ? name : "";
+		return new ImageResponse(
+			<TextOgCard
+				badgeLabel="DLSITE CIRCLE"
+				name={asciiName || "suzumina.click"}
+				subtitle=""
+				statLabel=""
+			/>,
+			{ ...size },
+		);
+	}
+
+	return new ImageResponse(
+		<TextOgCard badgeLabel="DLsiteサークル" name={name} subtitle="" statLabel={statLabel} />,
+		{
+			...size,
+			fonts: [{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" }],
+		},
+	);
+}

--- a/apps/web/src/app/circles/[circleId]/opengraph-image.tsx
+++ b/apps/web/src/app/circles/[circleId]/opengraph-image.tsx
@@ -1,6 +1,5 @@
-import { ImageResponse } from "next/og";
-import { loadMPlusRoundedSubset } from "@/lib/og-font";
-import { formatDisplayTitle } from "@/lib/og-text";
+import { buildOgImageResponse } from "@/lib/og-response";
+import { asciiOrEmpty, formatDisplayTitle } from "@/lib/og-text";
 import { TextOgCard } from "@/lib/og-text-card";
 import { getCircleInfo } from "./actions";
 
@@ -28,29 +27,19 @@ export default async function Image({ params }: OgImageParams) {
 	const name = circle ? formatDisplayTitle(circle.name, 30) : "すずみなくりっく！";
 	const statLabel = circle ? `${circle.workCount}作品` : "";
 
-	const fontBold = await loadMPlusRoundedSubset(
-		700,
-		`${name}DLsiteサークルすずみなくりっく！${statLabel}`,
-	).catch(() => null);
-
-	if (!fontBold) {
-		const asciiName = /^[\x20-\x7E]+$/.test(name) ? name : "";
-		return new ImageResponse(
+	return buildOgImageResponse({
+		size,
+		boldText: `${name}DLsiteサークルすずみなくりっく！${statLabel}`,
+		renderFallback: () => (
 			<TextOgCard
 				badgeLabel="DLSITE CIRCLE"
-				name={asciiName || "suzumina.click"}
+				name={asciiOrEmpty(name) || "suzumina.click"}
 				subtitle=""
 				statLabel=""
-			/>,
-			{ ...size },
-		);
-	}
-
-	return new ImageResponse(
-		<TextOgCard badgeLabel="DLsiteサークル" name={name} subtitle="" statLabel={statLabel} />,
-		{
-			...size,
-			fonts: [{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" }],
-		},
-	);
+			/>
+		),
+		renderFull: () => (
+			<TextOgCard badgeLabel="DLsiteサークル" name={name} subtitle="" statLabel={statLabel} />
+		),
+	});
 }

--- a/apps/web/src/app/creators/[creatorId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/opengraph-image.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ImageResponse は実描画せず、渡された element / options を検証できる形で捕捉する
+vi.mock("next/og", () => ({
+	ImageResponse: class {
+		element: React.ReactElement;
+		options: { fonts?: unknown[] } | undefined;
+		constructor(element: React.ReactElement, options?: { fonts?: unknown[] }) {
+			this.element = element;
+			this.options = options;
+		}
+	},
+}));
+vi.mock("../actions", () => ({ getCreatorInfo: vi.fn() }));
+vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import type { TextOgCardProps } from "@/lib/og-text-card";
+import { getCreatorInfo } from "../actions";
+import Image, { alt, contentType, size } from "../opengraph-image";
+
+describe("クリエイター詳細の OG 画像（app/creators/[creatorId]/opengraph-image.tsx）", () => {
+	it("1200×630 の PNG を宣言している", () => {
+		expect(size).toEqual({ width: 1200, height: 630 });
+		expect(contentType).toBe("image/png");
+		expect(alt).toContain("クリエイター情報");
+	});
+
+	it("クリエイター取得成功時は名称・役割・作品数を描画する", async () => {
+		vi.mocked(getCreatorInfo).mockResolvedValueOnce({
+			id: "CR00001",
+			name: "テストクリエイター",
+			types: ["voice"],
+			workCount: 8,
+		} as never);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ creatorId: "CR00001" }),
+		})) as unknown as { element: React.ReactElement<TextOgCardProps> };
+
+		expect(response.element.props.name).toBe("テストクリエイター");
+		expect(response.element.props.subtitle).toBe("声優");
+		expect(response.element.props.statLabel).toBe("8作品");
+	});
+
+	it("クリエイターが見つからない場合はサイト名版にフォールバックする", async () => {
+		vi.mocked(getCreatorInfo).mockResolvedValueOnce(null);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ creatorId: "unknown" }),
+		})) as unknown as { element: React.ReactElement<TextOgCardProps> };
+
+		expect(response.element.props.name).toBe("すずみなくりっく！");
+		expect(response.element.props.subtitle).toBe("");
+	});
+
+	it("フォント取得失敗でも 500 にせず ASCII 縮退版を描画する", async () => {
+		vi.mocked(getCreatorInfo).mockResolvedValueOnce({
+			id: "CR00001",
+			name: "Ascii Creator",
+			types: ["music"],
+			workCount: 2,
+		} as never);
+		vi.mocked(loadMPlusRoundedSubset).mockRejectedValue(new Error("font error"));
+
+		const response = (await Image({
+			params: Promise.resolve({ creatorId: "CR00001" }),
+		})) as unknown as {
+			element: React.ReactElement<TextOgCardProps>;
+			options: { fonts?: unknown[] };
+		};
+
+		expect(response.element.props.name).toBe("Ascii Creator");
+		expect(response.options.fonts).toBeUndefined();
+	});
+});

--- a/apps/web/src/app/creators/[creatorId]/opengraph-image.tsx
+++ b/apps/web/src/app/creators/[creatorId]/opengraph-image.tsx
@@ -1,7 +1,6 @@
 import { getCreatorTypeLabel } from "@suzumina.click/shared-types";
-import { ImageResponse } from "next/og";
-import { loadMPlusRoundedSubset } from "@/lib/og-font";
-import { formatDisplayTitle } from "@/lib/og-text";
+import { buildOgImageResponse } from "@/lib/og-response";
+import { asciiOrEmpty, formatDisplayTitle } from "@/lib/og-text";
 import { TextOgCard } from "@/lib/og-text-card";
 import { getCreatorInfo } from "./actions";
 
@@ -30,34 +29,24 @@ export default async function Image({ params }: OgImageParams) {
 	const typeLabel = creator ? getCreatorTypeLabel(creator.types) : "";
 	const statLabel = creator ? `${creator.workCount}作品` : "";
 
-	const fontBold = await loadMPlusRoundedSubset(
-		700,
-		`${name}${typeLabel}DLsiteクリエイターすずみなくりっく！${statLabel}`,
-	).catch(() => null);
-
-	if (!fontBold) {
-		const asciiName = /^[\x20-\x7E]+$/.test(name) ? name : "";
-		return new ImageResponse(
+	return buildOgImageResponse({
+		size,
+		boldText: `${name}${typeLabel}DLsiteクリエイターすずみなくりっく！${statLabel}`,
+		renderFallback: () => (
 			<TextOgCard
 				badgeLabel="DLSITE CREATOR"
-				name={asciiName || "suzumina.click"}
+				name={asciiOrEmpty(name) || "suzumina.click"}
 				subtitle=""
 				statLabel=""
-			/>,
-			{ ...size },
-		);
-	}
-
-	return new ImageResponse(
-		<TextOgCard
-			badgeLabel="DLsiteクリエイター"
-			name={name}
-			subtitle={typeLabel}
-			statLabel={statLabel}
-		/>,
-		{
-			...size,
-			fonts: [{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" }],
-		},
-	);
+			/>
+		),
+		renderFull: () => (
+			<TextOgCard
+				badgeLabel="DLsiteクリエイター"
+				name={name}
+				subtitle={typeLabel}
+				statLabel={statLabel}
+			/>
+		),
+	});
 }

--- a/apps/web/src/app/creators/[creatorId]/opengraph-image.tsx
+++ b/apps/web/src/app/creators/[creatorId]/opengraph-image.tsx
@@ -1,7 +1,63 @@
+import { getCreatorTypeLabel } from "@suzumina.click/shared-types";
+import { ImageResponse } from "next/og";
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import { formatDisplayTitle } from "@/lib/og-text";
+import { TextOgCard } from "@/lib/og-text-card";
+import { getCreatorInfo } from "./actions";
+
 /**
- * サイト既定 OG 画像の再輸出（SPR-171）。
- * このセグメントの page.tsx は openGraph を上書き定義しており、Next.js の metadata 解決は
- * openGraph フィールド単位の置換のため root の file-convention 画像が落ちる。
- * 同一セグメントの file-convention は metadata より優先されるため、ここで再輸出して補う。
+ * DLsiteクリエイター詳細の動的 OG 画像（SPR-268 段階導入③）。
+ * クリエイターは画像素材を持たないため、works/videos のジャケット/サムネイル付きカードとは異なり
+ * タイポグラフィ主体のカード（lib/og-text-card.tsx 共通コンポーネント。/circles と共用）で構成する。
+ * og:image / twitter:image はこの規約ファイルから自動出力される（generateMetadata の images 手書きはしない）。
+ * どの失敗経路でも 500 は返さない（クリエイター未取得→サイト名版 / フォント取得失敗→ASCII 縮退版）。
  */
-export { alt, contentType, default, size } from "@/app/opengraph-image";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "クリエイター情報 - すずみなくりっく！";
+
+interface OgImageParams {
+	params: Promise<{ creatorId: string }>;
+}
+
+export default async function Image({ params }: OgImageParams) {
+	const { creatorId } = await params;
+
+	const creator = await getCreatorInfo(creatorId).catch(() => null);
+
+	const name = creator ? formatDisplayTitle(creator.name, 30) : "すずみなくりっく！";
+	const typeLabel = creator ? getCreatorTypeLabel(creator.types) : "";
+	const statLabel = creator ? `${creator.workCount}作品` : "";
+
+	const fontBold = await loadMPlusRoundedSubset(
+		700,
+		`${name}${typeLabel}DLsiteクリエイターすずみなくりっく！${statLabel}`,
+	).catch(() => null);
+
+	if (!fontBold) {
+		const asciiName = /^[\x20-\x7E]+$/.test(name) ? name : "";
+		return new ImageResponse(
+			<TextOgCard
+				badgeLabel="DLSITE CREATOR"
+				name={asciiName || "suzumina.click"}
+				subtitle=""
+				statLabel=""
+			/>,
+			{ ...size },
+		);
+	}
+
+	return new ImageResponse(
+		<TextOgCard
+			badgeLabel="DLsiteクリエイター"
+			name={name}
+			subtitle={typeLabel}
+			statLabel={statLabel}
+		/>,
+		{
+			...size,
+			fonts: [{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" }],
+		},
+	);
+}

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,5 +1,16 @@
-import { ImageResponse } from "next/og";
-import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import {
+	OG_BACKGROUND as BACKGROUND,
+	OG_MINASE_400 as MINASE_400,
+	OG_MINASE_800 as MINASE_800,
+	OG_MUTED_FOREGROUND as MUTED_FOREGROUND,
+	OG_SUZUKA_50 as SUZUKA_50,
+	OG_SUZUKA_100 as SUZUKA_100,
+	OG_SUZUKA_200 as SUZUKA_200,
+	OG_SUZUKA_300 as SUZUKA_300,
+	OG_SUZUKA_500 as SUZUKA_500,
+	OG_SUZUKA_700 as SUZUKA_700,
+} from "@/lib/og-palette";
+import { buildOgImageResponse } from "@/lib/og-response";
 
 /**
  * サイト共通のデフォルト OG 画像（SPR-171）。
@@ -12,19 +23,6 @@ import { loadMPlusRoundedSubset } from "@/lib/og-font";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const alt = "すずみなくりっく！ - 涼花みなせ 非公式ファンサイト";
-
-// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
-// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
-const BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
-const SUZUKA_50 = "hsl(342, 70%, 97%)";
-const SUZUKA_100 = "hsl(341, 62%, 94%)";
-const SUZUKA_200 = "hsl(340, 54%, 88%)";
-const SUZUKA_300 = "hsl(339, 50%, 79%)";
-const SUZUKA_500 = "hsl(340, 58%, 46%)";
-const SUZUKA_700 = "hsl(339, 55%, 33%)";
-const MINASE_400 = "hsl(31, 38%, 73%)";
-const MINASE_800 = "hsl(27, 32%, 37%)";
-const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 
 /** 桜の花（5枚花弁・先端に切れ込み）。装飾用の SVG で、satori がそのまま描画できる */
 function SakuraBloom({
@@ -156,26 +154,17 @@ export default async function Image() {
 		domain: "suzumina.click",
 	};
 
-	// フォント取得失敗でも 500 にしない: 内蔵デフォルトフォント（latin のみ）で ASCII 縮退版を描画
-	const fontBold = await loadMPlusRoundedSubset(
-		700,
-		`${texts.badgeLabel}${texts.title}${texts.tagline}${texts.domain}`,
-	).catch(() => null);
-
-	if (!fontBold) {
-		return new ImageResponse(
+	return buildOgImageResponse({
+		size,
+		boldText: `${texts.badgeLabel}${texts.title}${texts.tagline}${texts.domain}`,
+		renderFallback: () => (
 			<DefaultOgCard
 				badgeLabel="Suzuka Minase Fan Site"
 				title="suzumina.click"
 				tagline="Sound buttons / Videos / Works"
 				domain="suzumina.click"
-			/>,
-			{ ...size },
-		);
-	}
-
-	return new ImageResponse(<DefaultOgCard {...texts} />, {
-		...size,
-		fonts: [{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" }],
+			/>
+		),
+		renderFull: () => <DefaultOgCard {...texts} />,
 	});
 }

--- a/apps/web/src/app/videos/[videoId]/opengraph-image.tsx
+++ b/apps/web/src/app/videos/[videoId]/opengraph-image.tsx
@@ -1,9 +1,18 @@
 import { parseDurationToSeconds } from "@suzumina.click/shared-types";
-import { ImageResponse } from "next/og";
 import { getVideoById } from "@/app/videos/actions";
-import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import {
+	OG_BACKGROUND as BACKGROUND,
+	OG_MINASE_300 as MINASE_300,
+	OG_MINASE_800 as MINASE_800,
+	OG_MINASE_950 as MINASE_950,
+	OG_MUTED_FOREGROUND as MUTED_FOREGROUND,
+	OG_SUZUKA_100 as SUZUKA_100,
+	OG_SUZUKA_500 as SUZUKA_500,
+	OG_SUZUKA_700 as SUZUKA_700,
+} from "@/lib/og-palette";
 import { loadRemoteImageDataUri } from "@/lib/og-remote-image";
-import { formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
+import { buildOgImageResponse } from "@/lib/og-response";
+import { asciiOrEmpty, formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
 
 /**
  * YouTube動画詳細の動的 OG 画像（SPR-268 段階導入② / /works/[workId] と同じ file-convention パターン）。
@@ -16,17 +25,6 @@ import { formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const alt = "動画情報 - すずみなくりっく！";
-
-// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
-// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
-const BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
-const SUZUKA_100 = "hsl(341, 62%, 94%)";
-const SUZUKA_500 = "hsl(340, 58%, 46%)";
-const SUZUKA_700 = "hsl(339, 55%, 33%)";
-const MINASE_300 = "hsl(32, 38%, 79%)";
-const MINASE_800 = "hsl(27, 32%, 37%)";
-const MINASE_950 = "hsl(25, 28%, 18%)";
-const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 
 // カード幅1200 - 左右padding128 - サムネ480 - gap56 = 536px（タイトル列の折り返し幅）
 const TITLE_MAX_WIDTH = 536;
@@ -167,51 +165,27 @@ export default async function Image({ params }: OgImageParams) {
 		? await loadRemoteImageDataUri(thumbnailUrl, ALLOWED_THUMBNAIL_HOSTNAMES)
 		: null;
 
-	const fontBold = await loadMPlusRoundedSubset(
-		700,
-		`${title}動画すずみなくりっく！${durationLabel}`,
-	).catch(() => null);
-	const fontRegular = await loadMPlusRoundedSubset(400, `${channelTitle}suzumina.click`).catch(
-		() => null,
-	);
-
-	if (!fontBold) {
-		const asciiTitle = /^[\x20-\x7E]+$/.test(title) ? title : "";
-		return new ImageResponse(
+	return buildOgImageResponse({
+		size,
+		boldText: `${title}動画すずみなくりっく！${durationLabel}`,
+		regularText: `${channelTitle}suzumina.click`,
+		renderFallback: () => (
 			<OgCard
 				badgeLabel="YOUTUBE VIDEO"
-				title={asciiTitle || "suzumina.click"}
+				title={asciiOrEmpty(title) || "suzumina.click"}
 				channelTitle=""
 				durationLabel=""
 				thumbnailDataUri={thumbnailDataUri}
-			/>,
-			{ ...size },
-		);
-	}
-
-	return new ImageResponse(
-		<OgCard
-			badgeLabel="動画"
-			title={title}
-			channelTitle={channelTitle}
-			durationLabel={durationLabel}
-			thumbnailDataUri={thumbnailDataUri}
-		/>,
-		{
-			...size,
-			fonts: [
-				{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" },
-				...(fontRegular
-					? [
-							{
-								name: "M PLUS Rounded 1c",
-								data: fontRegular,
-								weight: 400 as const,
-								style: "normal" as const,
-							},
-						]
-					: []),
-			],
-		},
-	);
+			/>
+		),
+		renderFull: () => (
+			<OgCard
+				badgeLabel="動画"
+				title={title}
+				channelTitle={channelTitle}
+				durationLabel={durationLabel}
+				thumbnailDataUri={thumbnailDataUri}
+			/>
+		),
+	});
 }

--- a/apps/web/src/app/works/[workId]/opengraph-image.tsx
+++ b/apps/web/src/app/works/[workId]/opengraph-image.tsx
@@ -1,8 +1,17 @@
-import { ImageResponse } from "next/og";
 import { getWorkById } from "@/app/works/actions";
-import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import {
+	OG_BACKGROUND as BACKGROUND,
+	OG_MINASE_300 as MINASE_300,
+	OG_MINASE_800 as MINASE_800,
+	OG_MINASE_950 as MINASE_950,
+	OG_MUTED_FOREGROUND as MUTED_FOREGROUND,
+	OG_SUZUKA_100 as SUZUKA_100,
+	OG_SUZUKA_500 as SUZUKA_500,
+	OG_SUZUKA_700 as SUZUKA_700,
+} from "@/lib/og-palette";
 import { loadRemoteImageDataUri } from "@/lib/og-remote-image";
-import { formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
+import { buildOgImageResponse } from "@/lib/og-response";
+import { asciiOrEmpty, formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
 
 /**
  * DLsite作品詳細の動的 OG 画像（SPR-268 / /buttons/[id] の opengraph-image と同じ file-convention パターン）。
@@ -15,17 +24,6 @@ import { formatDisplayTitle, truncateWithEllipsis } from "@/lib/og-text";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 export const alt = "DLsite作品情報 - すずみなくりっく！";
-
-// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
-// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
-const BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
-const SUZUKA_100 = "hsl(341, 62%, 94%)";
-const SUZUKA_500 = "hsl(340, 58%, 46%)";
-const SUZUKA_700 = "hsl(339, 55%, 33%)";
-const MINASE_300 = "hsl(32, 38%, 79%)";
-const MINASE_800 = "hsl(27, 32%, 37%)";
-const MINASE_950 = "hsl(25, 28%, 18%)";
-const MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
 
 // カード幅1200 - 左右padding128 - ジャケット420 - gap56 = 596px（タイトル列の折り返し幅）
 const TITLE_MAX_WIDTH = 590;
@@ -144,50 +142,27 @@ export default async function Image({ params }: OgImageParams) {
 		? await loadRemoteImageDataUri(jacketUrl, ALLOWED_JACKET_HOSTNAMES)
 		: null;
 
-	const fontBold = await loadMPlusRoundedSubset(700, `${title}DLsite作品すずみなくりっく！`).catch(
-		() => null,
-	);
-	const fontRegular = await loadMPlusRoundedSubset(400, `${circle}${price}suzumina.click`).catch(
-		() => null,
-	);
-
-	if (!fontBold) {
-		const asciiTitle = /^[\x20-\x7E]+$/.test(title) ? title : "";
-		return new ImageResponse(
+	return buildOgImageResponse({
+		size,
+		boldText: `${title}DLsite作品すずみなくりっく！`,
+		regularText: `${circle}${price}suzumina.click`,
+		renderFallback: () => (
 			<OgCard
 				badgeLabel="DLSITE WORK"
-				title={asciiTitle || "suzumina.click"}
+				title={asciiOrEmpty(title) || "suzumina.click"}
 				circle=""
 				price=""
 				jacketDataUri={jacketDataUri}
-			/>,
-			{ ...size },
-		);
-	}
-
-	return new ImageResponse(
-		<OgCard
-			badgeLabel="DLsite作品"
-			title={title}
-			circle={circle}
-			price={price}
-			jacketDataUri={jacketDataUri}
-		/>,
-		{
-			...size,
-			fonts: [
-				{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" },
-				...(fontRegular
-					? [
-							{
-								name: "M PLUS Rounded 1c",
-								data: fontRegular,
-								weight: 400 as const,
-								style: "normal" as const,
-							},
-						]
-					: []),
-			],
-		},
-	);
+			/>
+		),
+		renderFull: () => (
+			<OgCard
+				badgeLabel="DLsite作品"
+				title={title}
+				circle={circle}
+				price={price}
+				jacketDataUri={jacketDataUri}
+			/>
+		),
+	});
 }

--- a/apps/web/src/lib/__tests__/og-response.test.tsx
+++ b/apps/web/src/lib/__tests__/og-response.test.tsx
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ImageResponse は実描画せず、渡された element / options を検証できる形で捕捉する
+vi.mock("next/og", () => ({
+	ImageResponse: class {
+		element: React.ReactElement;
+		options: { fonts?: unknown[] } | undefined;
+		constructor(element: React.ReactElement, options?: { fonts?: unknown[] }) {
+			this.element = element;
+			this.options = options;
+		}
+	},
+}));
+vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import { buildOgImageResponse } from "../og-response";
+
+const size = { width: 1200, height: 630 };
+
+describe("buildOgImageResponse", () => {
+	beforeEach(() => {
+		vi.mocked(loadMPlusRoundedSubset).mockReset();
+	});
+
+	it("bold 取得成功時は renderFull を使い、bold フォントのみ付与する（regularText 省略時）", async () => {
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValueOnce(new ArrayBuffer(8));
+
+		const response = (await buildOgImageResponse({
+			size,
+			boldText: "title",
+			renderFallback: () => <div>fallback</div>,
+			renderFull: () => <div>full</div>,
+		})) as unknown as {
+			element: React.ReactElement<{ children: string }>;
+			options: { fonts?: unknown[] };
+		};
+
+		expect(response.element.props.children).toBe("full");
+		expect(response.options.fonts).toHaveLength(1);
+		expect(loadMPlusRoundedSubset).toHaveBeenCalledTimes(1);
+		expect(loadMPlusRoundedSubset).toHaveBeenCalledWith(700, "title");
+	});
+
+	it("regularText 指定時は bold 成功後に regular も取得し、2フォント付与する", async () => {
+		vi.mocked(loadMPlusRoundedSubset)
+			.mockResolvedValueOnce(new ArrayBuffer(8))
+			.mockResolvedValueOnce(new ArrayBuffer(4));
+
+		const response = (await buildOgImageResponse({
+			size,
+			boldText: "title",
+			regularText: "subtitle",
+			renderFallback: () => <div>fallback</div>,
+			renderFull: () => <div>full</div>,
+		})) as unknown as { options: { fonts?: { weight: number }[] } };
+
+		expect(response.options.fonts).toHaveLength(2);
+		expect(response.options.fonts?.map((f) => f.weight).sort()).toEqual([400, 700]);
+		expect(loadMPlusRoundedSubset).toHaveBeenNthCalledWith(2, 400, "subtitle");
+	});
+
+	it("regular 取得が失敗しても bold のみで描画を継続する", async () => {
+		vi.mocked(loadMPlusRoundedSubset)
+			.mockResolvedValueOnce(new ArrayBuffer(8))
+			.mockRejectedValueOnce(new Error("regular font error"));
+
+		const response = (await buildOgImageResponse({
+			size,
+			boldText: "title",
+			regularText: "subtitle",
+			renderFallback: () => <div>fallback</div>,
+			renderFull: () => <div>full</div>,
+		})) as unknown as { options: { fonts?: unknown[] } };
+
+		expect(response.options.fonts).toHaveLength(1);
+	});
+
+	it("bold 取得失敗時は renderFallback を使い、fonts 未指定・regular はフェッチしない", async () => {
+		vi.mocked(loadMPlusRoundedSubset).mockRejectedValueOnce(new Error("bold font error"));
+
+		const response = (await buildOgImageResponse({
+			size,
+			boldText: "title",
+			regularText: "subtitle",
+			renderFallback: () => <div>fallback</div>,
+			renderFull: () => <div>full</div>,
+		})) as unknown as {
+			element: React.ReactElement<{ children: string }>;
+			options: { fonts?: unknown[] };
+		};
+
+		expect(response.element.props.children).toBe("fallback");
+		expect(response.options.fonts).toBeUndefined();
+		// bold が失敗した時点で regular は取得しに行かない（無駄な外部fetchを避ける）
+		expect(loadMPlusRoundedSubset).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/lib/og-palette.ts
+++ b/apps/web/src/lib/og-palette.ts
@@ -1,0 +1,28 @@
+/**
+ * OG 画像（ImageResponse / satori）向けの桜霞パレット定数。
+ * 正本は packages/ui/src/styles/globals.css の :root。ImageResponse は CSS 変数を解決できないため
+ * ライトモード値をここに一箇所だけ転記し、app/opengraph-image.tsx・buttons/[id]・works/[workId]・
+ * videos/[videoId]・lib/og-text-card.tsx から共通利用する（SPR-268 全ルート完了時点でのレビュー指摘対応）。
+ * globals.css の値を変更したら、ここだけ追従すればよい。
+ */
+
+export const OG_BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
+
+export const OG_SUZUKA_50 = "hsl(342, 70%, 97%)";
+export const OG_SUZUKA_100 = "hsl(341, 62%, 94%)";
+export const OG_SUZUKA_200 = "hsl(340, 54%, 88%)";
+export const OG_SUZUKA_300 = "hsl(339, 50%, 79%)";
+export const OG_SUZUKA_500 = "hsl(340, 58%, 46%)";
+export const OG_SUZUKA_700 = "hsl(339, 55%, 33%)";
+
+export const OG_MINASE_50 = "hsl(36, 50%, 97%)";
+export const OG_MINASE_100 = "hsl(34, 44%, 93%)";
+export const OG_MINASE_200 = "hsl(33, 40%, 86%)";
+export const OG_MINASE_300 = "hsl(32, 38%, 79%)";
+export const OG_MINASE_400 = "hsl(31, 38%, 73%)";
+export const OG_MINASE_500 = "hsl(30, 38%, 66%)";
+export const OG_MINASE_600 = "hsl(29, 36%, 56%)";
+export const OG_MINASE_800 = "hsl(27, 32%, 37%)";
+export const OG_MINASE_950 = "hsl(25, 28%, 18%)";
+
+export const OG_MUTED_FOREGROUND = "hsl(324, 8%, 40%)";

--- a/apps/web/src/lib/og-response.ts
+++ b/apps/web/src/lib/og-response.ts
@@ -1,0 +1,59 @@
+import { ImageResponse } from "next/og";
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+
+/**
+ * OG 画像（ImageResponse）のフォント取得＋フォールバック構築を共通化するヘルパ。
+ * app/opengraph-image.tsx・app/buttons/[id]・app/works/[workId]・app/videos/[videoId]・
+ * app/circles/[circleId]・app/creators/[creatorId] の opengraph-image.tsx で共用する
+ * （SPR-268 全ルート完了時点でのレビュー指摘対応。フォント成功/失敗の分岐がルートごとに
+ * 複製されていたため一箇所に集約した）。
+ * ブランドフォント取得失敗でも 500 を返さない（ASCII 縮退版を描画）という各ルート共通の方針を、
+ * ここで一度だけ実装する。
+ */
+
+interface BuildOgImageResponseParams {
+	size: { width: number; height: number };
+	/** M PLUS Rounded 1c bold(700) サブセット取得に使う文字列（表示に使う全文字を含める） */
+	boldText: string;
+	/** regular(400) を使わないルートでは省略してよい */
+	regularText?: string;
+	/** ブランドフォント取得失敗時に描画する ASCII 縮退版の JSX */
+	renderFallback: () => React.ReactElement;
+	/** 通常時に描画する JSX */
+	renderFull: () => React.ReactElement;
+}
+
+export async function buildOgImageResponse({
+	size,
+	boldText,
+	regularText,
+	renderFallback,
+	renderFull,
+}: BuildOgImageResponseParams): Promise<InstanceType<typeof ImageResponse>> {
+	const fontBold = await loadMPlusRoundedSubset(700, boldText).catch(() => null);
+
+	if (!fontBold) {
+		return new ImageResponse(renderFallback(), { ...size });
+	}
+
+	const fontRegular = regularText
+		? await loadMPlusRoundedSubset(400, regularText).catch(() => null)
+		: null;
+
+	return new ImageResponse(renderFull(), {
+		...size,
+		fonts: [
+			{ name: "M PLUS Rounded 1c", data: fontBold, weight: 700, style: "normal" },
+			...(fontRegular
+				? [
+						{
+							name: "M PLUS Rounded 1c",
+							data: fontRegular,
+							weight: 400 as const,
+							style: "normal" as const,
+						},
+					]
+				: []),
+		],
+	});
+}

--- a/apps/web/src/lib/og-text-card.tsx
+++ b/apps/web/src/lib/og-text-card.tsx
@@ -1,0 +1,98 @@
+/**
+ * テキスト主体のOG画像カード（SPR-268 段階導入③）。
+ * サークル・クリエイターのように画像素材を持たないエンティティ向けの共通レイアウト。
+ * app/circles/[circleId]/opengraph-image.tsx・app/creators/[creatorId]/opengraph-image.tsx で共用する。
+ */
+
+// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
+// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
+export const OG_BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
+export const OG_SUZUKA_50 = "hsl(342, 70%, 97%)";
+export const OG_SUZUKA_100 = "hsl(341, 62%, 94%)";
+export const OG_SUZUKA_500 = "hsl(340, 58%, 46%)";
+export const OG_SUZUKA_700 = "hsl(339, 55%, 33%)";
+export const OG_MINASE_800 = "hsl(27, 32%, 37%)";
+export const OG_MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
+
+export interface TextOgCardProps {
+	badgeLabel: string;
+	name: string;
+	subtitle: string;
+	statLabel: string;
+}
+
+const NAME_MAX_WIDTH = 1000;
+
+/** バッジ + 名称 + サブタイトル + 件数を中央揃えで構成するテキスト主体レイアウト */
+export function TextOgCard({ badgeLabel, name, subtitle, statLabel }: TextOgCardProps) {
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				width: "100%",
+				height: "100%",
+				backgroundImage: `linear-gradient(160deg, ${OG_BACKGROUND} 55%, ${OG_SUZUKA_50} 100%)`,
+				fontFamily: "M PLUS Rounded 1c",
+			}}
+		>
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					gap: 28,
+					flexGrow: 1,
+					padding: "0 64px",
+				}}
+			>
+				<span
+					style={{
+						backgroundColor: OG_SUZUKA_100,
+						color: OG_SUZUKA_700,
+						fontWeight: 700,
+						fontSize: 26,
+						padding: "10px 32px",
+						borderRadius: 9999,
+					}}
+				>
+					{badgeLabel}
+				</span>
+				<div
+					style={{
+						display: "flex",
+						alignSelf: "center",
+						justifyContent: "center",
+						width: NAME_MAX_WIDTH,
+						textAlign: "center",
+						fontWeight: 700,
+						fontSize: 68,
+						lineHeight: 1.3,
+						color: OG_SUZUKA_500,
+					}}
+				>
+					{name}
+				</div>
+				{subtitle && <span style={{ fontSize: 30, color: OG_MUTED_FOREGROUND }}>{subtitle}</span>}
+				{statLabel && (
+					<span style={{ fontWeight: 700, fontSize: 32, color: OG_MINASE_800 }}>{statLabel}</span>
+				)}
+			</div>
+
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "center",
+					paddingBottom: 26,
+					fontWeight: 700,
+					fontSize: 26,
+					color: OG_MINASE_800,
+				}}
+			>
+				suzumina.click
+			</div>
+			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: OG_SUZUKA_500 }} />
+		</div>
+	);
+}

--- a/apps/web/src/lib/og-text-card.tsx
+++ b/apps/web/src/lib/og-text-card.tsx
@@ -4,15 +4,15 @@
  * app/circles/[circleId]/opengraph-image.tsx・app/creators/[creatorId]/opengraph-image.tsx で共用する。
  */
 
-// 桜霞パレット（正本は packages/ui/src/styles/globals.css の :root。
-// ImageResponse は CSS 変数を解決できないためライトモード値を転記している）
-export const OG_BACKGROUND = "hsl(340, 40%, 99%)"; // --background（パール白）
-export const OG_SUZUKA_50 = "hsl(342, 70%, 97%)";
-export const OG_SUZUKA_100 = "hsl(341, 62%, 94%)";
-export const OG_SUZUKA_500 = "hsl(340, 58%, 46%)";
-export const OG_SUZUKA_700 = "hsl(339, 55%, 33%)";
-export const OG_MINASE_800 = "hsl(27, 32%, 37%)";
-export const OG_MUTED_FOREGROUND = "hsl(324, 8%, 40%)";
+import {
+	OG_BACKGROUND,
+	OG_MINASE_800,
+	OG_MUTED_FOREGROUND,
+	OG_SUZUKA_50,
+	OG_SUZUKA_100,
+	OG_SUZUKA_500,
+	OG_SUZUKA_700,
+} from "@/lib/og-palette";
 
 export interface TextOgCardProps {
 	badgeLabel: string;

--- a/apps/web/src/lib/og-text.ts
+++ b/apps/web/src/lib/og-text.ts
@@ -33,3 +33,12 @@ export function stripUnsupportedGlyphs(text: string): string {
 export function formatDisplayTitle(text: string, max: number): string {
 	return truncateWithEllipsis(stripUnsupportedGlyphs(text), max);
 }
+
+/**
+ * ブランドフォント取得に失敗した ASCII 縮退版で使う値を返す。
+ * text が印字可能 ASCII のみで構成されていればそのまま、そうでなければ空文字
+ * （内蔵デフォルトフォントは latin のみのため、日本語等はそのままでは tofu 化する）
+ */
+export function asciiOrEmpty(text: string): string {
+	return /^[\x20-\x7E]+$/.test(text) ? text : "";
+}


### PR DESCRIPTION
## 概要（SPR-268 段階導入③・最終）

`/circles/[circleId]`・`/creators/[creatorId]` にタイポグラフィ主体の動的OG画像を追加する。works（#813）・videos（#814）と同じ file-convention パターンだが、サークル・クリエイターは画像素材（ジャケット/サムネイル）を持たないため、レイアウトはバッジ＋名称＋サブ情報の中央揃えテキストカードにしている。

これでSPR-268（詳細ページ別の動的OG画像生成）の対象4ルート（works/videos/circles/creators）すべてに着手完了。

## 変更内容

- **`lib/og-text-card.tsx` 新設**: circles・creators で共用するテキスト主体OGカードのプレゼンテーショナルコンポーネント（バッジ・名称・サブタイトル・件数・底部ドメイン）
- **`app/circles/[circleId]/opengraph-image.tsx`**: サークル名 + 作品数
- **`app/creators/[creatorId]/opengraph-image.tsx`**: クリエイター名 + 役割ラベル（`getCreatorTypeLabel`）+ 参加作品数
- フェイルセーフはworks/videosと同様（未取得→サイト名版、フォント取得失敗→ASCII縮退版）。一覧ページ（/circles・/creators）は従来どおりSPR-171のデフォルト画像を維持（スコープ外）

## 実装中に見つけた satori の挙動

固定幅を与えた見出し要素が、`alignItems: "center"` を設定した親flexコンテナ内で中央寄せされずに左端に張り付く挙動をローカルスクリーンショットで発見。`alignSelf: "center"` + 内部 `justifyContent: "center"` を明示することで解消した（`lib/og-text-card.tsx`）。

## 検証（ローカル dev + emulator 実測）

- `/circles/RG01001793`・`/creators/10006`（サンプルデータ）でog:imageが動的画像を指し、200で描画されることをスクリーンショットで確認（中央寄せ修正の前後を比較）
- `/circles`・`/creators`（一覧）は従来どおり汎用フォールバック画像を維持
- `pnpm verify` 全パス

## デプロイ後の確認

- [ ] 本番の `/circles/[id]`・`/creators/[id]` og:image が200を返すこと
- [ ] カードプレビューで表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)