### PR TITLE
fix(ci): Dependabot PR で Claude review が必ず失敗する不具合を修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,6 +51,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # claude-code-action は既定で bot 起因の workflow を拒否する（"Workflow initiated by
+          # non-human actor" エラー）。Dependabot PR でも review を回すため明示許可する。
+          # prompt は固定テンプレートで PR 本文/差分内容を埋め込まないため、bot 経由のプロンプト
+          # インジェクションのリスクは無い（"*" ではなく dependabot[bot] のみに限定して許可）。
+          allowed_bots: "dependabot[bot]"
           # 進捗トラッキングコメントを作成し、コメント投稿用ツールを有効化する（タグモード）。
           track_progress: true
           prompt: |


### PR DESCRIPTION
## Summary
- PR #840 (Dependabot: next 16.2.10→16.2.11) の CI 調査で発覚: `claude-code-action` は既定で bot 起因の workflow 実行を拒否するため、Dependabot が作成する全 PR で `Claude AI Review` ジョブが `Workflow initiated by non-human actor: dependabot (type: Bot)` エラーで毎回失敗していた。
- `allowed_bots: "dependabot[bot]"` を明示指定して許可する。prompt は固定テンプレート（PR本文/差分内容を埋め込まない）であることを確認済みのため、`"*"` ではなく dependabot に限定してプロンプトインジェクションのリスクを避けている。
- このジョブは advisory（非ブロッキング・必須チェックではない）だが、常に赤く見える状態は「レビュー未実行」と「重大所見なし」の区別を曖昧にするため修正する。

## Test plan
- [ ] マージ後、既存の Dependabot PR（例: #840）で workflow を re-run し、Claude review ジョブが実行・完了することを確認
- [ ] 新規 Dependabot PR 作成時に自動でジョブが成功することを確認

⚠️ Door 判定: `.github/workflows` の変更は CLAUDE.md の One-Way Door 対象（CI/CD）のため、AI レビューのみでの自己マージは推奨しない。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>