### PR TITLE
fix(web): トップCTA「音声ボタンを作る」の導線修正 (SPR-150)

### DIFF
--- a/apps/web/src/components/home/__tests__/dynamic-home-sections.test.tsx
+++ b/apps/web/src/components/home/__tests__/dynamic-home-sections.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CommunitySection } from "../dynamic-home-sections";
+
+describe("CommunitySection (SPR-150)", () => {
+	it("「音声ボタンを作る」CTAは動画一覧(/videos)へ遷移する（video_id無しで/buttons/createへ飛びエラーに落ちていたバグの修正）", () => {
+		render(<CommunitySection />);
+
+		const cta = screen.getByRole("link", { name: "音声ボタンを作る" });
+		expect(cta).toHaveAttribute("href", "/videos");
+	});
+
+	it("「サイトについて」CTAは変更しない", () => {
+		render(<CommunitySection />);
+
+		const aboutLink = screen.getByRole("link", { name: "サイトについて" });
+		expect(aboutLink).toHaveAttribute("href", "/about");
+	});
+});

--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -120,8 +120,13 @@ export function CommunitySection() {
 						音声ボタンを作成・共有して、ファンコミュニティを盛り上げよう！
 					</p>
 					<div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+						{/*
+						 * video_id 無しで /buttons/create に飛ぶと「動画IDが指定されていません」エラーに
+						 * 落ちていた（SPR-150）。動画一覧では各カードに video_id 付きの作成導線
+						 * （VideoCardActions）があるため、そこへ誘導する。
+						 */}
 						<Button asChild size="lg">
-							<Link href="/buttons/create" className="font-medium">
+							<Link href="/videos" className="font-medium">
 								音声ボタンを作る
 							</Link>
 						</Button>


### PR DESCRIPTION
## 概要

トップページ「コミュニティに参加しよう」セクションの「音声ボタンを作る」CTAが `video_id` 無しで `/buttons/create` に直接遷移し、「動画IDが指定されていません」エラー画面に落ちるバグを修正する（SPR-137 プロダクト見直しロードマップの最終項目）。

Linear: [SPR-150](https://linear.app/nothink/issue/SPR-150)

## 修正

`/videos` の各動画カードには既に `video_id` 付きの作成導線（`VideoCardActions` の「ボタン作成」ボタン）がある。CTAの遷移先を `/buttons/create` から `/videos` に変更し、そこで動画を選んでもらう形にした。`/buttons/create/page.tsx` 自身のエラー画面が「動画一覧から選ぶ」として案内している先と同じ着地点。

ラベル「音声ボタンを作る」はそのまま維持（動画を選んで作る導線として意味は通る）。

## 検証

- `pnpm verify` 全パス
- 新規テスト: `CommunitySection` の CTA href が `/videos` になっていることを確認
- ブラウザ確認（Firestore Emulator + `pnpm dev:local`）: トップページで CTA の href が `/videos` になっていることをアクセシビリティツリーで確認し、`/videos` への直接遷移が正常に動作することも確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)