### PR TITLE
fix(web): lintエラーを解消

### DIFF
--- a/apps/web/src/app/buttons/page.tsx
+++ b/apps/web/src/app/buttons/page.tsx
@@ -4,6 +4,7 @@ import {
 	ListPageLayout,
 } from "@suzumina.click/ui/components/custom";
 import { Suspense } from "react";
+import { warn } from "@/lib/logger";
 import type { AudioButtonQuery } from "@/types/audio-button";
 import { getAudioButtonsList } from "./actions";
 import AudioButtonsList from "./components/audio-buttons-list";
@@ -96,7 +97,7 @@ async function GroupedView({ view }: { view: "usage" | "video" }) {
 	const totalCount = result.success && result.data ? result.data.totalCount : buttons.length;
 	if (totalCount > buttons.length) {
 		// 上限到達＝グルーピング対象から静かに欠落する状態。無警告にしない（§1 silent fallback 禁止の精神）
-		console.warn(
+		warn(
 			`GroupedView: ボタン総数 ${totalCount} 件が取得上限 ${GROUP_FETCH_LIMIT} 件を超過。超過分はグループ表示から欠落しています`,
 		);
 	}

--- a/apps/web/src/lib/auth/__tests__/auth-redirect.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-redirect.test.ts
@@ -30,14 +30,12 @@ describe("isAuthGatedPath", () => {
 });
 
 describe("sanitizeRelativePath", () => {
-	it.each([
-		"/",
-		"/buttons",
-		"/buttons/RJ123456",
-		"/users/me",
-	])("同一オリジン相対パス %s はそのまま", (path) => {
-		expect(sanitizeRelativePath(path)).toBe(path);
-	});
+	it.each(["/", "/buttons", "/buttons/RJ123456", "/users/me"])(
+		"同一オリジン相対パス %s はそのまま",
+		(path) => {
+			expect(sanitizeRelativePath(path)).toBe(path);
+		},
+	);
 
 	it.each([
 		["https://evil.com", "/"],


### PR DESCRIPTION
## Summary
- `apps/web/src/app/buttons/page.tsx`: `console.warn` を既存の `lib/logger` の `warn` に置き換え、biome `noConsole` エラーを解消
- `apps/web/src/lib/auth/__tests__/auth-redirect.test.ts`: `it.each(...)` のフォーマットを biome の期待形に整形

依存関係アップグレード (#834系) とは無関係に既存していた lint エラーの修正。

## Test plan
- [x] `pnpm --filter @suzumina.click/web lint` 通過
- [x] `pnpm verify` 通過（lint:docs / lint:tokens / lint / typecheck / test すべて）

🤖 Generated with [Claude Code](https://claude.com/claude-code)