### PR TITLE
feat(web): ユーザープロフィールの動的OG画像生成（アバター無しユーザーのog:image欠落を解消）

### DIFF
--- a/apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+
+// ImageResponse は実描画せず、渡された element / options を検証できる形で捕捉する
+vi.mock("next/og", () => ({
+	ImageResponse: class {
+		element: React.ReactElement;
+		options: { fonts?: unknown[] } | undefined;
+		constructor(element: React.ReactElement, options?: { fonts?: unknown[] }) {
+			this.element = element;
+			this.options = options;
+		}
+	},
+}));
+vi.mock("@/lib/user-firestore", () => ({ getUserByDiscordId: vi.fn() }));
+vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+
+import { loadMPlusRoundedSubset } from "@/lib/og-font";
+import { getUserByDiscordId } from "@/lib/user-firestore";
+import Image, { alt, contentType, size } from "../opengraph-image";
+
+type OgCardProps = {
+	title: string;
+	secondaryLine?: string;
+	imageDataUri: string | null;
+};
+
+function makeUser(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		displayName: "テストユーザー",
+		isPublicProfile: true,
+		avatarUrl: "https://cdn.discordapp.com/avatars/123/abc.png",
+		...overrides,
+	};
+}
+
+describe("ユーザープロフィールの OG 画像（app/users/[userId]/opengraph-image.tsx）", () => {
+	it("1200×630 の PNG を宣言している", () => {
+		expect(size).toEqual({ width: 1200, height: 630 });
+		expect(contentType).toBe("image/png");
+		expect(alt).toContain("ユーザープロフィール");
+	});
+
+	it("公開プロフィールは表示名・アバターを描画する", async () => {
+		vi.mocked(getUserByDiscordId).mockResolvedValueOnce(makeUser() as never);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(4),
+				headers: new Headers({ "content-type": "image/png" }),
+			}),
+		);
+
+		const response = (await Image({
+			params: Promise.resolve({ userId: "123456789" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(response.element.props.title).toBe("テストユーザー");
+		expect(response.element.props.imageDataUri).toMatch(/^data:image\/png;base64,/);
+
+		vi.unstubAllGlobals();
+	});
+
+	it("アバター未設定でも og:image を返す（名前入りテキストのみカード）", async () => {
+		vi.mocked(getUserByDiscordId).mockResolvedValueOnce(
+			makeUser({ avatarUrl: undefined }) as never,
+		);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = (await Image({
+			params: Promise.resolve({ userId: "123456789" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(response.element.props.title).toBe("テストユーザー");
+		expect(response.element.props.imageDataUri).toBeNull();
+
+		vi.unstubAllGlobals();
+	});
+
+	it("非公開プロフィールは表示名・アバターを出さずサイト名版に落とす", async () => {
+		vi.mocked(getUserByDiscordId).mockResolvedValueOnce(
+			makeUser({ isPublicProfile: false }) as never,
+		);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = (await Image({
+			params: Promise.resolve({ userId: "123456789" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(response.element.props.title).toBe("すずみなくりっく！");
+		expect(response.element.props.imageDataUri).toBeNull();
+
+		vi.unstubAllGlobals();
+	});
+
+	it("ユーザーが見つからない場合はサイト名版にフォールバックする", async () => {
+		vi.mocked(getUserByDiscordId).mockResolvedValueOnce(null);
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ userId: "unknown" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(response.element.props.title).toBe("すずみなくりっく！");
+	});
+
+	it("取得エラー（throw）でも 500 にせずサイト名版に落とす", async () => {
+		vi.mocked(getUserByDiscordId).mockRejectedValueOnce(new Error("firestore error"));
+		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+
+		const response = (await Image({
+			params: Promise.resolve({ userId: "123456789" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps> };
+
+		expect(response.element.props.title).toBe("すずみなくりっく！");
+	});
+
+	it("フォント取得失敗でも 500 にせず ASCII 縮退版を描画する", async () => {
+		vi.mocked(getUserByDiscordId).mockResolvedValueOnce(
+			makeUser({ displayName: "Ascii User", avatarUrl: undefined }) as never,
+		);
+		vi.mocked(loadMPlusRoundedSubset).mockRejectedValue(new Error("font error"));
+
+		const response = (await Image({
+			params: Promise.resolve({ userId: "123456789" }),
+		})) as unknown as { element: React.ReactElement<OgCardProps>; options: { fonts?: unknown[] } };
+
+		expect(response.element.props.title).toBe("Ascii User");
+		expect(response.options.fonts).toBeUndefined();
+	});
+});

--- a/apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx
@@ -57,7 +57,13 @@ describe("ユーザープロフィールの OG 画像（app/users/[userId]/openg
 		})) as unknown as { element: React.ReactElement<OgCardProps> };
 
 		expect(response.element.props.title).toBe("テストユーザー");
+		expect(response.element.props.secondaryLine).toBe("音声ボタン作成メンバー");
 		expect(response.element.props.imageDataUri).toMatch(/^data:image\/png;base64,/);
+		// secondaryLine の文字が regular(400) サブセットに含まれること（欠けると tofu 化する）
+		expect(loadMPlusRoundedSubset).toHaveBeenCalledWith(
+			400,
+			expect.stringContaining("音声ボタン作成メンバー"),
+		);
 
 		vi.unstubAllGlobals();
 	});
@@ -85,7 +91,7 @@ describe("ユーザープロフィールの OG 画像（app/users/[userId]/openg
 		vi.mocked(getUserByDiscordId).mockResolvedValueOnce(
 			makeUser({ isPublicProfile: false }) as never,
 		);
-		vi.mocked(loadMPlusRoundedSubset).mockResolvedValue(new ArrayBuffer(8));
+		vi.mocked(loadMPlusRoundedSubset).mockClear().mockResolvedValue(new ArrayBuffer(8));
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
@@ -95,7 +101,10 @@ describe("ユーザープロフィールの OG 画像（app/users/[userId]/openg
 
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(response.element.props.title).toBe("すずみなくりっく！");
+		expect(response.element.props.secondaryLine).toBe("");
 		expect(response.element.props.imageDataUri).toBeNull();
+		// セカンダリ行が無いため regular(400) のフェッチ自体を省く
+		expect(loadMPlusRoundedSubset).not.toHaveBeenCalledWith(400, expect.anything());
 
 		vi.unstubAllGlobals();
 	});

--- a/apps/web/src/app/users/[userId]/opengraph-image.tsx
+++ b/apps/web/src/app/users/[userId]/opengraph-image.tsx
@@ -38,6 +38,7 @@ export default async function Image({ params }: OgImageParams) {
 	const publicUser = user?.isPublicProfile ? user : null;
 
 	const name = publicUser ? formatDisplayTitle(publicUser.displayName, 30) : "すずみなくりっく！";
+	const secondaryLine = publicUser ? "音声ボタン作成メンバー" : "";
 	const avatarDataUri = publicUser?.avatarUrl
 		? await loadRemoteImageDataUri(publicUser.avatarUrl, ALLOWED_AVATAR_HOSTNAMES)
 		: null;
@@ -45,7 +46,10 @@ export default async function Image({ params }: OgImageParams) {
 	return buildOgImageResponse({
 		size,
 		// suzumina.click は底部署名（OgFooter）用
-		boldText: `${name}ユーザープロフィールすずみなくりっく！suzumina.click`,
+		boldText: `${name}ユーザーすずみなくりっく！suzumina.click`,
+		// secondaryLine（regular ウェイト描画）の文字をサブセットに含める（works/videos と同じ規約）。
+		// 非公開/未取得でセカンダリ行が無い場合はフェッチ自体を省く
+		regularText: secondaryLine ? `${secondaryLine}suzumina.click` : undefined,
 		renderFallback: () => (
 			<MediaOgCard
 				badgeLabel="USER"
@@ -67,7 +71,7 @@ export default async function Image({ params }: OgImageParams) {
 				imageDataUri={avatarDataUri}
 				imageWidth={AVATAR_SIZE}
 				imageHeight={AVATAR_SIZE}
-				secondaryLine={publicUser ? "音声ボタン作成メンバー" : ""}
+				secondaryLine={secondaryLine}
 			/>
 		),
 	});

--- a/apps/web/src/app/users/[userId]/opengraph-image.tsx
+++ b/apps/web/src/app/users/[userId]/opengraph-image.tsx
@@ -1,0 +1,74 @@
+import { MediaOgCard } from "@/lib/og-media-card";
+import { loadRemoteImageDataUri } from "@/lib/og-remote-image";
+import { buildOgImageResponse, OG_IMAGE_CONTENT_TYPE, OG_IMAGE_SIZE } from "@/lib/og-response";
+import { asciiOrEmpty, formatDisplayTitle } from "@/lib/og-text";
+import { getUserByDiscordId } from "@/lib/user-firestore";
+
+/**
+ * ユーザープロフィールの動的 OG 画像（SPR-268 完了後の残タスク対応）。
+ * 従来は generateMetadata がアバターURLを直接 og:image に指定しており、アバター未設定ユーザーは
+ * og:image 自体が欠落していた。他詳細ルートと同じ file-convention（MediaOgCard）に統一し、
+ * アバター無しでも名前入りのブランドカードを返す。
+ * 非公開プロフィール（isPublicProfile=false）はページ同様に個人情報を出さず、サイト名版に落とす。
+ * どの失敗経路でも 500 は返さない（未取得/非公開→サイト名版 / アバター取得失敗→画像無し版 / フォント取得失敗→ASCII 縮退版）。
+ */
+
+export const size = OG_IMAGE_SIZE;
+export const contentType = OG_IMAGE_CONTENT_TYPE;
+export const alt = "ユーザープロフィール - すずみなくりっく！";
+
+const AVATAR_SIZE = 280;
+// カード幅1200 - 左右padding128 - アバター280 - gap56 = 736px（名前列の折り返し幅）
+const TITLE_MAX_WIDTH = 730;
+const TITLE_FONT_SIZE = 48;
+
+// next.config.mjs の images.remotePatterns と同じ許可ホスト（Discord CDN限定）
+const ALLOWED_AVATAR_HOSTNAMES = ["cdn.discordapp.com"];
+
+interface OgImageParams {
+	params: Promise<{ userId: string }>;
+}
+
+export default async function Image({ params }: OgImageParams) {
+	const { userId } = await params;
+
+	// getUserByDiscordId は取得失敗時に throw するため null に落とす。
+	// 非公開プロフィールはページ（notFound）と同じ扱いで、名前・アバターを画像に出さない
+	const user = await getUserByDiscordId(userId).catch(() => null);
+	const publicUser = user?.isPublicProfile ? user : null;
+
+	const name = publicUser ? formatDisplayTitle(publicUser.displayName, 30) : "すずみなくりっく！";
+	const avatarDataUri = publicUser?.avatarUrl
+		? await loadRemoteImageDataUri(publicUser.avatarUrl, ALLOWED_AVATAR_HOSTNAMES)
+		: null;
+
+	return buildOgImageResponse({
+		size,
+		// suzumina.click は底部署名（OgFooter）用
+		boldText: `${name}ユーザープロフィールすずみなくりっく！suzumina.click`,
+		renderFallback: () => (
+			<MediaOgCard
+				badgeLabel="USER"
+				title={asciiOrEmpty(name) || "suzumina.click"}
+				titleMaxWidth={TITLE_MAX_WIDTH}
+				titleFontSize={TITLE_FONT_SIZE}
+				imageDataUri={avatarDataUri}
+				imageWidth={AVATAR_SIZE}
+				imageHeight={AVATAR_SIZE}
+				ascii
+			/>
+		),
+		renderFull: () => (
+			<MediaOgCard
+				badgeLabel="ユーザー"
+				title={name}
+				titleMaxWidth={TITLE_MAX_WIDTH}
+				titleFontSize={TITLE_FONT_SIZE}
+				imageDataUri={avatarDataUri}
+				imageWidth={AVATAR_SIZE}
+				imageHeight={AVATAR_SIZE}
+				secondaryLine={publicUser ? "音声ボタン作成メンバー" : ""}
+			/>
+		),
+	});
+}

--- a/apps/web/src/app/users/[userId]/page.tsx
+++ b/apps/web/src/app/users/[userId]/page.tsx
@@ -27,16 +27,26 @@ export async function generateMetadata({ params }: UserProfilePageProps): Promis
 			};
 		}
 
+		// 非公開プロフィールは本人以外 notFound だが、metadata は viewer 非依存のため
+		// displayName 等を出さない汎用表記に落とす（公開出力への個人情報漏れ防止）
+		if (!user.isPublicProfile) {
+			return {
+				title: "プロフィール",
+				description: "ユーザープロフィールページ",
+				robots: { index: false, follow: false },
+			};
+		}
+
 		return {
 			title: `${user.displayName}のプロフィール`,
 			description: `${user.displayName}さんの作成した音声ボタンをチェック。涼花みなせファンコミュニティ suzumina.click`,
 			alternates: {
 				canonical: `/users/${resolvedParams.userId}`,
 			},
+			// og:image は同セグメントの opengraph-image.tsx（file-convention）が自動出力する
 			openGraph: {
 				title: `${user.displayName}のプロフィール`,
 				description: `${user.displayName}さんのプロフィール`,
-				images: user.avatarUrl ? [{ url: user.avatarUrl }] : undefined,
 			},
 		};
 	} catch {


### PR DESCRIPTION
## 概要

OGP整備ストリーム（SPR-171 / SPR-249 / SPR-268、#810〜#817）完了後の残タスク対応。`/users/[userId]` は唯一 og:image が file-convention 化されていない詳細ルートで、generateMetadata がアバターURLを直接 og:image に指定していたため、**アバター未設定ユーザーは og:image 自体が欠落**していた（`openGraph` 上書きにより root のfile-convention画像も落ちる構造）。

## 変更内容

- **`app/users/[userId]/opengraph-image.tsx` 新設**: 他詳細ルートと同じ共通部品（`MediaOgCard` / `buildOgImageResponse` / `loadRemoteImageDataUri`）でアバター＋表示名のカードを生成
  - アバター有り: Discord アバター（280×280、ホストallowlist=cdn.discordapp.com）＋表示名
  - アバター無し: 名前入りテキストのみカード（og:image は必ず返る）
  - 未取得/取得エラー: サイト名版に縮退（500は返さない）
- **プライバシー整合**: 非公開プロフィール（`isPublicProfile=false`）はページの notFound と整合させ、OG画像でも表示名・アバターを出さずサイト名版に落とす
- **generateMetadata の情報漏れ修正（見つけた既存バグ）**: 従来は `isPublicProfile` を確認せずに displayName を title / og:title に出力していた（ページ本体は404を返すのにメタタグだけ個人情報が漏れる）。非公開プロフィールは汎用表記＋noindex に変更
- generateMetadata の `images` 手書きを撤去（file-convention に一本化、他ルートと同じ流儀）

## 検証

- テスト7本（公開＋アバター有/無・非公開・未取得・取得throw・フォント失敗）追加、`pnpm verify` 全パス
- Emulator には users データが無いため、ローカルはフォールバック経路（存在しないID→サイト名版200）とスクリーンショットで確認

## デプロイ後の確認

- [ ] 実ユーザー（アバター有り）の `/users/[id]/opengraph-image` が200でアバター入りカードを返す
- [ ] アバター無しユーザーでも og:image が返る
- [ ] 非公開プロフィールの og:image / メタタグに個人情報が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)