### PR TITLE
fix(web): sitemap.xml にクリエイター/サークル詳細ページを追加

### DIFF
--- a/apps/web/src/app/__tests__/sitemap.test.ts
+++ b/apps/web/src/app/__tests__/sitemap.test.ts
@@ -55,6 +55,13 @@ function buildSnapshot(docs: SnapshotDoc[]) {
 	return { docs };
 }
 
+// creators/circles は Firestore Timestamp（toDate() を持つオブジェクト）で updatedAt/createdAt を
+// 保持する（works/videos/audioButtons の string ISO とは型が異なる。CLAUDE.md §1）。
+// 実データ形状を再現するための最小フェイク。
+function fakeTimestamp(iso: string) {
+	return { toDate: () => new Date(iso) };
+}
+
 const DEFAULT_EMPTY_COLLECTIONS = ["creators", "circles"];
 
 function buildCollectionResolvers(
@@ -142,14 +149,14 @@ describe("sitemap", () => {
 				buildSnapshot([
 					{
 						id: "creator-1",
-						data: () => ({ updatedAt: "2024-05-01T00:00:00Z" }),
+						data: () => ({ updatedAt: fakeTimestamp("2024-05-01T00:00:00Z") }),
 					},
 				]),
 			circles: async () =>
 				buildSnapshot([
 					{
 						id: "circle-1",
-						data: () => ({ updatedAt: "2024-06-01T00:00:00Z" }),
+						data: () => ({ updatedAt: fakeTimestamp("2024-06-01T00:00:00Z") }),
 					},
 				]),
 		});
@@ -166,6 +173,19 @@ describe("sitemap", () => {
 		expect(urls).toContain("https://suzumina.click/creators/creator-1");
 		expect(urls).toContain("https://suzumina.click/circles/circle-1");
 		expect(result.length).toBe(STATIC_PATHS.length + 6);
+
+		// creators/circles は Firestore Timestamp（toDate() 経由）を lastModified に変換する。
+		// toDate() を無視して new Date(Timestamp) すると Invalid Date になり、Next.js の
+		// toISOString() 呼び出し時に RangeError で sitemap 全体が壊れるため回帰検知する。
+		const byUrl = new Map(result.map((entry) => [entry.url, entry]));
+		const creatorEntry = byUrl.get("https://suzumina.click/creators/creator-1");
+		const circleEntry = byUrl.get("https://suzumina.click/circles/circle-1");
+		expect(creatorEntry?.lastModified).toBeInstanceOf(Date);
+		expect(Number.isNaN((creatorEntry?.lastModified as Date)?.getTime())).toBe(false);
+		expect(creatorEntry?.lastModified).toEqual(new Date("2024-05-01T00:00:00Z"));
+		expect(circleEntry?.lastModified).toBeInstanceOf(Date);
+		expect(Number.isNaN((circleEntry?.lastModified as Date)?.getTime())).toBe(false);
+		expect(circleEntry?.lastModified).toEqual(new Date("2024-06-01T00:00:00Z"));
 	});
 
 	it("Firestore 障害時の fallback: getFirestore が throw した場合は静的ページのみを返す", async () => {

--- a/apps/web/src/app/__tests__/sitemap.test.ts
+++ b/apps/web/src/app/__tests__/sitemap.test.ts
@@ -55,16 +55,20 @@ function buildSnapshot(docs: SnapshotDoc[]) {
 	return { docs };
 }
 
+const DEFAULT_EMPTY_COLLECTIONS = ["creators", "circles"];
+
 function buildCollectionResolvers(
 	resolvers: Record<string, () => Promise<{ docs: SnapshotDoc[] }>>,
 ) {
 	return {
 		collection: (name: string) => {
-			const resolver = resolvers[name];
+			const resolver =
+				resolvers[name] ??
+				(DEFAULT_EMPTY_COLLECTIONS.includes(name) ? async () => buildSnapshot([]) : undefined);
 			if (!resolver) {
 				throw new Error(`Unexpected collection: ${name}`);
 			}
-			// sitemap.ts は videos/works を `.collection().limit().get()`、
+			// sitemap.ts は videos/works/creators/circles を `.collection().limit().get()`、
 			// audioButtons を `.collection().where().limit().get()` で呼び分ける。
 			// 両方のチェーンを同じ resolver に解決する。
 			const limitChain = { get: () => resolver() };
@@ -134,6 +138,20 @@ describe("sitemap", () => {
 						data: () => ({ updatedAt: "2024-04-01T00:00:00Z" }),
 					},
 				]),
+			creators: async () =>
+				buildSnapshot([
+					{
+						id: "creator-1",
+						data: () => ({ updatedAt: "2024-05-01T00:00:00Z" }),
+					},
+				]),
+			circles: async () =>
+				buildSnapshot([
+					{
+						id: "circle-1",
+						data: () => ({ updatedAt: "2024-06-01T00:00:00Z" }),
+					},
+				]),
 		});
 
 		(getFirestore as any).mockReturnValue(firestoreMock);
@@ -145,7 +163,9 @@ describe("sitemap", () => {
 		expect(urls).toContain("https://suzumina.click/videos/video-2");
 		expect(urls).toContain("https://suzumina.click/works/RJ123456");
 		expect(urls).toContain("https://suzumina.click/buttons/audio-1");
-		expect(result.length).toBe(STATIC_PATHS.length + 4);
+		expect(urls).toContain("https://suzumina.click/creators/creator-1");
+		expect(urls).toContain("https://suzumina.click/circles/circle-1");
+		expect(result.length).toBe(STATIC_PATHS.length + 6);
 	});
 
 	it("Firestore 障害時の fallback: getFirestore が throw した場合は静的ページのみを返す", async () => {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,3 +1,4 @@
+import type { Firestore } from "@google-cloud/firestore";
 import type { MetadataRoute } from "next";
 import { unstable_cache } from "next/cache";
 import { connection } from "next/server";
@@ -14,72 +15,125 @@ import { warn as logWarn } from "@/lib/logger";
 // TTL を 1h→24h に延長して全件 read 頻度を 24分の1 に抑える。
 const SITEMAP_REVALIDATE_SECONDS = 86400;
 
+function lastModifiedOf(data: { updatedAt?: unknown; createdAt?: unknown }): Date {
+	return new Date(
+		(data.updatedAt as string | undefined) || (data.createdAt as string | undefined) || Date.now(),
+	);
+}
+
+// 動画ページ一覧。videos コレクションには isPublic フィールドが無く、可視性は status.privacyStatus で判定する。
+// 一覧ページ (apps/web/src/app/videos/actions.ts) と同じく、status 未設定も公開扱いする。
+async function getVideoPages(
+	firestore: Firestore,
+	baseUrl: string,
+): Promise<MetadataRoute.Sitemap> {
+	try {
+		const snapshot = await firestore.collection("videos").limit(50000).get();
+		return snapshot.docs
+			.filter((doc) => {
+				const privacyStatus = doc.data().status?.privacyStatus;
+				return !doc.data().status || privacyStatus === "public";
+			})
+			.map((doc) => ({
+				url: `${baseUrl}/videos/${doc.id}`,
+				lastModified: lastModifiedOf(doc.data()),
+				changeFrequency: "weekly" as const,
+				priority: 0.7,
+			}));
+	} catch (error) {
+		logWarn("Failed to fetch videos for sitemap:", { error });
+		return [];
+	}
+}
+
+// 作品ページ一覧。works コレクションには公開/非公開の概念が無く、全件が公開対象。
+async function getWorkPages(firestore: Firestore, baseUrl: string): Promise<MetadataRoute.Sitemap> {
+	try {
+		const snapshot = await firestore.collection("works").limit(50000).get();
+		return snapshot.docs.map((doc) => ({
+			url: `${baseUrl}/works/${doc.id}`,
+			lastModified: lastModifiedOf(doc.data()),
+			changeFrequency: "monthly" as const,
+			priority: 0.6,
+		}));
+	} catch (error) {
+		logWarn("Failed to fetch works for sitemap:", { error });
+		return [];
+	}
+}
+
+// 音声ボタンページ一覧。公開ボタン（isPublic=true）のみ対象。
+async function getAudioButtonPages(
+	firestore: Firestore,
+	baseUrl: string,
+): Promise<MetadataRoute.Sitemap> {
+	try {
+		const snapshot = await firestore
+			.collection("audioButtons")
+			.where("isPublic", "==", true)
+			.limit(50000)
+			.get();
+		return snapshot.docs.map((doc) => ({
+			url: `${baseUrl}/buttons/${doc.id}`,
+			lastModified: lastModifiedOf(doc.data()),
+			changeFrequency: "monthly" as const,
+			priority: 0.5,
+		}));
+	} catch (error) {
+		logWarn("Failed to fetch audio buttons for sitemap:", { error });
+		return [];
+	}
+}
+
+// クリエイターページ一覧。creators コレクションには公開/非公開の概念が無く、全件が公開対象。
+async function getCreatorPages(
+	firestore: Firestore,
+	baseUrl: string,
+): Promise<MetadataRoute.Sitemap> {
+	try {
+		const snapshot = await firestore.collection("creators").limit(50000).get();
+		return snapshot.docs.map((doc) => ({
+			url: `${baseUrl}/creators/${doc.id}`,
+			lastModified: lastModifiedOf(doc.data()),
+			changeFrequency: "weekly" as const,
+			priority: 0.5,
+		}));
+	} catch (error) {
+		logWarn("Failed to fetch creators for sitemap:", { error });
+		return [];
+	}
+}
+
+// サークルページ一覧。circles コレクションには公開/非公開の概念が無く、全件が公開対象。
+async function getCirclePages(
+	firestore: Firestore,
+	baseUrl: string,
+): Promise<MetadataRoute.Sitemap> {
+	try {
+		const snapshot = await firestore.collection("circles").limit(50000).get();
+		return snapshot.docs.map((doc) => ({
+			url: `${baseUrl}/circles/${doc.id}`,
+			lastModified: lastModifiedOf(doc.data()),
+			changeFrequency: "weekly" as const,
+			priority: 0.5,
+		}));
+	} catch (error) {
+		logWarn("Failed to fetch circles for sitemap:", { error });
+		return [];
+	}
+}
+
 const getDynamicSitemapPages = unstable_cache(
 	async (baseUrl: string): Promise<MetadataRoute.Sitemap> => {
 		const firestore = getFirestore();
-		const dynamicPages: MetadataRoute.Sitemap = [];
-
-		// 動画ページを追加
-		// videos コレクションには isPublic フィールドが無く、可視性は status.privacyStatus で判定する。
-		// 一覧ページ (apps/web/src/app/videos/actions.ts) と同じく、status 未設定も公開扱いする。
-		try {
-			const videosSnapshot = await firestore.collection("videos").limit(50000).get();
-
-			for (const doc of videosSnapshot.docs) {
-				const video = doc.data();
-				const privacyStatus = video.status?.privacyStatus;
-				if (video.status && privacyStatus !== "public") continue;
-				dynamicPages.push({
-					url: `${baseUrl}/videos/${doc.id}`,
-					lastModified: new Date(video.updatedAt || video.createdAt || Date.now()),
-					changeFrequency: "weekly",
-					priority: 0.7,
-				});
-			}
-		} catch (error) {
-			logWarn("Failed to fetch videos for sitemap:", { error });
-		}
-
-		// 作品ページを追加
-		// works コレクションには公開/非公開の概念が無く、全件が公開対象。
-		try {
-			const worksSnapshot = await firestore.collection("works").limit(50000).get();
-
-			for (const doc of worksSnapshot.docs) {
-				const work = doc.data();
-				dynamicPages.push({
-					url: `${baseUrl}/works/${doc.id}`,
-					lastModified: new Date(work.updatedAt || work.createdAt || Date.now()),
-					changeFrequency: "monthly",
-					priority: 0.6,
-				});
-			}
-		} catch (error) {
-			logWarn("Failed to fetch works for sitemap:", { error });
-		}
-
-		// 音声ボタンページを追加
-		try {
-			const audioButtonsSnapshot = await firestore
-				.collection("audioButtons")
-				.where("isPublic", "==", true)
-				.limit(50000)
-				.get();
-
-			for (const doc of audioButtonsSnapshot.docs) {
-				const audioButton = doc.data();
-				dynamicPages.push({
-					url: `${baseUrl}/buttons/${doc.id}`,
-					lastModified: new Date(audioButton.updatedAt || audioButton.createdAt || Date.now()),
-					changeFrequency: "monthly",
-					priority: 0.5,
-				});
-			}
-		} catch (error) {
-			logWarn("Failed to fetch audio buttons for sitemap:", { error });
-		}
-
-		return dynamicPages;
+		const [videoPages, workPages, audioButtonPages, creatorPages, circlePages] = await Promise.all([
+			getVideoPages(firestore, baseUrl),
+			getWorkPages(firestore, baseUrl),
+			getAudioButtonPages(firestore, baseUrl),
+			getCreatorPages(firestore, baseUrl),
+			getCirclePages(firestore, baseUrl),
+		]);
+		return [...videoPages, ...workPages, ...audioButtonPages, ...creatorPages, ...circlePages];
 	},
 	["sitemap-dynamic-pages"],
 	{ revalidate: SITEMAP_REVALIDATE_SECONDS, tags: ["sitemap"] },

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,4 +1,4 @@
-import type { Firestore } from "@google-cloud/firestore";
+import type { DocumentData, Firestore, Query, WhereFilterOp } from "@google-cloud/firestore";
 import type { MetadataRoute } from "next";
 import { unstable_cache } from "next/cache";
 import { connection } from "next/server";
@@ -15,125 +15,97 @@ import { warn as logWarn } from "@/lib/logger";
 // TTL を 1h→24h に延長して全件 read 頻度を 24分の1 に抑える。
 const SITEMAP_REVALIDATE_SECONDS = 86400;
 
-function lastModifiedOf(data: { updatedAt?: unknown; createdAt?: unknown }): Date {
-	return new Date(
-		(data.updatedAt as string | undefined) || (data.createdAt as string | undefined) || Date.now(),
-	);
+// works/videos/audioButtons は string ISO、creators/circles は Firestore Timestamp と
+// 型が混在している（CLAUDE.md §1）。Timestamp は toDate() を経由しないと Invalid Date になるため、
+// videos/actions.ts の convertTimestamp と同じパターンで両対応する。
+function toDateValue(value: unknown): Date | string | undefined {
+	if (value && typeof value === "object" && "toDate" in value) {
+		return (value as { toDate(): Date }).toDate();
+	}
+	return value as Date | string | undefined;
 }
 
-// 動画ページ一覧。videos コレクションには isPublic フィールドが無く、可視性は status.privacyStatus で判定する。
-// 一覧ページ (apps/web/src/app/videos/actions.ts) と同じく、status 未設定も公開扱いする。
-async function getVideoPages(
+function lastModifiedOf(data: { updatedAt?: unknown; createdAt?: unknown }): Date {
+	return new Date(toDateValue(data.updatedAt) || toDateValue(data.createdAt) || Date.now());
+}
+
+type CollectionPageConfig = {
+	collection: string;
+	/** ログメッセージ用の表示名（例: audioButtons → "audio buttons"）。省略時は collection をそのまま使う。 */
+	label?: string;
+	urlPrefix: string;
+	changeFrequency: NonNullable<MetadataRoute.Sitemap[number]["changeFrequency"]>;
+	priority: number;
+	/** isPublic 等での事前フィルタが必要なコレクションのみ指定（例: audioButtons） */
+	where?: [field: string, op: WhereFilterOp, value: unknown];
+	/** レコード単位の可視性判定（例: videos の status.privacyStatus） */
+	isVisible?: (data: DocumentData) => boolean;
+};
+
+// コレクション全件を sitemap エントリへ変換する共通ロジック。
+// コレクションごとの差分（コレクション名・URLプレフィックス・優先度・可視性判定）のみを
+// 呼び出し側で指定する。取得失敗はログを残しつつ空配列にフォールバックし、他コレクションへ波及させない。
+async function getCollectionPages(
 	firestore: Firestore,
 	baseUrl: string,
+	config: CollectionPageConfig,
 ): Promise<MetadataRoute.Sitemap> {
 	try {
-		const snapshot = await firestore.collection("videos").limit(50000).get();
+		let query: Query = firestore.collection(config.collection);
+		if (config.where) {
+			query = query.where(...config.where);
+		}
+		const snapshot = await query.limit(50000).get();
 		return snapshot.docs
-			.filter((doc) => {
-				const privacyStatus = doc.data().status?.privacyStatus;
-				return !doc.data().status || privacyStatus === "public";
-			})
+			.filter((doc) => !config.isVisible || config.isVisible(doc.data()))
 			.map((doc) => ({
-				url: `${baseUrl}/videos/${doc.id}`,
+				url: `${baseUrl}${config.urlPrefix}/${doc.id}`,
 				lastModified: lastModifiedOf(doc.data()),
-				changeFrequency: "weekly" as const,
-				priority: 0.7,
+				changeFrequency: config.changeFrequency,
+				priority: config.priority,
 			}));
 	} catch (error) {
-		logWarn("Failed to fetch videos for sitemap:", { error });
+		logWarn(`Failed to fetch ${config.label ?? config.collection} for sitemap:`, { error });
 		return [];
 	}
 }
 
-// 作品ページ一覧。works コレクションには公開/非公開の概念が無く、全件が公開対象。
-async function getWorkPages(firestore: Firestore, baseUrl: string): Promise<MetadataRoute.Sitemap> {
-	try {
-		const snapshot = await firestore.collection("works").limit(50000).get();
-		return snapshot.docs.map((doc) => ({
-			url: `${baseUrl}/works/${doc.id}`,
-			lastModified: lastModifiedOf(doc.data()),
-			changeFrequency: "monthly" as const,
-			priority: 0.6,
-		}));
-	} catch (error) {
-		logWarn("Failed to fetch works for sitemap:", { error });
-		return [];
-	}
-}
-
-// 音声ボタンページ一覧。公開ボタン（isPublic=true）のみ対象。
-async function getAudioButtonPages(
-	firestore: Firestore,
-	baseUrl: string,
-): Promise<MetadataRoute.Sitemap> {
-	try {
-		const snapshot = await firestore
-			.collection("audioButtons")
-			.where("isPublic", "==", true)
-			.limit(50000)
-			.get();
-		return snapshot.docs.map((doc) => ({
-			url: `${baseUrl}/buttons/${doc.id}`,
-			lastModified: lastModifiedOf(doc.data()),
-			changeFrequency: "monthly" as const,
-			priority: 0.5,
-		}));
-	} catch (error) {
-		logWarn("Failed to fetch audio buttons for sitemap:", { error });
-		return [];
-	}
-}
-
-// クリエイターページ一覧。creators コレクションには公開/非公開の概念が無く、全件が公開対象。
-async function getCreatorPages(
-	firestore: Firestore,
-	baseUrl: string,
-): Promise<MetadataRoute.Sitemap> {
-	try {
-		const snapshot = await firestore.collection("creators").limit(50000).get();
-		return snapshot.docs.map((doc) => ({
-			url: `${baseUrl}/creators/${doc.id}`,
-			lastModified: lastModifiedOf(doc.data()),
-			changeFrequency: "weekly" as const,
-			priority: 0.5,
-		}));
-	} catch (error) {
-		logWarn("Failed to fetch creators for sitemap:", { error });
-		return [];
-	}
-}
-
-// サークルページ一覧。circles コレクションには公開/非公開の概念が無く、全件が公開対象。
-async function getCirclePages(
-	firestore: Firestore,
-	baseUrl: string,
-): Promise<MetadataRoute.Sitemap> {
-	try {
-		const snapshot = await firestore.collection("circles").limit(50000).get();
-		return snapshot.docs.map((doc) => ({
-			url: `${baseUrl}/circles/${doc.id}`,
-			lastModified: lastModifiedOf(doc.data()),
-			changeFrequency: "weekly" as const,
-			priority: 0.5,
-		}));
-	} catch (error) {
-		logWarn("Failed to fetch circles for sitemap:", { error });
-		return [];
-	}
-}
+// コレクションごとの設定一覧。
+// - videos: isPublic フィールドが無く、可視性は status.privacyStatus で判定する。
+//   一覧ページ (apps/web/src/app/videos/actions.ts) と同じく、status 未設定も公開扱いする。
+// - works/creators/circles: 公開/非公開の概念が無く、全件が公開対象。
+// - audioButtons: 公開ボタン（isPublic=true）のみ対象。
+const COLLECTION_PAGE_CONFIGS: CollectionPageConfig[] = [
+	{
+		collection: "videos",
+		urlPrefix: "/videos",
+		changeFrequency: "weekly",
+		priority: 0.7,
+		isVisible: (data) => {
+			const privacyStatus = data.status?.privacyStatus;
+			return !data.status || privacyStatus === "public";
+		},
+	},
+	{ collection: "works", urlPrefix: "/works", changeFrequency: "monthly", priority: 0.6 },
+	{
+		collection: "audioButtons",
+		label: "audio buttons",
+		urlPrefix: "/buttons",
+		changeFrequency: "monthly",
+		priority: 0.5,
+		where: ["isPublic", "==", true],
+	},
+	{ collection: "creators", urlPrefix: "/creators", changeFrequency: "weekly", priority: 0.5 },
+	{ collection: "circles", urlPrefix: "/circles", changeFrequency: "weekly", priority: 0.5 },
+];
 
 const getDynamicSitemapPages = unstable_cache(
 	async (baseUrl: string): Promise<MetadataRoute.Sitemap> => {
 		const firestore = getFirestore();
-		const [videoPages, workPages, audioButtonPages, creatorPages, circlePages] = await Promise.all([
-			getVideoPages(firestore, baseUrl),
-			getWorkPages(firestore, baseUrl),
-			getAudioButtonPages(firestore, baseUrl),
-			getCreatorPages(firestore, baseUrl),
-			getCirclePages(firestore, baseUrl),
-		]);
-		return [...videoPages, ...workPages, ...audioButtonPages, ...creatorPages, ...circlePages];
+		const pagesByCollection = await Promise.all(
+			COLLECTION_PAGE_CONFIGS.map((config) => getCollectionPages(firestore, baseUrl, config)),
+		);
+		return pagesByCollection.flat();
 	},
 	["sitemap-dynamic-pages"],
 	{ revalidate: SITEMAP_REVALIDATE_SECONDS, tags: ["sitemap"] },


### PR DESCRIPTION
## Summary
- Google Search Console で「クロール済み - インデックス未登録」となっていた `creators/*` 詳細ページの実態を調査。原因は `sitemap.xml` が `creators`(1,178件) / `circles`(383件) の詳細URLを一切含んでいなかったこと（`videos`/`works`/`audioButtons` は個別URLを含んでいたが、creators/circlesは一覧ページのみ）。
- `apps/web/src/app/sitemap.ts` に `creators`/`circles` の個別URL生成を追加。各コレクション取得を独立関数に分割し、Biome の複雑度上限（15）を回避しつつ可読性を確保。
- テスト（`sitemap.test.ts`）に creators/circles を含む正常系アサーションを追加。

## 調査メモ（PRの範囲外・参考情報）
- `works/RJ01562032` 等、既にsitemap掲載済みのページの未インデックスは、robots/canonical/応答とも正常でコード側の不具合ではなく、Google側のクロール優先度判断と判断（対応不要）。
- 別途、GSCの「サイトマップ取得エラー」（`取得できませんでした`）も調査。2026-07-03頃の一時的な404が原因でGoogle側のステータスが以後更新されていなかったのみで、現在の `sitemap.xml` は健全（有効なXML・200・低レイテンシ、Cloud Runログでbingbot/Yandex等は定常的に200取得）。ユーザー側でGSCのサイトマップを再送信済み。

## Test plan
- [x] `pnpm --filter @suzumina.click/web test -- sitemap.test.ts` 全通過（132 files / 1090 tests）
- [x] `pnpm exec biome check apps/web/src/app/sitemap.ts apps/web/src/app/__tests__/sitemap.test.ts` エラーなし
- [x] `pnpm --filter @suzumina.click/web typecheck` エラーなし
- [ ] デプロイ後、GSCで `creators/*` の一部URLを「インデックス登録をリクエスト」して再クロールを促す

🤖 Generated with [Claude Code](https://claude.com/claude-code)