### PR TITLE
test(web): ユーザーOG画像テストにnext/cacheモックを追加

### DIFF
--- a/apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx
+++ b/apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx
@@ -13,6 +13,8 @@ vi.mock("next/og", () => ({
 }));
 vi.mock("@/lib/user-firestore", () => ({ getUserByDiscordId: vi.fn() }));
 vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+// vitest では "use cache" ディレクティブは no-op になり cacheLife が cache スコープ外呼び出しになるためモックする
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
 
 import { loadMPlusRoundedSubset } from "@/lib/og-font";
 import { getUserByDiscordId } from "@/lib/user-firestore";


### PR DESCRIPTION
## Summary
- `apps/web/src/app/users/[userId]/__tests__/opengraph-image.test.tsx` の「公開プロフィールは表示名・アバターを描画する」テストが origin/main の時点で既に失敗していた（自分の変更とは無関係）
- 原因は実装バグではなくテスト側のモック漏れ：`loadRemoteImageDataUri` が内部で使う `"use cache"` ディレクティブ + `cacheLife("days")` は vitest では no-op になり、cache スコープ外で `cacheLife` を呼ぶ形になって戻り値が壊れる
- `works`/`videos` の同種テストには既に `vi.mock("next/cache", () => ({ cacheLife: vi.fn() }))` の回避策が入っていたが、PR #818/#819 で新規追加された users のテストにはこのモックが抜けていた
- 同じモックを追加して解消（実装コードの変更なし）

## Test plan
- [x] `pnpm --filter @suzumina.click/web test` で対象テストファイルを含む全131ファイルが pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)