### PR TITLE
feat(ui): 検索結果ゼロ一覧6箇所にEmptyStateを導入（ADR-012 Group A）

### DIFF
--- a/apps/web/src/app/buttons/components/audio-buttons-list.tsx
+++ b/apps/web/src/app/buttons/components/audio-buttons-list.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { AudioButtonPlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList } from "@suzumina.click/ui/components/custom";
+import { ConfigurableList, EmptyState } from "@suzumina.click/ui/components/custom";
+import { SearchX } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { AudioButtonListItem } from "@/components/audio/audio-button-list-item";
 import { ListWrapper } from "@/components/list/list-wrapper";
@@ -145,6 +146,12 @@ export default function AudioButtonsList({ searchParams, initialData }: AudioBut
 				}}
 				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
 				emptyMessage="音声ボタンが見つかりませんでした"
+				emptyState={
+					<EmptyState
+						icon={<SearchX className="h-6 w-6" />}
+						title="音声ボタンが見つかりませんでした"
+					/>
+				}
 			/>
 		</ListWrapper>
 	);

--- a/apps/web/src/app/circles/components/circles-list.tsx
+++ b/apps/web/src/app/circles/components/circles-list.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import type { CirclePlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList, type StandardListParams } from "@suzumina.click/ui/components/custom";
+import {
+	ConfigurableList,
+	EmptyState,
+	type StandardListParams,
+} from "@suzumina.click/ui/components/custom";
+import { SearchX } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useMemo } from "react";
 import { ListWrapper } from "@/components/list/list-wrapper";
@@ -93,6 +98,12 @@ export default function CirclesList({ initialData }: CirclesListProps) {
 				defaultSort="name"
 				itemsPerPageOptions={[12, 24, 48]}
 				emptyMessage="サークルが見つかりませんでした"
+				emptyState={
+					<EmptyState
+						icon={<SearchX className="h-6 w-6" />}
+						title="サークルが見つかりませんでした"
+					/>
+				}
 				searchPlaceholder="サークル名で検索"
 			/>
 		</ListWrapper>

--- a/apps/web/src/app/creators/components/creators-list.tsx
+++ b/apps/web/src/app/creators/components/creators-list.tsx
@@ -5,8 +5,13 @@ import {
 	type CreatorPageInfo,
 	type CreatorType,
 } from "@suzumina.click/shared-types";
-import { ConfigurableList, type StandardListParams } from "@suzumina.click/ui/components/custom";
+import {
+	ConfigurableList,
+	EmptyState,
+	type StandardListParams,
+} from "@suzumina.click/ui/components/custom";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
+import { SearchX } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useMemo } from "react";
 import { ListWrapper } from "@/components/list/list-wrapper";
@@ -125,6 +130,12 @@ export default function CreatorsList({ initialData }: CreatorsListProps) {
 				}}
 				itemsPerPageOptions={[12, 24, 48]}
 				emptyMessage="クリエイターが見つかりませんでした"
+				emptyState={
+					<EmptyState
+						icon={<SearchX className="h-6 w-6" />}
+						title="クリエイターが見つかりませんでした"
+					/>
+				}
 				searchPlaceholder="クリエイター名で検索"
 			/>
 		</ListWrapper>

--- a/apps/web/src/app/videos/components/video-list.tsx
+++ b/apps/web/src/app/videos/components/video-list.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList } from "@suzumina.click/ui/components/custom";
+import { ConfigurableList, EmptyState } from "@suzumina.click/ui/components/custom";
+import { SearchX } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { ListWrapper } from "@/components/list/list-wrapper";
 import {
@@ -107,6 +108,7 @@ export default function VideoList({ initialData }: VideoListProps) {
 				}}
 				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
 				emptyMessage="動画がありません"
+				emptyState={<EmptyState icon={<SearchX className="h-6 w-6" />} title="動画がありません" />}
 			/>
 		</ListWrapper>
 	);

--- a/apps/web/src/app/works/components/__tests__/works-list.test.tsx
+++ b/apps/web/src/app/works/components/__tests__/works-list.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@suzumina.click/ui/components/custom", () => ({
 	ConfigurableList: ({ items }: { items: unknown[] }) => (
 		<div data-testid="configurable-list">{items.length}</div>
 	),
+	EmptyState: () => null,
 }));
 
 vi.mock("@/components/list/list-wrapper", () => ({

--- a/apps/web/src/app/works/components/works-list.tsx
+++ b/apps/web/src/app/works/components/works-list.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList, type StandardListParams } from "@suzumina.click/ui/components/custom";
+import {
+	ConfigurableList,
+	EmptyState,
+	type StandardListParams,
+} from "@suzumina.click/ui/components/custom";
+import { SearchX } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ListWrapper } from "@/components/list/list-wrapper";
 import { WorkListItem } from "@/components/work/work-list-item";
@@ -167,6 +172,9 @@ export default function WorksList({ initialData, initialParams }: WorksListProps
 				}}
 				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
 				emptyMessage="作品が見つかりませんでした"
+				emptyState={
+					<EmptyState icon={<SearchX className="h-6 w-6" />} title="作品が見つかりませんでした" />
+				}
 			/>
 		</ListWrapper>
 	);

--- a/apps/web/src/components/work/works-list-for-owner.tsx
+++ b/apps/web/src/components/work/works-list-for-owner.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { WorkListResultPlain, WorkPlainObject } from "@suzumina.click/shared-types";
-import { ConfigurableList } from "@suzumina.click/ui/components/custom";
+import { ConfigurableList, EmptyState } from "@suzumina.click/ui/components/custom";
+import { SearchX } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { ListWrapper } from "@/components/list/list-wrapper";
 import { WorkListItem } from "@/components/work/work-list-item";
@@ -78,6 +79,9 @@ export function WorksListForOwner({ initialData, fetchWorks }: WorksListForOwner
 				sorts={WORK_SORT_OPTIONS}
 				itemsPerPageOptions={DEFAULT_ITEMS_PER_PAGE_OPTIONS}
 				emptyMessage="作品が見つかりませんでした"
+				emptyState={
+					<EmptyState icon={<SearchX className="h-6 w-6" />} title="作品が見つかりませんでした" />
+				}
 			/>
 		</ListWrapper>
 	);

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -273,5 +273,6 @@ vi.mock("lucide-react", () => {
 		Volume2: createMockIcon("Volume2"),
 		LineChart: createMockIcon("LineChart"),
 		Image: createMockIcon("Image"),
+		SearchX: createMockIcon("SearchX"),
 	};
 });

--- a/docs/decisions/frontend/ADR-012-reui-adoption-policy.md
+++ b/docs/decisions/frontend/ADR-012-reui-adoption-policy.md
@@ -268,6 +268,17 @@ Empty State フェーズでスコープ外とした残り6箇所（`audio-button
   JSX 構築時点で React が例外を投げていた。モックに `EmptyState: () => null` を追加して解消。
   同種のフルモジュールモックを持つ `videos/__tests__/page.test.tsx` は `VideoList` 自体を
   別途モックしており実コードパスを通らないため無影響だった（要 grep 確認済み・他に該当なし）
+- **バグ修正（PR #845 AI レビュー起因）: コントロールバーが検索語ありのとき `emptyMessage` を
+  無視していた**。`configurable-list-controls.tsx` は `searchQuery` が truthy な 0 件時のみ
+  固定文言「検索結果がありません」を独立して出す分岐を持っており、`emptyState`（本体）と
+  `emptyMessage` を揃えても、検索語ありのケースではコントロールバー側だけこの固定文言に
+  差し替わり両者が食い違う（例: `/works?q=...` で本体「作品が見つかりませんでした」・
+  コントロールバー「検索結果がありません」）。この固定文言分岐自体を削除し、
+  0 件時は searchQuery の有無によらず常に `emptyMessage` を表示するよう単純化した
+  （`searchQuery` prop は本コンポーネントで他に用途が無いため合わせて削除）。
+  文言ソースを `emptyMessage`/`emptyState.title` の 1 つに揃えたことで、
+  Group A（本体・コントロールバーとも同一文言）だけでなく Group B
+  （`favorites-list.tsx` の「お気に入りがまだありません」）でも両者が一致するようになった
 
 ### combobox.tsx（在file・手書きプリミティブ）実装ノート
 

--- a/docs/decisions/frontend/ADR-012-reui-adoption-policy.md
+++ b/docs/decisions/frontend/ADR-012-reui-adoption-policy.md
@@ -219,9 +219,10 @@ ADR-005 の「他が成功したから／無料で使えるから」を理由に
    `illustrated` を除去。`user-profile-content.tsx` のみ `titleAs="h3"` を追加
 - **調査結果（UX監査）に基づく分類と対応**:
   - **Group A**（`ConfigurableList` の `emptyMessage` 経由・検索結果ゼロ、6ファイルでほぼ同一文言）:
-    今回はスコープ外（`ConfigurableList` の `emptyMessage` は文字列限定で、そのままでは
-    アイコン・CTA を持てない。Group B のため `emptyState?: React.ReactNode` prop を追加したので、
-    残る6箇所への展開は低リスクな追加作業として次回以降に持ち越し）
+    当初はスコープ外としていたが（`ConfigurableList` の `emptyMessage` は文字列限定で、
+    そのままではアイコン・CTA を持てないため）、Group B で追加した
+    `emptyState?: React.ReactNode` prop を使い後日実装した（詳細は後述の
+    「Group A の実装」参照）
   - **Group B**（「まだ何もない」＋CTAが妥当）: `favorites-list.tsx`（`ConfigurableList` に新設した
     `emptyState` prop 経由）・`user-profile-content.tsx`・`related-audio-buttons.tsx` を `illustrated`
     で統一。3箇所とも実装がバラバラだったのを統一した
@@ -244,6 +245,29 @@ ADR-005 の「他が成功したから／無料で使えるから」を理由に
 - **jsdom テストでの lucide-react モック**: `apps/web/vitest.setup.ts` はアイコンをホワイトリスト方式で
   モックしている。新規アイコン（`Volume2`/`LineChart`/`Image`）を追加していないと
   `No "X" export is defined on the "lucide-react" mock` で落ちる。EmptyState 導入時は要確認
+
+### Group A（`ConfigurableList` 検索結果ゼロ）の実装（2026-07-24）
+
+Empty State フェーズでスコープ外とした残り6箇所（`audio-buttons-list.tsx` / `creators-list.tsx` /
+`circles-list.tsx` / `video-list.tsx` / `works-list.tsx` / `works-list-for-owner.tsx`）に
+`emptyState` prop を追加した。Group B と異なり CTA が不要（検索条件を変える以外にユーザーが
+取れる行動が無い）ため、6箇所とも `<EmptyState icon={<SearchX />} title={...} />` のみの
+最小構成で統一した。
+
+- **アイコンは `SearchX`（lucide-react）に統一**: 「検索してヒットしなかった」ことを表す
+  Group A 共通の意味に対して、Group B の `Heart`/`Volume2` のような対象別アイコンは不要。
+  6箇所で1種類のアイコンに揃えることで「検索結果ゼロ」という状態自体が視覚的に一貫する
+- **`title` は既存の `emptyMessage` と同一文言に揃える**: `emptyMessage` はコントロールバーの
+  要約表示、`emptyState` はリスト本体の表示で、両者は独立した prop のため文言を別々に書くと
+  矛盾した表現が同時に見える状態になり得る（実際に `video-list.tsx` で最初
+  `emptyState` 側だけ「動画が見つかりませんでした」と書いてしまい、既存の
+  `emptyMessage="動画がありません"` と表現が食い違っていたため、既存文言に合わせて修正した）
+- **バグ修正: `works-list.test.tsx` の `vi.mock` が `EmptyState` を export していなかった**。
+  `@suzumina.click/ui/components/custom` をフルモジュールモックして `ConfigurableList` だけ
+  差し替えている既存テストで、`EmptyState` の実 import が `undefined` になり `WorksList` の
+  JSX 構築時点で React が例外を投げていた。モックに `EmptyState: () => null` を追加して解消。
+  同種のフルモジュールモックを持つ `videos/__tests__/page.test.tsx` は `VideoList` 自体を
+  別途モックしており実コードパスを通らないため無影響だった（要 grep 確認済み・他に該当なし）
 
 ### combobox.tsx（在file・手書きプリミティブ）実装ノート
 

--- a/packages/ui/src/components/custom/configurable-list.tsx
+++ b/packages/ui/src/components/custom/configurable-list.tsx
@@ -264,7 +264,6 @@ export function ConfigurableList<T>({
 				isRefreshing={isRefreshing}
 				paginationStartIndex={pagination.startIndex}
 				paginationEndIndex={pagination.endIndex}
-				searchQuery={fetchParams.search || ""}
 				emptyMessage={emptyMessage}
 				sortOptions={sortOptions}
 				currentSort={fetchParams.sort || ""}

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-controls.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-controls.tsx
@@ -10,7 +10,6 @@ interface ConfigurableListControlsProps {
 	isRefreshing: boolean;
 	paginationStartIndex: number;
 	paginationEndIndex: number;
-	searchQuery?: string;
 	emptyMessage: string;
 	sortOptions: Option[];
 	currentSort: string;
@@ -26,7 +25,6 @@ export function ConfigurableListControls({
 	isRefreshing,
 	paginationStartIndex,
 	paginationEndIndex,
-	searchQuery,
 	emptyMessage,
 	sortOptions,
 	currentSort,
@@ -49,8 +47,6 @@ export function ConfigurableListControls({
 						{Math.min(paginationEndIndex, actualTotal)}件を表示
 						{isRefreshing && <span className="text-xs">（更新中...）</span>}
 					</>
-				) : searchQuery ? (
-					"検索結果がありません"
 				) : (
 					emptyMessage
 				)}


### PR DESCRIPTION
## Summary
- `ConfigurableList` を使う検索系一覧6箇所（buttons/creators/circles/videos/works/owner-works）に `emptyState` prop で `EmptyState`（`SearchX` アイコン）を追加し、テキストのみだった空表示を統一
- `title` は既存 `emptyMessage` と同一文言に揃え、コントロールバー要約とリスト本体の表示に矛盾が出ないようにした
- バグ修正: `works-list.test.tsx` の `vi.mock("@suzumina.click/ui/components/custom", ...)` が `EmptyState` を export しておらず、実 import が `undefined` になり `WorksList` の JSX 構築時に例外が発生していた（`EmptyState: () => null` を追加して解消）
- ADR-012 に Group A の実装内容（アイコン選定理由・文言統一方針・上記バグ）を追記

## Test plan
- [x] `pnpm verify`（lint:docs + lint:tokens + lint + typecheck + test、カバレッジ閾値含む）green
- [x] `works-list.test.tsx` / `videos/__tests__/page.test.tsx` の個別テストで修正確認済み
- [x] Firestore Emulator + 実ブラウザで `/works?q=zzzzznonexistentquery` と `/circles?q=zzzzznonexistentquery` を確認し、EmptyState（SearchXアイコン＋文言）がリスト本体に、既存の要約文言がコントロールバーに正しく表示されることをスクリーンショットで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)