### PR TITLE
chore(ui): 未使用のaccordion keyframes/トークンを削除

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -109,8 +109,6 @@
 		--heart-foreground: 344 50% 99%; /* heart 面上の文字（≒白）。bg-heart 上 ≈4.8:1 ✓ */
 
 		/* Animation keyframes */
-		--animate-accordion-down: accordion-down 0.2s ease-out;
-		--animate-accordion-up: accordion-up 0.2s ease-out;
 		--animate-focus-pulse: focus-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 		--animate-shimmer: shimmer 2s linear infinite;
 	}
@@ -510,24 +508,6 @@
 	}
 
 	/* Keyframe definitions for animations */
-	@keyframes accordion-down {
-		from {
-			height: 0;
-		}
-		to {
-			height: var(--radix-accordion-content-height);
-		}
-	}
-
-	@keyframes accordion-up {
-		from {
-			height: var(--radix-accordion-content-height);
-		}
-		to {
-			height: 0;
-		}
-	}
-
 	@keyframes focus-pulse {
 		0%,
 		100% {

--- a/scripts/lint-css-tokens.mjs
+++ b/scripts/lint-css-tokens.mjs
@@ -39,8 +39,6 @@ const ALLOWLIST = new Set([
 	"radius-lg",
 	// animation: --animate-* は globals.css 内の @keyframes/utility と対で定義した体系。
 	// tw-animate-css 連携の予約で、個別 var() 参照は出ないことがある。
-	"animate-accordion-down",
-	"animate-accordion-up",
 	"animate-focus-pulse",
 	"animate-shimmer",
 ]);


### PR DESCRIPTION
## Summary
- `packages/ui/src/styles/globals.css` の `@keyframes accordion-down` / `accordion-up` と対応する `--animate-accordion-*` トークンを削除
- Accordion コンポーネントはリポジトリに存在せず、PR #838 で Radix UI から Base UI へ全面移行済みのため `--radix-accordion-content-height` を設定するコードも無い、二重に死んだCSSだった

## Test plan
- [x] `grep -rn "accordion" packages/ui/src apps/web/src` で参照ゼロを確認
- [x] `pnpm --filter @suzumina.click/ui lint` （既存の無関係な noArrayIndexKey warning のみ、新規エラーなし）
- [x] `pnpm lint:tokens` （全 :root トークンが参照済みであることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)