### PR TITLE
refactor(web): OGP画像の署名とバッジを全カード共通アトムに統一

### DIFF
--- a/apps/web/src/app/buttons/[id]/opengraph-image.tsx
+++ b/apps/web/src/app/buttons/[id]/opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { getAudioButtonById } from "@/app/buttons/actions";
+import { OgBadge, OgFooter } from "@/lib/og-branding";
 import {
 	OG_BACKGROUND as BACKGROUND,
 	OG_MINASE_50 as MINASE_50,
@@ -10,9 +11,6 @@ import {
 	OG_MINASE_800 as MINASE_800,
 	OG_MINASE_950 as MINASE_950,
 	OG_MUTED_FOREGROUND as MUTED_FOREGROUND,
-	OG_SUZUKA_100 as SUZUKA_100,
-	OG_SUZUKA_500 as SUZUKA_500,
-	OG_SUZUKA_700 as SUZUKA_700,
 } from "@/lib/og-palette";
 import { buildOgImageResponse, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/lib/og-response";
 import {
@@ -131,11 +129,12 @@ function VideoIcon() {
 }
 
 interface OgCardProps {
-	siteName: string;
 	badgeLabel: string;
 	buttonText: string;
 	durationLabel: string;
 	videoTitle: string;
+	/** ASCII 縮退版（ブランドフォント無し）。署名の日本語サイト名を tofu 化させないため省略する */
+	ascii?: boolean;
 }
 
 // AudioButton 再現カードの寸法（1200 - 左右 padding 64×2 = カード最大幅 1072。
@@ -144,8 +143,9 @@ const CARD_MAX_WIDTH = 1072;
 const BUTTON_TEXT_MAX_WIDTH = 750;
 const BUTTON_TEXT_FONT_SIZE = 56;
 
-/** 1a 案レイアウト: ヘッダー + AudioButton 再現カード + メタ行 + 底部バー（通常版と ASCII 縮退版で共用） */
-function OgCard({ siteName, badgeLabel, buttonText, durationLabel, videoTitle }: OgCardProps) {
+/** 1a 案レイアウト: ヘッダー + AudioButton 再現カード + メタ行 + 底部署名（通常版と ASCII 縮退版で共用。
+ * 旧ヘッダー左のサイト名は底部署名（lib/og-branding.tsx の OgFooter）へ統一移動した） */
+function OgCard({ badgeLabel, buttonText, durationLabel, videoTitle, ascii = false }: OgCardProps) {
 	// 1行に収まらない場合のみ明示幅を与えて折り返す（satori は auto 幅入れ子で折り返せない）
 	const needsWrap = estimateTextWidth(buttonText, BUTTON_TEXT_FONT_SIZE) > BUTTON_TEXT_MAX_WIDTH;
 	return (
@@ -159,28 +159,16 @@ function OgCard({ siteName, badgeLabel, buttonText, durationLabel, videoTitle }:
 				fontFamily: "M PLUS Rounded 1c",
 			}}
 		>
-			{/* ヘッダー: サイト名 + 音声ボタンピル */}
+			{/* ヘッダー: 音声ボタンピル（右寄せ） */}
 			<div
 				style={{
 					display: "flex",
 					alignItems: "center",
-					justifyContent: "space-between",
+					justifyContent: "flex-end",
 					padding: "48px 64px 0",
 				}}
 			>
-				<span style={{ fontWeight: 700, fontSize: 36, color: SUZUKA_500 }}>{siteName}</span>
-				<span
-					style={{
-						backgroundColor: SUZUKA_100,
-						color: SUZUKA_700,
-						fontWeight: 700,
-						fontSize: 25,
-						padding: "10px 30px",
-						borderRadius: 9999,
-					}}
-				>
-					{badgeLabel}
-				</span>
+				<OgBadge label={badgeLabel} />
 			</div>
 
 			{/* 中央: サイトの AudioButton を再現したカード */}
@@ -243,8 +231,8 @@ function OgCard({ siteName, badgeLabel, buttonText, durationLabel, videoTitle }:
 				</div>
 			</div>
 
-			{/* メタ行: 再生秒数ピル + 元動画タイトル */}
-			<div style={{ display: "flex", alignItems: "center", gap: 28, padding: "0 64px 44px" }}>
+			{/* メタ行: 再生秒数ピル + 元動画タイトル（下に底部署名が続くため間隔を詰める） */}
+			<div style={{ display: "flex", alignItems: "center", gap: 28, padding: "0 64px 28px" }}>
 				{durationLabel && (
 					<div
 						style={{
@@ -290,8 +278,7 @@ function OgCard({ siteName, badgeLabel, buttonText, durationLabel, videoTitle }:
 				)}
 			</div>
 
-			{/* 底部バー */}
-			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: SUZUKA_500 }} />
+			<OgFooter ascii={ascii} />
 		</div>
 	);
 }
@@ -320,21 +307,21 @@ export default async function Image({ params }: OgImageParams) {
 
 	return buildOgImageResponse({
 		size,
-		boldText: `${heading}${durationLabel}すずみなくりっく！音声ボタン`,
+		// suzumina.click は底部署名（OgFooter）用
+		boldText: `${heading}${durationLabel}すずみなくりっく！音声ボタンsuzumina.click`,
 		// videoTitle が空（未設定・ボタン未取得のフォールバック経路）なら regular(400) のフェッチ自体を省く
 		regularText: videoTitle || undefined,
 		renderFallback: () => (
 			<OgCard
-				siteName="suzumina.click"
 				badgeLabel="SOUND BUTTON"
 				buttonText={asciiOrEmpty(buttonText) || "suzumina.click"}
 				durationLabel={durationSec != null ? `${durationSec.toFixed(1)}s` : ""}
 				videoTitle=""
+				ascii
 			/>
 		),
 		renderFull: () => (
 			<OgCard
-				siteName="すずみなくりっく！"
 				badgeLabel="音声ボタン"
 				buttonText={heading}
 				durationLabel={durationLabel}

--- a/apps/web/src/app/circles/[circleId]/opengraph-image.tsx
+++ b/apps/web/src/app/circles/[circleId]/opengraph-image.tsx
@@ -29,13 +29,15 @@ export default async function Image({ params }: OgImageParams) {
 
 	return buildOgImageResponse({
 		size,
-		boldText: `${name}DLsiteサークルすずみなくりっく！${statLabel}`,
+		// suzumina.click は底部署名（OgFooter）用
+		boldText: `${name}DLsiteサークルすずみなくりっく！${statLabel}suzumina.click`,
 		renderFallback: () => (
 			<TextOgCard
 				badgeLabel="DLSITE CIRCLE"
 				name={asciiOrEmpty(name) || "suzumina.click"}
 				subtitle=""
 				statLabel=""
+				ascii
 			/>
 		),
 		renderFull: () => (

--- a/apps/web/src/app/creators/[creatorId]/opengraph-image.tsx
+++ b/apps/web/src/app/creators/[creatorId]/opengraph-image.tsx
@@ -31,13 +31,15 @@ export default async function Image({ params }: OgImageParams) {
 
 	return buildOgImageResponse({
 		size,
-		boldText: `${name}${typeLabel}DLsiteクリエイターすずみなくりっく！${statLabel}`,
+		// suzumina.click は底部署名（OgFooter）用
+		boldText: `${name}${typeLabel}DLsiteクリエイターすずみなくりっく！${statLabel}suzumina.click`,
 		renderFallback: () => (
 			<TextOgCard
 				badgeLabel="DLSITE CREATOR"
 				name={asciiOrEmpty(name) || "suzumina.click"}
 				subtitle=""
 				statLabel=""
+				ascii
 			/>
 		),
 		renderFull: () => (

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,14 +1,13 @@
+import { OgBadge, OgFooter } from "@/lib/og-branding";
 import {
 	OG_BACKGROUND as BACKGROUND,
 	OG_MINASE_400 as MINASE_400,
-	OG_MINASE_800 as MINASE_800,
 	OG_MUTED_FOREGROUND as MUTED_FOREGROUND,
 	OG_SUZUKA_50 as SUZUKA_50,
 	OG_SUZUKA_100 as SUZUKA_100,
 	OG_SUZUKA_200 as SUZUKA_200,
 	OG_SUZUKA_300 as SUZUKA_300,
 	OG_SUZUKA_500 as SUZUKA_500,
-	OG_SUZUKA_700 as SUZUKA_700,
 } from "@/lib/og-palette";
 import { buildOgImageResponse, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/lib/og-response";
 
@@ -58,11 +57,12 @@ interface DefaultOgCardProps {
 	badgeLabel: string;
 	title: string;
 	tagline: string;
-	domain: string;
+	/** ASCII 縮退版（ブランドフォント無し）。署名の日本語サイト名を tofu 化させないため省略する */
+	ascii?: boolean;
 }
 
-/** 中央ブランドロックアップ + 桜装飾 + 底部バー（/buttons/[id] の OG と視覚言語を揃える） */
-function DefaultOgCard({ badgeLabel, title, tagline, domain }: DefaultOgCardProps) {
+/** 中央ブランドロックアップ + 桜装飾 + 底部署名（署名・バッジは lib/og-branding.tsx が正本） */
+function DefaultOgCard({ badgeLabel, title, tagline, ascii = false }: DefaultOgCardProps) {
 	return (
 		<div
 			style={{
@@ -112,36 +112,12 @@ function DefaultOgCard({ badgeLabel, title, tagline, domain }: DefaultOgCardProp
 					flexGrow: 1,
 				}}
 			>
-				<span
-					style={{
-						backgroundColor: SUZUKA_100,
-						color: SUZUKA_700,
-						fontWeight: 700,
-						fontSize: 28,
-						padding: "12px 36px",
-						borderRadius: 9999,
-					}}
-				>
-					{badgeLabel}
-				</span>
+				<OgBadge label={badgeLabel} />
 				<span style={{ fontWeight: 700, fontSize: 104, color: SUZUKA_500 }}>{title}</span>
 				<span style={{ fontWeight: 700, fontSize: 32, color: MUTED_FOREGROUND }}>{tagline}</span>
 			</div>
 
-			{/* 底部: ドメイン + suzuka バー（/buttons/[id] の OG と共通の締め） */}
-			<div
-				style={{
-					display: "flex",
-					justifyContent: "center",
-					paddingBottom: 26,
-					fontWeight: 700,
-					fontSize: 26,
-					color: MINASE_800,
-				}}
-			>
-				{domain}
-			</div>
-			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: SUZUKA_500 }} />
+			<OgFooter ascii={ascii} />
 		</div>
 	);
 }
@@ -151,18 +127,18 @@ export default async function Image() {
 		badgeLabel: "涼花みなせ 非公式ファンサイト",
 		title: "すずみなくりっく！",
 		tagline: "音声ボタン・動画・DLsite作品情報",
-		domain: "suzumina.click",
 	};
 
 	return buildOgImageResponse({
 		size,
-		boldText: `${texts.badgeLabel}${texts.title}${texts.tagline}${texts.domain}`,
+		// suzumina.click は底部署名（OgFooter）用
+		boldText: `${texts.badgeLabel}${texts.title}${texts.tagline}suzumina.click`,
 		renderFallback: () => (
 			<DefaultOgCard
 				badgeLabel="Suzuka Minase Fan Site"
 				title="suzumina.click"
 				tagline="Sound buttons / Videos / Works"
-				domain="suzumina.click"
+				ascii
 			/>
 		),
 		renderFull: () => <DefaultOgCard {...texts} />,

--- a/apps/web/src/app/videos/[videoId]/opengraph-image.tsx
+++ b/apps/web/src/app/videos/[videoId]/opengraph-image.tsx
@@ -75,6 +75,7 @@ export default async function Image({ params }: OgImageParams) {
 				imageDataUri={thumbnailDataUri}
 				imageWidth={THUMBNAIL_WIDTH}
 				imageHeight={THUMBNAIL_HEIGHT}
+				ascii
 			/>
 		),
 		renderFull: () => (

--- a/apps/web/src/app/works/[workId]/opengraph-image.tsx
+++ b/apps/web/src/app/works/[workId]/opengraph-image.tsx
@@ -57,6 +57,7 @@ export default async function Image({ params }: OgImageParams) {
 				imageDataUri={jacketDataUri}
 				imageWidth={JACKET_WIDTH}
 				imageHeight={JACKET_HEIGHT}
+				ascii
 			/>
 		),
 		renderFull: () => (

--- a/apps/web/src/lib/__tests__/og-branding.test.tsx
+++ b/apps/web/src/lib/__tests__/og-branding.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { OgBadge, OgFooter } from "../og-branding";
+
+describe("OgBadge", () => {
+	it("ラベルを統一スタイル（25px・ピル形状）で描画する", () => {
+		render(<OgBadge label="音声ボタン" />);
+
+		const badge = screen.getByText("音声ボタン");
+		expect(badge.style.fontSize).toBe("25px");
+		expect(badge.style.borderRadius).toBe("9999px");
+	});
+
+	it("style で配置指定を上書きできる", () => {
+		render(<OgBadge label="DLsite作品" style={{ alignSelf: "flex-start" }} />);
+
+		expect(screen.getByText("DLsite作品").style.alignSelf).toBe("flex-start");
+	});
+});
+
+describe("OgFooter", () => {
+	it("通常時はサイト名とドメインを描画する", () => {
+		render(<OgFooter />);
+
+		expect(screen.getByText("すずみなくりっく！")).toBeInTheDocument();
+		expect(screen.getByText("suzumina.click")).toBeInTheDocument();
+	});
+
+	it("ascii 時は日本語サイト名を出さずドメインのみ描画する（tofu 化回避）", () => {
+		render(<OgFooter ascii />);
+
+		expect(screen.queryByText("すずみなくりっく！")).not.toBeInTheDocument();
+		expect(screen.getByText("suzumina.click")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/lib/og-branding.tsx
+++ b/apps/web/src/lib/og-branding.tsx
@@ -1,0 +1,54 @@
+import { OG_MINASE_800, OG_SUZUKA_100, OG_SUZUKA_500, OG_SUZUKA_700 } from "@/lib/og-palette";
+
+/**
+ * OG 画像のブランド署名・バッジの正本（全カード共通アトム）。
+ * X 等のタイムラインでカードが並んだとき同一サイトと認識できるよう、
+ * 4系統のカードレイアウト（root / buttons / works・videos / circles・creators）で
+ * 署名（底部左: サイト名＋ドメイン＋suzuka バー）とバッジピルの見た目をここに統一する。
+ */
+
+/** バッジピル。配置（alignSelf 等）はカード側の文脈に依存するため style で渡す */
+export function OgBadge({ label, style }: { label: string; style?: React.CSSProperties }) {
+	return (
+		<span
+			style={{
+				backgroundColor: OG_SUZUKA_100,
+				color: OG_SUZUKA_700,
+				fontWeight: 700,
+				fontSize: 25,
+				padding: "10px 30px",
+				borderRadius: 9999,
+				...style,
+			}}
+		>
+			{label}
+		</span>
+	);
+}
+
+/**
+ * 底部署名（サイト名＋ドメイン）＋ suzuka バー。カードの最下部に置く。
+ * ascii=true（ブランドフォント取得失敗の縮退版）では日本語サイト名が tofu 化するため
+ * ドメイン表記のみに落とす
+ */
+export function OgFooter({ ascii = false }: { ascii?: boolean }) {
+	return (
+		<div style={{ display: "flex", flexDirection: "column" }}>
+			<div style={{ display: "flex", alignItems: "center", gap: 14, padding: "0 64px 40px" }}>
+				{ascii ? (
+					<span style={{ fontWeight: 700, fontSize: 30, color: OG_SUZUKA_500 }}>
+						suzumina.click
+					</span>
+				) : (
+					<>
+						<span style={{ fontWeight: 700, fontSize: 30, color: OG_SUZUKA_500 }}>
+							すずみなくりっく！
+						</span>
+						<span style={{ fontSize: 22, color: OG_MINASE_800 }}>suzumina.click</span>
+					</>
+				)}
+			</div>
+			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: OG_SUZUKA_500 }} />
+		</div>
+	);
+}

--- a/apps/web/src/lib/og-media-card.tsx
+++ b/apps/web/src/lib/og-media-card.tsx
@@ -1,19 +1,17 @@
+import { OgBadge, OgFooter } from "@/lib/og-branding";
 import {
 	OG_BACKGROUND,
 	OG_MINASE_300,
-	OG_MINASE_800,
 	OG_MINASE_950,
 	OG_MUTED_FOREGROUND,
-	OG_SUZUKA_100,
 	OG_SUZUKA_500,
-	OG_SUZUKA_700,
 } from "@/lib/og-palette";
 
 /**
  * 画像（ジャケット/サムネイル）+ タイトル + 2行のメタ情報の2カラムレイアウト。
  * app/works/[workId]/opengraph-image.tsx・app/videos/[videoId]/opengraph-image.tsx で共用する
  * （両ルートの OgCard がジャケット/サムネイルの差異以外ほぼ同一だったため SPR-268 完了時点で統合）。
- * 通常版と ASCII 縮退版の両方でこのコンポーネントを使う。
+ * 通常版と ASCII 縮退版の両方でこのコンポーネントを使う。署名・バッジは lib/og-branding.tsx が正本。
  */
 
 const DEFAULT_EMPHASIS_FONT_SIZE = 30;
@@ -32,6 +30,8 @@ export interface MediaOgCardProps {
 	/** 強調行（価格・再生時間等）。空文字なら非表示 */
 	emphasisLine?: string;
 	emphasisFontSize?: number;
+	/** ASCII 縮退版（ブランドフォント無し）。署名の日本語サイト名を tofu 化させないため省略する */
+	ascii?: boolean;
 }
 
 export function MediaOgCard({
@@ -45,6 +45,7 @@ export function MediaOgCard({
 	secondaryLine,
 	emphasisLine,
 	emphasisFontSize = DEFAULT_EMPHASIS_FONT_SIZE,
+	ascii = false,
 }: MediaOgCardProps) {
 	return (
 		<div
@@ -90,19 +91,7 @@ export function MediaOgCard({
 						minWidth: 0,
 					}}
 				>
-					<span
-						style={{
-							alignSelf: "flex-start",
-							backgroundColor: OG_SUZUKA_100,
-							color: OG_SUZUKA_700,
-							fontWeight: 700,
-							fontSize: 25,
-							padding: "10px 30px",
-							borderRadius: 9999,
-						}}
-					>
-						{badgeLabel}
-					</span>
+					<OgBadge label={badgeLabel} style={{ alignSelf: "flex-start" }} />
 					<div
 						style={{
 							width: titleMaxWidth,
@@ -125,14 +114,7 @@ export function MediaOgCard({
 				</div>
 			</div>
 
-			<div style={{ display: "flex", alignItems: "center", gap: 14, padding: "0 64px 40px" }}>
-				<span style={{ fontWeight: 700, fontSize: 30, color: OG_SUZUKA_500 }}>
-					すずみなくりっく！
-				</span>
-				<span style={{ fontSize: 22, color: OG_MINASE_800 }}>suzumina.click</span>
-			</div>
-
-			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: OG_SUZUKA_500 }} />
+			<OgFooter ascii={ascii} />
 		</div>
 	);
 }

--- a/apps/web/src/lib/og-text-card.tsx
+++ b/apps/web/src/lib/og-text-card.tsx
@@ -2,16 +2,16 @@
  * テキスト主体のOG画像カード（SPR-268 段階導入③）。
  * サークル・クリエイターのように画像素材を持たないエンティティ向けの共通レイアウト。
  * app/circles/[circleId]/opengraph-image.tsx・app/creators/[creatorId]/opengraph-image.tsx で共用する。
+ * 署名・バッジは lib/og-branding.tsx が正本。
  */
 
+import { OgBadge, OgFooter } from "@/lib/og-branding";
 import {
 	OG_BACKGROUND,
 	OG_MINASE_800,
 	OG_MUTED_FOREGROUND,
 	OG_SUZUKA_50,
-	OG_SUZUKA_100,
 	OG_SUZUKA_500,
-	OG_SUZUKA_700,
 } from "@/lib/og-palette";
 
 export interface TextOgCardProps {
@@ -19,12 +19,20 @@ export interface TextOgCardProps {
 	name: string;
 	subtitle: string;
 	statLabel: string;
+	/** ASCII 縮退版（ブランドフォント無し）。署名の日本語サイト名を tofu 化させないため省略する */
+	ascii?: boolean;
 }
 
 const NAME_MAX_WIDTH = 1000;
 
 /** バッジ + 名称 + サブタイトル + 件数を中央揃えで構成するテキスト主体レイアウト */
-export function TextOgCard({ badgeLabel, name, subtitle, statLabel }: TextOgCardProps) {
+export function TextOgCard({
+	badgeLabel,
+	name,
+	subtitle,
+	statLabel,
+	ascii = false,
+}: TextOgCardProps) {
 	return (
 		<div
 			style={{
@@ -47,18 +55,7 @@ export function TextOgCard({ badgeLabel, name, subtitle, statLabel }: TextOgCard
 					padding: "0 64px",
 				}}
 			>
-				<span
-					style={{
-						backgroundColor: OG_SUZUKA_100,
-						color: OG_SUZUKA_700,
-						fontWeight: 700,
-						fontSize: 26,
-						padding: "10px 32px",
-						borderRadius: 9999,
-					}}
-				>
-					{badgeLabel}
-				</span>
+				<OgBadge label={badgeLabel} />
 				<div
 					style={{
 						display: "flex",
@@ -80,19 +77,7 @@ export function TextOgCard({ badgeLabel, name, subtitle, statLabel }: TextOgCard
 				)}
 			</div>
 
-			<div
-				style={{
-					display: "flex",
-					justifyContent: "center",
-					paddingBottom: 26,
-					fontWeight: 700,
-					fontSize: 26,
-					color: OG_MINASE_800,
-				}}
-			>
-				suzumina.click
-			</div>
-			<div style={{ display: "flex", height: 14, flexShrink: 0, backgroundColor: OG_SUZUKA_500 }} />
+			<OgFooter ascii={ascii} />
 		</div>
 	);
 }


### PR DESCRIPTION
## 概要

OGP整備（SPR-171 / SPR-249 / SPR-268 / #816）完了時点で、4系統のカードレイアウト間に残っていた**ブランド署名の位置・形式の不統一**と**バッジピルのサイズ揺れ**を解消する。X等のタイムラインでカードが並んだとき、同一サイトのカードだと認識できる固定アンカー（底部左の署名）を全カードに持たせるのが目的。

## 従来の不統一

| カード | 署名 | バッジ |
|---|---|---|
| root | 底部**中央**にドメインのみ | 28px |
| buttons/[id] | **上部ヘッダー左**にサイト名（36px）、底部署名なし | 25px |
| works/videos | 底部左にサイト名＋ドメイン | 25px |
| circles/creators | 底部**中央**にドメインのみ（日本語サイト名なし） | 26px |

## 変更内容

- **`lib/og-branding.tsx` 新設**（署名・バッジの正本）
  - `OgFooter`: 底部左「すずみなくりっく！＋suzumina.click」＋suzukaバー。works/videos形式を正として全カードに適用
  - `OgBadge`: ピルの見た目を25pxに統一。配置（alignSelf等）はカード文脈依存のためstyleで渡す
- buttonsはヘッダー左のサイト名を撤去しバッジ右寄せのみに（署名は底部へ統一移動）。rootとcircles/creatorsは底部中央ドメインを統一署名に置換
- **`ascii` propを全カードに追加**: フォント取得失敗の縮退版では日本語サイト名を出さずドメインのみ表示。works/videosの縮退版footerが日本語のままtofu化していた**潜在バグもこれで解消**
- 各ルートの`boldText`に`suzumina.click`を追加（署名のドメインをブランドフォントで描画）
- `og-branding`のテスト追加（統一スタイル・ascii分岐）

## 検証

- ローカルdev + emulatorで root / buttons / circles をスクリーンショット確認（統一署名が全カード底部左に表示）、全6ルートの200応答を確認
- `pnpm verify` 全パス（既存テストは無変更で通過）

## 意図的に統一しないもの

レイアウト4系統（ブランドロックアップ/AudioButton再現/メディア2カラム/タイポグラフィ）はコンテンツの性質に合わせた意図的な差別化として維持。背景処理（フラット/グラデ）と桜モチーフ（rootのみ）もカードの個性として残す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)