### PR TITLE
feat(ui): packages/ui を Radix UI から Base UI へ全面移行

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://ui.shadcn.com/schema.json",
-	"style": "new-york",
+	"style": "base-vega",
 	"rsc": true,
 	"tsx": true,
 	"tailwind": {

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -152,9 +152,11 @@ export default function AboutPage() {
 							<p className="text-xs text-muted-foreground mb-4">
 								（返信をお約束するものではありません）
 							</p>
-							<Button variant="outline" size="sm" asChild>
-								<Link href="/contact">お問い合わせページ</Link>
-							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								render={<Link href="/contact">お問い合わせページ</Link>}
+							/>
 						</CardContent>
 					</Card>
 

--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -96,27 +96,36 @@ async function ErrorContent({ searchParams }: AuthErrorPageProps) {
 
 					<div className="space-y-3">
 						{errorInfo.showRetry && (
-							<Button asChild className="w-full group">
-								<Link href="/auth/signin" className="flex items-center gap-2">
-									<RotateCw className="h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
-									再度ログインを試す
-								</Link>
-							</Button>
+							<Button
+								className="w-full group"
+								render={
+									<Link href="/auth/signin" className="flex items-center gap-2">
+										<RotateCw className="h-4 w-4 group-hover:rotate-180 transition-transform duration-500" />
+										再度ログインを試す
+									</Link>
+								}
+							/>
 						)}
 
-						<Button variant="outline" asChild className="w-full group">
-							<Link href="/" className="flex items-center gap-2">
-								<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
-								ホームに戻る
-							</Link>
-						</Button>
+						<Button
+							variant="outline"
+							className="w-full group"
+							render={
+								<Link href="/" className="flex items-center gap-2">
+									<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
+									ホームに戻る
+								</Link>
+							}
+						/>
 					</div>
 
 					<div className="space-y-2 pt-4 border-t">
 						<p className="text-sm text-muted-foreground">解決しない場合は</p>
-						<Button variant="link" size="sm" asChild>
-							<Link href="/contact">お問い合わせページ</Link>
-						</Button>
+						<Button
+							variant="link"
+							size="sm"
+							render={<Link href="/contact">お問い合わせページ</Link>}
+						/>
 					</div>
 
 					<div className="pt-4 border-t">

--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -36,12 +36,16 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 		return (
 			<div className="container mx-auto px-4 py-8 max-w-4xl">
 				<div className="mb-6">
-					<Button variant="ghost" size="sm" asChild>
-						<Link href="/buttons" className="flex items-center gap-2">
-							<ArrowLeft className="h-4 w-4" />
-							音声ボタン一覧に戻る
-						</Link>
-					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						render={
+							<Link href="/buttons" className="flex items-center gap-2">
+								<ArrowLeft className="h-4 w-4" />
+								音声ボタン一覧に戻る
+							</Link>
+						}
+					/>
 				</div>
 
 				<div className="flex flex-col items-center justify-center py-12 text-center space-y-4">
@@ -51,12 +55,8 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 						音声ボタンを作成するには、元となるYouTube動画を指定する必要があります。
 					</p>
 					<div className="flex gap-3">
-						<Button asChild>
-							<Link href="/videos">動画一覧から選ぶ</Link>
-						</Button>
-						<Button variant="outline" asChild>
-							<Link href="/buttons">音声ボタン一覧</Link>
-						</Button>
+						<Button render={<Link href="/videos">動画一覧から選ぶ</Link>} />
+						<Button variant="outline" render={<Link href="/buttons">音声ボタン一覧</Link>} />
 					</div>
 				</div>
 			</div>
@@ -78,12 +78,16 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 		return (
 			<div className="container mx-auto px-4 py-8 max-w-4xl">
 				<div className="mb-6">
-					<Button variant="ghost" size="sm" asChild>
-						<Link href="/videos" className="flex items-center gap-2">
-							<ArrowLeft className="h-4 w-4" />
-							動画一覧に戻る
-						</Link>
-					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						render={
+							<Link href="/videos" className="flex items-center gap-2">
+								<ArrowLeft className="h-4 w-4" />
+								動画一覧に戻る
+							</Link>
+						}
+					/>
 				</div>
 
 				<div className="flex flex-col items-center justify-center py-12 text-center space-y-4">
@@ -92,18 +96,19 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 					<p className="text-muted-foreground max-w-md">{errorMessage}</p>
 					<p className="text-sm text-muted-foreground">動画タイトル: {videoResult.title}</p>
 					<div className="flex gap-3">
-						<Button asChild>
-							<Link href="/videos">配信アーカイブを選ぶ</Link>
-						</Button>
-						<Button variant="outline" asChild>
-							<a
-								href={`https://youtube.com/watch?v=${videoId}`}
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								YouTubeで見る
-							</a>
-						</Button>
+						<Button render={<Link href="/videos">配信アーカイブを選ぶ</Link>} />
+						<Button
+							variant="outline"
+							render={
+								<a
+									href={`https://youtube.com/watch?v=${videoId}`}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									YouTubeで見る
+								</a>
+							}
+						/>
 					</div>
 				</div>
 			</div>
@@ -115,12 +120,16 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 		return (
 			<div className="container mx-auto px-4 py-8 max-w-4xl">
 				<div className="mb-6">
-					<Button variant="ghost" size="sm" asChild>
-						<Link href="/videos" className="flex items-center gap-2">
-							<ArrowLeft className="h-4 w-4" />
-							動画一覧に戻る
-						</Link>
-					</Button>
+					<Button
+						variant="ghost"
+						size="sm"
+						render={
+							<Link href="/videos" className="flex items-center gap-2">
+								<ArrowLeft className="h-4 w-4" />
+								動画一覧に戻る
+							</Link>
+						}
+					/>
 				</div>
 
 				<div className="flex flex-col items-center justify-center py-12 text-center space-y-4">
@@ -133,18 +142,19 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 					</p>
 					<p className="text-sm text-muted-foreground">動画タイトル: {videoResult.title}</p>
 					<div className="flex gap-3">
-						<Button asChild>
-							<Link href="/videos">他の動画を選ぶ</Link>
-						</Button>
-						<Button variant="outline" asChild>
-							<a
-								href={`https://youtube.com/watch?v=${videoId}`}
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								YouTubeで見る
-							</a>
-						</Button>
+						<Button render={<Link href="/videos">他の動画を選ぶ</Link>} />
+						<Button
+							variant="outline"
+							render={
+								<a
+									href={`https://youtube.com/watch?v=${videoId}`}
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									YouTubeで見る
+								</a>
+							}
+						/>
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/app/buttons/error.tsx
+++ b/apps/web/src/app/buttons/error.tsx
@@ -55,18 +55,24 @@ export default function ButtonsError({
 						</Button>
 
 						<div className="flex flex-col sm:flex-row gap-2 justify-center">
-							<Button variant="outline" asChild>
-								<Link href="/" className="flex items-center gap-2">
-									<Home className="h-4 w-4" />
-									ホームへ
-								</Link>
-							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/buttons" className="flex items-center gap-2">
-									<Music className="h-4 w-4" />
-									音声ボタントップ
-								</Link>
-							</Button>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/" className="flex items-center gap-2">
+										<Home className="h-4 w-4" />
+										ホームへ
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/buttons" className="flex items-center gap-2">
+										<Music className="h-4 w-4" />
+										音声ボタントップ
+									</Link>
+								}
+							/>
 						</div>
 					</div>
 
@@ -74,12 +80,8 @@ export default function ButtonsError({
 					<div className="pt-4 border-t">
 						<p className="text-sm text-muted-foreground mb-2">他のコンテンツもご覧ください：</p>
 						<div className="flex flex-wrap gap-2 justify-center">
-							<Button variant="link" size="sm" asChild>
-								<Link href="/videos">動画一覧</Link>
-							</Button>
-							<Button variant="link" size="sm" asChild>
-								<Link href="/works">作品一覧</Link>
-							</Button>
+							<Button variant="link" size="sm" render={<Link href="/videos">動画一覧</Link>} />
+							<Button variant="link" size="sm" render={<Link href="/works">作品一覧</Link>} />
 						</div>
 					</div>
 

--- a/apps/web/src/app/contact/components/contact-form.tsx
+++ b/apps/web/src/app/contact/components/contact-form.tsx
@@ -139,6 +139,7 @@ export function ContactForm() {
 					お問い合わせ種別 <span className="text-destructive">*</span>
 				</Label>
 				<Select
+					items={categoryOptions}
 					onValueChange={(value) =>
 						setValue("category", value as z.infer<typeof contactFormSchema>["category"])
 					}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -55,19 +55,28 @@ export default function GlobalError({
 									再試行する
 								</Button>
 
-								<Button variant="outline" className="w-full group" asChild>
-									<a href="/" className="flex items-center gap-2">
-										<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
-										ホームに戻る
-									</a>
-								</Button>
+								<Button
+									variant="outline"
+									className="w-full group"
+									render={
+										<a href="/" className="flex items-center gap-2">
+											<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
+											ホームに戻る
+										</a>
+									}
+								/>
 
-								<Button variant="ghost" size="sm" className="w-full" asChild>
-									<a href="/contact" className="flex items-center gap-2 text-xs">
-										<Send className="h-3 w-3" />
-										エラーを報告する
-									</a>
-								</Button>
+								<Button
+									variant="ghost"
+									size="sm"
+									className="w-full"
+									render={
+										<a href="/contact" className="flex items-center gap-2 text-xs">
+											<Send className="h-3 w-3" />
+											エラーを報告する
+										</a>
+									}
+								/>
 							</div>
 
 							{/* エラー詳細（開発環境のみ） */}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -36,44 +36,66 @@ export default function NotFound() {
 					<div className="space-y-3">
 						<h2 className="text-sm font-semibold text-muted-foreground">人気のページへ</h2>
 
-						<Button asChild className="w-full group">
-							<Link href="/" className="flex items-center gap-2">
-								<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
-								ホームに戻る
-							</Link>
-						</Button>
+						<Button
+							className="w-full group"
+							render={
+								<Link href="/" className="flex items-center gap-2">
+									<Home className="h-4 w-4 group-hover:scale-110 transition-transform" />
+									ホームに戻る
+								</Link>
+							}
+						/>
 
 						<div className="grid grid-cols-3 gap-2">
-							<Button variant="outline" size="sm" asChild className="group">
-								<Link href="/buttons" className="flex flex-col items-center gap-1 py-3">
-									<Music className="h-4 w-4 group-hover:scale-110 transition-transform" />
-									<span className="text-xs">音声ボタン</span>
-								</Link>
-							</Button>
-							<Button variant="outline" size="sm" asChild className="group">
-								<Link href="/videos" className="flex flex-col items-center gap-1 py-3">
-									<Play className="h-4 w-4 group-hover:scale-110 transition-transform" />
-									<span className="text-xs">動画一覧</span>
-								</Link>
-							</Button>
-							<Button variant="outline" size="sm" asChild className="group">
-								<Link href="/works" className="flex flex-col items-center gap-1 py-3">
-									<BookOpen className="h-4 w-4 group-hover:scale-110 transition-transform" />
-									<span className="text-xs">作品一覧</span>
-								</Link>
-							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								className="group"
+								render={
+									<Link href="/buttons" className="flex flex-col items-center gap-1 py-3">
+										<Music className="h-4 w-4 group-hover:scale-110 transition-transform" />
+										<span className="text-xs">音声ボタン</span>
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								size="sm"
+								className="group"
+								render={
+									<Link href="/videos" className="flex flex-col items-center gap-1 py-3">
+										<Play className="h-4 w-4 group-hover:scale-110 transition-transform" />
+										<span className="text-xs">動画一覧</span>
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								size="sm"
+								className="group"
+								render={
+									<Link href="/works" className="flex flex-col items-center gap-1 py-3">
+										<BookOpen className="h-4 w-4 group-hover:scale-110 transition-transform" />
+										<span className="text-xs">作品一覧</span>
+									</Link>
+								}
+							/>
 						</div>
 					</div>
 
 					{/* 追加のヘルプ */}
 					<div className="space-y-2 pt-4 border-t">
 						<p className="text-sm text-muted-foreground">お探しのものが見つからない場合は</p>
-						<Button variant="link" size="sm" asChild>
-							<Link href="/contact">
-								<Search className="h-3 w-3 mr-1" />
-								お問い合わせページ
-							</Link>
-						</Button>
+						<Button
+							variant="link"
+							size="sm"
+							render={
+								<Link href="/contact">
+									<Search className="h-3 w-3 mr-1" />
+									お問い合わせページ
+								</Link>
+							}
+						/>
 					</div>
 
 					{/* 追加情報 */}

--- a/apps/web/src/app/users/[userId]/components/user-profile-content.tsx
+++ b/apps/web/src/app/users/[userId]/components/user-profile-content.tsx
@@ -77,12 +77,16 @@ function UserHeader({ user, isOwnProfile }: { user: FrontendUserData; isOwnProfi
 			</div>
 			<div className="flex gap-2">
 				{isOwnProfile && (
-					<Button variant="outline" size="sm" asChild>
-						<Link href="/settings">
-							<Settings className="w-4 h-4 mr-2" />
-							設定
-						</Link>
-					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						render={
+							<Link href="/settings">
+								<Settings className="w-4 h-4 mr-2" />
+								設定
+							</Link>
+						}
+					/>
 				)}
 			</div>
 		</div>
@@ -111,11 +115,7 @@ function AudioButtonsList({
 							? "まだ音声ボタンを作成していません。動画ページから音声ボタンを作成してみましょう。"
 							: `${user.displayName}さんはまだ公開している音声ボタンがありません。`}
 					</p>
-					{isOwnProfile && (
-						<Button asChild>
-							<Link href="/videos">動画を見る</Link>
-						</Button>
-					)}
+					{isOwnProfile && <Button render={<Link href="/videos">動画を見る</Link>} />}
 				</CardContent>
 			</Card>
 		);
@@ -261,9 +261,7 @@ export function UserProfileContent({
 							<p className="text-muted-foreground mb-4">
 								お気に入りに登録した音声ボタンを管理できます。
 							</p>
-							<Button asChild>
-								<Link href="/favorites">お気に入り一覧を見る</Link>
-							</Button>
+							<Button render={<Link href="/favorites">お気に入り一覧を見る</Link>} />
 						</CardContent>
 					</Card>
 				)}

--- a/apps/web/src/app/users/[userId]/error.tsx
+++ b/apps/web/src/app/users/[userId]/error.tsx
@@ -59,18 +59,24 @@ export default function UserProfileError({
 								<RefreshCw className="w-4 h-4" />
 								再試行
 							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/" className="flex items-center gap-2">
-									<Home className="w-4 h-4" />
-									ホームに戻る
-								</Link>
-							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/users/me" className="flex items-center gap-2">
-									<User className="w-4 h-4" />
-									マイプロフィール
-								</Link>
-							</Button>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/" className="flex items-center gap-2">
+										<Home className="w-4 h-4" />
+										ホームに戻る
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/users/me" className="flex items-center gap-2">
+										<User className="w-4 h-4" />
+										マイプロフィール
+									</Link>
+								}
+							/>
 						</div>
 
 						{/* ヘルプリンク */}

--- a/apps/web/src/app/users/[userId]/not-found.tsx
+++ b/apps/web/src/app/users/[userId]/not-found.tsx
@@ -34,24 +34,32 @@ export default function UserNotFound() {
 
 						{/* アクションボタン */}
 						<div className="flex flex-col sm:flex-row gap-3 justify-center">
-							<Button asChild>
-								<Link href="/" className="flex items-center gap-2">
-									<Home className="w-4 h-4" />
-									ホームに戻る
-								</Link>
-							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/users/me" className="flex items-center gap-2">
-									<User className="w-4 h-4" />
-									マイプロフィール
-								</Link>
-							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/buttons" className="flex items-center gap-2">
-									<Search className="w-4 h-4" />
-									音声ボタンを探す
-								</Link>
-							</Button>
+							<Button
+								render={
+									<Link href="/" className="flex items-center gap-2">
+										<Home className="w-4 h-4" />
+										ホームに戻る
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/users/me" className="flex items-center gap-2">
+										<User className="w-4 h-4" />
+										マイプロフィール
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/buttons" className="flex items-center gap-2">
+										<Search className="w-4 h-4" />
+										音声ボタンを探す
+									</Link>
+								}
+							/>
 						</div>
 
 						{/* ヘルプ */}

--- a/apps/web/src/app/videos/[videoId]/components/related-audio-buttons.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/related-audio-buttons.tsx
@@ -35,12 +35,16 @@ export function RelatedAudioButtons({
 			<div className="text-center py-8 text-muted-foreground">
 				<p className="mb-4">この動画の音声ボタンはまだありません</p>
 				{canCreateButton && (
-					<Button asChild size="sm" variant="outline">
-						<Link href={`/buttons/create?video_id=${videoId}`}>
-							<Plus className="h-4 w-4 mr-2" />
-							最初の音声ボタンを作る
-						</Link>
-					</Button>
+					<Button
+						size="sm"
+						variant="outline"
+						render={
+							<Link href={`/buttons/create?video_id=${videoId}`}>
+								<Plus className="h-4 w-4 mr-2" />
+								最初の音声ボタンを作る
+							</Link>
+						}
+					/>
 				)}
 			</div>
 		);
@@ -70,12 +74,16 @@ export function RelatedAudioButtons({
 			{/* もっと見るボタン */}
 			{totalCount > audioButtons.length && (
 				<div className="text-center pt-2">
-					<Button asChild variant="outline" size="sm">
-						<Link href={`/buttons?videoId=${videoId}`}>
-							<ArrowRight className="h-4 w-4 mr-2" />
-							すべての音声ボタンを見る ({totalCount}件)
-						</Link>
-					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						render={
+							<Link href={`/buttons?videoId=${videoId}`}>
+								<ArrowRight className="h-4 w-4 mr-2" />
+								すべての音声ボタンを見る ({totalCount}件)
+							</Link>
+						}
+					/>
 				</div>
 			)}
 		</div>

--- a/apps/web/src/app/videos/[videoId]/components/video-detail.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/video-detail.tsx
@@ -207,17 +207,17 @@ export default function VideoDetail({
 									size="lg"
 									variant="secondary"
 									className="bg-white/90 hover:bg-white text-black shadow-lg transition-all duration-300 group-hover/play:scale-110"
-									asChild
-								>
-									<a
-										href={youtubeUrl}
-										target="_blank"
-										rel="noopener noreferrer"
-										aria-label={`${video.title}をYouTubeで再生`}
-									>
-										<PlayCircle className="h-8 w-8" />
-									</a>
-								</Button>
+									render={
+										<a
+											href={youtubeUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											aria-label={`${video.title}をYouTubeで再生`}
+										>
+											<PlayCircle className="h-8 w-8" />
+										</a>
+									}
+								/>
 							</div>
 
 							{/* ホバー時のオーバーレイ */}
@@ -296,30 +296,34 @@ export default function VideoDetail({
 									size="lg"
 									className="bg-primary hover:bg-primary/90 text-primary-foreground"
 									disabled={!canCreateButton}
-									asChild={canCreateButton}
 									title={canCreateButton ? undefined : canCreateButtonData.reason || undefined}
+									render={
+										canCreateButton ? (
+											<Link
+												href={`/buttons/create?video_id=${video.videoId}`}
+												className="flex items-center whitespace-nowrap"
+											>
+												<Plus className="h-4 w-4 mr-2" />
+												ボタンを作成
+											</Link>
+										) : undefined
+									}
 								>
-									{canCreateButton ? (
-										<Link
-											href={`/buttons/create?video_id=${video.videoId}`}
-											className="flex items-center whitespace-nowrap"
-										>
-											<Plus className="h-4 w-4 mr-2" />
-											ボタンを作成
-										</Link>
-									) : (
-										<span className="flex items-center whitespace-nowrap">
-											<Plus className="h-4 w-4 mr-2" />
-											ボタンを作成
-										</span>
-									)}
+									<span className="flex items-center whitespace-nowrap">
+										<Plus className="h-4 w-4 mr-2" />
+										ボタンを作成
+									</span>
 								</Button>
-								<Button size="lg" variant="outline" asChild>
-									<a href={youtubeUrl} target="_blank" rel="noopener noreferrer">
-										<PlayCircle className="h-4 w-4 mr-2" />
-										YouTubeで見る
-									</a>
-								</Button>
+								<Button
+									size="lg"
+									variant="outline"
+									render={
+										<a href={youtubeUrl} target="_blank" rel="noopener noreferrer">
+											<PlayCircle className="h-4 w-4 mr-2" />
+											YouTubeで見る
+										</a>
+									}
+								/>
 							</div>
 
 							{/* タブナビゲーション */}
@@ -805,10 +809,8 @@ export default function VideoDetail({
 									size="sm"
 									variant="outline"
 									className="text-primary border-border hover:bg-accent"
-									asChild
-								>
-									<Link href={`/buttons/create?video_id=${video.videoId}`}>新規作成</Link>
-								</Button>
+									render={<Link href={`/buttons/create?video_id=${video.videoId}`}>新規作成</Link>}
+								/>
 							)}
 						</div>
 

--- a/apps/web/src/app/videos/components/video-card-actions.tsx
+++ b/apps/web/src/app/videos/components/video-card-actions.tsx
@@ -60,13 +60,13 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 			size="sm"
 			variant="outline"
 			className="flex-1 border text-muted-foreground hover:bg-accent min-h-[44px] text-sm"
-			asChild
-		>
-			<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
-				<Eye className="h-4 w-4 mr-1" aria-hidden="true" />
-				詳細を見る
-			</Link>
-		</Button>
+			render={
+				<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
+					<Eye className="h-4 w-4 mr-1" aria-hidden="true" />
+					詳細を見る
+				</Link>
+			}
+		/>
 	);
 
 	if (variant === "sidebar") {
@@ -75,13 +75,13 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 				variant="outline"
 				size="sm"
 				className="w-full border text-muted-foreground hover:bg-accent min-h-[44px]"
-				asChild
-			>
-				<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
-					<ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
-					動画を見る
-				</Link>
-			</Button>
+				render={
+					<Link href={`/videos/${video.id}`} aria-describedby={`video-title-${video.id}`}>
+						<ExternalLink className="h-4 w-4 mr-2" aria-hidden="true" />
+						動画を見る
+					</Link>
+				}
+			/>
 		);
 	}
 
@@ -90,16 +90,21 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 	let createAction: ReactNode;
 	if (gate.canCreate) {
 		createAction = (
-			<Button size="sm" variant="default" className="flex-1 min-h-[44px] text-sm" asChild>
-				<Link
-					href={`/buttons/create?video_id=${video.id}`}
-					aria-label={`${video.title}の音声ボタンを作成`}
-					className="flex items-center whitespace-nowrap"
-				>
-					<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
-					ボタン作成
-				</Link>
-			</Button>
+			<Button
+				size="sm"
+				variant="default"
+				className="flex-1 min-h-[44px] text-sm"
+				render={
+					<Link
+						href={`/buttons/create?video_id=${video.id}`}
+						aria-label={`${video.title}の音声ボタンを作成`}
+						className="flex items-center whitespace-nowrap"
+					>
+						<Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+						ボタン作成
+					</Link>
+				}
+			/>
 		);
 	} else if ("liveMarking" in gate) {
 		// バッジと同色ペアで時制を明示する: live = destructive 赤（「配信中」バッジと同色・赤は live 専用）、
@@ -114,25 +119,25 @@ export default function VideoCardActions({ video, variant }: VideoCardActionsPro
 						? "flex-1 min-h-[44px] text-sm"
 						: "flex-1 min-h-[44px] text-sm bg-info text-info-foreground hover:bg-info/90"
 				}
-				asChild
-			>
-				<Link
-					href={`/live?v=${video.videoId}`}
-					aria-label={
-						isLiveNow
-							? `${video.title}の配信中マーキングを開く`
-							: `${video.title}の配信待機（マーキング）を開く`
-					}
-					className="flex items-center whitespace-nowrap"
-				>
-					{isLiveNow ? (
-						<Bookmark className="h-4 w-4 mr-1" aria-hidden="true" />
-					) : (
-						<Clock className="h-4 w-4 mr-1" aria-hidden="true" />
-					)}
-					{isLiveNow ? "配信中マーク" : "配信待機"}
-				</Link>
-			</Button>
+				render={
+					<Link
+						href={`/live?v=${video.videoId}`}
+						aria-label={
+							isLiveNow
+								? `${video.title}の配信中マーキングを開く`
+								: `${video.title}の配信待機（マーキング）を開く`
+						}
+						className="flex items-center whitespace-nowrap"
+					>
+						{isLiveNow ? (
+							<Bookmark className="h-4 w-4 mr-1" aria-hidden="true" />
+						) : (
+							<Clock className="h-4 w-4 mr-1" aria-hidden="true" />
+						)}
+						{isLiveNow ? "配信中マーク" : "配信待機"}
+					</Link>
+				}
+			/>
 		);
 	} else {
 		// 作成不可（理由あり）: aria-disabled で理由を提示。

--- a/apps/web/src/app/videos/components/video-card.tsx
+++ b/apps/web/src/app/videos/components/video-card.tsx
@@ -104,13 +104,13 @@ function VideoCard({ video, variant = "grid", priority = false, searchQuery }: V
 					{actualButtonCount > 0 && (
 						<div className="absolute top-2 left-2">
 							<Badge
-								asChild
 								variant="secondary"
 								className="bg-white/90 text-foreground cursor-pointer hover:bg-white"
 								aria-label={`${actualButtonCount}個の音声ボタン一覧を見る`}
-							>
-								<Link href={`/buttons?videoId=${video.id}`}>{actualButtonCount} ボタン</Link>
-							</Badge>
+								render={
+									<Link href={`/buttons?videoId=${video.id}`}>{actualButtonCount} ボタン</Link>
+								}
+							/>
 						</div>
 					)}
 					{video.status?.embeddable === false && (

--- a/apps/web/src/app/videos/error.tsx
+++ b/apps/web/src/app/videos/error.tsx
@@ -51,18 +51,24 @@ export default function VideosError({
 						</Button>
 
 						<div className="flex flex-col sm:flex-row gap-2 justify-center">
-							<Button variant="outline" asChild>
-								<Link href="/" className="flex items-center gap-2">
-									<Home className="h-4 w-4" />
-									ホームへ
-								</Link>
-							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/videos" className="flex items-center gap-2">
-									<Play className="h-4 w-4" />
-									動画一覧トップ
-								</Link>
-							</Button>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/" className="flex items-center gap-2">
+										<Home className="h-4 w-4" />
+										ホームへ
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/videos" className="flex items-center gap-2">
+										<Play className="h-4 w-4" />
+										動画一覧トップ
+									</Link>
+								}
+							/>
 						</div>
 					</div>
 
@@ -70,12 +76,8 @@ export default function VideosError({
 					<div className="pt-4 border-t">
 						<p className="text-sm text-muted-foreground mb-2">他のコンテンツもご覧ください：</p>
 						<div className="flex flex-wrap gap-2 justify-center">
-							<Button variant="link" size="sm" asChild>
-								<Link href="/buttons">音声ボタン</Link>
-							</Button>
-							<Button variant="link" size="sm" asChild>
-								<Link href="/works">作品一覧</Link>
-							</Button>
+							<Button variant="link" size="sm" render={<Link href="/buttons">音声ボタン</Link>} />
+							<Button variant="link" size="sm" render={<Link href="/works">作品一覧</Link>} />
 						</div>
 					</div>
 				</CardContent>

--- a/apps/web/src/app/works/[workId]/components/sample-image-gallery.tsx
+++ b/apps/web/src/app/works/[workId]/components/sample-image-gallery.tsx
@@ -189,31 +189,33 @@ export default function SampleImageGallery({ sampleImages, workTitle }: SampleIm
 				<div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
 					{sampleImages.map((image, index) => (
 						<Dialog key={image.thumb}>
-							<DialogTrigger asChild>
-								<button
-									type="button"
-									className="relative aspect-square bg-muted rounded-lg overflow-hidden cursor-pointer hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-info"
-									onClick={() => setSelectedImageIndex(index)}
-									onKeyDown={(e) => {
-										if (e.key === "Enter" || e.key === " ") {
-											e.preventDefault();
-											setSelectedImageIndex(index);
-										}
-									}}
-									aria-label={`${workTitle} サンプル画像 ${index + 1}を拡大表示`}
-								>
-									<SampleThumbnail
-										src={image.thumb}
-										alt={`${workTitle} サンプル画像 ${index + 1}`}
-										className="w-full h-full"
-									/>
-									{image.width && image.height && (
-										<div className="absolute bottom-1 right-1 bg-black bg-opacity-60 text-white text-xs px-1 py-0.5 rounded pointer-events-none">
-											{image.width}×{image.height}
-										</div>
-									)}
-								</button>
-							</DialogTrigger>
+							<DialogTrigger
+								render={
+									<button
+										type="button"
+										className="relative aspect-square bg-muted rounded-lg overflow-hidden cursor-pointer hover:opacity-90 transition-opacity focus:outline-none focus:ring-2 focus:ring-info"
+										onClick={() => setSelectedImageIndex(index)}
+										onKeyDown={(e) => {
+											if (e.key === "Enter" || e.key === " ") {
+												e.preventDefault();
+												setSelectedImageIndex(index);
+											}
+										}}
+										aria-label={`${workTitle} サンプル画像 ${index + 1}を拡大表示`}
+									>
+										<SampleThumbnail
+											src={image.thumb}
+											alt={`${workTitle} サンプル画像 ${index + 1}`}
+											className="w-full h-full"
+										/>
+										{image.width && image.height && (
+											<div className="absolute bottom-1 right-1 bg-black bg-opacity-60 text-white text-xs px-1 py-0.5 rounded pointer-events-none">
+												{image.width}×{image.height}
+											</div>
+										)}
+									</button>
+								}
+							/>
 							<DialogContent
 								className="max-w-none w-auto h-auto p-0 bg-transparent border-none shadow-none"
 								style={{

--- a/apps/web/src/app/works/[workId]/components/work-detail.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-detail.tsx
@@ -285,13 +285,13 @@ export default function WorkDetail({ work }: WorkDetailProps) {
 								</Button>
 								<Button
 									className="flex-1 bg-destructive hover:bg-destructive/90 text-white"
-									asChild
-								>
-									<a href={work.workUrl} target="_blank" rel="noopener noreferrer">
-										<ShoppingCart className="h-4 w-4 mr-2" />
-										DLsiteで購入
-									</a>
-								</Button>
+									render={
+										<a href={work.workUrl} target="_blank" rel="noopener noreferrer">
+											<ShoppingCart className="h-4 w-4 mr-2" />
+											DLsiteで購入
+										</a>
+									}
+								/>
 							</div>
 						</div>
 					</div>
@@ -563,10 +563,8 @@ export default function WorkDetail({ work }: WorkDetailProps) {
 								<Button
 									variant="outline"
 									className="w-full border text-foreground hover:bg-accent"
-									asChild
-								>
-									<Link href={`/circles/${work.circleId}`}>他の作品を見る</Link>
-								</Button>
+									render={<Link href={`/circles/${work.circleId}`}>他の作品を見る</Link>}
+								/>
 							) : (
 								<Button
 									variant="outline"

--- a/apps/web/src/app/works/components/work-card.tsx
+++ b/apps/web/src/app/works/components/work-card.tsx
@@ -252,26 +252,26 @@ export default function WorkCard({ work, variant = "default", priority = false }
 							size="sm"
 							variant="outline"
 							className="flex-1 border text-muted-foreground hover:bg-accent min-h-[44px] text-sm"
-							asChild
-						>
-							<Link href={`/works/${work.id}`} aria-describedby={`work-title-${work.id}`}>
-								詳細{isCompact ? "を見る" : ""}
-							</Link>
-						</Button>
+							render={
+								<Link href={`/works/${work.id}`} aria-describedby={`work-title-${work.id}`}>
+									詳細{isCompact ? "を見る" : ""}
+								</Link>
+							}
+						/>
 						<Button
 							size="sm"
 							className="bg-destructive hover:bg-destructive/90 text-white min-h-[44px] min-w-[44px] px-3"
-							asChild
-						>
-							<a
-								href={work.workUrl}
-								target="_blank"
-								rel="noopener noreferrer"
-								aria-label={`${work.title}をDLsiteで購入`}
-							>
-								<ExternalLink className="h-4 w-4" aria-hidden="true" />
-							</a>
-						</Button>
+							render={
+								<a
+									href={work.workUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									aria-label={`${work.title}をDLsiteで購入`}
+								>
+									<ExternalLink className="h-4 w-4" aria-hidden="true" />
+								</a>
+							}
+						/>
 					</fieldset>
 				</div>
 			</div>

--- a/apps/web/src/app/works/error.tsx
+++ b/apps/web/src/app/works/error.tsx
@@ -53,18 +53,24 @@ export default function WorksError({
 						</Button>
 
 						<div className="flex flex-col sm:flex-row gap-2 justify-center">
-							<Button variant="outline" asChild>
-								<Link href="/" className="flex items-center gap-2">
-									<Home className="h-4 w-4" />
-									ホームへ
-								</Link>
-							</Button>
-							<Button variant="outline" asChild>
-								<Link href="/works" className="flex items-center gap-2">
-									<BookOpen className="h-4 w-4" />
-									作品一覧トップ
-								</Link>
-							</Button>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/" className="flex items-center gap-2">
+										<Home className="h-4 w-4" />
+										ホームへ
+									</Link>
+								}
+							/>
+							<Button
+								variant="outline"
+								render={
+									<Link href="/works" className="flex items-center gap-2">
+										<BookOpen className="h-4 w-4" />
+										作品一覧トップ
+									</Link>
+								}
+							/>
 						</div>
 					</div>
 
@@ -72,12 +78,8 @@ export default function WorksError({
 					<div className="pt-4 border-t">
 						<p className="text-sm text-muted-foreground mb-2">他のコンテンツもご覧ください：</p>
 						<div className="flex flex-wrap gap-2 justify-center">
-							<Button variant="link" size="sm" asChild>
-								<Link href="/videos">動画一覧</Link>
-							</Button>
-							<Button variant="link" size="sm" asChild>
-								<Link href="/buttons">音声ボタン</Link>
-							</Button>
+							<Button variant="link" size="sm" render={<Link href="/videos">動画一覧</Link>} />
+							<Button variant="link" size="sm" render={<Link href="/buttons">音声ボタン</Link>} />
 						</div>
 					</div>
 

--- a/apps/web/src/components/audio-button-detail/audio-button-hero-header.tsx
+++ b/apps/web/src/components/audio-button-detail/audio-button-hero-header.tsx
@@ -86,14 +86,16 @@ export function AudioButtonHeroHeader({
 							<MoreHorizontal className="h-[18px] w-[18px]" />
 						</DropdownMenuTrigger>
 						<DropdownMenuContent align="end" className="min-w-[190px]">
-							<DropdownMenuItem asChild>
-								<Link href={`/buttons/${audioButtonId}/edit`}>
-									<Pencil className="h-3.5 w-3.5" />
-									編集ページを開く
-								</Link>
-							</DropdownMenuItem>
+							<DropdownMenuItem
+								render={
+									<Link href={`/buttons/${audioButtonId}/edit`}>
+										<Pencil className="h-3.5 w-3.5" />
+										編集ページを開く
+									</Link>
+								}
+							/>
 							<DropdownMenuSeparator />
-							<DropdownMenuItem variant="destructive" onSelect={() => setConfirmOpen(true)}>
+							<DropdownMenuItem variant="destructive" onClick={() => setConfirmOpen(true)}>
 								<Trash2 className="h-3.5 w-3.5" />
 								削除…
 							</DropdownMenuItem>

--- a/apps/web/src/components/audio/audio-button-edit-button.tsx
+++ b/apps/web/src/components/audio/audio-button-edit-button.tsx
@@ -26,11 +26,16 @@ export function AudioButtonEditButton({ audioButtonId, createdBy }: AudioButtonE
 	}
 
 	return (
-		<Button variant="outline" size="sm" asChild className="flex items-center gap-1">
-			<Link href={`/buttons/${audioButtonId}/edit`}>
-				<Pencil className="h-4 w-4" />
-				編集
-			</Link>
-		</Button>
+		<Button
+			variant="outline"
+			size="sm"
+			className="flex items-center gap-1"
+			render={
+				<Link href={`/buttons/${audioButtonId}/edit`}>
+					<Pencil className="h-4 w-4" />
+					編集
+				</Link>
+			}
+		/>
 	);
 }

--- a/apps/web/src/components/home/__tests__/home-search.test.tsx
+++ b/apps/web/src/components/home/__tests__/home-search.test.tsx
@@ -30,7 +30,7 @@ describe("HomeSearch", () => {
 		const user = userEvent.setup();
 		render(<HomeSearch />);
 
-		await user.click(screen.getByRole("radio", { name: "動画" }));
+		await user.click(screen.getByRole("button", { name: "動画" }));
 		await user.type(screen.getByRole("textbox"), "歌枠");
 		await user.click(screen.getByRole("button", { name: "検索" }));
 
@@ -41,7 +41,7 @@ describe("HomeSearch", () => {
 		const user = userEvent.setup();
 		render(<HomeSearch />);
 
-		await user.click(screen.getByRole("radio", { name: "作品" }));
+		await user.click(screen.getByRole("button", { name: "作品" }));
 		await user.type(screen.getByRole("textbox"), "ASMR");
 		await user.click(screen.getByRole("button", { name: "検索" }));
 

--- a/apps/web/src/components/home/dynamic-home-sections.tsx
+++ b/apps/web/src/components/home/dynamic-home-sections.tsx
@@ -52,11 +52,14 @@ function AudioButtonsSectionHeader() {
 				</h2>
 				<p className="text-sm sm:text-base text-muted-foreground">最新の音声ボタンをチェック！</p>
 			</div>
-			<Button asChild variant="outline">
-				<Link href="/buttons" className="font-medium">
-					すべて見る
-				</Link>
-			</Button>
+			<Button
+				variant="outline"
+				render={
+					<Link href="/buttons" className="font-medium">
+						すべて見る
+					</Link>
+				}
+			/>
 		</div>
 	);
 }
@@ -125,16 +128,23 @@ export function CommunitySection() {
 						 * 落ちていた（SPR-150）。動画一覧では各カードに video_id 付きの作成導線
 						 * （VideoCardActions）があるため、そこへ誘導する。
 						 */}
-						<Button asChild size="lg">
-							<Link href="/videos" className="font-medium">
-								音声ボタンを作る
-							</Link>
-						</Button>
-						<Button asChild size="lg" variant="outline">
-							<Link href="/about" className="font-medium">
-								サイトについて
-							</Link>
-						</Button>
+						<Button
+							size="lg"
+							render={
+								<Link href="/videos" className="font-medium">
+									音声ボタンを作る
+								</Link>
+							}
+						/>
+						<Button
+							size="lg"
+							variant="outline"
+							render={
+								<Link href="/about" className="font-medium">
+									サイトについて
+								</Link>
+							}
+						/>
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/components/home/home-search.tsx
+++ b/apps/web/src/components/home/home-search.tsx
@@ -42,12 +42,12 @@ const HomeSearch = memo(function HomeSearch() {
 	return (
 		<div className="max-w-md mx-auto space-y-3 md:mx-0">
 			<ToggleGroup
-				type="single"
-				value={target}
+				value={[target]}
 				// 単一選択を強制（同じ項目の再クリックで空にしない）
 				onValueChange={(value) => {
-					if (value) {
-						setTarget(value as SearchTarget);
+					const next = value[0];
+					if (next) {
+						setTarget(next as SearchTarget);
 					}
 				}}
 				aria-label="検索対象"

--- a/apps/web/src/components/layout/mobile-menu.tsx
+++ b/apps/web/src/components/layout/mobile-menu.tsx
@@ -14,16 +14,18 @@ interface MobileMenuProps {
 export default function MobileMenu({ user }: MobileMenuProps) {
 	return (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button
-					variant="outline"
-					size="icon"
-					className="md:hidden min-h-[44px] min-w-[44px]"
-					aria-label="メニューを開く"
-				>
-					<Menu className="h-5 w-5" aria-hidden="true" />
-				</Button>
-			</SheetTrigger>
+			<SheetTrigger
+				render={
+					<Button
+						variant="outline"
+						size="icon"
+						className="md:hidden min-h-[44px] min-w-[44px]"
+						aria-label="メニューを開く"
+					>
+						<Menu className="h-5 w-5" aria-hidden="true" />
+					</Button>
+				}
+			/>
 			<SheetContent
 				side="right"
 				className="w-[280px] sm:w-[320px] md:w-[400px]"

--- a/apps/web/src/components/live/live-capture-view.tsx
+++ b/apps/web/src/components/live/live-capture-view.tsx
@@ -254,17 +254,20 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 											</span>
 										) : (
 											firstDraft && (
-												<Button asChild size="sm">
-													{/* /buttons ツリーへの遷移はフルロード（intercepting route 回避・SPR-252）。
-													    先頭の下書きから開けば同一動画のキューは create 側が読み込み、
-													    連続仕上げ（SPR-266 第2段）につながる */}
-													<a
-														href={`/buttons/create?video_id=${group.videoId}&start_time=${firstDraft.suggestedStartTime}&draft_id=${firstDraft.id}`}
-													>
-														<ExternalLink className="h-3.5 w-3.5 mr-1" />
-														まとめて仕上げる
-													</a>
-												</Button>
+												<Button
+													size="sm"
+													render={
+														// /buttons ツリーへの遷移はフルロード（intercepting route 回避・SPR-252）。
+														// 先頭の下書きから開けば同一動画のキューは create 側が読み込み、
+														// 連続仕上げ（SPR-266 第2段）につながる
+														<a
+															href={`/buttons/create?video_id=${group.videoId}&start_time=${firstDraft.suggestedStartTime}&draft_id=${firstDraft.id}`}
+														>
+															<ExternalLink className="h-3.5 w-3.5 mr-1" />
+															まとめて仕上げる
+														</a>
+													}
+												/>
 											)
 										)}
 									</div>
@@ -285,15 +288,19 @@ export function LiveCaptureView({ video, initialDrafts }: LiveCaptureViewProps) 
 													</p>
 												</div>
 												{!isCurrentLiveVideo && (
-													<Button asChild size="sm" variant="outline">
-														{/* この1件だけを仕上げたいときの個別導線（フルロード・SPR-252） */}
-														<a
-															href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
-														>
-															<ExternalLink className="h-3.5 w-3.5 mr-1" />
-															仕上げる
-														</a>
-													</Button>
+													<Button
+														size="sm"
+														variant="outline"
+														render={
+															// この1件だけを仕上げたいときの個別導線（フルロード・SPR-252）
+															<a
+																href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
+															>
+																<ExternalLink className="h-3.5 w-3.5 mr-1" />
+																仕上げる
+															</a>
+														}
+													/>
 												)}
 												<Button
 													size="sm"

--- a/apps/web/src/components/sections/videos-section.tsx
+++ b/apps/web/src/components/sections/videos-section.tsx
@@ -26,11 +26,14 @@ export function VideosSection({ videos = [], loading = true, error = null }: Vid
 								涼花みなせさんの最新動画をチェック！
 							</p>
 						</div>
-						<Button asChild variant="outline">
-							<Link href="/videos" className="font-medium">
-								すべて見る
-							</Link>
-						</Button>
+						<Button
+							variant="outline"
+							render={
+								<Link href="/videos" className="font-medium">
+									すべて見る
+								</Link>
+							}
+						/>
 					</div>
 					<LoadingSkeleton variant="carousel" height={300} />
 				</div>
@@ -63,11 +66,14 @@ export function VideosSection({ videos = [], loading = true, error = null }: Vid
 							涼花みなせさんの最新動画をチェック！
 						</p>
 					</div>
-					<Button asChild variant="outline">
-						<Link href="/videos" className="font-medium">
-							すべて見る
-						</Link>
-					</Button>
+					<Button
+						variant="outline"
+						render={
+							<Link href="/videos" className="font-medium">
+								すべて見る
+							</Link>
+						}
+					/>
 				</div>
 				<LazyFeaturedVideosCarousel videos={videos} />
 			</div>

--- a/apps/web/src/components/sections/works-section.tsx
+++ b/apps/web/src/components/sections/works-section.tsx
@@ -45,11 +45,14 @@ export function WorksSection({
 								涼花みなせさんの最新作品をチェック！
 							</p>
 						</div>
-						<Button asChild variant="outline">
-							<Link href="/works" className="font-medium">
-								すべて見る
-							</Link>
-						</Button>
+						<Button
+							variant="outline"
+							render={
+								<Link href="/works" className="font-medium">
+									すべて見る
+								</Link>
+							}
+						/>
 					</div>
 					<LoadingSkeleton variant="carousel" height={350} />
 				</div>
@@ -91,11 +94,14 @@ export function WorksSection({
 								: "年齢制限のない作品をお楽しみください"}
 						</p>
 					</div>
-					<Button asChild variant="outline">
-						<Link href="/works" className="font-medium">
-							すべて見る
-						</Link>
-					</Button>
+					<Button
+						variant="outline"
+						render={
+							<Link href="/works" className="font-medium">
+								すべて見る
+							</Link>
+						}
+					/>
 				</div>
 				<LazyFeaturedWorksCarousel works={worksToShow} />
 			</div>

--- a/apps/web/src/components/ui/delete-confirm-dialog.tsx
+++ b/apps/web/src/components/ui/delete-confirm-dialog.tsx
@@ -10,7 +10,6 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@suzumina.click/ui/components/ui/alert-dialog";
-import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Loader2, Trash2 } from "lucide-react";
 
 interface DeleteConfirmDialogProps {
@@ -42,25 +41,23 @@ export function DeleteConfirmDialog({
 				</AlertDialogHeader>
 				<AlertDialogFooter>
 					<AlertDialogCancel disabled={isDeleting}>キャンセル</AlertDialogCancel>
-					<AlertDialogAction asChild>
-						<Button
-							variant="destructive"
-							onClick={onConfirm}
-							disabled={isDeleting}
-							className="gap-2"
-						>
-							{isDeleting ? (
-								<>
-									<Loader2 className="h-4 w-4 animate-spin" />
-									削除中...
-								</>
-							) : (
-								<>
-									<Trash2 className="h-4 w-4" />
-									削除する
-								</>
-							)}
-						</Button>
+					<AlertDialogAction
+						variant="destructive"
+						onClick={onConfirm}
+						disabled={isDeleting}
+						className="gap-2"
+					>
+						{isDeleting ? (
+							<>
+								<Loader2 className="h-4 w-4 animate-spin" />
+								削除中...
+							</>
+						) : (
+							<>
+								<Trash2 className="h-4 w-4" />
+								削除する
+							</>
+						)}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/apps/web/src/components/user/user-menu.tsx
+++ b/apps/web/src/components/user/user-menu.tsx
@@ -113,7 +113,7 @@ export default function UserMenu({ user }: UserMenuProps) {
 				/>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem
-					// asChild を使わず DropdownMenuItem 自体を押下対象にする（選択でメニューは閉じる）。
+					// render を使わず DropdownMenuItem 自体を押下対象にする（クリックでメニューは閉じる）。
 					onClick={() => void handleSignOut()}
 					className="flex items-center gap-2 cursor-pointer"
 				>

--- a/apps/web/src/components/user/user-menu.tsx
+++ b/apps/web/src/components/user/user-menu.tsx
@@ -5,6 +5,7 @@ import { Button } from "@suzumina.click/ui/components/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
@@ -48,60 +49,72 @@ export default function UserMenu({ user }: UserMenuProps) {
 
 	return (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button
-					variant="ghost"
-					className="flex items-center gap-2 h-auto p-2"
-					aria-label="ユーザーメニューを開く"
-				>
-					<UserAvatar
-						discordId={user.discordId}
-						avatar={user.avatar}
-						displayName={user.displayName}
-						size={32}
-						className="w-8 h-8"
-					/>
-					<div className="hidden sm:block text-left">
-						<p className="text-sm font-medium text-foreground">{user.displayName}</p>
-					</div>
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent className="w-56" align="end" forceMount>
-				<DropdownMenuLabel className="font-normal">
-					<div className="flex flex-col space-y-1">
-						<p className="text-sm font-medium leading-none">{user.displayName}</p>
-					</div>
-				</DropdownMenuLabel>
+			<DropdownMenuTrigger
+				render={
+					<Button
+						variant="ghost"
+						className="flex items-center gap-2 h-auto p-2"
+						aria-label="ユーザーメニューを開く"
+					>
+						<UserAvatar
+							discordId={user.discordId}
+							avatar={user.avatar}
+							displayName={user.displayName}
+							size={32}
+							className="w-8 h-8"
+						/>
+						<div className="hidden sm:block text-left">
+							<p className="text-sm font-medium text-foreground">{user.displayName}</p>
+						</div>
+					</Button>
+				}
+			/>
+			<DropdownMenuContent className="w-56" align="end">
+				<DropdownMenuGroup>
+					<DropdownMenuLabel className="font-normal">
+						<div className="flex flex-col space-y-1">
+							<p className="text-sm font-medium leading-none">{user.displayName}</p>
+						</div>
+					</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
-				<DropdownMenuItem asChild>
-					<Link href="/users/me" className="flex items-center gap-2 cursor-pointer">
-						<User className="h-4 w-4" />
-						<span>マイページ</span>
-					</Link>
-				</DropdownMenuItem>
-				<DropdownMenuItem asChild>
-					<Link href="/favorites" className="flex items-center gap-2 cursor-pointer">
-						<Heart className="h-4 w-4" />
-						<span>お気に入り</span>
-					</Link>
-				</DropdownMenuItem>
+				<DropdownMenuItem
+					render={
+						<Link href="/users/me" className="flex items-center gap-2 cursor-pointer">
+							<User className="h-4 w-4" />
+							<span>マイページ</span>
+						</Link>
+					}
+				/>
+				<DropdownMenuItem
+					render={
+						<Link href="/favorites" className="flex items-center gap-2 cursor-pointer">
+							<Heart className="h-4 w-4" />
+							<span>お気に入り</span>
+						</Link>
+					}
+				/>
 				{/* 配信終了後も下書きの仕上げに戻れるよう常設する（動画カード側の導線は live/upcoming 時のみ） */}
-				<DropdownMenuItem asChild>
-					<Link href="/live" className="flex items-center gap-2 cursor-pointer">
-						<Bookmark className="h-4 w-4" />
-						<span>配信中マーキング</span>
-					</Link>
-				</DropdownMenuItem>
-				<DropdownMenuItem asChild>
-					<Link href="/settings" className="flex items-center gap-2 cursor-pointer">
-						<Settings className="h-4 w-4" />
-						<span>設定</span>
-					</Link>
-				</DropdownMenuItem>
+				<DropdownMenuItem
+					render={
+						<Link href="/live" className="flex items-center gap-2 cursor-pointer">
+							<Bookmark className="h-4 w-4" />
+							<span>配信中マーキング</span>
+						</Link>
+					}
+				/>
+				<DropdownMenuItem
+					render={
+						<Link href="/settings" className="flex items-center gap-2 cursor-pointer">
+							<Settings className="h-4 w-4" />
+							<span>設定</span>
+						</Link>
+					}
+				/>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem
 					// asChild を使わず DropdownMenuItem 自体を押下対象にする（選択でメニューは閉じる）。
-					onSelect={() => void handleSignOut()}
+					onClick={() => void handleSignOut()}
 					className="flex items-center gap-2 cursor-pointer"
 				>
 					<LogOut className="h-4 w-4" />

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -12,9 +12,9 @@
 
 - **Tailwind CSS v4**（`@theme` + CSS 変数駆動。`tailwind.config` は廃止）
 - **React 19 / Next.js 16**
-- **radix-ui 統合パッケージ**（個別 `@radix-ui/react-*` ではなく単一 `radix-ui` から import。new-york style）
+- **@base-ui/react**（shadcn/ui が 2026年7月に既定へ切替。旧 radix-ui 統合パッケージから移行済み）
 - **Storybook 10**（react-vite / a11y / vitest アドオン。a11y 違反は CI fail）
-- **shadcn/ui**（new-york / baseColor=stone）。保守方針は [ADR-011](../../docs/decisions/frontend/ADR-011-shadcn-ui-maintenance-policy.md)
+- **shadcn/ui**（base-vega / baseColor=stone。base-vega は旧 new-york 相当）。保守方針は [ADR-011](../../docs/decisions/frontend/ADR-011-shadcn-ui-maintenance-policy.md)
 
 ## 📦 パッケージ構成
 

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://ui.shadcn.com/schema.json",
-	"style": "new-york",
+	"style": "base-vega",
 	"rsc": true,
 	"tsx": true,
 	"tailwind": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,12 +21,12 @@
 		"chromatic": "chromatic --build-script-name=build-storybook --only-changed"
 	},
 	"dependencies": {
+		"@base-ui/react": "^1.6.0",
 		"@suzumina.click/shared-types": "workspace:*",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"embla-carousel-react": "8.6.0",
 		"lucide-react": "^1.25.0",
-		"radix-ui": "1.6.2",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.6.0",
 		"tw-animate-css": "^1.4.0"

--- a/packages/ui/src/components/custom/__tests__/configurable-list.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/configurable-list.test.tsx
@@ -556,12 +556,13 @@ describe("ConfigurableList", () => {
 		expect(screen.getByTestId("item-2")).toBeInTheDocument();
 
 		// ページサイズ変更を開始
+		const user = userEvent.setup();
 		const pageSizeSelect = screen.getByText("2件/ページ");
-		fireEvent.click(pageSizeSelect);
+		await user.click(pageSizeSelect);
 
 		// セレクトボックスが開くのを待つ
 		const option4 = await screen.findByText("4件/ページ");
-		fireEvent.click(option4);
+		await user.click(option4);
 
 		// データ取得中でも既存データが表示され続けることを確認
 		expect(screen.getByTestId("item-1")).toBeInTheDocument();

--- a/packages/ui/src/components/custom/audio-button.stories.tsx
+++ b/packages/ui/src/components/custom/audio-button.stories.tsx
@@ -126,7 +126,7 @@ export const AuthenticatedWithLikes: Story = {
 };
 
 // お気に入りピルは詳細 popover(ActionPillRow)内にあるため、まず「詳細を表示」を開いてから取得する。
-// radix popover は portal 描画なので within(canvasElement) では拾えず、screen(document.body) で探す。
+// popover は portal 描画なので within(canvasElement) では拾えず、screen(document.body) で探す。
 export const FavoriteToggleInteraction: Story = {
 	args: {
 		audioButton: mockAudioButton,

--- a/packages/ui/src/components/custom/audio-button.tsx
+++ b/packages/ui/src/components/custom/audio-button.tsx
@@ -156,15 +156,17 @@ export function AudioButton({
 					</button>
 
 					{/* 詳細表示ボタン - Popover専用エリア */}
-					<PopoverTrigger asChild>
-						<button
-							type="button"
-							className="relative z-10 flex min-h-[44px] min-w-[44px] flex-none items-center justify-center border-l border-minase-200 text-minase-600 transition-colors hover:bg-minase-100 hover:text-minase-700"
-							aria-label="詳細を表示"
-						>
-							<MoreHorizontal className="h-4 w-4" />
-						</button>
-					</PopoverTrigger>
+					<PopoverTrigger
+						render={
+							<button
+								type="button"
+								className="relative z-10 flex min-h-[44px] min-w-[44px] flex-none items-center justify-center border-l border-minase-200 text-minase-600 transition-colors hover:bg-minase-100 hover:text-minase-700"
+								aria-label="詳細を表示"
+							>
+								<MoreHorizontal className="h-4 w-4" />
+							</button>
+						}
+					/>
 				</div>
 
 				<PopoverContent

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-controls.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-controls.tsx
@@ -60,7 +60,15 @@ export function ConfigurableListControls({
 			<div className="flex items-center gap-3">
 				{/* ソート選択 */}
 				{sortOptions.length > 0 && (
-					<Select value={currentSort} onValueChange={onSortChange}>
+					<Select
+						items={sortOptions}
+						value={currentSort}
+						onValueChange={(value) => {
+							if (value !== null) {
+								onSortChange(value);
+							}
+						}}
+					>
 						<SelectTrigger className="h-8 w-[140px]" aria-label="並び順">
 							<SelectValue placeholder="並び順" />
 						</SelectTrigger>
@@ -78,7 +86,18 @@ export function ConfigurableListControls({
 				{itemsPerPageOptions &&
 					itemsPerPageOptions.length > 0 &&
 					(actualTotal > 0 || (initialTotal && initialTotal > 0)) && (
-						<Select value={currentItemsPerPage.toString()} onValueChange={onItemsPerPageChange}>
+						<Select
+							items={itemsPerPageOptions.map((option) => ({
+								value: option.toString(),
+								label: `${option}件/ページ`,
+							}))}
+							value={currentItemsPerPage.toString()}
+							onValueChange={(value) => {
+								if (value !== null) {
+									onItemsPerPageChange(value);
+								}
+							}}
+						>
 							<SelectTrigger className="h-8 w-[140px]" aria-label="表示件数">
 								<SelectValue />
 							</SelectTrigger>

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-filters.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-filters.tsx
@@ -30,7 +30,7 @@ function SelectFilter({
 }) {
 	const options = generateOptions(config);
 	return (
-		<Select value={value?.toString() || ""} onValueChange={onChange}>
+		<Select items={options} value={value?.toString() || ""} onValueChange={onChange}>
 			<SelectTrigger className="w-[180px]" aria-label={config.label || "絞り込み"}>
 				<SelectValue placeholder={config.placeholder || `${config.label}を選択`} />
 			</SelectTrigger>
@@ -256,39 +256,41 @@ function TagsFilter({
 
 	return (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button variant="outline" size="sm" className="h-9 border-dashed" disabled={!hasOptions}>
-					{config.label || keyName}
-					{selectedValues.length > 0 && (
-						<>
-							<div className="mx-1 h-4 w-[1px] bg-border" />
-							<Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
-								{selectedValues.length}
-							</Badge>
-							<div className="hidden space-x-1 lg:flex">
-								{selectedValues.length > 2 ? (
-									<Badge variant="secondary" className="rounded-sm px-1 font-normal">
-										{selectedValues.length}件選択中
-									</Badge>
-								) : (
-									options
-										.filter((option) => selectedValues.includes(option.value))
-										.map((option) => (
-											<Badge
-												key={option.value}
-												variant="secondary"
-												className="rounded-sm px-1 font-normal"
-											>
-												{option.label}
-											</Badge>
-										))
-								)}
-							</div>
-						</>
-					)}
-					<ChevronDown className="ml-2 h-4 w-4" />
-				</Button>
-			</PopoverTrigger>
+			<PopoverTrigger
+				render={
+					<Button variant="outline" size="sm" className="h-9 border-dashed" disabled={!hasOptions}>
+						{config.label || keyName}
+						{selectedValues.length > 0 && (
+							<>
+								<div className="mx-1 h-4 w-[1px] bg-border" />
+								<Badge variant="secondary" className="rounded-sm px-1 font-normal lg:hidden">
+									{selectedValues.length}
+								</Badge>
+								<div className="hidden space-x-1 lg:flex">
+									{selectedValues.length > 2 ? (
+										<Badge variant="secondary" className="rounded-sm px-1 font-normal">
+											{selectedValues.length}件選択中
+										</Badge>
+									) : (
+										options
+											.filter((option) => selectedValues.includes(option.value))
+											.map((option) => (
+												<Badge
+													key={option.value}
+													variant="secondary"
+													className="rounded-sm px-1 font-normal"
+												>
+													{option.label}
+												</Badge>
+											))
+									)}
+								</div>
+							</>
+						)}
+						<ChevronDown className="ml-2 h-4 w-4" />
+					</Button>
+				}
+			/>
 			<PopoverContent className="w-[300px] p-0" align="start">
 				<div className="p-4">
 					<div className="mb-2 text-sm font-medium">{config.label || keyName}</div>

--- a/packages/ui/src/components/custom/three-layer-tag-display/category-display.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/category-display.tsx
@@ -66,9 +66,10 @@ export function CategoryDisplay({
 			</h4>
 			<div className={cn("flex flex-wrap", sizeClasses.layerContainer)}>
 				{tagHref ? (
-					<Badge asChild className={badgeClassName}>
-						<Link href={tagHref(categoryName, "category")}>{content}</Link>
-					</Badge>
+					<Badge
+						className={badgeClassName}
+						render={<Link href={tagHref(categoryName, "category")}>{content}</Link>}
+					/>
 				) : (
 					<Badge className={badgeClassName} onClick={onTagClick ? handleClick : undefined}>
 						{content}

--- a/packages/ui/src/components/custom/three-layer-tag-display/compact-tag-display.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/compact-tag-display.tsx
@@ -72,9 +72,10 @@ export function CompactTagDisplay({
 				return (
 					<li key={`${tag.type}-${tag.text}-${index}`}>
 						{tagHref ? (
-							<Badge asChild className={badgeClassName}>
-								<Link href={tagHref(tag.text, tag.type)}>{renderContent(tag.text)}</Link>
-							</Badge>
+							<Badge
+								className={badgeClassName}
+								render={<Link href={tagHref(tag.text, tag.type)}>{renderContent(tag.text)}</Link>}
+							/>
 						) : (
 							<Badge
 								className={badgeClassName}

--- a/packages/ui/src/components/custom/three-layer-tag-display/tag-layer.tsx
+++ b/packages/ui/src/components/custom/three-layer-tag-display/tag-layer.tsx
@@ -100,9 +100,11 @@ export function TagLayer({
 
 					if (tagHref) {
 						return (
-							<Badge key={`${tag}-${index}`} asChild className={itemClassName}>
-								<Link href={tagHref(tag, layer)}>{renderContent(tag)}</Link>
-							</Badge>
+							<Badge
+								key={`${tag}-${index}`}
+								className={itemClassName}
+								render={<Link href={tagHref(tag, layer)}>{renderContent(tag)}</Link>}
+							/>
 						);
 					}
 

--- a/packages/ui/src/components/ui/__tests__/dialog.test.tsx
+++ b/packages/ui/src/components/ui/__tests__/dialog.test.tsx
@@ -130,12 +130,12 @@ describe("Dialog - Custom Props", () => {
 			const content = screen.getByTestId("content");
 
 			// Check animation classes
-			expect(content).toHaveClass("data-[state=open]:animate-in");
-			expect(content).toHaveClass("data-[state=closed]:animate-out");
-			expect(content).toHaveClass("data-[state=closed]:fade-out-0");
-			expect(content).toHaveClass("data-[state=open]:fade-in-0");
-			expect(content).toHaveClass("data-[state=closed]:zoom-out-95");
-			expect(content).toHaveClass("data-[state=open]:zoom-in-95");
+			expect(content).toHaveClass("data-[open]:animate-in");
+			expect(content).toHaveClass("data-[closed]:animate-out");
+			expect(content).toHaveClass("data-[closed]:fade-out-0");
+			expect(content).toHaveClass("data-[open]:fade-in-0");
+			expect(content).toHaveClass("data-[closed]:zoom-out-95");
+			expect(content).toHaveClass("data-[open]:zoom-in-95");
 		});
 	});
 

--- a/packages/ui/src/components/ui/alert-dialog.stories.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.stories.tsx
@@ -29,9 +29,7 @@ type Story = StoryObj<typeof meta>;
 export const Basic: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">アラートを表示</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">アラートを表示</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>確認</AlertDialogTitle>
@@ -51,9 +49,7 @@ export const Basic: Story = {
 export const OpenInteraction: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">アラートを表示</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">アラートを表示</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>確認</AlertDialogTitle>
@@ -78,12 +74,14 @@ export const OpenInteraction: Story = {
 export const DeleteConfirmation: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="destructive">
-					<TrashIcon className="mr-2 h-4 w-4" />
-					削除
-				</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger
+				render={
+					<Button variant="destructive">
+						<TrashIcon className="mr-2 h-4 w-4" />
+						削除
+					</Button>
+				}
+			/>
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
@@ -107,9 +105,7 @@ export const DeleteConfirmation: Story = {
 export const LogoutConfirmation: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="ghost">ログアウト</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="ghost">ログアウト</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>ログアウト</AlertDialogTitle>
@@ -129,9 +125,7 @@ export const LogoutConfirmation: Story = {
 export const SaveChanges: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">ページを離れる</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">ページを離れる</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
@@ -155,9 +149,7 @@ export const SaveChanges: Story = {
 export const PublishContent: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button>記事を公開</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button>記事を公開</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
@@ -183,9 +175,7 @@ export const PublishContent: Story = {
 export const AccountDeletion: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="destructive">アカウント削除</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="destructive">アカウント削除</Button>} />
 			<AlertDialogContent className="max-w-md">
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2 text-destructive">
@@ -216,9 +206,7 @@ export const AccountDeletion: Story = {
 export const DataExport: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">データをエクスポート</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">データをエクスポート</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>データのエクスポート</AlertDialogTitle>
@@ -239,9 +227,7 @@ export const DataExport: Story = {
 export const ResetSettings: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">設定をリセット</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">設定をリセット</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>設定のリセット</AlertDialogTitle>
@@ -264,9 +250,7 @@ export const ResetSettings: Story = {
 export const CustomStyling: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">カスタムスタイル</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">カスタムスタイル</Button>} />
 			<AlertDialogContent className="border-blue-200 bg-gradient-to-br from-blue-50 to-purple-50">
 				<AlertDialogHeader>
 					<AlertDialogTitle className="text-blue-900">プレミアム機能</AlertDialogTitle>
@@ -291,9 +275,7 @@ export const CustomStyling: Story = {
 export const MultipleActions: Story = {
 	render: () => (
 		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button variant="outline">ファイル処理</Button>
-			</AlertDialogTrigger>
+			<AlertDialogTrigger render={<Button variant="outline">ファイル処理</Button>} />
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle>ファイルの処理方法</AlertDialogTitle>

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { AlertDialog as AlertDialogPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
@@ -22,12 +22,12 @@ function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialog
 function AlertDialogOverlay({
 	className,
 	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Backdrop>) {
 	return (
-		<AlertDialogPrimitive.Overlay
+		<AlertDialogPrimitive.Backdrop
 			data-slot="alert-dialog-overlay"
 			className={cn(
-				"fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				"fixed inset-0 z-50 bg-black/50 data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:animate-in data-[open]:fade-in-0",
 				className,
 			)}
 			{...props}
@@ -39,17 +39,17 @@ function AlertDialogContent({
 	className,
 	size = "default",
 	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Popup> & {
 	size?: "default" | "sm";
 }) {
 	return (
 		<AlertDialogPortal>
 			<AlertDialogOverlay />
-			<AlertDialogPrimitive.Content
+			<AlertDialogPrimitive.Popup
 				data-slot="alert-dialog-content"
 				data-size={size}
 				className={cn(
-					"group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+					"group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
 					className,
 				)}
 				{...props}
@@ -126,22 +126,8 @@ function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) 
 	);
 }
 
-function AlertDialogAction({
-	className,
-	variant = "default",
-	size = "default",
-	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
-	Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
-	return (
-		<Button variant={variant} size={size} asChild>
-			<AlertDialogPrimitive.Action
-				data-slot="alert-dialog-action"
-				className={cn(className)}
-				{...props}
-			/>
-		</Button>
-	);
+function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
+	return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
 }
 
 function AlertDialogCancel({
@@ -149,16 +135,15 @@ function AlertDialogCancel({
 	variant = "outline",
 	size = "default",
 	...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+}: React.ComponentProps<typeof AlertDialogPrimitive.Close> &
 	Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
 	return (
-		<Button variant={variant} size={size} asChild>
-			<AlertDialogPrimitive.Cancel
-				data-slot="alert-dialog-cancel"
-				className={cn(className)}
-				{...props}
-			/>
-		</Button>
+		<AlertDialogPrimitive.Close
+			data-slot="alert-dialog-cancel"
+			className={cn(className)}
+			render={<Button variant={variant} size={size} />}
+			{...props}
+		/>
 	);
 }
 

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -1,7 +1,6 @@
+import { useRender } from "@base-ui/react/use-render";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
-import { Slot } from "radix-ui";
-import type * as React from "react";
 
 const badgeVariants = cva(
 	"inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
@@ -27,19 +26,19 @@ const badgeVariants = cva(
 function Badge({
 	className,
 	variant = "default",
-	asChild = false,
+	render,
 	...props
-}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-	const Comp = asChild ? Slot.Root : "span";
-
-	return (
-		<Comp
-			data-slot="badge"
-			data-variant={variant}
-			className={cn(badgeVariants({ variant }), className)}
-			{...props}
-		/>
-	);
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+	return useRender({
+		defaultTagName: "span",
+		render,
+		props: {
+			"data-slot": "badge",
+			"data-variant": variant,
+			className: cn(badgeVariants({ variant }), className),
+			...props,
+		},
+	});
 }
 
 export { Badge, badgeVariants };

--- a/packages/ui/src/components/ui/button.stories.tsx
+++ b/packages/ui/src/components/ui/button.stories.tsx
@@ -19,9 +19,6 @@ const meta = {
 			control: { type: "select" },
 			options: ["default", "sm", "lg", "icon"],
 		},
-		asChild: {
-			control: { type: "boolean" },
-		},
 		disabled: {
 			control: { type: "boolean" },
 		},

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,7 +1,6 @@
+import { useRender } from "@base-ui/react/use-render";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
-import { Slot as SlotPrimitive } from "radix-ui";
-import type * as React from "react";
 
 const buttonVariants = cva(
 	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 dark:disabled:opacity-30 dark:disabled:bg-muted/50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -42,21 +41,18 @@ function Button({
 	className,
 	variant,
 	size,
-	asChild = false,
+	render,
 	...props
-}: React.ComponentProps<"button"> &
-	VariantProps<typeof buttonVariants> & {
-		asChild?: boolean;
-	}) {
-	const Comp = asChild ? SlotPrimitive.Slot : "button";
-
-	return (
-		<Comp
-			data-slot="button"
-			className={cn(buttonVariants({ variant, size, className }))}
-			{...props}
-		/>
-	);
+}: useRender.ComponentProps<"button"> & VariantProps<typeof buttonVariants>) {
+	return useRender({
+		defaultTagName: "button",
+		render,
+		props: {
+			"data-slot": "button",
+			className: cn(buttonVariants({ variant, size, className })),
+			...props,
+		},
+	});
 }
 
 export { Button, buttonVariants };

--- a/packages/ui/src/components/ui/checkbox.stories.tsx
+++ b/packages/ui/src/components/ui/checkbox.stories.tsx
@@ -18,8 +18,10 @@ const meta = {
 			control: { type: "boolean" },
 		},
 		checked: {
-			control: { type: "select" },
-			options: [true, false, "indeterminate"],
+			control: { type: "boolean" },
+		},
+		indeterminate: {
+			control: { type: "boolean" },
 		},
 	},
 } satisfies Meta<typeof Checkbox>;
@@ -39,7 +41,7 @@ export const Checked: Story = {
 
 export const Indeterminate: Story = {
 	args: {
-		checked: "indeterminate",
+		indeterminate: true,
 	},
 };
 
@@ -82,6 +84,6 @@ export const ToggleInteraction: Story = {
 		const checkbox = canvas.getByRole("checkbox");
 		await expect(checkbox).not.toBeChecked();
 		await userEvent.click(checkbox);
-		await expect(args.onCheckedChange).toHaveBeenCalledWith(true);
+		await expect(args.onCheckedChange).toHaveBeenCalledWith(true, expect.anything());
 	},
 };

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { CheckIcon } from "lucide-react";
-import { Checkbox as CheckboxPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
@@ -10,7 +10,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
 		<CheckboxPrimitive.Root
 			data-slot="checkbox"
 			className={cn(
-				"peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+				"peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[checked]:bg-primary",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/ui/collapsible.stories.tsx
+++ b/packages/ui/src/components/ui/collapsible.stories.tsx
@@ -361,7 +361,8 @@ export const AnimationExample: Story = {
 							</Button>
 						}
 					/>
-					<CollapsibleContent className="overflow-hidden data-[closed]:animate-collapsible-up data-[open]:animate-collapsible-down">
+					{/* Base UI は --collapsible-panel-height を提供する（tw-animate-css の collapsible keyframes は radix 変数前提のため不使用） */}
+					<CollapsibleContent className="overflow-hidden h-(--collapsible-panel-height) transition-[height] duration-200 data-[starting-style]:h-0 data-[ending-style]:h-0">
 						<div className="mt-2 p-4 border rounded-lg bg-gradient-to-br from-blue-50 to-purple-50">
 							<h4 className="font-medium mb-2">アニメーション</h4>
 							<p className="text-sm text-muted-foreground">

--- a/packages/ui/src/components/ui/collapsible.stories.tsx
+++ b/packages/ui/src/components/ui/collapsible.stories.tsx
@@ -23,14 +23,16 @@ export const Basic: Story = {
 		return (
 			<div className="w-[350px]">
 				<Collapsible open={isOpen} onOpenChange={setIsOpen}>
-					<CollapsibleTrigger asChild>
-						<Button variant="outline" className="w-full justify-between">
-							詳細を表示
-							<ChevronDownIcon
-								className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
-							/>
-						</Button>
-					</CollapsibleTrigger>
+					<CollapsibleTrigger
+						render={
+							<Button variant="outline" className="w-full justify-between">
+								詳細を表示
+								<ChevronDownIcon
+									className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+								/>
+							</Button>
+						}
+					/>
 					<CollapsibleContent className="mt-2 p-4 border rounded-lg bg-muted/30">
 						<p className="text-sm">
 							これは折りたたみ可能なコンテンツです。ボタンをクリックすることで表示・非表示を切り替えることができます。
@@ -81,16 +83,18 @@ export const FAQ: Story = {
 						open={openItems.includes(item.id)}
 						onOpenChange={() => toggleItem(item.id)}
 					>
-						<CollapsibleTrigger asChild>
-							<Button variant="outline" className="w-full justify-between p-4 h-auto text-left">
-								<span className="font-medium">{item.question}</span>
-								<ChevronDownIcon
-									className={`h-4 w-4 transition-transform flex-shrink-0 ml-2 ${
-										openItems.includes(item.id) ? "rotate-180" : ""
-									}`}
-								/>
-							</Button>
-						</CollapsibleTrigger>
+						<CollapsibleTrigger
+							render={
+								<Button variant="outline" className="w-full justify-between p-4 h-auto text-left">
+									<span className="font-medium">{item.question}</span>
+									<ChevronDownIcon
+										className={`h-4 w-4 transition-transform flex-shrink-0 ml-2 ${
+											openItems.includes(item.id) ? "rotate-180" : ""
+										}`}
+									/>
+								</Button>
+							}
+						/>
 						<CollapsibleContent className="px-4 pb-4 pt-2">
 							<p className="text-sm text-muted-foreground">{item.answer}</p>
 						</CollapsibleContent>
@@ -319,14 +323,16 @@ export const ControlledExample: Story = {
 				</div>
 
 				<Collapsible open={isOpen} onOpenChange={setIsOpen}>
-					<CollapsibleTrigger asChild>
-						<Button variant="outline" className="w-full justify-between">
-							制御されたコラプシブル
-							<ChevronDownIcon
-								className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
-							/>
-						</Button>
-					</CollapsibleTrigger>
+					<CollapsibleTrigger
+						render={
+							<Button variant="outline" className="w-full justify-between">
+								制御されたコラプシブル
+								<ChevronDownIcon
+									className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+								/>
+							</Button>
+						}
+					/>
 					<CollapsibleContent className="mt-2 p-4 border rounded-lg">
 						<p className="text-sm">このコラプシブルは外部のボタンからも制御できます。</p>
 					</CollapsibleContent>
@@ -343,17 +349,19 @@ export const AnimationExample: Story = {
 		return (
 			<div className="w-[350px]">
 				<Collapsible open={isOpen} onOpenChange={setIsOpen}>
-					<CollapsibleTrigger asChild>
-						<Button variant="outline" className="w-full justify-between">
-							アニメーション付き
-							<ChevronDownIcon
-								className={`h-4 w-4 transition-transform duration-200 ${
-									isOpen ? "rotate-180" : ""
-								}`}
-							/>
-						</Button>
-					</CollapsibleTrigger>
-					<CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
+					<CollapsibleTrigger
+						render={
+							<Button variant="outline" className="w-full justify-between">
+								アニメーション付き
+								<ChevronDownIcon
+									className={`h-4 w-4 transition-transform duration-200 ${
+										isOpen ? "rotate-180" : ""
+									}`}
+								/>
+							</Button>
+						}
+					/>
+					<CollapsibleContent className="overflow-hidden data-[closed]:animate-collapsible-up data-[open]:animate-collapsible-down">
 						<div className="mt-2 p-4 border rounded-lg bg-gradient-to-br from-blue-50 to-purple-50">
 							<h4 className="font-medium mb-2">アニメーション</h4>
 							<p className="text-sm text-muted-foreground">

--- a/packages/ui/src/components/ui/collapsible.tsx
+++ b/packages/ui/src/components/ui/collapsible.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Collapsible as CollapsiblePrimitive } from "radix-ui";
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible";
 
 function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
 	return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
@@ -8,14 +8,12 @@ function Collapsible({ ...props }: React.ComponentProps<typeof CollapsiblePrimit
 
 function CollapsibleTrigger({
 	...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
-	return <CollapsiblePrimitive.CollapsibleTrigger data-slot="collapsible-trigger" {...props} />;
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+	return <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />;
 }
 
-function CollapsibleContent({
-	...props
-}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
-	return <CollapsiblePrimitive.CollapsibleContent data-slot="collapsible-content" {...props} />;
+function CollapsibleContent({ ...props }: React.ComponentProps<typeof CollapsiblePrimitive.Panel>) {
+	return <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />;
 }
 
 export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/packages/ui/src/components/ui/dialog.stories.tsx
+++ b/packages/ui/src/components/ui/dialog.stories.tsx
@@ -32,9 +32,7 @@ export const Default: Story = {
 		const usernameId = React.useId();
 		return (
 			<Dialog>
-				<DialogTrigger asChild>
-					<Button variant="outline">Open Dialog</Button>
-				</DialogTrigger>
+				<DialogTrigger render={<Button variant="outline">Open Dialog</Button>} />
 				<DialogContent className="sm:max-w-[425px]">
 					<DialogHeader>
 						<DialogTitle>Edit profile</DialogTitle>
@@ -68,9 +66,7 @@ export const Default: Story = {
 export const Simple: Story = {
 	render: () => (
 		<Dialog>
-			<DialogTrigger asChild>
-				<Button>Simple Dialog</Button>
-			</DialogTrigger>
+			<DialogTrigger render={<Button>Simple Dialog</Button>} />
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>Simple Dialog</DialogTitle>
@@ -84,9 +80,7 @@ export const Simple: Story = {
 export const Opens: Story = {
 	render: () => (
 		<Dialog>
-			<DialogTrigger asChild>
-				<Button>Open Dialog</Button>
-			</DialogTrigger>
+			<DialogTrigger render={<Button>Open Dialog</Button>} />
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>Dialog Opened</DialogTitle>

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { XIcon } from "lucide-react";
-import { Dialog as DialogPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
@@ -25,12 +25,12 @@ function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.C
 function DialogOverlay({
 	className,
 	...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+}: React.ComponentProps<typeof DialogPrimitive.Backdrop>) {
 	return (
-		<DialogPrimitive.Overlay
+		<DialogPrimitive.Backdrop
 			data-slot="dialog-overlay"
 			className={cn(
-				"fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				"fixed inset-0 z-50 bg-black/50 data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:animate-in data-[open]:fade-in-0",
 				className,
 			)}
 			{...props}
@@ -43,16 +43,16 @@ function DialogContent({
 	children,
 	showCloseButton = true,
 	...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+}: React.ComponentProps<typeof DialogPrimitive.Popup> & {
 	showCloseButton?: boolean;
 }) {
 	return (
 		<DialogPortal data-slot="dialog-portal">
 			<DialogOverlay />
-			<DialogPrimitive.Content
+			<DialogPrimitive.Popup
 				data-slot="dialog-content"
 				className={cn(
-					"fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+					"fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95 sm:max-w-lg",
 					className,
 				)}
 				{...props}
@@ -61,13 +61,13 @@ function DialogContent({
 				{showCloseButton && (
 					<DialogPrimitive.Close
 						data-slot="dialog-close"
-						className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+						className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 					>
 						<XIcon />
 						<span className="sr-only">Close</span>
 					</DialogPrimitive.Close>
 				)}
-			</DialogPrimitive.Content>
+			</DialogPrimitive.Popup>
 		</DialogPortal>
 	);
 }
@@ -98,9 +98,7 @@ function DialogFooter({
 		>
 			{children}
 			{showCloseButton && (
-				<DialogPrimitive.Close asChild>
-					<Button variant="outline">Close</Button>
-				</DialogPrimitive.Close>
+				<DialogPrimitive.Close render={<Button variant="outline">Close</Button>} />
 			)}
 		</div>
 	);

--- a/packages/ui/src/components/ui/dropdown-menu.stories.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.stories.tsx
@@ -53,11 +53,11 @@ type Story = StoryObj<typeof DropdownMenu>;
 export const Default: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline">メニューを開く</Button>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger render={<Button variant="outline">メニューを開く</Button>} />
 			<DropdownMenuContent className="w-56">
-				<DropdownMenuLabel>アカウント</DropdownMenuLabel>
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>アカウント</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem>
 					<User className="mr-2 h-4 w-4" />
@@ -80,11 +80,11 @@ export const Default: Story = {
 export const WithShortcuts: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline">ショートカット付きメニュー</Button>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger render={<Button variant="outline">ショートカット付きメニュー</Button>} />
 			<DropdownMenuContent className="w-56">
-				<DropdownMenuLabel>アクション</DropdownMenuLabel>
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>アクション</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem>
 					<Plus className="mr-2 h-4 w-4" />
@@ -115,11 +115,11 @@ export const WithShortcuts: Story = {
 export const WithCheckboxes: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline">表示設定</Button>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger render={<Button variant="outline">表示設定</Button>} />
 			<DropdownMenuContent className="w-56">
-				<DropdownMenuLabel>表示オプション</DropdownMenuLabel>
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>表示オプション</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuCheckboxItem checked>サイドバーを表示</DropdownMenuCheckboxItem>
 				<DropdownMenuCheckboxItem checked={false}>ツールバーを表示</DropdownMenuCheckboxItem>
@@ -134,11 +134,11 @@ export const WithCheckboxes: Story = {
 export const WithRadioGroup: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline">テーマ設定</Button>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger render={<Button variant="outline">テーマ設定</Button>} />
 			<DropdownMenuContent className="w-56">
-				<DropdownMenuLabel>テーマ</DropdownMenuLabel>
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>テーマ</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuRadioGroup value="light">
 					<DropdownMenuRadioItem value="light">ライトテーマ</DropdownMenuRadioItem>
@@ -153,11 +153,11 @@ export const WithRadioGroup: Story = {
 export const WithSubmenus: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline">サブメニュー付き</Button>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger render={<Button variant="outline">サブメニュー付き</Button>} />
 			<DropdownMenuContent className="w-56">
-				<DropdownMenuLabel>マイアカウント</DropdownMenuLabel>
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>マイアカウント</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuGroup>
 					<DropdownMenuItem>
@@ -223,20 +223,24 @@ export const WithSubmenus: Story = {
 export const UserMenu: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="ghost" className="relative h-8 w-8 rounded-full">
-					<div className="h-8 w-8 rounded-full bg-suzuka-500 flex items-center justify-center text-white text-sm font-medium">
-						U
-					</div>
-				</Button>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent className="w-56" align="end" forceMount>
-				<DropdownMenuLabel className="font-normal">
-					<div className="flex flex-col space-y-1">
-						<p className="text-sm font-medium leading-none">ユーザー名</p>
-						<p className="text-xs leading-none text-muted-foreground">user@example.com</p>
-					</div>
-				</DropdownMenuLabel>
+			<DropdownMenuTrigger
+				render={
+					<Button variant="ghost" className="relative h-8 w-8 rounded-full">
+						<div className="h-8 w-8 rounded-full bg-suzuka-500 flex items-center justify-center text-white text-sm font-medium">
+							U
+						</div>
+					</Button>
+				}
+			/>
+			<DropdownMenuContent className="w-56" align="end">
+				<DropdownMenuGroup>
+					<DropdownMenuLabel className="font-normal">
+						<div className="flex flex-col space-y-1">
+							<p className="text-sm font-medium leading-none">ユーザー名</p>
+							<p className="text-xs leading-none text-muted-foreground">user@example.com</p>
+						</div>
+					</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuGroup>
 					<DropdownMenuItem>
@@ -271,11 +275,13 @@ export const ContextMenu: Story = {
 		<div className="flex flex-col items-center space-y-4">
 			<p className="text-sm text-muted-foreground">音声ボタンのコンテキストメニュー例</p>
 			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button variant="outline" size="icon" aria-label="操作メニュー">
-						<MoreHorizontal className="h-4 w-4" />
-					</Button>
-				</DropdownMenuTrigger>
+				<DropdownMenuTrigger
+					render={
+						<Button variant="outline" size="icon" aria-label="操作メニュー">
+							<MoreHorizontal className="h-4 w-4" />
+						</Button>
+					}
+				/>
 				<DropdownMenuContent align="end">
 					<DropdownMenuItem>
 						<span>再生</span>
@@ -302,17 +308,21 @@ export const ContextMenu: Story = {
 export const StatusMenu: Story = {
 	render: () => (
 		<DropdownMenu>
-			<DropdownMenuTrigger asChild>
-				<Button variant="outline">
-					<div className="flex items-center space-x-2">
-						<div className="w-2 h-2 bg-green-500 rounded-full" />
-						<span>オンライン</span>
-						<ChevronRight className="h-4 w-4 rotate-90" />
-					</div>
-				</Button>
-			</DropdownMenuTrigger>
+			<DropdownMenuTrigger
+				render={
+					<Button variant="outline">
+						<div className="flex items-center space-x-2">
+							<div className="w-2 h-2 bg-green-500 rounded-full" />
+							<span>オンライン</span>
+							<ChevronRight className="h-4 w-4 rotate-90" />
+						</div>
+					</Button>
+				}
+			/>
 			<DropdownMenuContent className="w-56">
-				<DropdownMenuLabel>ステータス</DropdownMenuLabel>
+				<DropdownMenuGroup>
+					<DropdownMenuLabel>ステータス</DropdownMenuLabel>
+				</DropdownMenuGroup>
 				<DropdownMenuSeparator />
 				<DropdownMenuRadioGroup value="online">
 					<DropdownMenuRadioItem value="online">

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Menu as DropdownMenuPrimitive } from "@base-ui/react/menu";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
-import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -23,20 +23,34 @@ function DropdownMenuTrigger({
 
 function DropdownMenuContent({
 	className,
+	align = "start",
+	alignOffset = 0,
+	side = "bottom",
 	sideOffset = 4,
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Popup> &
+	Pick<
+		React.ComponentProps<typeof DropdownMenuPrimitive.Positioner>,
+		"align" | "alignOffset" | "side" | "sideOffset"
+	>) {
 	return (
 		<DropdownMenuPrimitive.Portal>
-			<DropdownMenuPrimitive.Content
-				data-slot="dropdown-menu-content"
+			<DropdownMenuPrimitive.Positioner
+				className="isolate z-50 outline-none"
+				align={align}
+				alignOffset={alignOffset}
+				side={side}
 				sideOffset={sideOffset}
-				className={cn(
-					"z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-					className,
-				)}
-				{...props}
-			/>
+			>
+				<DropdownMenuPrimitive.Popup
+					data-slot="dropdown-menu-content"
+					className={cn(
+						"z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95",
+						className,
+					)}
+					{...props}
+				/>
+			</DropdownMenuPrimitive.Positioner>
 		</DropdownMenuPrimitive.Portal>
 	);
 }
@@ -60,7 +74,7 @@ function DropdownMenuItem({
 			data-inset={inset}
 			data-variant={variant}
 			className={cn(
-				"relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+				"relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:data-highlighted:bg-destructive/10 data-[variant=destructive]:data-highlighted:text-destructive dark:data-[variant=destructive]:data-highlighted:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
 				className,
 			)}
 			{...props}
@@ -78,16 +92,16 @@ function DropdownMenuCheckboxItem({
 		<DropdownMenuPrimitive.CheckboxItem
 			data-slot="dropdown-menu-checkbox-item"
 			className={cn(
-				"relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			checked={checked}
 			{...props}
 		>
 			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<DropdownMenuPrimitive.ItemIndicator>
+				<DropdownMenuPrimitive.CheckboxItemIndicator>
 					<CheckIcon className="size-4" />
-				</DropdownMenuPrimitive.ItemIndicator>
+				</DropdownMenuPrimitive.CheckboxItemIndicator>
 			</span>
 			{children}
 		</DropdownMenuPrimitive.CheckboxItem>
@@ -109,15 +123,15 @@ function DropdownMenuRadioItem({
 		<DropdownMenuPrimitive.RadioItem
 			data-slot="dropdown-menu-radio-item"
 			className={cn(
-				"relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
 		>
 			<span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
-				<DropdownMenuPrimitive.ItemIndicator>
+				<DropdownMenuPrimitive.RadioItemIndicator>
 					<CircleIcon className="size-2 fill-current" />
-				</DropdownMenuPrimitive.ItemIndicator>
+				</DropdownMenuPrimitive.RadioItemIndicator>
 			</span>
 			{children}
 		</DropdownMenuPrimitive.RadioItem>
@@ -128,11 +142,11 @@ function DropdownMenuLabel({
 	className,
 	inset,
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.GroupLabel> & {
 	inset?: boolean;
 }) {
 	return (
-		<DropdownMenuPrimitive.Label
+		<DropdownMenuPrimitive.GroupLabel
 			data-slot="dropdown-menu-label"
 			data-inset={inset}
 			className={cn("px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
@@ -164,8 +178,10 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"spa
 	);
 }
 
-function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
-	return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+function DropdownMenuSub({
+	...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubmenuRoot>) {
+	return <DropdownMenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -173,36 +189,41 @@ function DropdownMenuSubTrigger({
 	inset,
 	children,
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubmenuTrigger> & {
 	inset?: boolean;
 }) {
 	return (
-		<DropdownMenuPrimitive.SubTrigger
+		<DropdownMenuPrimitive.SubmenuTrigger
 			data-slot="dropdown-menu-sub-trigger"
 			data-inset={inset}
 			className={cn(
-				"flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+				"flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[inset]:pl-8 data-popup-open:bg-accent data-popup-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
 				className,
 			)}
 			{...props}
 		>
 			{children}
 			<ChevronRightIcon className="ml-auto size-4" />
-		</DropdownMenuPrimitive.SubTrigger>
+		</DropdownMenuPrimitive.SubmenuTrigger>
 	);
 }
 
 function DropdownMenuSubContent({
 	className,
+	align = "start",
+	alignOffset = -3,
+	side = "right",
+	sideOffset = 0,
 	...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+}: React.ComponentProps<typeof DropdownMenuContent>) {
 	return (
-		<DropdownMenuPrimitive.SubContent
+		<DropdownMenuContent
 			data-slot="dropdown-menu-sub-content"
-			className={cn(
-				"z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-				className,
-			)}
+			className={cn("w-auto", className)}
+			align={align}
+			alignOffset={alignOffset}
+			side={side}
+			sideOffset={sideOffset}
 			{...props}
 		/>
 	);

--- a/packages/ui/src/components/ui/label.tsx
+++ b/packages/ui/src/components/ui/label.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Label as LabelPrimitive } from "radix-ui";
 import type * as React from "react";
 
-function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+function Label({ className, ...props }: React.ComponentProps<"label">) {
 	return (
-		<LabelPrimitive.Root
+		// biome-ignore lint/a11y/noLabelWithoutControl: 汎用ラッパー。htmlFor/子要素は呼び出し側が props 経由で渡す
+		<label
 			data-slot="label"
 			className={cn(
 				"flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",

--- a/packages/ui/src/components/ui/navigation-menu.stories.tsx
+++ b/packages/ui/src/components/ui/navigation-menu.stories.tsx
@@ -35,53 +35,61 @@ export const Default: Story = {
 					<NavigationMenuContent>
 						<div className="grid gap-3 p-4 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
 							<div className="row-span-3">
-								<NavigationMenuLink asChild>
-									<a
-										className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-suzuka-500/20 to-suzuka-600/20 p-6 no-underline outline-none focus:shadow-md"
-										href="#"
-									>
-										<PlayCircle className="h-6 w-6" />
-										<div className="mb-2 mt-4 text-lg font-medium">suzumina.click</div>
-										<p className="text-sm leading-tight text-muted-foreground">
-											涼花みなせの音声ボタンと動画を楽しめるファンサイト
-										</p>
-									</a>
-								</NavigationMenuLink>
+								<NavigationMenuLink
+									render={
+										<a
+											className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-suzuka-500/20 to-suzuka-600/20 p-6 no-underline outline-none focus:shadow-md"
+											href="#"
+										>
+											<PlayCircle className="h-6 w-6" />
+											<div className="mb-2 mt-4 text-lg font-medium">suzumina.click</div>
+											<p className="text-sm leading-tight text-muted-foreground">
+												涼花みなせの音声ボタンと動画を楽しめるファンサイト
+											</p>
+										</a>
+									}
+								/>
 							</div>
 							<div className="grid gap-1">
-								<NavigationMenuLink asChild>
-									<a
-										href="#"
-										className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-									>
-										<div className="text-sm font-medium leading-none">音声ボタン</div>
-										<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-											涼花みなせの音声を楽しめるボタン集
-										</p>
-									</a>
-								</NavigationMenuLink>
-								<NavigationMenuLink asChild>
-									<a
-										href="#"
-										className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-									>
-										<div className="text-sm font-medium leading-none">動画一覧</div>
-										<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-											YouTube動画の一覧とお気に入り管理
-										</p>
-									</a>
-								</NavigationMenuLink>
-								<NavigationMenuLink asChild>
-									<a
-										href="#"
-										className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-									>
-										<div className="text-sm font-medium leading-none">作品一覧</div>
-										<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-											DLsite作品の情報と購入リンク
-										</p>
-									</a>
-								</NavigationMenuLink>
+								<NavigationMenuLink
+									render={
+										<a
+											href="#"
+											className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+										>
+											<div className="text-sm font-medium leading-none">音声ボタン</div>
+											<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+												涼花みなせの音声を楽しめるボタン集
+											</p>
+										</a>
+									}
+								/>
+								<NavigationMenuLink
+									render={
+										<a
+											href="#"
+											className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+										>
+											<div className="text-sm font-medium leading-none">動画一覧</div>
+											<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+												YouTube動画の一覧とお気に入り管理
+											</p>
+										</a>
+									}
+								/>
+								<NavigationMenuLink
+									render={
+										<a
+											href="#"
+											className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+										>
+											<div className="text-sm font-medium leading-none">作品一覧</div>
+											<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+												DLsite作品の情報と購入リンク
+											</p>
+										</a>
+									}
+								/>
 							</div>
 						</div>
 					</NavigationMenuContent>
@@ -90,30 +98,34 @@ export const Default: Story = {
 					<NavigationMenuTrigger>コミュニティ</NavigationMenuTrigger>
 					<NavigationMenuContent>
 						<div className="grid w-[400px] gap-3 p-4 md:grid-cols-2">
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<Users className="h-4 w-4 mb-2" />
-									<div className="text-sm font-medium leading-none">Discord</div>
-									<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-										ファンコミュニティに参加
-									</p>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<ExternalLink className="h-4 w-4 mb-2" />
-									<div className="text-sm font-medium leading-none">公式サイト</div>
-									<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-										涼花みなせ公式ホームページ
-									</p>
-								</a>
-							</NavigationMenuLink>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<Users className="h-4 w-4 mb-2" />
+										<div className="text-sm font-medium leading-none">Discord</div>
+										<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+											ファンコミュニティに参加
+										</p>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<ExternalLink className="h-4 w-4 mb-2" />
+										<div className="text-sm font-medium leading-none">公式サイト</div>
+										<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+											涼花みなせ公式ホームページ
+										</p>
+									</a>
+								}
+							/>
 						</div>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
@@ -138,30 +150,36 @@ export const SimpleMenu: Story = {
 					<NavigationMenuTrigger>メニュー</NavigationMenuTrigger>
 					<NavigationMenuContent>
 						<div className="grid gap-1 p-2 w-[300px]">
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">項目1</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">項目2</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">項目3</div>
-								</a>
-							</NavigationMenuLink>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">項目1</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">項目2</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">項目3</div>
+									</a>
+								}
+							/>
 						</div>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
@@ -178,33 +196,39 @@ export const WithIcons: Story = {
 					<NavigationMenuTrigger>メディア</NavigationMenuTrigger>
 					<NavigationMenuContent>
 						<div className="grid gap-1 p-2 w-[250px]">
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="flex items-center select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<Video className="mr-3 h-4 w-4" />
-									<div className="text-sm font-medium">動画</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="flex items-center select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<Music className="mr-3 h-4 w-4" />
-									<div className="text-sm font-medium">音楽</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="flex items-center select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<PlayCircle className="mr-3 h-4 w-4" />
-									<div className="text-sm font-medium">プレイリスト</div>
-								</a>
-							</NavigationMenuLink>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="flex items-center select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<Video className="mr-3 h-4 w-4" />
+										<div className="text-sm font-medium">動画</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="flex items-center select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<Music className="mr-3 h-4 w-4" />
+										<div className="text-sm font-medium">音楽</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="flex items-center select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<PlayCircle className="mr-3 h-4 w-4" />
+										<div className="text-sm font-medium">プレイリスト</div>
+									</a>
+								}
+							/>
 						</div>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
@@ -221,22 +245,26 @@ export const MultipleMenus: Story = {
 					<NavigationMenuTrigger>音声</NavigationMenuTrigger>
 					<NavigationMenuContent>
 						<div className="grid gap-1 p-2 w-[200px]">
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">音声ボタン</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">音声参照</div>
-								</a>
-							</NavigationMenuLink>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">音声ボタン</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">音声参照</div>
+									</a>
+								}
+							/>
 						</div>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
@@ -244,30 +272,36 @@ export const MultipleMenus: Story = {
 					<NavigationMenuTrigger>動画</NavigationMenuTrigger>
 					<NavigationMenuContent>
 						<div className="grid gap-1 p-2 w-[200px]">
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">最新動画</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">人気動画</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">プレイリスト</div>
-								</a>
-							</NavigationMenuLink>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">最新動画</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">人気動画</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">プレイリスト</div>
+									</a>
+								}
+							/>
 						</div>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
@@ -285,30 +319,34 @@ export const MultipleMenus: Story = {
 	),
 };
 
-export const WithoutViewport: Story = {
+export const SingleColumnMenu: Story = {
 	render: () => (
-		<NavigationMenu viewport={false}>
+		<NavigationMenu>
 			<NavigationMenuList>
 				<NavigationMenuItem>
 					<NavigationMenuTrigger>シンプルメニュー</NavigationMenuTrigger>
 					<NavigationMenuContent>
 						<div className="grid gap-1 p-2 w-[200px]">
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">項目1</div>
-								</a>
-							</NavigationMenuLink>
-							<NavigationMenuLink asChild>
-								<a
-									href="#"
-									className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-								>
-									<div className="text-sm font-medium">項目2</div>
-								</a>
-							</NavigationMenuLink>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">項目1</div>
+									</a>
+								}
+							/>
+							<NavigationMenuLink
+								render={
+									<a
+										href="#"
+										className="block select-none rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+									>
+										<div className="text-sm font-medium">項目2</div>
+									</a>
+								}
+							/>
 						</div>
 					</NavigationMenuContent>
 				</NavigationMenuItem>
@@ -333,53 +371,61 @@ export const RealWorldExample: Story = {
 								<NavigationMenuContent>
 									<div className="grid gap-3 p-6 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
 										<div className="row-span-3">
-											<NavigationMenuLink asChild>
-												<a
-													className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-suzuka-500/20 to-suzuka-600/20 p-6 no-underline outline-none focus:shadow-md"
-													href="#"
-												>
-													<PlayCircle className="h-6 w-6" />
-													<div className="mb-2 mt-4 text-lg font-medium">音声ボタン</div>
-													<p className="text-sm leading-tight text-muted-foreground">
-														涼花みなせの様々な音声を楽しめる
-													</p>
-												</a>
-											</NavigationMenuLink>
+											<NavigationMenuLink
+												render={
+													<a
+														className="flex h-full w-full select-none flex-col justify-end rounded-md bg-gradient-to-b from-suzuka-500/20 to-suzuka-600/20 p-6 no-underline outline-none focus:shadow-md"
+														href="#"
+													>
+														<PlayCircle className="h-6 w-6" />
+														<div className="mb-2 mt-4 text-lg font-medium">音声ボタン</div>
+														<p className="text-sm leading-tight text-muted-foreground">
+															涼花みなせの様々な音声を楽しめる
+														</p>
+													</a>
+												}
+											/>
 										</div>
 										<div className="grid gap-1">
-											<NavigationMenuLink asChild>
-												<a
-													href="#"
-													className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-												>
-													<div className="text-sm font-medium leading-none">音声ボタン一覧</div>
-													<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-														全ての音声ボタンを閲覧
-													</p>
-												</a>
-											</NavigationMenuLink>
-											<NavigationMenuLink asChild>
-												<a
-													href="#"
-													className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-												>
-													<div className="text-sm font-medium leading-none">音声参照</div>
-													<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-														YouTube動画の音声参照機能
-													</p>
-												</a>
-											</NavigationMenuLink>
-											<NavigationMenuLink asChild>
-												<a
-													href="#"
-													className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-												>
-													<div className="text-sm font-medium leading-none">新規作成</div>
-													<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
-														新しい音声ボタンを作成
-													</p>
-												</a>
-											</NavigationMenuLink>
+											<NavigationMenuLink
+												render={
+													<a
+														href="#"
+														className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+													>
+														<div className="text-sm font-medium leading-none">音声ボタン一覧</div>
+														<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+															全ての音声ボタンを閲覧
+														</p>
+													</a>
+												}
+											/>
+											<NavigationMenuLink
+												render={
+													<a
+														href="#"
+														className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+													>
+														<div className="text-sm font-medium leading-none">音声参照</div>
+														<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+															YouTube動画の音声参照機能
+														</p>
+													</a>
+												}
+											/>
+											<NavigationMenuLink
+												render={
+													<a
+														href="#"
+														className="block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+													>
+														<div className="text-sm font-medium leading-none">新規作成</div>
+														<p className="line-clamp-2 text-sm leading-snug text-muted-foreground">
+															新しい音声ボタンを作成
+														</p>
+													</a>
+												}
+											/>
 										</div>
 									</div>
 								</NavigationMenuContent>

--- a/packages/ui/src/components/ui/navigation-menu.tsx
+++ b/packages/ui/src/components/ui/navigation-menu.tsx
@@ -1,21 +1,19 @@
+import { NavigationMenu as NavigationMenuPrimitive } from "@base-ui/react/navigation-menu";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { cva } from "class-variance-authority";
 import { ChevronDownIcon } from "lucide-react";
-import { NavigationMenu as NavigationMenuPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function NavigationMenu({
+	align = "start",
 	className,
 	children,
-	viewport = true,
 	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
-	viewport?: boolean;
-}) {
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> &
+	Pick<React.ComponentProps<typeof NavigationMenuPrimitive.Positioner>, "align">) {
 	return (
 		<NavigationMenuPrimitive.Root
 			data-slot="navigation-menu"
-			data-viewport={viewport}
 			className={cn(
 				"group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
 				className,
@@ -23,7 +21,7 @@ function NavigationMenu({
 			{...props}
 		>
 			{children}
-			{viewport && <NavigationMenuViewport />}
+			<NavigationMenuPositioner align={align} />
 		</NavigationMenuPrimitive.Root>
 	);
 }
@@ -55,7 +53,7 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-	"group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=open]:bg-accent/50 data-[state=open]:text-accent-foreground data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent",
+	"group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-[color,box-shadow] outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-popup-open:bg-accent/50 data-popup-open:text-accent-foreground data-popup-open:hover:bg-accent data-popup-open:focus:bg-accent",
 );
 
 function NavigationMenuTrigger({
@@ -71,7 +69,7 @@ function NavigationMenuTrigger({
 		>
 			{children}{" "}
 			<ChevronDownIcon
-				className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+				className="relative top-[1px] ml-1 size-3 transition duration-300 group-data-popup-open:rotate-180"
 				aria-hidden="true"
 			/>
 		</NavigationMenuPrimitive.Trigger>
@@ -86,8 +84,7 @@ function NavigationMenuContent({
 		<NavigationMenuPrimitive.Content
 			data-slot="navigation-menu-content"
 			className={cn(
-				"top-0 left-0 w-full p-2 pr-2.5 data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 data-[motion^=from-]:animate-in data-[motion^=from-]:fade-in data-[motion^=to-]:animate-out data-[motion^=to-]:fade-out md:absolute md:w-auto",
-				"group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95",
+				"h-full w-auto p-2 pr-2.5 transition-[opacity,transform] duration-300 data-[activation-direction=left]:data-[starting-style]:-translate-x-52 data-[activation-direction=left]:data-[ending-style]:translate-x-52 data-[activation-direction=right]:data-[starting-style]:translate-x-52 data-[activation-direction=right]:data-[ending-style]:-translate-x-52 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
 				className,
 			)}
 			{...props}
@@ -95,21 +92,35 @@ function NavigationMenuContent({
 	);
 }
 
-function NavigationMenuViewport({
+function NavigationMenuPositioner({
 	className,
+	side = "bottom",
+	sideOffset = 8,
+	align = "start",
+	alignOffset = 0,
 	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Positioner>) {
 	return (
-		<div className={cn("absolute top-full left-0 isolate z-50 flex justify-center")}>
-			<NavigationMenuPrimitive.Viewport
-				data-slot="navigation-menu-viewport"
+		<NavigationMenuPrimitive.Portal>
+			<NavigationMenuPrimitive.Positioner
+				side={side}
+				sideOffset={sideOffset}
+				align={align}
+				alignOffset={alignOffset}
 				className={cn(
-					"origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+					"isolate z-50 h-(--positioner-height) w-(--positioner-width) max-w-(--available-width) transition-[top,left,right,bottom] duration-300 data-[instant]:transition-none",
 					className,
 				)}
 				{...props}
-			/>
-		</div>
+			>
+				<NavigationMenuPrimitive.Popup className="relative h-(--popup-height) w-(--popup-width) origin-(--transform-origin) overflow-hidden rounded-md border bg-popover text-popover-foreground shadow transition-[opacity,transform,width,height] duration-300 data-[starting-style]:zoom-out-95 data-[starting-style]:opacity-0 data-[ending-style]:zoom-out-95 data-[ending-style]:opacity-0">
+					<NavigationMenuPrimitive.Viewport
+						data-slot="navigation-menu-viewport"
+						className="relative size-full overflow-hidden"
+					/>
+				</NavigationMenuPrimitive.Popup>
+			</NavigationMenuPrimitive.Positioner>
+		</NavigationMenuPrimitive.Portal>
 	);
 }
 
@@ -121,7 +132,7 @@ function NavigationMenuLink({
 		<NavigationMenuPrimitive.Link
 			data-slot="navigation-menu-link"
 			className={cn(
-				"flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 data-[active=true]:bg-accent/50 data-[active=true]:text-accent-foreground data-[active=true]:hover:bg-accent data-[active=true]:focus:bg-accent [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+				"flex flex-col gap-1 rounded-sm p-2 text-sm transition-all outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 data-[active]:bg-accent/50 data-[active]:text-accent-foreground data-[active]:hover:bg-accent data-[active]:focus:bg-accent [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
 				className,
 			)}
 			{...props}
@@ -132,18 +143,18 @@ function NavigationMenuLink({
 function NavigationMenuIndicator({
 	className,
 	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) {
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Icon>) {
 	return (
-		<NavigationMenuPrimitive.Indicator
+		<NavigationMenuPrimitive.Icon
 			data-slot="navigation-menu-indicator"
 			className={cn(
-				"top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:animate-in data-[state=visible]:fade-in",
+				"top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
 				className,
 			)}
 			{...props}
 		>
 			<div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
-		</NavigationMenuPrimitive.Indicator>
+		</NavigationMenuPrimitive.Icon>
 	);
 }
 
@@ -154,7 +165,7 @@ export {
 	NavigationMenuItem,
 	NavigationMenuLink,
 	NavigationMenuList,
+	NavigationMenuPositioner,
 	NavigationMenuTrigger,
-	NavigationMenuViewport,
 	navigationMenuTriggerStyle,
 };

--- a/packages/ui/src/components/ui/popover.stories.tsx
+++ b/packages/ui/src/components/ui/popover.stories.tsx
@@ -23,9 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const Basic: Story = {
 	render: () => (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button variant="outline">ポップオーバーを開く</Button>
-			</PopoverTrigger>
+			<PopoverTrigger render={<Button variant="outline">ポップオーバーを開く</Button>} />
 			<PopoverContent>
 				<div className="space-y-2">
 					<h4 className="font-medium leading-none">ポップオーバー</h4>
@@ -41,12 +39,14 @@ export const Basic: Story = {
 export const WithForm: Story = {
 	render: () => (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button variant="outline">
-					<UserIcon className="mr-2 h-4 w-4" />
-					プロフィール編集
-				</Button>
-			</PopoverTrigger>
+			<PopoverTrigger
+				render={
+					<Button variant="outline">
+						<UserIcon className="mr-2 h-4 w-4" />
+						プロフィール編集
+					</Button>
+				}
+			/>
 			<PopoverContent className="w-80">
 				<div className="space-y-4">
 					<div className="space-y-2">
@@ -84,54 +84,42 @@ export const Positioning: Story = {
 	render: () => (
 		<div className="grid grid-cols-3 gap-4 p-8">
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">上部</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">上部</Button>} />
 				<PopoverContent side="top" className="w-56">
 					<p className="text-sm">ボタンの上部に表示されるポップオーバーです。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">右側</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">右側</Button>} />
 				<PopoverContent side="right" className="w-56">
 					<p className="text-sm">ボタンの右側に表示されるポップオーバーです。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">下部（デフォルト）</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">下部(デフォルト)</Button>} />
 				<PopoverContent side="bottom" className="w-56">
 					<p className="text-sm">ボタンの下部に表示されるポップオーバーです。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">左側</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">左側</Button>} />
 				<PopoverContent side="left" className="w-56">
 					<p className="text-sm">ボタンの左側に表示されるポップオーバーです。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">開始位置揃え</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">開始位置揃え</Button>} />
 				<PopoverContent align="start" className="w-56">
 					<p className="text-sm">開始位置に揃えて表示されます。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">終了位置揃え</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">終了位置揃え</Button>} />
 				<PopoverContent align="end" className="w-56">
 					<p className="text-sm">終了位置に揃えて表示されます。</p>
 				</PopoverContent>
@@ -145,11 +133,13 @@ export const InfoPopover: Story = {
 		<div className="flex items-center gap-2">
 			<span>ユーザー名</span>
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="ghost" size="sm" className="h-4 w-4 p-0" aria-label="詳細情報">
-						<InfoIcon className="h-3 w-3" />
-					</Button>
-				</PopoverTrigger>
+				<PopoverTrigger
+					render={
+						<Button variant="ghost" size="sm" className="h-4 w-4 p-0" aria-label="詳細情報">
+							<InfoIcon className="h-3 w-3" />
+						</Button>
+					}
+				/>
 				<PopoverContent className="w-64">
 					<div className="space-y-2">
 						<h4 className="font-medium text-sm">ユーザー名について</h4>
@@ -166,12 +156,14 @@ export const InfoPopover: Story = {
 export const MenuPopover: Story = {
 	render: () => (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button variant="outline">
-					<SettingsIcon className="mr-2 h-4 w-4" />
-					設定メニュー
-				</Button>
-			</PopoverTrigger>
+			<PopoverTrigger
+				render={
+					<Button variant="outline">
+						<SettingsIcon className="mr-2 h-4 w-4" />
+						設定メニュー
+					</Button>
+				}
+			/>
 			<PopoverContent className="w-56">
 				<div className="space-y-1">
 					<Button variant="ghost" className="w-full justify-start">
@@ -200,27 +192,21 @@ export const CustomWidth: Story = {
 	render: () => (
 		<div className="flex gap-4">
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">小さい</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">小さい</Button>} />
 				<PopoverContent className="w-48">
 					<p className="text-sm">これは小さいポップオーバーです。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">デフォルト</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">デフォルト</Button>} />
 				<PopoverContent>
-					<p className="text-sm">これはデフォルトサイズ（w-72）のポップオーバーです。</p>
+					<p className="text-sm">これはデフォルトサイズ(w-72)のポップオーバーです。</p>
 				</PopoverContent>
 			</Popover>
 
 			<Popover>
-				<PopoverTrigger asChild>
-					<Button variant="outline">大きい</Button>
-				</PopoverTrigger>
+				<PopoverTrigger render={<Button variant="outline">大きい</Button>} />
 				<PopoverContent className="w-96">
 					<p className="text-sm">
 						これは大きいポップオーバーです。より多くのコンテンツを含むことができます。
@@ -234,9 +220,7 @@ export const CustomWidth: Story = {
 export const WithoutPadding: Story = {
 	render: () => (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button variant="outline">パディングなし</Button>
-			</PopoverTrigger>
+			<PopoverTrigger render={<Button variant="outline">パディングなし</Button>} />
 			<PopoverContent className="w-56 p-0">
 				<div className="space-y-0">
 					<div className="p-3 border-b">
@@ -261,9 +245,7 @@ export const WithoutPadding: Story = {
 export const OpenInteraction: Story = {
 	render: () => (
 		<Popover>
-			<PopoverTrigger asChild>
-				<Button variant="outline">ポップオーバーを開く</Button>
-			</PopoverTrigger>
+			<PopoverTrigger render={<Button variant="outline">ポップオーバーを開く</Button>} />
 			<PopoverContent aria-label="ポップオーバー">
 				<p className="text-sm">ポップオーバーの内容</p>
 			</PopoverContent>
@@ -295,9 +277,7 @@ export const ControlledExample: Story = {
 					</span>
 				</div>
 				<Popover open={open} onOpenChange={setOpen}>
-					<PopoverTrigger asChild>
-						<Button variant="outline">制御されたポップオーバー</Button>
-					</PopoverTrigger>
+					<PopoverTrigger render={<Button variant="outline">制御されたポップオーバー</Button>} />
 					<PopoverContent>
 						<div className="space-y-2">
 							<h4 className="font-medium">制御されたポップオーバー</h4>

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Popover as PopoverPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
@@ -15,27 +15,33 @@ function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimiti
 function PopoverContent({
 	className,
 	align = "center",
+	side = "bottom",
 	sideOffset = 4,
 	...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+}: React.ComponentProps<typeof PopoverPrimitive.Popup> &
+	Pick<
+		React.ComponentProps<typeof PopoverPrimitive.Positioner>,
+		"align" | "alignOffset" | "side" | "sideOffset"
+	>) {
 	return (
 		<PopoverPrimitive.Portal>
-			<PopoverPrimitive.Content
-				data-slot="popover-content"
+			<PopoverPrimitive.Positioner
 				align={align}
+				side={side}
 				sideOffset={sideOffset}
-				className={cn(
-					"z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-					className,
-				)}
-				{...props}
-			/>
+				className="isolate z-50"
+			>
+				<PopoverPrimitive.Popup
+					data-slot="popover-content"
+					className={cn(
+						"z-50 w-72 origin-(--transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95",
+						className,
+					)}
+					{...props}
+				/>
+			</PopoverPrimitive.Positioner>
 		</PopoverPrimitive.Portal>
 	);
-}
-
-function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
-	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
 function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -48,13 +54,25 @@ function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
 	);
 }
 
-function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
-	return <div data-slot="popover-title" className={cn("font-medium", className)} {...props} />;
+function PopoverTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Title>) {
+	return (
+		<PopoverPrimitive.Title
+			data-slot="popover-title"
+			className={cn("font-medium", className)}
+			{...props}
+		/>
+	);
 }
 
-function PopoverDescription({ className, ...props }: React.ComponentProps<"p">) {
+function PopoverDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Description>) {
 	return (
-		<p
+		<PopoverPrimitive.Description
 			data-slot="popover-description"
 			className={cn("text-muted-foreground", className)}
 			{...props}
@@ -62,12 +80,4 @@ function PopoverDescription({ className, ...props }: React.ComponentProps<"p">) 
 	);
 }
 
-export {
-	Popover,
-	PopoverAnchor,
-	PopoverContent,
-	PopoverDescription,
-	PopoverHeader,
-	PopoverTitle,
-	PopoverTrigger,
-};
+export { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger };

--- a/packages/ui/src/components/ui/progress.tsx
+++ b/packages/ui/src/components/ui/progress.tsx
@@ -1,17 +1,20 @@
 "use client";
 
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Progress as ProgressPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Progress({
 	className,
 	value,
 	...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: Omit<React.ComponentProps<typeof ProgressPrimitive.Root>, "value"> & {
+	value?: number | null;
+}) {
 	return (
 		<ProgressPrimitive.Root
 			data-slot="progress"
+			value={value ?? 0}
 			className={cn("relative h-2 w-full overflow-hidden rounded-full bg-primary/20", className)}
 			{...props}
 		>

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -1,16 +1,14 @@
 "use client";
 
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { CircleIcon } from "lucide-react";
-import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
 import type * as React from "react";
 
-function RadioGroup({
-	className,
-	...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+function RadioGroup({ className, ...props }: React.ComponentProps<typeof RadioGroupPrimitive>) {
 	return (
-		<RadioGroupPrimitive.Root
+		<RadioGroupPrimitive
 			data-slot="radio-group"
 			className={cn("grid gap-3", className)}
 			{...props}
@@ -18,12 +16,9 @@ function RadioGroup({
 	);
 }
 
-function RadioGroupItem({
-	className,
-	...props
-}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+function RadioGroupItem({ className, ...props }: React.ComponentProps<typeof Radio.Root>) {
 	return (
-		<RadioGroupPrimitive.Item
+		<Radio.Root
 			data-slot="radio-group-item"
 			className={cn(
 				"aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
@@ -31,13 +26,13 @@ function RadioGroupItem({
 			)}
 			{...props}
 		>
-			<RadioGroupPrimitive.Indicator
+			<Radio.Indicator
 				data-slot="radio-group-indicator"
 				className="relative flex items-center justify-center"
 			>
 				<CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
-			</RadioGroupPrimitive.Indicator>
-		</RadioGroupPrimitive.Item>
+			</Radio.Indicator>
+		</Radio.Root>
 	);
 }
 

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -1,13 +1,11 @@
 "use client";
 
+import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import { Select as SelectPrimitive } from "radix-ui";
 import type * as React from "react";
 
-function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-	return <SelectPrimitive.Root data-slot="select" {...props} />;
-}
+const Select = SelectPrimitive.Root;
 
 function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
 	return <SelectPrimitive.Group data-slot="select-group" {...props} />;
@@ -36,9 +34,7 @@ function SelectTrigger({
 			{...props}
 		>
 			{children}
-			<SelectPrimitive.Icon asChild>
-				<ChevronDownIcon className="size-4 opacity-50" />
-			</SelectPrimitive.Icon>
+			<SelectPrimitive.Icon render={<ChevronDownIcon className="size-4 opacity-50" />} />
 		</SelectPrimitive.Trigger>
 	);
 }
@@ -46,43 +42,50 @@ function SelectTrigger({
 function SelectContent({
 	className,
 	children,
-	position = "item-aligned",
+	side = "bottom",
+	sideOffset = 4,
 	align = "center",
+	alignOffset = 0,
+	alignItemWithTrigger = true,
 	...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Popup> &
+	Pick<
+		React.ComponentProps<typeof SelectPrimitive.Positioner>,
+		"align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+	>) {
 	return (
 		<SelectPrimitive.Portal>
-			<SelectPrimitive.Content
-				data-slot="select-content"
-				className={cn(
-					"relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-					position === "popper" &&
-						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-					className,
-				)}
-				position={position}
+			<SelectPrimitive.Positioner
+				side={side}
+				sideOffset={sideOffset}
 				align={align}
-				{...props}
+				alignOffset={alignOffset}
+				alignItemWithTrigger={alignItemWithTrigger}
+				className="isolate z-50"
 			>
-				<SelectScrollUpButton />
-				<SelectPrimitive.Viewport
+				<SelectPrimitive.Popup
+					data-slot="select-content"
 					className={cn(
-						"p-1",
-						position === "popper" &&
-							"h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1",
+						"relative z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[closed]:animate-out data-[closed]:fade-out-0 data-[closed]:zoom-out-95 data-[open]:animate-in data-[open]:fade-in-0 data-[open]:zoom-in-95",
+						className,
 					)}
+					{...props}
 				>
-					{children}
-				</SelectPrimitive.Viewport>
-				<SelectScrollDownButton />
-			</SelectPrimitive.Content>
+					<SelectScrollUpButton />
+					<SelectPrimitive.List className="p-1">{children}</SelectPrimitive.List>
+					<SelectScrollDownButton />
+				</SelectPrimitive.Popup>
+			</SelectPrimitive.Positioner>
 		</SelectPrimitive.Portal>
 	);
 }
 
-function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+function SelectLabel({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.GroupLabel>) {
 	return (
-		<SelectPrimitive.Label
+		<SelectPrimitive.GroupLabel
 			data-slot="select-label"
 			className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
 			{...props}
@@ -99,7 +102,7 @@ function SelectItem({
 		<SelectPrimitive.Item
 			data-slot="select-item"
 			className={cn(
-				"relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				"relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
 				className,
 			)}
 			{...props}
@@ -133,30 +136,30 @@ function SelectSeparator({
 function SelectScrollUpButton({
 	className,
 	...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
 	return (
-		<SelectPrimitive.ScrollUpButton
+		<SelectPrimitive.ScrollUpArrow
 			data-slot="select-scroll-up-button"
 			className={cn("flex cursor-default items-center justify-center py-1", className)}
 			{...props}
 		>
 			<ChevronUpIcon className="size-4" />
-		</SelectPrimitive.ScrollUpButton>
+		</SelectPrimitive.ScrollUpArrow>
 	);
 }
 
 function SelectScrollDownButton({
 	className,
 	...props
-}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
 	return (
-		<SelectPrimitive.ScrollDownButton
+		<SelectPrimitive.ScrollDownArrow
 			data-slot="select-scroll-down-button"
 			className={cn("flex cursor-default items-center justify-center py-1", className)}
 			{...props}
 		>
 			<ChevronDownIcon className="size-4" />
-		</SelectPrimitive.ScrollDownButton>
+		</SelectPrimitive.ScrollDownArrow>
 	);
 }
 

--- a/packages/ui/src/components/ui/separator.stories.tsx
+++ b/packages/ui/src/components/ui/separator.stories.tsx
@@ -18,10 +18,6 @@ const meta: Meta<typeof Separator> = {
 			options: ["horizontal", "vertical"],
 			description: "セパレーターの方向",
 		},
-		decorative: {
-			control: "boolean",
-			description: "装飾的な要素として扱うかどうか",
-		},
 	},
 };
 

--- a/packages/ui/src/components/ui/separator.tsx
+++ b/packages/ui/src/components/ui/separator.tsx
@@ -1,19 +1,17 @@
 "use client";
 
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Separator as SeparatorPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Separator({
 	className,
 	orientation = "horizontal",
-	decorative = true,
 	...props
-}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+}: React.ComponentProps<typeof SeparatorPrimitive>) {
 	return (
-		<SeparatorPrimitive.Root
+		<SeparatorPrimitive
 			data-slot="separator"
-			decorative={decorative}
 			orientation={orientation}
 			className={cn(
 				"shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",

--- a/packages/ui/src/components/ui/sheet.stories.tsx
+++ b/packages/ui/src/components/ui/sheet.stories.tsx
@@ -33,9 +33,7 @@ type Story = StoryObj<typeof Sheet>;
 export const Default: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline">シートを開く</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button variant="outline">シートを開く</Button>} />
 			<SheetContent>
 				<SheetHeader>
 					<SheetTitle>シートのタイトル</SheetTitle>
@@ -49,11 +47,13 @@ export const Default: Story = {
 					</p>
 				</div>
 				<SheetFooter>
-					<SheetClose asChild>
-						<Button type="button" variant="secondary">
-							閉じる
-						</Button>
-					</SheetClose>
+					<SheetClose
+						render={
+							<Button type="button" variant="secondary">
+								閉じる
+							</Button>
+						}
+					/>
 				</SheetFooter>
 			</SheetContent>
 		</Sheet>
@@ -63,9 +63,7 @@ export const Default: Story = {
 export const LeftSide: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline">左からシートを開く</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button variant="outline">左からシートを開く</Button>} />
 			<SheetContent side="left">
 				<SheetHeader>
 					<SheetTitle>左側シート</SheetTitle>
@@ -82,9 +80,7 @@ export const LeftSide: Story = {
 export const TopSide: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline">上からシートを開く</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button variant="outline">上からシートを開く</Button>} />
 			<SheetContent side="top">
 				<SheetHeader>
 					<SheetTitle>上部シート</SheetTitle>
@@ -101,9 +97,7 @@ export const TopSide: Story = {
 export const BottomSide: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline">下からシートを開く</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button variant="outline">下からシートを開く</Button>} />
 			<SheetContent side="bottom">
 				<SheetHeader>
 					<SheetTitle>下部シート</SheetTitle>
@@ -120,11 +114,13 @@ export const BottomSide: Story = {
 export const MobileMenu: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline" size="icon" aria-label="メニューを開く">
-					<Menu className="h-4 w-4" />
-				</Button>
-			</SheetTrigger>
+			<SheetTrigger
+				render={
+					<Button variant="outline" size="icon" aria-label="メニューを開く">
+						<Menu className="h-4 w-4" />
+					</Button>
+				}
+			/>
 			<SheetContent side="left">
 				<SheetHeader>
 					<SheetTitle>suzumina.click</SheetTitle>
@@ -132,45 +128,69 @@ export const MobileMenu: Story = {
 				</SheetHeader>
 				<div className="py-4 space-y-4">
 					<div className="space-y-2">
-						<Button variant="ghost" className="w-full justify-start" asChild>
-							<a href="#">
-								<Home className="mr-2 h-4 w-4" />
-								ホーム
-							</a>
-						</Button>
-						<Button variant="ghost" className="w-full justify-start" asChild>
-							<a href="#">
-								<Users className="mr-2 h-4 w-4" />
-								音声ボタン
-							</a>
-						</Button>
-						<Button variant="ghost" className="w-full justify-start" asChild>
-							<a href="#">
-								<Settings className="mr-2 h-4 w-4" />
-								動画一覧
-							</a>
-						</Button>
-						<Button variant="ghost" className="w-full justify-start" asChild>
-							<a href="#">
-								<Settings className="mr-2 h-4 w-4" />
-								作品一覧
-							</a>
-						</Button>
+						<Button
+							variant="ghost"
+							className="w-full justify-start"
+							render={
+								<a href="#">
+									<Home className="mr-2 h-4 w-4" />
+									ホーム
+								</a>
+							}
+						/>
+						<Button
+							variant="ghost"
+							className="w-full justify-start"
+							render={
+								<a href="#">
+									<Users className="mr-2 h-4 w-4" />
+									音声ボタン
+								</a>
+							}
+						/>
+						<Button
+							variant="ghost"
+							className="w-full justify-start"
+							render={
+								<a href="#">
+									<Settings className="mr-2 h-4 w-4" />
+									動画一覧
+								</a>
+							}
+						/>
+						<Button
+							variant="ghost"
+							className="w-full justify-start"
+							render={
+								<a href="#">
+									<Settings className="mr-2 h-4 w-4" />
+									作品一覧
+								</a>
+							}
+						/>
 					</div>
 					<Separator />
 					<div className="space-y-2">
-						<Button variant="ghost" className="w-full justify-start" asChild>
-							<a href="#">
-								<Settings className="mr-2 h-4 w-4" />
-								設定
-							</a>
-						</Button>
-						<Button variant="ghost" className="w-full justify-start" asChild>
-							<a href="#">
-								<LogOut className="mr-2 h-4 w-4" />
-								ログアウト
-							</a>
-						</Button>
+						<Button
+							variant="ghost"
+							className="w-full justify-start"
+							render={
+								<a href="#">
+									<Settings className="mr-2 h-4 w-4" />
+									設定
+								</a>
+							}
+						/>
+						<Button
+							variant="ghost"
+							className="w-full justify-start"
+							render={
+								<a href="#">
+									<LogOut className="mr-2 h-4 w-4" />
+									ログアウト
+								</a>
+							}
+						/>
 					</div>
 				</div>
 			</SheetContent>
@@ -181,9 +201,7 @@ export const MobileMenu: Story = {
 export const FormSheet: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button>フォームシートを開く</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button>フォームシートを開く</Button>} />
 			<SheetContent>
 				<SheetHeader>
 					<SheetTitle>音声ボタンを作成</SheetTitle>
@@ -231,11 +249,13 @@ export const FormSheet: Story = {
 					</div>
 				</div>
 				<SheetFooter>
-					<SheetClose asChild>
-						<Button type="button" variant="outline">
-							キャンセル
-						</Button>
-					</SheetClose>
+					<SheetClose
+						render={
+							<Button type="button" variant="outline">
+								キャンセル
+							</Button>
+						}
+					/>
 					<Button type="button">作成</Button>
 				</SheetFooter>
 			</SheetContent>
@@ -246,9 +266,7 @@ export const FormSheet: Story = {
 export const OpenInteraction: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline">シートを開く</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button variant="outline">シートを開く</Button>} />
 			<SheetContent>
 				<SheetHeader>
 					<SheetTitle>シートのタイトル</SheetTitle>
@@ -268,9 +286,7 @@ export const OpenInteraction: Story = {
 export const WithoutHeaderFooter: Story = {
 	render: () => (
 		<Sheet>
-			<SheetTrigger asChild>
-				<Button variant="outline">シンプルシート</Button>
-			</SheetTrigger>
+			<SheetTrigger render={<Button variant="outline">シンプルシート</Button>} />
 			<SheetContent>
 				<div className="p-4">
 					<h2 className="text-lg font-semibold mb-4">シンプルなシート</h2>

--- a/packages/ui/src/components/ui/sheet.tsx
+++ b/packages/ui/src/components/ui/sheet.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { XIcon } from "lucide-react";
-import { Dialog as SheetPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
@@ -24,12 +24,12 @@ function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Po
 function SheetOverlay({
 	className,
 	...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+}: React.ComponentProps<typeof SheetPrimitive.Backdrop>) {
 	return (
-		<SheetPrimitive.Overlay
+		<SheetPrimitive.Backdrop
 			data-slot="sheet-overlay"
 			className={cn(
-				"fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+				"fixed inset-0 z-50 bg-black/50 data-[closed]:animate-out data-[closed]:fade-out-0 data-[open]:animate-in data-[open]:fade-in-0",
 				className,
 			)}
 			{...props}
@@ -43,37 +43,37 @@ function SheetContent({
 	side = "right",
 	showCloseButton = true,
 	...props
-}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+}: React.ComponentProps<typeof SheetPrimitive.Popup> & {
 	side?: "top" | "right" | "bottom" | "left";
 	showCloseButton?: boolean;
 }) {
 	return (
 		<SheetPortal>
 			<SheetOverlay />
-			<SheetPrimitive.Content
+			<SheetPrimitive.Popup
 				data-slot="sheet-content"
 				className={cn(
-					"fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+					"fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[closed]:animate-out data-[closed]:duration-300 data-[open]:animate-in data-[open]:duration-500",
 					side === "right" &&
-						"inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+						"inset-y-0 right-0 h-full w-3/4 border-l data-[closed]:slide-out-to-right data-[open]:slide-in-from-right sm:max-w-sm",
 					side === "left" &&
-						"inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+						"inset-y-0 left-0 h-full w-3/4 border-r data-[closed]:slide-out-to-left data-[open]:slide-in-from-left sm:max-w-sm",
 					side === "top" &&
-						"inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+						"inset-x-0 top-0 h-auto border-b data-[closed]:slide-out-to-top data-[open]:slide-in-from-top",
 					side === "bottom" &&
-						"inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+						"inset-x-0 bottom-0 h-auto border-t data-[closed]:slide-out-to-bottom data-[open]:slide-in-from-bottom",
 					className,
 				)}
 				{...props}
 			>
 				{children}
 				{showCloseButton && (
-					<SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+					<SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
 						<XIcon className="size-4" />
 						<span className="sr-only">Close</span>
 					</SheetPrimitive.Close>
 				)}
-			</SheetPrimitive.Content>
+			</SheetPrimitive.Popup>
 		</SheetPortal>
 	);
 }

--- a/packages/ui/src/components/ui/slider.tsx
+++ b/packages/ui/src/components/ui/slider.tsx
@@ -1,17 +1,17 @@
 "use client";
 
+import { Slider as SliderPrimitive } from "@base-ui/react/slider";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Slider as SliderPrimitive } from "radix-ui";
 import * as React from "react";
 
-function Slider({
+function Slider<Value extends number | readonly number[] = number | readonly number[]>({
 	className,
 	defaultValue,
 	value,
 	min = 0,
 	max = 100,
 	...props
-}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+}: SliderPrimitive.Root.Props<Value>) {
 	const _values = React.useMemo(
 		() => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
 		[value, defaultValue, min, max],
@@ -24,32 +24,36 @@ function Slider({
 			value={value}
 			min={min}
 			max={max}
-			className={cn(
-				"relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
-				className,
-			)}
+			thumbAlignment="edge"
 			{...props}
 		>
-			<SliderPrimitive.Track
-				data-slot="slider-track"
+			<SliderPrimitive.Control
 				className={cn(
-					"relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+					"relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+					className,
 				)}
 			>
-				<SliderPrimitive.Range
-					data-slot="slider-range"
+				<SliderPrimitive.Track
+					data-slot="slider-track"
 					className={cn(
-						"absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+						"relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
 					)}
-				/>
-			</SliderPrimitive.Track>
-			{Array.from({ length: _values.length }, (_, index) => (
-				<SliderPrimitive.Thumb
-					data-slot="slider-thumb"
-					key={index}
-					className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
-				/>
-			))}
+				>
+					<SliderPrimitive.Indicator
+						data-slot="slider-range"
+						className={cn(
+							"absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full",
+						)}
+					/>
+				</SliderPrimitive.Track>
+				{Array.from({ length: _values.length }, (_, index) => (
+					<SliderPrimitive.Thumb
+						data-slot="slider-thumb"
+						key={index}
+						className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+					/>
+				))}
+			</SliderPrimitive.Control>
 		</SliderPrimitive.Root>
 	);
 }

--- a/packages/ui/src/components/ui/switch.stories.tsx
+++ b/packages/ui/src/components/ui/switch.stories.tsx
@@ -74,7 +74,7 @@ export const ToggleInteraction: Story = {
 		const canvas = within(canvasElement);
 		const sw = canvas.getByRole("switch");
 		await userEvent.click(sw);
-		await expect(args.onCheckedChange).toHaveBeenCalledWith(true);
+		await expect(args.onCheckedChange).toHaveBeenCalledWith(true, expect.anything());
 	},
 };
 

--- a/packages/ui/src/components/ui/switch.tsx
+++ b/packages/ui/src/components/ui/switch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Switch as SwitchPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Switch({
@@ -16,7 +16,7 @@ function Switch({
 			data-slot="switch"
 			data-size={size}
 			className={cn(
-				"peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+				"peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[checked]:bg-primary data-[unchecked]:bg-input dark:data-[unchecked]:bg-input/80",
 				className,
 			)}
 			{...props}
@@ -24,7 +24,7 @@ function Switch({
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+					"pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[checked]:translate-x-[calc(100%-2px)] data-[unchecked]:translate-x-0 dark:data-[checked]:bg-primary-foreground dark:data-[unchecked]:bg-foreground",
 				)}
 			/>
 		</SwitchPrimitive.Root>

--- a/packages/ui/src/components/ui/tabs.tsx
+++ b/packages/ui/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
 import { cn } from "@suzumina.click/ui/lib/utils";
-import { Tabs as TabsPrimitive } from "radix-ui";
 import type * as React from "react";
 
 function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
@@ -27,12 +27,12 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
 	);
 }
 
-function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Tab>) {
 	return (
-		<TabsPrimitive.Trigger
+		<TabsPrimitive.Tab
 			data-slot="tabs-trigger"
 			className={cn(
-				"data-[state=active]:bg-primary data-[state=active]:text-primary-foreground data-[state=active]:border-primary data-[state=active]:shadow-md data-[state=inactive]:hover:bg-accent data-[state=inactive]:hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,border-color] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"data-[active]:bg-primary data-[active]:text-primary-foreground data-[active]:border-primary data-[active]:shadow-md not-data-[active]:hover:bg-accent not-data-[active]:hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow,border-color] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
@@ -40,9 +40,9 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
 	);
 }
 
-function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Panel>) {
 	return (
-		<TabsPrimitive.Content
+		<TabsPrimitive.Panel
 			data-slot="tabs-content"
 			className={cn("flex-1 outline-none", className)}
 			{...props}

--- a/packages/ui/src/components/ui/toggle-group.stories.tsx
+++ b/packages/ui/src/components/ui/toggle-group.stories.tsx
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Single: Story = {
 	render: () => (
-		<ToggleGroup type="single" defaultValue="buttons" aria-label="検索対象">
+		<ToggleGroup defaultValue={["buttons"]} aria-label="検索対象">
 			<ToggleGroupItem value="buttons">音声ボタン</ToggleGroupItem>
 			<ToggleGroupItem value="videos">動画</ToggleGroupItem>
 			<ToggleGroupItem value="works">作品</ToggleGroupItem>
@@ -34,8 +34,7 @@ export const Single: Story = {
 export const FullWidth: Story = {
 	render: () => (
 		<ToggleGroup
-			type="single"
-			defaultValue="buttons"
+			defaultValue={["buttons"]}
 			aria-label="検索対象"
 			className="grid w-full grid-cols-3"
 		>
@@ -54,7 +53,7 @@ export const FullWidth: Story = {
 
 export const SwitchSelection: Story = {
 	render: () => (
-		<ToggleGroup type="single" defaultValue="buttons" aria-label="検索対象">
+		<ToggleGroup defaultValue={["buttons"]} aria-label="検索対象">
 			<ToggleGroupItem value="buttons">音声ボタン</ToggleGroupItem>
 			<ToggleGroupItem value="videos">動画</ToggleGroupItem>
 			<ToggleGroupItem value="works">作品</ToggleGroupItem>
@@ -62,12 +61,12 @@ export const SwitchSelection: Story = {
 	),
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		const buttons = canvas.getByRole("radio", { name: "音声ボタン" });
-		await expect(buttons).toHaveAttribute("data-state", "on");
+		const buttons = canvas.getByRole("button", { name: "音声ボタン" });
+		await expect(buttons).toHaveAttribute("data-pressed");
 
-		const videos = canvas.getByRole("radio", { name: "動画" });
+		const videos = canvas.getByRole("button", { name: "動画" });
 		await userEvent.click(videos);
-		await expect(videos).toHaveAttribute("data-state", "on");
-		await expect(buttons).toHaveAttribute("data-state", "off");
+		await expect(videos).toHaveAttribute("data-pressed");
+		await expect(buttons).not.toHaveAttribute("data-pressed");
 	},
 };

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -1,9 +1,10 @@
 "use client";
 
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group";
 import { toggleVariants } from "@suzumina.click/ui/components/ui/toggle";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import type { VariantProps } from "class-variance-authority";
-import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui";
 import * as React from "react";
 
 const ToggleGroupContext = React.createContext<
@@ -23,12 +24,12 @@ function ToggleGroup({
 	spacing = 0,
 	children,
 	...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+}: React.ComponentProps<typeof ToggleGroupPrimitive> &
 	VariantProps<typeof toggleVariants> & {
 		spacing?: number;
 	}) {
 	return (
-		<ToggleGroupPrimitive.Root
+		<ToggleGroupPrimitive
 			data-slot="toggle-group"
 			data-variant={variant}
 			data-size={size}
@@ -43,7 +44,7 @@ function ToggleGroup({
 			<ToggleGroupContext.Provider value={{ variant, size, spacing }}>
 				{children}
 			</ToggleGroupContext.Provider>
-		</ToggleGroupPrimitive.Root>
+		</ToggleGroupPrimitive>
 	);
 }
 
@@ -53,11 +54,11 @@ function ToggleGroupItem({
 	variant,
 	size,
 	...props
-}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> & VariantProps<typeof toggleVariants>) {
+}: React.ComponentProps<typeof TogglePrimitive> & VariantProps<typeof toggleVariants>) {
 	const context = React.useContext(ToggleGroupContext);
 
 	return (
-		<ToggleGroupPrimitive.Item
+		<TogglePrimitive
 			data-slot="toggle-group-item"
 			data-variant={context.variant || variant}
 			data-size={context.size || size}
@@ -74,7 +75,7 @@ function ToggleGroupItem({
 			{...props}
 		>
 			{children}
-		</ToggleGroupPrimitive.Item>
+		</TogglePrimitive>
 	);
 }
 

--- a/packages/ui/src/components/ui/toggle.stories.tsx
+++ b/packages/ui/src/components/ui/toggle.stories.tsx
@@ -57,8 +57,8 @@ export const TogglesOn: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		const toggle = canvas.getByRole("button", { name: "太字" });
-		await expect(toggle).toHaveAttribute("data-state", "off");
+		await expect(toggle).not.toHaveAttribute("data-pressed");
 		await userEvent.click(toggle);
-		await expect(toggle).toHaveAttribute("data-state", "on");
+		await expect(toggle).toHaveAttribute("data-pressed");
 	},
 };

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -1,13 +1,13 @@
 "use client";
 
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
 import { cn } from "@suzumina.click/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
-import { Toggle as TogglePrimitive } from "radix-ui";
 import type * as React from "react";
 
 const toggleVariants = cva(
 	// active(on) はブランド色（suzuka=primary）に正規化。upstream の中立 bg-accent では home-search のトグルの選択状態が弱い。tabs と同じ in-file 例外（ADR-011）。
-	"inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[pressed]:bg-primary data-[pressed]:text-primary-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {
@@ -33,9 +33,9 @@ function Toggle({
 	variant,
 	size,
 	...props
-}: React.ComponentProps<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>) {
+}: React.ComponentProps<typeof TogglePrimitive> & VariantProps<typeof toggleVariants>) {
 	return (
-		<TogglePrimitive.Root
+		<TogglePrimitive
 			data-slot="toggle"
 			className={cn(toggleVariants({ variant, size, className }))}
 			{...props}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 13.0.2
       '@secretlint/secretlint-rule-pattern':
         specifier: ^13.0.2
-        version: 13.0.2
+        version: 13.0.2(supports-color@10.2.2)
       '@secretlint/secretlint-rule-preset-recommend':
         specifier: ^13.0.2
         version: 13.0.2
@@ -49,7 +49,7 @@ importers:
         version: 6.1.3
       secretlint:
         specifier: ^13.0.2
-        version: 13.0.2
+        version: 13.0.2(supports-color@10.2.2)
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -61,16 +61,16 @@ importers:
     dependencies:
       '@google-cloud/firestore':
         specifier: ^8.6.0
-        version: 8.6.0
+        version: 8.6.0(supports-color@10.2.2)
       '@google-cloud/functions-framework':
         specifier: ^5.0.5
-        version: 5.0.5
+        version: 5.0.5(supports-color@10.2.2)
       '@suzumina.click/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
       googleapis:
         specifier: ^173.0.0
-        version: 173.0.0
+        version: 173.0.0(supports-color@10.2.2)
     devDependencies:
       '@suzumina.click/typescript-config':
         specifier: workspace:*
@@ -104,7 +104,7 @@ importers:
     dependencies:
       '@google-cloud/firestore':
         specifier: ^8.6.0
-        version: 8.6.0
+        version: 8.6.0(supports-color@10.2.2)
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.81.0(react@19.2.7))
@@ -116,13 +116,13 @@ importers:
         version: link:../../packages/ui
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
+        version: 1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10)
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.7)
       next:
         specifier: ^16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -207,7 +207,7 @@ importers:
     dependencies:
       '@google-cloud/firestore':
         specifier: ^8.6.0
-        version: 8.6.0
+        version: 8.6.0(supports-color@10.2.2)
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
@@ -235,6 +235,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@suzumina.click/shared-types':
         specifier: workspace:*
         version: link:../shared-types
@@ -250,9 +253,6 @@ importers:
       lucide-react:
         specifier: ^1.25.0
         version: 1.25.0(react@19.2.7)
-      radix-ui:
-        specifier: 1.6.2
-        version: 1.6.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -277,7 +277,7 @@ importers:
         version: 10.5.2(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vitest@4.1.10)
       '@storybook/react-vite':
         specifier: ^10.5.2
-        version: 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@suzumina.click/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -319,7 +319,7 @@ importers:
         version: 20.10.6
       next:
         specifier: ^16.2.10
-        version: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       playwright:
         specifier: ^1.61.1
         version: 1.61.1
@@ -331,7 +331,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       remark-gfm:
         specifier: ^4.0.1
-        version: 4.0.1
+        version: 4.0.1(supports-color@10.2.2)
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -437,6 +437,33 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -1476,696 +1503,6 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@radix-ui/number@1.1.2':
-    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
-
-  '@radix-ui/primitive@1.1.5':
-    resolution: {integrity: sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==}
-
-  '@radix-ui/react-accessible-icon@1.1.11':
-    resolution: {integrity: sha512-HQDOFTKwSnmUij6l54wYJJtxTAnxI71+YJLOrjm2ladFB8HAV5Jt7hwaZPhWTGBkYoW4+ZAOfNZrLDh/qvxSYA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-accordion@1.2.16':
-    resolution: {integrity: sha512-BpZJNmetujnGgUI6OX0jEhEmlA46WPqgub8Rv09Kyquwd0cc1ndMKpiPYCjmBU6KSSRPAMtgLpEoZSG/tdNIWQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-alert-dialog@1.1.19':
-    resolution: {integrity: sha512-FA7n1f6D/DwGE0+AWxiY5LacNbbExQuEgMubeG06idEaH+mSLuf9dp/qBNqOnvbTQ+4gZ2ue1RATF1Ub91Mg5g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-arrow@1.1.11':
-    resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-aspect-ratio@1.1.11':
-    resolution: {integrity: sha512-IUAhIVpBUvP5NNICjlaB1OFmtRLGqQqTF3ZOSGPoq3XeLXRFtHiWTRxSVEULgOd9GQR2c7tsYqDnhUennapZnw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-avatar@1.2.2':
-    resolution: {integrity: sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-checkbox@1.3.7':
-    resolution: {integrity: sha512-JroKHfQBfh+fDuzpPsBC+pESkhuq8ql4hljTguz8MWnS35cISr3d/Jhl9kYrB44FlDtxCArYdDvTx+BSsJ64rQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-collapsible@1.1.16':
-    resolution: {integrity: sha512-opfXRe6nnzyGmCDPx+l1Aqo/RbqWtQal2FnsBqF9hhePp6j0LsRoBaRxcMOlTv+uYTJVtWYZKg9t9wTe+BA/ZA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-collection@1.1.12':
-    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-compose-refs@1.1.3':
-    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-context-menu@2.3.3':
-    resolution: {integrity: sha512-PS+gKE0z2prJ74Y0sM+brAGK4mYOHIR7TlcV5EJgUQ6E0xMvyswkK2X4yRqyganrzsRL+WCSKAPu0NQITICRWg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-context@1.2.0':
-    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-dialog@1.1.19':
-    resolution: {integrity: sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-direction@1.1.2':
-    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-dismissable-layer@1.1.15':
-    resolution: {integrity: sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-dropdown-menu@2.1.20':
-    resolution: {integrity: sha512-slfm+rRaZRuQBvHq60lXvSVUPhid0IPtjSZzIuUlWZMUs01iYZNlGS3mJgRD3ChLQVBAYlKiL/tFyWGX+dz8Xw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-guards@1.1.4':
-    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-focus-scope@1.1.12':
-    resolution: {integrity: sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-form@0.1.12':
-    resolution: {integrity: sha512-JTX94E4LDL91rzLg7X0mHPdxr0A8JEdVwZEmeOwZJSMDHCGW5DFtSlTSJozUyUs807IQmnvbfzKZFVCK5DmkqQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-hover-card@1.1.19':
-    resolution: {integrity: sha512-2KTgMLQtKvicznQgbindEI2RZ3QbDIwU5gabjUPwFJsormjGDz+rUvO4NANmYwzEEpTcTONUt33vBHIfTIVSfw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-id@1.1.2':
-    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-label@2.1.11':
-    resolution: {integrity: sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.20':
-    resolution: {integrity: sha512-VsUrXxFe9d2ScbZF0fR/oPR1+qjyeLs5p0jzG8h90puMoA9bq4SirYlXbE+USRg9Q2qTeJSFNqjw2nts8jJe4w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menubar@1.1.20':
-    resolution: {integrity: sha512-gzFZvybgmwYsFBWDqanycIoEYnhyk8MMnuLamdFVHUZYGp4COM+sqXiwbnn0VMWqGLeeU7GV7jm+dXRa+Wufag==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-navigation-menu@1.2.18':
-    resolution: {integrity: sha512-K9HiuxZ6xCwSaHcIuUpxyhy4w5gpwzWjh9dHTSbMN3Ix4qAyVObS9RlU3zMycb0PO3v9Tpk0BXMwWvXOUbVXew==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-one-time-password-field@0.1.12':
-    resolution: {integrity: sha512-nQLu5OAcORDQp1EHAv6k3mJGV1hjMTw2NTGVAsGE1g/mWeNqAd1R5jyaAs3U+A8ZD/W8XNPY2yKT0ZdQnqo3NA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-password-toggle-field@0.1.7':
-    resolution: {integrity: sha512-gB1Mr8vzdv1XzDjrtJTXmL0JORRs1B4g7ngUs0F+H2VvMOwXTZMTmLCl0wZZ3m7ylX8TssI7NCvgiSHmLuTm/A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popover@1.1.19':
-    resolution: {integrity: sha512-jkrTdQVxnIB8fpn0NyyxW9CTB5aCXZZelVz5z+Xmii6g5WxMqS3fInNslZ63puP39+Puu4jYohUK31y3dT87gQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popper@1.3.3':
-    resolution: {integrity: sha512-mS7dGpyjv6b+gsDjLF7e0ia1W4Im1B1hSCy2yuXlHuvnZxHKagfDaobt/KAKt27EpZMit2pss8eJBVyVjEWM+g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-portal@1.1.13':
-    resolution: {integrity: sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-presence@1.1.7':
-    resolution: {integrity: sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-primitive@2.1.7':
-    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-progress@1.1.12':
-    resolution: {integrity: sha512-ZPHyI0JyzoH/rP0tq2uRaIZTj/4s8+kAbqPz+e2N8+ejHvwPJ889dHhqn+vh7PNvNeq+boAoH9yzqeoShzwF2w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-radio-group@1.4.3':
-    resolution: {integrity: sha512-WwZFjWV4s3aC1QtR3k04R+oANHtX2q6fgKlc7MCEiDNlnTxCZ3H8k3mHtEgVlOejystwk1WQgarQhNOQZ2bK1g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-roving-focus@1.1.15':
-    resolution: {integrity: sha512-40svmmugfM3mUN7VUDGVE1tQGOhyi8enlGD0CNJEcMM36C1f71PKM21DFgNHUfem0XnA+d8H8oN3Z9ZpJjSslg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-scroll-area@1.2.14':
-    resolution: {integrity: sha512-bBODCWZK7JTbQLHs0uIP4f73wIWatakK4OS33UzkR1x897wu0PuO658a3f+6P2GEGyDzGYMuHRatMVoAk9WZTw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.3.3':
-    resolution: {integrity: sha512-L5RQTXz6Anxsf9CCv+pTgiAsUpyVj7rJxsGtmhFaEOJ++cVfXucv4qWfsIO0AIB4NAhi3yovWGVMKKS1Xf1Wrg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.11':
-    resolution: {integrity: sha512-jRhe86+8PF7VZ1u14eOWVOuh2BuAhALg/FT1VcMC4OHedMTRUazDnDlKTt+yxo5cRNKHMfmvZ4sSQtWDeMV4CQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slider@1.4.3':
-    resolution: {integrity: sha512-CWVVj+XaTom0SKCqw1EUgb0NuiLwS+N3OFG73mVEezKEjgNIvZiu0EevMelSSU+CbX3owbqJweG2gPU31WGC5A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.3.0':
-    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-switch@1.3.3':
-    resolution: {integrity: sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tabs@1.1.17':
-    resolution: {integrity: sha512-nRyXnrAVCwjeXcHbvEbLS6ndbTeKHG1RqCP4A8Gw5L4cemDzPXdD8rAmr6wet0v57R69wGvuIIsFjHSVkZiMzQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toast@1.2.19':
-    resolution: {integrity: sha512-SxfVZfVOibWKWdkf0Xx1awW2d09fQu4V4PXDY1j5hi4MVf7MWdJZqTBJMa1KWtOr1S6GGtCk02nniZ0Iia+dHw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toggle-group@1.1.15':
-    resolution: {integrity: sha512-gIC5Q+Xljg7lmUdzSuDoy0t97yZn1sZl00Ra37ZvKrYdWnQLU6sWLd09yG8cIB9jUAlQfHgJ2ACAG00MFwsqSQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toggle@1.1.14':
-    resolution: {integrity: sha512-QI/hB65XKWACA66P64A+aHxtLUgHJeJLkaQa+awUNXT6T3swndtY5DojeHA+vldrTspMTtFBd7HfZ9QGbM1Qrw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toolbar@1.1.15':
-    resolution: {integrity: sha512-t/iEuVjUnXXtrsGK40AA43uIx37sn3AqZ7oAVnPICK6lFJP6dzMzWR3U9b6eCfFjb6wtSEqkJ9Rn9xDjiOx20g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.12':
-    resolution: {integrity: sha512-U3HoftgWnmla78vzQbLvKKb7bUYJxoiiqYFzp1wu/TBMyDqMZSuCl3aRICsD6EfVEwcJD2mumGDGUXLFVqQHKA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-use-callback-ref@1.1.2':
-    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-controllable-state@1.2.3':
-    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-effect-event@0.0.3':
-    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-escape-keydown@1.1.3':
-    resolution: {integrity: sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-is-hydrated@0.1.1':
-    resolution: {integrity: sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-layout-effect@1.1.2':
-    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-previous@1.1.2':
-    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-rect@1.1.2':
-    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-size@1.1.2':
-    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-visually-hidden@1.2.7':
-    resolution: {integrity: sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/rect@1.1.2':
-    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
-
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
@@ -3040,10 +2377,6 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  aria-hidden@1.2.6:
-    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
-    engines: {node: '>=10'}
-
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -3439,9 +2772,6 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  detect-node-es@1.1.0:
-    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
-
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -3719,10 +3049,6 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
-
-  get-nonce@1.0.1:
-    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
-    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -4562,19 +3888,6 @@ packages:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
-  radix-ui@1.6.2:
-    resolution: {integrity: sha512-OwYUjzMwiInCUxgAWpPsavXC3Kh4iyi/49uU1/qZTG3RQDlvegyk1GOMiGvSkjua1RDb3JD3fo3eroL9FV4GQw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -4622,36 +3935,6 @@ packages:
       '@types/react':
         optional: true
       redux:
-        optional: true
-
-  react-remove-scroll-bar@2.3.8:
-    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-remove-scroll@2.7.2:
-    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  react-style-singleton@2.2.3:
-    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   react@19.2.7:
@@ -5170,26 +4453,6 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
-  use-callback-ref@1.3.3:
-    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  use-sidecar@1.1.3:
-    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -5431,20 +4694,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5469,19 +4732,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@10.2.2)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5510,7 +4773,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -5518,7 +4781,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5526,6 +4789,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@floating-ui/utils': 0.2.12
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -5782,22 +5068,22 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@google-cloud/firestore@8.6.0':
+  '@google-cloud/firestore@8.6.0(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
-      google-gax: 5.0.6
+      google-gax: 5.0.6(supports-color@10.2.2)
       protobufjs: 8.7.1
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/functions-framework@5.0.5':
+  '@google-cloud/functions-framework@5.0.5(supports-color@10.2.2)':
     dependencies:
       '@types/express': 5.0.6
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@10.2.2)
       cloudevents: 10.0.0
-      express: 5.2.1
+      express: 5.2.1(supports-color@10.2.2)
       minimist: 1.2.8
       on-finished: 2.4.1
       read-package-up: 11.0.0
@@ -6247,752 +5533,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@radix-ui/number@1.1.2': {}
-
-  '@radix-ui/primitive@1.1.5': {}
-
-  '@radix-ui/react-accessible-icon@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-accordion@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-alert-dialog@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-arrow@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-aspect-ratio@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-avatar@1.2.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-checkbox@1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-collapsible@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-context-menu@2.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-context@1.2.0(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-dialog@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-dismissable-layer@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-dropdown-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-focus-scope@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-form@0.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-hover-card@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-label@2.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-menu@2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-menubar@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-navigation-menu@1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-one-time-password-field@0.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-password-toggle-field@0.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-popover@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-popper@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/rect': 1.1.2
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-portal@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-presence@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-progress@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-radio-group@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-roving-focus@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-scroll-area@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-select@2.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      aria-hidden: 1.2.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-separator@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-slider@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-switch@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-tabs@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-toast@1.2.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-toggle-group@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-toggle@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-toolbar@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toggle-group': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-tooltip@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-escape-keydown@1.1.3(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-is-hydrated@0.1.1(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/rect': 1.1.2
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.17)(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      react: 19.2.7
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  '@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
-  '@radix-ui/rect@1.1.2': {}
-
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -7069,35 +5609,35 @@ snapshots:
     dependencies:
       '@secretlint/types': 13.0.2
 
-  '@secretlint/config-loader@13.0.2':
+  '@secretlint/config-loader@13.0.2(supports-color@10.2.2)':
     dependencies:
       '@secretlint/profiler': 13.0.2
       '@secretlint/resolver': 13.0.2
       '@secretlint/types': 13.0.2
       ajv: 8.20.0
-      debug: 4.4.3
-      rc-config-loader: 4.1.4
+      debug: 4.4.3(supports-color@10.2.2)
+      rc-config-loader: 4.1.4(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/core@13.0.2':
+  '@secretlint/core@13.0.2(supports-color@10.2.2)':
     dependencies:
       '@secretlint/profiler': 13.0.2
       '@secretlint/types': 13.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       structured-source: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/formatter@13.0.2':
+  '@secretlint/formatter@13.0.2(supports-color@10.2.2)':
     dependencies:
       '@secretlint/resolver': 13.0.2
       '@secretlint/types': 13.0.2
-      '@textlint/linter-formatter': 15.7.1
+      '@textlint/linter-formatter': 15.7.1(supports-color@10.2.2)
       '@textlint/module-interop': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 5.6.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       pluralize: 8.0.0
       strip-ansi: 7.2.0
       table: 6.9.0
@@ -7105,15 +5645,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@secretlint/node@13.0.2':
+  '@secretlint/node@13.0.2(supports-color@10.2.2)':
     dependencies:
-      '@secretlint/config-loader': 13.0.2
-      '@secretlint/core': 13.0.2
-      '@secretlint/formatter': 13.0.2
+      '@secretlint/config-loader': 13.0.2(supports-color@10.2.2)
+      '@secretlint/core': 13.0.2(supports-color@10.2.2)
+      '@secretlint/formatter': 13.0.2(supports-color@10.2.2)
       '@secretlint/profiler': 13.0.2
       '@secretlint/source-creator': 13.0.2
       '@secretlint/types': 13.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       p-map: 7.0.4
     transitivePeerDependencies:
       - supports-color
@@ -7126,9 +5666,9 @@ snapshots:
     dependencies:
       node-sarif-builder: 4.1.0
 
-  '@secretlint/secretlint-rule-pattern@13.0.2':
+  '@secretlint/secretlint-rule-pattern@13.0.2(supports-color@10.2.2)':
     dependencies:
-      '@secretlint/tester': 13.0.2
+      '@secretlint/tester': 13.0.2(supports-color@10.2.2)
       '@secretlint/types': 13.0.2
       '@textlint/regexp-string-matcher': 2.0.2
       micromatch: 4.0.8
@@ -7142,10 +5682,10 @@ snapshots:
       '@secretlint/types': 13.0.2
       istextorbinary: 9.5.0
 
-  '@secretlint/tester@13.0.2':
+  '@secretlint/tester@13.0.2(supports-color@10.2.2)':
     dependencies:
-      '@secretlint/config-loader': 13.0.2
-      '@secretlint/core': 13.0.2
+      '@secretlint/config-loader': 13.0.2(supports-color@10.2.2)
+      '@secretlint/core': 13.0.2(supports-color@10.2.2)
       '@secretlint/source-creator': 13.0.2
       '@secretlint/types': 13.0.2
     transitivePeerDependencies:
@@ -7238,16 +5778,16 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@storybook/react-vite@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@10.2.2)(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@7.0.2)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0
       '@storybook/builder-vite': 10.5.2(esbuild@0.28.1)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-      '@storybook/react': 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@7.0.2)
+      '@storybook/react': 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@10.2.2)(typescript@7.0.2)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.7
-      react-docgen: 8.0.3
+      react-docgen: 8.0.3(supports-color@10.2.2)
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
       storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7263,12 +5803,12 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@7.0.2)':
+  '@storybook/react@10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.5.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       react: 19.2.7
-      react-docgen: 8.0.3
+      react-docgen: 8.0.3(supports-color@10.2.2)
       react-docgen-typescript: 2.4.0(typescript@7.0.2)
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.5.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7388,7 +5928,7 @@ snapshots:
 
   '@textlint/ast-node-types@15.7.1': {}
 
-  '@textlint/linter-formatter@15.7.1':
+  '@textlint/linter-formatter@15.7.1(supports-color@10.2.2)':
     dependencies:
       '@azu/format-text': 1.0.2
       '@azu/style-format': 1.0.1
@@ -7396,7 +5936,7 @@ snapshots:
       '@textlint/resolver': 15.7.1
       '@textlint/types': 15.7.1
       chalk: 4.1.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       js-yaml: 5.2.1
       lodash: 4.18.1
       pluralize: 2.0.0
@@ -7784,9 +6324,9 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7828,10 +6368,6 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  aria-hidden@1.2.6:
-    dependencies:
-      tslib: 2.8.1
-
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -7870,7 +6406,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.37: {}
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
+  better-auth@1.6.23(@opentelemetry/api@1.9.0)(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.4.3))(jose@6.2.1)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.2)
@@ -7890,7 +6426,7 @@ snapshots:
       nanostores: 1.3.0
       zod: 4.4.3
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -7913,11 +6449,11 @@ snapshots:
     dependencies:
       editions: 6.22.0
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
       content-type: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -8102,9 +6638,11 @@ snapshots:
 
   debounce@1.2.1: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.2.2):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   decimal.js-light@2.5.1: {}
 
@@ -8136,8 +6674,6 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
-
-  detect-node-es@1.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -8293,20 +6829,20 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express@5.2.1:
+  express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.0.1
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -8317,9 +6853,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@10.2.2)
+      send: 1.2.1(supports-color@10.2.2)
+      serve-static: 2.2.1(supports-color@10.2.2)
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
@@ -8351,9 +6887,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -8401,26 +6937,26 @@ snapshots:
 
   functional-red-black-tree@1.0.1: {}
 
-  gaxios@7.1.3:
+  gaxios@7.1.3(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
 
-  gaxios@7.1.4:
+  gaxios@7.1.4(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.2:
+  gcp-metadata@8.1.2(supports-color@10.2.2):
     dependencies:
-      gaxios: 7.1.4
+      gaxios: 7.1.4(supports-color@10.2.2)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -8444,8 +6980,6 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
-
-  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -8471,49 +7005,49 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  google-auth-library@10.6.1:
+  google-auth-library@10.6.1(supports-color@10.2.2):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.3
-      gcp-metadata: 8.1.2
+      gaxios: 7.1.3(supports-color@10.2.2)
+      gcp-metadata: 8.1.2(supports-color@10.2.2)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
-  google-gax@5.0.6:
+  google-gax@5.0.6(supports-color@10.2.2):
     dependencies:
       '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.0
       duplexify: 4.1.3
-      google-auth-library: 10.6.1
+      google-auth-library: 10.6.1(supports-color@10.2.2)
       google-logging-utils: 1.1.3
       node-fetch: 3.3.2
       object-hash: 3.0.0
       proto3-json-serializer: 3.0.4
       protobufjs: 8.7.1
-      retry-request: 8.0.2
+      retry-request: 8.0.2(supports-color@10.2.2)
       rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@8.0.1:
+  googleapis-common@8.0.1(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      gaxios: 7.1.4
-      google-auth-library: 10.6.1
+      gaxios: 7.1.4(supports-color@10.2.2)
+      google-auth-library: 10.6.1(supports-color@10.2.2)
       qs: 6.15.2
       url-template: 2.0.8
     transitivePeerDependencies:
       - supports-color
 
-  googleapis@173.0.0:
+  googleapis@173.0.0(supports-color@10.2.2):
     dependencies:
-      google-auth-library: 10.6.1
-      googleapis-common: 8.0.1
+      google-auth-library: 10.6.1(supports-color@10.2.2)
+      googleapis-common: 8.0.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8574,25 +7108,25 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@10.2.2):
     dependencies:
       '@tootallnate/once': 2.0.1
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
+      agent-base: 6.0.2(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8899,14 +7433,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@10.2.2)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -8924,51 +7458,51 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@10.2.2):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9167,10 +7701,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@10.2.2):
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -9230,7 +7764,7 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.59.0
 
-  next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -9239,7 +7773,7 @@ snapshots:
       postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.10
       '@next/swc-darwin-x64': 16.2.10
@@ -9479,69 +8013,6 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
-  radix-ui@1.6.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@radix-ui/primitive': 1.1.5
-      '@radix-ui/react-accessible-icon': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-accordion': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-alert-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-aspect-ratio': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-avatar': 1.2.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-checkbox': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collapsible': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-context-menu': 2.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-dismissable-layer': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-dropdown-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-focus-scope': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-form': 0.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-hover-card': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-label': 2.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-menu': 2.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-menubar': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-navigation-menu': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-one-time-password-field': 0.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-password-toggle-field': 0.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popover': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-popper': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-presence': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-progress': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-radio-group': 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-roving-focus': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-scroll-area': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-select': 2.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slider': 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-switch': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-tabs': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toast': 1.2.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toggle': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toggle-group': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-toolbar': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-tooltip': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-escape-keydown': 1.1.3(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
-      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      '@types/react-dom': 19.2.3(@types/react@19.2.17)
-
   range-parser@1.2.1: {}
 
   raw-body@3.0.2:
@@ -9551,9 +8022,9 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  rc-config-loader@4.1.4:
+  rc-config-loader@4.1.4(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       js-yaml: 5.2.1
       json5: 2.2.3
       require-from-string: 2.0.2
@@ -9564,10 +8035,10 @@ snapshots:
     dependencies:
       typescript: 7.0.2
 
-  react-docgen@8.0.3:
+  react-docgen@8.0.3(supports-color@10.2.2):
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.7(supports-color@10.2.2)
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -9600,33 +8071,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       redux: 5.0.1
-
-  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
-      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
-      tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
-      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      get-nonce: 1.0.1
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
 
   react@19.2.7: {}
 
@@ -9697,21 +8141,21 @@ snapshots:
 
   redux@5.0.1: {}
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@10.2.2)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9743,10 +8187,10 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  retry-request@8.0.2:
+  retry-request@8.0.2(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      teeny-request: 10.1.0
+      teeny-request: 10.1.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -9782,9 +8226,9 @@ snapshots:
 
   rou3@0.7.12: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -9806,15 +8250,15 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  secretlint@13.0.2:
+  secretlint@13.0.2(supports-color@10.2.2):
     dependencies:
       '@secretlint/config-creator': 13.0.2
-      '@secretlint/formatter': 13.0.2
-      '@secretlint/node': 13.0.2
+      '@secretlint/formatter': 13.0.2(supports-color@10.2.2)
+      '@secretlint/node': 13.0.2(supports-color@10.2.2)
       '@secretlint/profiler': 13.0.2
       '@secretlint/resolver': 13.0.2
       '@secretlint/walker': 13.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       read-pkg: 10.1.0
     transitivePeerDependencies:
       - supports-color
@@ -9826,9 +8270,9 @@ snapshots:
   semver@7.8.5:
     optional: true
 
-  send@1.2.1:
+  send@1.2.1(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -9842,12 +8286,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -10063,12 +8507,12 @@ snapshots:
 
   stubs@3.0.0: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
     optionalDependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@10.2.2)
 
   supports-color@10.2.2: {}
 
@@ -10105,10 +8549,10 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  teeny-request@10.1.0:
+  teeny-request@10.1.0(supports-color@10.2.2):
     dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@10.2.2)
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
       node-fetch: 3.3.2
       stream-events: 1.0.5
     transitivePeerDependencies:
@@ -10266,21 +8710,6 @@ snapshots:
       picocolors: 1.1.1
 
   url-template@2.0.8: {}
-
-  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
-
-  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
-    dependencies:
-      detect-node-es: 1.1.0
-      react: 19.2.7
-      tslib: 2.8.1
-    optionalDependencies:
-      '@types/react': 19.2.17
 
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:


### PR DESCRIPTION
## Summary

shadcn/ui が2026年7月にBase UIをデフォルト採用したことに伴い、`packages/ui` の shadcn/ui ベースコンポーネント全19個(separator / label / progress / collapsible / toggle / badge / button / checkbox / switch / radio-group / toggle-group / popover / tabs / dialog / alert-dialog / sheet / dropdown-menu / select / navigation-menu / slider)を `@base-ui/react` へ移行し、`radix-ui` 依存を完全に除去しました。

- `asChild` → `render` prop への全面書き換え(コンポーネント本体・Storybook・`apps/web` の呼び出し元すべて)
- `data-state=open/closed` → `data-open`/`data-closed` 等の属性名変更
- `ToggleGroup`: `type="single/multiple"` → `multiple` boolean、`value` の配列化(`apps/web` の検索対象切替を追随)
- `Select`: `SelectValue` が選択ラベルを自動表示しないため `items` prop を追加
- `AlertDialog`: `Action` プリミティブが存在しないため素の `Button` に変更
- `DropdownMenu`: `GroupLabel` が `Menu.Group` 祖先を要求するため呼び出し元を `Group` でラップ
- `components.json` の `style` を `new-york` → `base-vega` に更新(shadcn 最新スキーマの命名変更に追随)

移行過程で自動テストが3件の実バグを検出・修正済み:
1. 検索フォームの送信が動作しなくなる(`Button` の `render` デフォルト実装ミスで `type="submit"` が消える)
2. ドロップダウンメニューを開くとクラッシュ(`MenuGroupLabel` が `Menu.Group` 祖先必須)
3. セレクトのトリガーに選択ラベルでなく生の value が表示される

## Test plan

- [x] `pnpm verify`(lint:docs + lint:tokens + lint + typecheck + test、全ワークスペース)が exit code 0 で通過
- [x] `packages/ui` ユニットテスト 385件・Storybook a11y/interaction テスト 352件、`apps/web` テスト 1090件、すべて通過
- [x] 実ブラウザ(`pnpm dev:local`)で検索フォーム送信・404ページのリンクボタン・トグルグループ・Storybook 各コンポーネントの開閉動作を確認
- [ ] レビュー後、本番相当環境での目視確認(One-Way Door 判定・下記参照)

## Note

`packages/ui` の Firestore スキーマ非依存の UI ライブラリ変更ですが、変更範囲が広く `apps/web` 全体に波及するため、セルフマージ・ポリシー上は Two-Way Door(戻せる)の中でも慎重にレビューします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)