### PR TITLE
feat(web): ボタン一覧に3ビュー切替（すべて/用途別/動画ごと）と featured セクション (SPR-257 PR②)

### DIFF
--- a/apps/web/src/app/buttons/components/__tests__/buttons-views.test.tsx
+++ b/apps/web/src/app/buttons/components/__tests__/buttons-views.test.tsx
@@ -1,0 +1,155 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ButtonsViewNav } from "../buttons-view-nav";
+import { FeaturedAudioButtons } from "../featured-audio-buttons";
+import { GroupedButtonsView } from "../grouped-buttons-view";
+
+vi.mock("@/components/audio/audio-button-with-play-count", () => ({
+	AudioButtonWithPlayCount: ({ audioButton }: { audioButton: { buttonText: string } }) => (
+		<div data-testid="audio-button">{audioButton.buttonText}</div>
+	),
+}));
+vi.mock("@/hooks/use-favorite-status-bulk", () => ({
+	useFavoriteStatusBulk: () => ({ favoriteStates: new Map([["b1", true]]) }),
+}));
+vi.mock("@/hooks/use-like-dislike-status-bulk", () => ({
+	useLikeDislikeStatusBulk: () => ({
+		likeDislikeStates: new Map([["b1", { isLiked: true, isDisliked: false }]]),
+	}),
+}));
+
+function makeButton(id: string, buttonText: string, playCount = 0): AudioButtonPlainObject {
+	return {
+		id,
+		buttonText,
+		videoId: "v1",
+		videoTitle: "テスト動画",
+		startTime: 0,
+		endTime: 1,
+		duration: 1,
+		tags: [],
+		creatorId: "u1",
+		creatorName: "作成者",
+		isPublic: true,
+		stats: { playCount, likeCount: 0, dislikeCount: 0, favoriteCount: 0, engagementRate: 0 },
+		createdAt: "2026-07-01T00:00:00.000Z",
+		updatedAt: "2026-07-01T00:00:00.000Z",
+		_computed: {
+			isPopular: false,
+			engagementRate: 0,
+			engagementRatePercentage: 0,
+			popularityScore: 0,
+			searchableText: buttonText,
+			durationText: "1秒",
+			relativeTimeText: "1日前",
+		},
+	} as AudioButtonPlainObject;
+}
+
+describe("ButtonsViewNav", () => {
+	it("3ビューのリンクを表示し、現在ビューに aria-current を付ける", () => {
+		render(<ButtonsViewNav currentView="usage" />);
+
+		expect(screen.getByRole("link", { name: "すべて" })).toHaveAttribute("href", "/buttons");
+		expect(screen.getByRole("link", { name: "用途別" })).toHaveAttribute(
+			"href",
+			"/buttons?view=usage",
+		);
+		expect(screen.getByRole("link", { name: "動画ごと" })).toHaveAttribute(
+			"href",
+			"/buttons?view=video",
+		);
+		expect(screen.getByRole("link", { name: "用途別" })).toHaveAttribute("aria-current", "page");
+		expect(screen.getByRole("link", { name: "すべて" })).not.toHaveAttribute("aria-current");
+	});
+
+	it("公式語彙9カテゴリのチップを表示し、絞り込み中のタグを active にする", () => {
+		render(<ButtonsViewNav currentView="all" activeTags={["笑い"]} />);
+
+		const chip = screen.getByRole("link", { name: "笑い" });
+		expect(chip).toHaveAttribute("href", `/buttons?tags=${encodeURIComponent("笑い")}`);
+		expect(chip.className).toContain("bg-suzuka-500");
+		expect(screen.getByRole("link", { name: "あいさつ" }).className).not.toContain("bg-suzuka-500");
+		expect(screen.getByRole("link", { name: "名言・迷言" })).toBeInTheDocument();
+	});
+});
+
+describe("GroupedButtonsView", () => {
+	it("グループカードに見出し・件数・もっと見る・丸め注記を表示する", () => {
+		render(
+			<GroupedButtonsView
+				heading="用途別のボタン"
+				totalCount={5}
+				groups={[
+					{
+						key: "笑い",
+						title: "笑い",
+						total: 5,
+						buttons: [makeButton("b1", "ボタン1"), makeButton("b2", "ボタン2")],
+						moreHref: "/buttons?tags=笑い",
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByRole("heading", { name: "用途別のボタン" })).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: "笑い" })).toBeInTheDocument();
+		expect(screen.getAllByTestId("audio-button")).toHaveLength(2);
+		expect(screen.getByRole("link", { name: "もっと見る →" })).toHaveAttribute(
+			"href",
+			"/buttons?tags=笑い",
+		);
+		expect(screen.getByText("ほか 3 件は「もっと見る」から")).toBeInTheDocument();
+	});
+
+	it("動画ごとグループはサムネイルと「動画を見る」リンクを表示する", () => {
+		render(
+			<GroupedButtonsView
+				heading="動画ごとのボタン"
+				totalCount={1}
+				groups={[
+					{
+						key: "v1",
+						title: "テスト動画",
+						total: 1,
+						buttons: [makeButton("b1", "ボタン1")],
+						thumbnailUrl: "https://example.com/t.jpg",
+						videoHref: "/videos/v1",
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByRole("img", { name: "テスト動画" })).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: "動画を見る" })).toHaveAttribute("href", "/videos/v1");
+	});
+
+	it("グループが空なら空状態メッセージを出す", () => {
+		render(<GroupedButtonsView heading="用途別のボタン" totalCount={0} groups={[]} />);
+
+		expect(screen.getByText("条件にあうボタンが見つかりませんでした")).toBeInTheDocument();
+	});
+});
+
+describe("FeaturedAudioButtons", () => {
+	it("よく押されてるボタンに再生数ラベル、新着ボタンに NEW バッジを表示する", () => {
+		render(
+			<FeaturedAudioButtons
+				popular={[makeButton("b1", "人気ボタン", 42)]}
+				fresh={[makeButton("b2", "新着ボタン")]}
+			/>,
+		);
+
+		expect(screen.getByRole("heading", { name: "よく押されてるボタン" })).toBeInTheDocument();
+		expect(screen.getByText("42回再生")).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: "新着ボタン" })).toBeInTheDocument();
+		expect(screen.getByText("NEW")).toBeInTheDocument();
+	});
+
+	it("両方空なら何も描画しない", () => {
+		const { container } = render(<FeaturedAudioButtons popular={[]} fresh={[]} />);
+
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/apps/web/src/app/buttons/components/__tests__/buttons-views.test.tsx
+++ b/apps/web/src/app/buttons/components/__tests__/buttons-views.test.tsx
@@ -130,6 +130,39 @@ describe("GroupedButtonsView", () => {
 
 		expect(screen.getByText("条件にあうボタンが見つかりませんでした")).toBeInTheDocument();
 	});
+
+	it("moreHref のないグループでも cap 超過の件数は表示する（未分類・AIレビュー対応）", () => {
+		render(
+			<GroupedButtonsView
+				heading="用途別のボタン"
+				totalCount={12}
+				groups={[
+					{
+						key: "未分類",
+						title: "未分類",
+						total: 12,
+						buttons: [makeButton("b1", "ボタン1")],
+					},
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("ほか 11 件")).toBeInTheDocument();
+	});
+
+	it("取得上限で切られた場合は実総数と表示対象件数を併記する（AIレビュー対応）", () => {
+		render(
+			<GroupedButtonsView
+				heading="用途別のボタン"
+				totalCount={250}
+				truncatedTo={200}
+				groups={[{ key: "笑い", title: "笑い", total: 1, buttons: [makeButton("b1", "ボタン1")] }]}
+			/>,
+		);
+
+		expect(screen.getByText("250件")).toBeInTheDocument();
+		expect(screen.getByText("（最新 200 件を表示中）")).toBeInTheDocument();
+	});
 });
 
 describe("FeaturedAudioButtons", () => {

--- a/apps/web/src/app/buttons/components/buttons-view-nav.tsx
+++ b/apps/web/src/app/buttons/components/buttons-view-nav.tsx
@@ -1,0 +1,73 @@
+import { AUDIO_BUTTON_USAGE_TAGS } from "@suzumina.click/shared-types";
+import { cn } from "@suzumina.click/ui/lib/utils";
+import Link from "next/link";
+
+/**
+ * 一覧の表示切替（すべて/用途別/動画ごと）と公式用途タグのチップ行（SPR-257 PR②）。
+ * しぐれういボタンの「全一覧/会話用途別/元動画別」と同型の3ビュー構造。
+ * 状態は持たず URL で表現する（ビュー切替はフィルタをクリアした素の遷移・チップは ?tags= 絞り込み）。
+ * デザイン正本: Claude Design「ボタン一覧.dc.html」（改訂版）
+ */
+
+export type ButtonsView = "all" | "usage" | "video";
+
+const VIEWS: Array<{ view: ButtonsView; label: string; href: string }> = [
+	{ view: "all", label: "すべて", href: "/buttons" },
+	{ view: "usage", label: "用途別", href: "/buttons?view=usage" },
+	{ view: "video", label: "動画ごと", href: "/buttons?view=video" },
+];
+
+interface ButtonsViewNavProps {
+	currentView: ButtonsView;
+	/** 現在の ?tags= 絞り込み（チップの active 表示用） */
+	activeTags?: string[];
+}
+
+export function ButtonsViewNav({ currentView, activeTags = [] }: ButtonsViewNavProps) {
+	return (
+		<div className="mb-4 flex flex-col gap-3">
+			<nav aria-label="表示切替" className="flex">
+				<div className="inline-flex gap-0.5 rounded-full bg-muted p-[3px]">
+					{VIEWS.map(({ view, label, href }) => (
+						<Link
+							key={view}
+							href={href}
+							aria-current={currentView === view ? "page" : undefined}
+							className={cn(
+								"rounded-full px-4 py-1.5 text-[13px] font-bold no-underline transition-colors",
+								"focus-visible:outline-3 focus-visible:outline-suzuka-400 focus-visible:outline-offset-2",
+								currentView === view
+									? "bg-card text-foreground shadow"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+						>
+							{label}
+						</Link>
+					))}
+				</div>
+			</nav>
+
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="mr-0.5 text-xs font-bold text-muted-foreground">タグ:</span>
+				{AUDIO_BUTTON_USAGE_TAGS.map((tag) => {
+					const active = activeTags.includes(tag);
+					return (
+						<Link
+							key={tag}
+							href={`/buttons?tags=${encodeURIComponent(tag)}`}
+							className={cn(
+								"rounded-full border border-border px-3.5 py-1.5 text-xs font-bold no-underline transition-colors",
+								"focus-visible:outline-3 focus-visible:outline-suzuka-400 focus-visible:outline-offset-2",
+								active
+									? "border-suzuka-500 bg-suzuka-500 text-white"
+									: "bg-secondary text-secondary-foreground hover:border-suzuka-300",
+							)}
+						>
+							{tag}
+						</Link>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/app/buttons/components/featured-audio-buttons.tsx
+++ b/apps/web/src/app/buttons/components/featured-audio-buttons.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { Heart } from "lucide-react";
+import { useMemo } from "react";
+import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
+import { useFavoriteStatusBulk } from "@/hooks/use-favorite-status-bulk";
+import { useLikeDislikeStatusBulk } from "@/hooks/use-like-dislike-status-bulk";
+
+/**
+ * featured セクション（SPR-257 PR②）: よく押されてるボタン + 新着ボタン。
+ * フィルタなしの一覧上部にのみ表示する（呼び出し側で制御）。
+ * デザイン正本: Claude Design「ボタン一覧.dc.html」（改訂版）
+ */
+
+interface FeaturedAudioButtonsProps {
+	popular: AudioButtonPlainObject[];
+	fresh: AudioButtonPlainObject[];
+}
+
+export function FeaturedAudioButtons({ popular, fresh }: FeaturedAudioButtonsProps) {
+	const allIds = useMemo(
+		() => [...new Set([...popular, ...fresh].map((b) => b.id))],
+		[popular, fresh],
+	);
+	const { favoriteStates } = useFavoriteStatusBulk(allIds);
+	const { likeDislikeStates } = useLikeDislikeStatusBulk(allIds);
+
+	const renderButton = (button: AudioButtonPlainObject) => (
+		<AudioButtonWithPlayCount
+			key={button.id}
+			audioButton={button}
+			initialIsFavorited={favoriteStates.get(button.id) || false}
+			initialIsLiked={likeDislikeStates.get(button.id)?.isLiked || false}
+		/>
+	);
+
+	if (popular.length === 0 && fresh.length === 0) return null;
+
+	return (
+		<div className="mb-7 flex flex-col gap-6">
+			{popular.length > 0 && (
+				<section>
+					<div className="mb-3.5 flex items-center gap-2">
+						<Heart className="h-4 w-4 fill-heart text-heart" aria-hidden="true" />
+						<h2 className="text-lg font-extrabold">よく押されてるボタン</h2>
+					</div>
+					<div className="flex flex-wrap gap-3.5">
+						{popular.map((button) => (
+							<div key={button.id} className="flex flex-col items-start gap-1.5">
+								{renderButton(button)}
+								<span className="pl-3 text-[11.5px] font-bold text-heart">
+									{button.stats.playCount}回再生
+								</span>
+							</div>
+						))}
+					</div>
+				</section>
+			)}
+
+			{fresh.length > 0 && (
+				<section>
+					<div className="mb-3.5 flex items-center gap-2">
+						<span className="rounded-full bg-heart px-2.5 py-0.5 text-[10.5px] font-extrabold tracking-[0.08em] text-heart-foreground">
+							NEW
+						</span>
+						<h2 className="text-lg font-extrabold">新着ボタン</h2>
+					</div>
+					<div className="flex flex-wrap gap-3">{fresh.map(renderButton)}</div>
+					<div className="mt-6 h-px bg-border" />
+				</section>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/app/buttons/components/grouped-buttons-view.tsx
+++ b/apps/web/src/app/buttons/components/grouped-buttons-view.tsx
@@ -29,11 +29,19 @@ export interface ButtonGroup {
 
 interface GroupedButtonsViewProps {
 	heading: string;
+	/** 実総数（count() 集計値） */
 	totalCount: number;
+	/** 取得上限で切られた場合の実表示対象件数（未指定なら全件表示） */
+	truncatedTo?: number;
 	groups: ButtonGroup[];
 }
 
-export function GroupedButtonsView({ heading, totalCount, groups }: GroupedButtonsViewProps) {
+export function GroupedButtonsView({
+	heading,
+	totalCount,
+	truncatedTo,
+	groups,
+}: GroupedButtonsViewProps) {
 	const allIds = useMemo(() => groups.flatMap((g) => g.buttons.map((b) => b.id)), [groups]);
 	const { favoriteStates } = useFavoriteStatusBulk(allIds);
 	const { likeDislikeStates } = useLikeDislikeStatusBulk(allIds);
@@ -51,6 +59,9 @@ export function GroupedButtonsView({ heading, totalCount, groups }: GroupedButto
 			<div className="flex items-baseline gap-2.5">
 				<h2 className="text-lg font-extrabold">{heading}</h2>
 				<span className="text-[13px] text-muted-foreground">{totalCount}件</span>
+				{truncatedTo !== undefined && (
+					<span className="text-xs text-muted-foreground">（最新 {truncatedTo} 件を表示中）</span>
+				)}
 			</div>
 
 			{groups.map((group) => (
@@ -107,9 +118,11 @@ export function GroupedButtonsView({ heading, totalCount, groups }: GroupedButto
 						})}
 					</div>
 
-					{group.total > group.buttons.length && group.moreHref && (
+					{group.total > group.buttons.length && (
 						<p className="mt-3.5 text-xs text-muted-foreground">
-							ほか {group.total - group.buttons.length} 件は「もっと見る」から
+							{group.moreHref
+								? `ほか ${group.total - group.buttons.length} 件は「もっと見る」から`
+								: `ほか ${group.total - group.buttons.length} 件`}
 						</p>
 					)}
 				</div>

--- a/apps/web/src/app/buttons/components/grouped-buttons-view.tsx
+++ b/apps/web/src/app/buttons/components/grouped-buttons-view.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import Link from "next/link";
+import { useMemo } from "react";
+import { AudioButtonWithPlayCount } from "@/components/audio/audio-button-with-play-count";
+import { useFavoriteStatusBulk } from "@/hooks/use-favorite-status-bulk";
+import { useLikeDislikeStatusBulk } from "@/hooks/use-like-dislike-status-bulk";
+
+/**
+ * 用途別/動画ごとビューのグループカード描画（SPR-257 PR②）。
+ * ビュー内の全ボタン ID を1回の bulk 取得で解決し、各ボタンへ初期値として注入する
+ * （グループごとに取得すると 9〜28 回に分裂するため、ビュー単位で束ねる）。
+ * デザイン正本: Claude Design「ボタン一覧.dc.html」（改訂版）
+ */
+
+export interface ButtonGroup {
+	key: string;
+	title: string;
+	/** グループの総件数（表示は buttons の上限つき） */
+	total: number;
+	buttons: AudioButtonPlainObject[];
+	/** 「もっと見る」の遷移先（省略時は非表示） */
+	moreHref?: string;
+	/** 動画ごとビュー用のサムネイルとリンク */
+	thumbnailUrl?: string;
+	videoHref?: string;
+}
+
+interface GroupedButtonsViewProps {
+	heading: string;
+	totalCount: number;
+	groups: ButtonGroup[];
+}
+
+export function GroupedButtonsView({ heading, totalCount, groups }: GroupedButtonsViewProps) {
+	const allIds = useMemo(() => groups.flatMap((g) => g.buttons.map((b) => b.id)), [groups]);
+	const { favoriteStates } = useFavoriteStatusBulk(allIds);
+	const { likeDislikeStates } = useLikeDislikeStatusBulk(allIds);
+
+	if (groups.length === 0) {
+		return (
+			<div className="py-12 text-center text-sm text-muted-foreground">
+				条件にあうボタンが見つかりませんでした
+			</div>
+		);
+	}
+
+	return (
+		<section className="flex flex-col gap-4">
+			<div className="flex items-baseline gap-2.5">
+				<h2 className="text-lg font-extrabold">{heading}</h2>
+				<span className="text-[13px] text-muted-foreground">{totalCount}件</span>
+			</div>
+
+			{groups.map((group) => (
+				<div
+					key={group.key}
+					className="rounded-[20px] border border-border bg-card p-4 shadow-sm sm:p-5"
+				>
+					<div className="mb-4 flex items-center gap-3">
+						{group.thumbnailUrl && (
+							<div
+								role="img"
+								aria-label={group.title}
+								className="aspect-video w-[96px] flex-none rounded-[10px] bg-muted bg-cover bg-center sm:w-[128px]"
+								style={{ backgroundImage: `url(${group.thumbnailUrl})` }}
+							/>
+						)}
+						<div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2.5 gap-y-1">
+							<h3 className="line-clamp-2 text-[15px] font-extrabold leading-snug">
+								{group.title}
+							</h3>
+							<span className="rounded-full bg-secondary px-2.5 py-0.5 text-xs font-extrabold text-secondary-foreground">
+								{group.total}件
+							</span>
+						</div>
+						{group.videoHref && (
+							<Link
+								href={group.videoHref}
+								className="flex-none rounded-full border border-border px-3.5 py-1.5 text-xs font-bold text-foreground no-underline transition-colors hover:bg-accent"
+							>
+								動画を見る
+							</Link>
+						)}
+						{group.moreHref && (
+							<Link
+								href={group.moreHref}
+								className="flex-none rounded-full px-3 py-1.5 text-[13px] font-bold text-suzuka-600 no-underline transition-colors hover:bg-accent hover:text-suzuka-700"
+							>
+								もっと見る →
+							</Link>
+						)}
+					</div>
+
+					<div className="flex flex-wrap gap-3">
+						{group.buttons.map((button) => {
+							const likeDislikeStatus = likeDislikeStates.get(button.id);
+							return (
+								<AudioButtonWithPlayCount
+									key={button.id}
+									audioButton={button}
+									initialIsFavorited={favoriteStates.get(button.id) || false}
+									initialIsLiked={likeDislikeStatus?.isLiked || false}
+								/>
+							);
+						})}
+					</div>
+
+					{group.total > group.buttons.length && group.moreHref && (
+						<p className="mt-3.5 text-xs text-muted-foreground">
+							ほか {group.total - group.buttons.length} 件は「もっと見る」から
+						</p>
+					)}
+				</div>
+			))}
+		</section>
+	);
+}

--- a/apps/web/src/app/buttons/lib/__tests__/group-buttons.test.ts
+++ b/apps/web/src/app/buttons/lib/__tests__/group-buttons.test.ts
@@ -1,0 +1,97 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { groupByUsageTag, groupByVideo } from "../group-buttons";
+
+function makeButton(
+	id: string,
+	tags: string[],
+	videoId = "v1",
+	createdAt = "2026-07-01T00:00:00.000Z",
+): AudioButtonPlainObject {
+	return {
+		id,
+		buttonText: `ボタン${id}`,
+		videoId,
+		videoTitle: `動画${videoId}`,
+		videoThumbnailUrl: `https://example.com/${videoId}.jpg`,
+		startTime: 0,
+		endTime: 1,
+		duration: 1,
+		tags,
+		creatorId: "u1",
+		creatorName: "作成者",
+		isPublic: true,
+		stats: { playCount: 0, likeCount: 0, dislikeCount: 0, favoriteCount: 0, engagementRate: 0 },
+		createdAt,
+		updatedAt: createdAt,
+		_computed: {
+			isPopular: false,
+			engagementRate: 0,
+			engagementRatePercentage: 0,
+			popularityScore: 0,
+			searchableText: "",
+			durationText: "1秒",
+			relativeTimeText: "1日前",
+		},
+	} as AudioButtonPlainObject;
+}
+
+describe("groupByUsageTag", () => {
+	it("公式語彙の表示順でグループ化し、出典系タグは無視する", () => {
+		const buttons = [
+			makeButton("b1", ["龍が如く極", "名言・迷言"]),
+			makeButton("b2", ["あいさつ"]),
+			makeButton("b3", ["名言・迷言"]),
+		];
+
+		const groups = groupByUsageTag(buttons, 10);
+
+		expect(groups.map((g) => g.title)).toEqual(["あいさつ", "名言・迷言"]);
+		expect(groups[1]?.buttons.map((b) => b.id)).toEqual(["b1", "b3"]);
+		expect(groups[1]?.moreHref).toBe(`/buttons?tags=${encodeURIComponent("名言・迷言")}`);
+	});
+
+	it("cap を超えるグループは表示を丸めて total に総数を残す", () => {
+		const buttons = Array.from({ length: 5 }, (_, i) => makeButton(`b${i}`, ["笑い"]));
+
+		const groups = groupByUsageTag(buttons, 3);
+
+		expect(groups[0]?.total).toBe(5);
+		expect(groups[0]?.buttons).toHaveLength(3);
+	});
+
+	it("用途タグなしのボタンは末尾の「未分類」グループに入る", () => {
+		const buttons = [makeButton("b1", ["あいさつ"]), makeButton("b2", ["龍が如く極"])];
+
+		const groups = groupByUsageTag(buttons, 10);
+
+		expect(groups.map((g) => g.title)).toEqual(["あいさつ", "未分類"]);
+		expect(groups[1]?.buttons.map((b) => b.id)).toEqual(["b2"]);
+	});
+});
+
+describe("groupByVideo", () => {
+	it("動画ごとにまとめ、最新ボタンの作成日時が新しい動画から並べる", () => {
+		const buttons = [
+			makeButton("old", [], "v1", "2026-06-01T00:00:00.000Z"),
+			makeButton("newer", [], "v2", "2026-07-10T00:00:00.000Z"),
+			makeButton("newest-in-v1", [], "v1", "2026-07-15T00:00:00.000Z"),
+		];
+
+		const groups = groupByVideo(buttons, 10);
+
+		expect(groups.map((g) => g.key)).toEqual(["v1", "v2"]);
+		expect(groups[0]?.total).toBe(2);
+		expect(groups[0]?.videoHref).toBe("/videos/v1");
+		expect(groups[0]?.moreHref).toBe("/buttons?videoId=v1");
+	});
+
+	it("サムネイル未設定なら YouTube のサムネイルへフォールバックする", () => {
+		const button = makeButton("b1", [], "vX");
+		button.videoThumbnailUrl = undefined;
+
+		const groups = groupByVideo([button], 10);
+
+		expect(groups[0]?.thumbnailUrl).toBe("https://img.youtube.com/vi/vX/hqdefault.jpg");
+	});
+});

--- a/apps/web/src/app/buttons/lib/group-buttons.ts
+++ b/apps/web/src/app/buttons/lib/group-buttons.ts
@@ -1,0 +1,75 @@
+import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
+import { AUDIO_BUTTON_USAGE_TAGS, isAudioButtonUsageTag } from "@suzumina.click/shared-types";
+import type { ButtonGroup } from "../components/grouped-buttons-view";
+
+/**
+ * 用途別/動画ごとビューのグルーピング（SPR-257 PR②・純関数）。
+ * 全ボタンは in-memory で受け取り、表示は各グループ cap 件に丸める（総数は total に保持）。
+ */
+
+/** 用途別: 公式語彙の表示順（AUDIO_BUTTON_USAGE_TAGS が正）でグループ化。未分類は末尾に置く */
+export function groupByUsageTag(buttons: AudioButtonPlainObject[], cap: number): ButtonGroup[] {
+	const byTag = new Map<string, AudioButtonPlainObject[]>();
+	const untagged: AudioButtonPlainObject[] = [];
+	for (const button of buttons) {
+		const usageTag = (button.tags ?? []).find(isAudioButtonUsageTag);
+		if (usageTag) {
+			const list = byTag.get(usageTag) ?? [];
+			list.push(button);
+			byTag.set(usageTag, list);
+		} else {
+			untagged.push(button);
+		}
+	}
+
+	const groups: ButtonGroup[] = [];
+	for (const tag of AUDIO_BUTTON_USAGE_TAGS) {
+		const list = byTag.get(tag);
+		if (!list || list.length === 0) continue;
+		groups.push({
+			key: tag,
+			title: tag,
+			total: list.length,
+			buttons: list.slice(0, cap),
+			moreHref: `/buttons?tags=${encodeURIComponent(tag)}`,
+		});
+	}
+	if (untagged.length > 0) {
+		groups.push({
+			key: "未分類",
+			title: "未分類",
+			total: untagged.length,
+			buttons: untagged.slice(0, cap),
+		});
+	}
+	return groups;
+}
+
+/** 動画ごと: videoId でグループ化し、最新ボタンの作成日時が新しい動画から並べる */
+export function groupByVideo(buttons: AudioButtonPlainObject[], cap: number): ButtonGroup[] {
+	const byVideo = new Map<string, AudioButtonPlainObject[]>();
+	for (const button of buttons) {
+		const list = byVideo.get(button.videoId) ?? [];
+		list.push(button);
+		byVideo.set(button.videoId, list);
+	}
+
+	return [...byVideo.entries()]
+		.map(([videoId, list]) => ({ videoId, list, latest: latestCreatedAt(list) }))
+		.sort((a, b) => b.latest.localeCompare(a.latest))
+		.map(({ videoId, list }) => ({
+			key: videoId,
+			title: list[0]?.videoTitle ?? "",
+			total: list.length,
+			buttons: list.slice(0, cap),
+			thumbnailUrl:
+				list[0]?.videoThumbnailUrl || `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`,
+			videoHref: `/videos/${videoId}`,
+			moreHref: `/buttons?videoId=${encodeURIComponent(videoId)}`,
+		}));
+}
+
+function latestCreatedAt(buttons: AudioButtonPlainObject[]): string {
+	// createdAt は ISO string（audioButtons の時刻規約）のため文字列比較で最新を選べる
+	return buttons.reduce((max, b) => (b.createdAt > max ? b.createdAt : max), "");
+}

--- a/apps/web/src/app/buttons/page.tsx
+++ b/apps/web/src/app/buttons/page.tsx
@@ -92,6 +92,14 @@ async function GroupedView({ view }: { view: "usage" | "video" }) {
 		limit: GROUP_FETCH_LIMIT,
 	});
 	const buttons = result.success && result.data ? result.data.audioButtons : [];
+	// 見出しの総数は count() 集計の実総数を使う（取得上限で切られた件数を「総数」と偽らない）
+	const totalCount = result.success && result.data ? result.data.totalCount : buttons.length;
+	if (totalCount > buttons.length) {
+		// 上限到達＝グルーピング対象から静かに欠落する状態。無警告にしない（§1 silent fallback 禁止の精神）
+		console.warn(
+			`GroupedView: ボタン総数 ${totalCount} 件が取得上限 ${GROUP_FETCH_LIMIT} 件を超過。超過分はグループ表示から欠落しています`,
+		);
+	}
 	const groups =
 		view === "usage"
 			? groupByUsageTag(buttons, GROUP_DISPLAY_CAP)
@@ -100,7 +108,8 @@ async function GroupedView({ view }: { view: "usage" | "video" }) {
 	return (
 		<GroupedButtonsView
 			heading={view === "usage" ? "用途別のボタン" : "動画ごとのボタン"}
-			totalCount={buttons.length}
+			totalCount={totalCount}
+			truncatedTo={totalCount > buttons.length ? buttons.length : undefined}
 			groups={groups}
 		/>
 	);
@@ -123,6 +132,7 @@ async function FeaturedSection() {
 export default async function AudioButtonsPage({ searchParams }: AudioButtonsPageProps) {
 	const resolvedSearchParams = await searchParams;
 	const view = parseView(resolvedSearchParams.view);
+	// featured はビューを問わず表示する（3ビュー共通のヒーロー枠＝デザイン正本どおり。絞り込み時のみ非表示）
 	const showFeatured = isUnfiltered(resolvedSearchParams);
 
 	// limitパラメータの処理（デフォルト: 12）

--- a/apps/web/src/app/buttons/page.tsx
+++ b/apps/web/src/app/buttons/page.tsx
@@ -7,6 +7,10 @@ import { Suspense } from "react";
 import type { AudioButtonQuery } from "@/types/audio-button";
 import { getAudioButtonsList } from "./actions";
 import AudioButtonsList from "./components/audio-buttons-list";
+import { type ButtonsView, ButtonsViewNav } from "./components/buttons-view-nav";
+import { FeaturedAudioButtons } from "./components/featured-audio-buttons";
+import { GroupedButtonsView } from "./components/grouped-buttons-view";
+import { groupByUsageTag, groupByVideo } from "./lib/group-buttons";
 
 interface SearchParams {
 	q?: string;
@@ -16,6 +20,8 @@ interface SearchParams {
 	page?: string;
 	limit?: string;
 	videoId?: string;
+	/** 表示切替（すべて/用途別/動画ごと・SPR-257） */
+	view?: string;
 	// 高度フィルタパラメータ
 	playCountMin?: string;
 	playCountMax?: string;
@@ -26,6 +32,35 @@ interface SearchParams {
 	createdAfter?: string;
 	createdBefore?: string;
 	creatorId?: string;
+}
+
+/** グループビューが一度に扱う取得上限（本番80件・in-memory 基盤のため一括取得で足りる） */
+const GROUP_FETCH_LIMIT = 200;
+/** グループカードごとの表示上限（超過分は「もっと見る」へ誘導） */
+const GROUP_DISPLAY_CAP = 10;
+
+function parseView(view: string | undefined): ButtonsView {
+	return view === "usage" || view === "video" ? view : "all";
+}
+
+/** featured（よく押されてる/新着）を出すか＝絞り込み・ページ送りのない素の一覧のみ */
+function isUnfiltered(params: SearchParams): boolean {
+	const filterKeys: Array<keyof SearchParams> = [
+		"q",
+		"tags",
+		"videoId",
+		"creatorId",
+		"playCountMin",
+		"playCountMax",
+		"likeCountMin",
+		"likeCountMax",
+		"favoriteCountMin",
+		"favoriteCountMax",
+		"createdAfter",
+		"createdBefore",
+	];
+	if (filterKeys.some((key) => params[key])) return false;
+	return !params.page || Number(params.page) <= 1;
 }
 
 // タグパラメータをパースする関数（複雑度を下げるため分離）
@@ -49,8 +84,46 @@ interface AudioButtonsPageProps {
 	searchParams: Promise<SearchParams>;
 }
 
+/** 用途別/動画ごとビュー（全件を1回取得して in-memory グルーピング） */
+async function GroupedView({ view }: { view: "usage" | "video" }) {
+	const result = await getAudioButtonsList({
+		sortBy: "newest",
+		page: 1,
+		limit: GROUP_FETCH_LIMIT,
+	});
+	const buttons = result.success && result.data ? result.data.audioButtons : [];
+	const groups =
+		view === "usage"
+			? groupByUsageTag(buttons, GROUP_DISPLAY_CAP)
+			: groupByVideo(buttons, GROUP_DISPLAY_CAP);
+
+	return (
+		<GroupedButtonsView
+			heading={view === "usage" ? "用途別のボタン" : "動画ごとのボタン"}
+			totalCount={buttons.length}
+			groups={groups}
+		/>
+	);
+}
+
+/** featured セクション（よく押されてる4件 + 新着6件） */
+async function FeaturedSection() {
+	const [popularResult, freshResult] = await Promise.all([
+		getAudioButtonsList({ sortBy: "mostPlayed", page: 1, limit: 4 }),
+		getAudioButtonsList({ sortBy: "newest", page: 1, limit: 6 }),
+	]);
+	return (
+		<FeaturedAudioButtons
+			popular={popularResult.success && popularResult.data ? popularResult.data.audioButtons : []}
+			fresh={freshResult.success && freshResult.data ? freshResult.data.audioButtons : []}
+		/>
+	);
+}
+
 export default async function AudioButtonsPage({ searchParams }: AudioButtonsPageProps) {
 	const resolvedSearchParams = await searchParams;
+	const view = parseView(resolvedSearchParams.view);
+	const showFeatured = isUnfiltered(resolvedSearchParams);
 
 	// limitパラメータの処理（デフォルト: 12）
 	const limitValue = resolvedSearchParams.limit ? Number(resolvedSearchParams.limit) : 12;
@@ -91,8 +164,15 @@ export default async function AudioButtonsPage({ searchParams }: AudioButtonsPag
 		limit: validLimit,
 	};
 
-	// 初期データを取得（Server Component最適化）
-	const initialData = await getAudioButtonsList(query);
+	// 初期データを取得（Server Component最適化・「すべて」ビューのみ）
+	const initialData = view === "all" ? await getAudioButtonsList(query) : undefined;
+
+	const listFallback = (
+		<div className="text-center py-12">
+			<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+			<p className="mt-2 text-muted-foreground">読み込み中...</p>
+		</div>
+	);
 
 	return (
 		<ListPageLayout>
@@ -102,16 +182,23 @@ export default async function AudioButtonsPage({ searchParams }: AudioButtonsPag
 			/>
 
 			<ListPageContent>
-				<Suspense
-					fallback={
-						<div className="text-center py-12">
-							<div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-							<p className="mt-2 text-muted-foreground">読み込み中...</p>
-						</div>
-					}
-				>
-					<AudioButtonsList searchParams={resolvedSearchParams} initialData={initialData} />
-				</Suspense>
+				<ButtonsViewNav currentView={view} activeTags={tags} />
+
+				{showFeatured && (
+					<Suspense fallback={null}>
+						<FeaturedSection />
+					</Suspense>
+				)}
+
+				{view === "all" ? (
+					<Suspense fallback={listFallback}>
+						<AudioButtonsList searchParams={resolvedSearchParams} initialData={initialData} />
+					</Suspense>
+				) : (
+					<Suspense fallback={listFallback}>
+						<GroupedView view={view} />
+					</Suspense>
+				)}
 			</ListPageContent>
 		</ListPageLayout>
 	);


### PR DESCRIPTION
## 概要

[SPR-257](https://linear.app/nothink/issue/SPR-257) の **PR②/②**（PR① #824 の後続）。市井調査で実証済みの「しぐれうい式3ビュー構造」を一覧に導入します。デザイン正本は Claude Design「ボタン一覧.dc.html」改訂版（3ビュー対応版・受け入れ確認済み）。

## 変更内容

**ButtonsViewNav（新設・RSC）**
- 表示切替「すべて / 用途別 / 動画ごと」— 状態を持たず `?view=` の URL で表現（切替はフィルタをクリアした素の遷移）
- 公式用途9カテゴリのタグチップ行 — `?tags=` 絞り込みへのリンク（正本: shared-types `AUDIO_BUTTON_USAGE_TAGS`）

**用途別ビュー（新設）** — 公式語彙の表示順で in-memory グルーピング（全ボタンに用途タグ1つが SPR-260 で保証済み・新規インデックス不要）。カードごと10件で丸め、「もっと見る →」でタグ絞り込みへ。防御的に「未分類」グループも用意

**動画ごとビュー（新設）** — videoId でグループ化し最新ボタンの作成日時順。サムネイル（videoThumbnailUrl → YouTube フォールバック）+ 件数 + 内部 `/videos/{id}` リンク

**featured セクション（新設）** — よく押されてるボタン4件（再生数ラベル付き）+ 新着6件。**絞り込み・ページ送りのない素の一覧でのみ表示**

**per-user 状態** — ビュー単位で bulk 取得1組（fav/like）に束ねて各ボタンへ初期値注入（グループごとに取得を分裂させない）

## 設計上の判断

- **既存「すべて」ビュー（ConfigurableList）は不変更** — 検索/並び替え/件数/ページングは従来どおりで、URL パラメータ（q/tags/videoId/page/sort/limit）完全互換。検索・詳細フィルタは「すべて」ビューの役割という住み分け（しぐれうい原型と同型）
- デザインのツールバー統合カード（検索/並び替えを1カードに集約する見た目刷新）は本 PR ではスコープ外（ConfigurableList の共有部品を触るため、必要なら後続で）

## 検証

- `pnpm verify` 通過（グルーピング純関数5件 + ビューコンポーネント7件のテスト新設）
- Emulator + 実ブラウザ（スクリーンショット確認済み）:
  - 3ビューの表示・切替、featured の再生数ラベル/NEW バッジ
  - 用途別: 9カテゴリが公式順で表示・「ほか 8 件/23 件はもっと見るから」の丸め表記
  - 動画ごと: 30グループ・サムネ・内部リンク・最新順
  - **URL 互換**: `?tags=あいさつ`（7件絞り込み+チップactive+featured非表示）・`?videoId=`（8件絞り込み）
  - モバイル（375px）: トグル/チップのラップ・featured 縦積み

🤖 Generated with [Claude Code](https://claude.com/claude-code)