### PR TITLE
fix(web): トップページのカルーセル矢印ボタンがカード画像に重なる問題を修正

### DIFF
--- a/apps/web/src/components/content/featured-videos-carousel.tsx
+++ b/apps/web/src/components/content/featured-videos-carousel.tsx
@@ -24,7 +24,7 @@ export function FeaturedVideosCarousel({ videos }: FeaturedVideosCarouselProps) 
 
 	return (
 		<Carousel
-			className="w-full sm:px-10 lg:px-12"
+			className="w-full sm:px-12"
 			opts={{
 				align: "start",
 				slidesToScroll: "auto",
@@ -45,8 +45,8 @@ export function FeaturedVideosCarousel({ videos }: FeaturedVideosCarouselProps) 
 					</CarouselItem>
 				))}
 			</CarouselContent>
-			<CarouselPrevious className="hidden sm:flex sm:left-0 lg:left-0 h-10 w-10 sm:h-12 sm:w-12" />
-			<CarouselNext className="hidden sm:flex sm:right-0 lg:right-0 h-10 w-10 sm:h-12 sm:w-12" />
+			<CarouselPrevious className="hidden sm:flex sm:left-0 h-12 w-12" />
+			<CarouselNext className="hidden sm:flex sm:right-0 h-12 w-12" />
 		</Carousel>
 	);
 }

--- a/apps/web/src/components/content/featured-videos-carousel.tsx
+++ b/apps/web/src/components/content/featured-videos-carousel.tsx
@@ -24,7 +24,7 @@ export function FeaturedVideosCarousel({ videos }: FeaturedVideosCarouselProps) 
 
 	return (
 		<Carousel
-			className="w-full"
+			className="w-full sm:px-10 lg:px-12"
 			opts={{
 				align: "start",
 				slidesToScroll: "auto",
@@ -45,8 +45,8 @@ export function FeaturedVideosCarousel({ videos }: FeaturedVideosCarouselProps) 
 					</CarouselItem>
 				))}
 			</CarouselContent>
-			<CarouselPrevious className="left-1 sm:left-2 h-10 w-10 sm:h-12 sm:w-12" />
-			<CarouselNext className="right-1 sm:right-2 h-10 w-10 sm:h-12 sm:w-12" />
+			<CarouselPrevious className="hidden sm:flex sm:left-0 lg:left-0 h-10 w-10 sm:h-12 sm:w-12" />
+			<CarouselNext className="hidden sm:flex sm:right-0 lg:right-0 h-10 w-10 sm:h-12 sm:w-12" />
 		</Carousel>
 	);
 }

--- a/apps/web/src/components/content/featured-works-carousel.tsx
+++ b/apps/web/src/components/content/featured-works-carousel.tsx
@@ -24,7 +24,7 @@ export function FeaturedWorksCarousel({ works }: FeaturedWorksCarouselProps) {
 
 	return (
 		<Carousel
-			className="w-full"
+			className="w-full sm:px-10 lg:px-12"
 			opts={{
 				align: "start",
 				slidesToScroll: "auto",
@@ -48,8 +48,8 @@ export function FeaturedWorksCarousel({ works }: FeaturedWorksCarouselProps) {
 					</CarouselItem>
 				))}
 			</CarouselContent>
-			<CarouselPrevious className="left-1 sm:left-2 h-10 w-10 sm:h-12 sm:w-12" />
-			<CarouselNext className="right-1 sm:right-2 h-10 w-10 sm:h-12 sm:w-12" />
+			<CarouselPrevious className="hidden sm:flex sm:left-0 lg:left-0 h-10 w-10 sm:h-12 sm:w-12" />
+			<CarouselNext className="hidden sm:flex sm:right-0 lg:right-0 h-10 w-10 sm:h-12 sm:w-12" />
 		</Carousel>
 	);
 }

--- a/apps/web/src/components/content/featured-works-carousel.tsx
+++ b/apps/web/src/components/content/featured-works-carousel.tsx
@@ -24,7 +24,7 @@ export function FeaturedWorksCarousel({ works }: FeaturedWorksCarouselProps) {
 
 	return (
 		<Carousel
-			className="w-full sm:px-10 lg:px-12"
+			className="w-full sm:px-12"
 			opts={{
 				align: "start",
 				slidesToScroll: "auto",
@@ -48,8 +48,8 @@ export function FeaturedWorksCarousel({ works }: FeaturedWorksCarouselProps) {
 					</CarouselItem>
 				))}
 			</CarouselContent>
-			<CarouselPrevious className="hidden sm:flex sm:left-0 lg:left-0 h-10 w-10 sm:h-12 sm:w-12" />
-			<CarouselNext className="hidden sm:flex sm:right-0 lg:right-0 h-10 w-10 sm:h-12 sm:w-12" />
+			<CarouselPrevious className="hidden sm:flex sm:left-0 h-12 w-12" />
+			<CarouselNext className="hidden sm:flex sm:right-0 h-12 w-12" />
 		</Carousel>
 	);
 }


### PR DESCRIPTION
## Summary
- トップページの新着動画/新着作品カルーセルで、前後移動ボタン（矢印）がカード端のサムネイル画像に重なって配置されており、誤クリックを誘発していた
- `Carousel` に矢印専用ガター（`sm:px-10 lg:px-12`）を確保し、`CarouselPrevious`/`CarouselNext` をそのガター内（`left-0`/`right-0`）に配置してカード領域との重なりをゼロにした
- モバイル幅（`sm` 未満）ではガターを確保せず、矢印ボタン自体を非表示にしてスワイプ操作のみに統一

## Test plan
- [x] `pnpm verify`（lint + typecheck + test）がパスすることを確認
- [x] Firestore Emulator + シードデータでローカル起動し、デスクトップ幅で矢印がカード画像に重ならずガター内に収まることを確認
- [x] モバイル幅（375px）で矢印ボタンが非表示になり、カードがそのまま端まで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)