### PR TITLE
DLsite/YouTube 同期パイプラインの積み残しタスク解消 (SPR-263/SPR-264)

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -27,7 +27,8 @@
 		"check:integrity": "dotenv -e .env -- tsx src/tools/core/run-data-integrity-check.ts",
 		"check:price-history": "dotenv -e .env -- tsx src/tools/check-price-history.ts",
 		"debug:price-history": "dotenv -e .env -- tsx src/tools/debug-price-history.ts",
-		"tools:backfill-video-status": "dotenv -e .env -- tsx src/tools/backfill-video-status.ts"
+		"tools:backfill-video-status": "dotenv -e .env -- tsx src/tools/backfill-video-status.ts",
+		"tools:backfill-missing-videos": "dotenv -e .env -- tsx src/tools/backfill-missing-videos.ts"
 	},
 	"main": "lib/index.js",
 	"engines": {

--- a/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
@@ -91,6 +91,43 @@ describe("WorkMapper", () => {
 		});
 	});
 
+	describe("salesStatus（SPR-264: フラットフィールドからのマッピング）", () => {
+		it("is_discount_workがtrueの作品はisSale/isDiscountがtrueになる", () => {
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				is_discount_work: true,
+				on_sale: 1,
+			});
+
+			expect(work.salesStatus?.isSale).toBe(true);
+			expect(work.salesStatus?.isDiscount).toBe(true);
+			expect(work.salesStatus?.onSale).toBe(1);
+		});
+
+		it("is_discount_workがfalseの作品はisSale/isDiscountがfalseになる", () => {
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				is_discount_work: false,
+			});
+
+			expect(work.salesStatus?.isSale).toBe(false);
+			expect(work.salesStatus?.isDiscount).toBe(false);
+		});
+
+		it("実APIに存在しないネストされたsales_statusフィールドには依存しない", () => {
+			// SPR-264: 旧実装は`raw.sales_status`（実APIには存在しないネストオブジェクト）を
+			// 参照しており、常にsalesStatusがundefinedになっていた。フラットフィールドのみで
+			// 判定できることを確認する。
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				is_discount_work: true,
+			});
+
+			expect(work.salesStatus).toBeDefined();
+			expect(work.salesStatus?.isSale).toBe(true);
+		});
+	});
+
 	describe("toPrice", () => {
 		it("通常価格を正しくマッピングできる", () => {
 			const price = WorkMapper.toPrice(mockRawApiData);

--- a/apps/functions/src/services/mappers/work-mapper.ts
+++ b/apps/functions/src/services/mappers/work-mapper.ts
@@ -401,22 +401,26 @@ function formatDateDisplay(dateStr: string): string | undefined {
 
 /**
  * 販売状態情報の変換
+ *
+ * SPR-264: 旧実装は存在しないネストオブジェクト `raw.sales_status` を読んでおり、
+ * 常に undefined を返していた（実測150件で0件・実APIはフラットフィールドのみ返す）。
+ * `isSale`（セール中判定）は work-tiering.ts の volatile ティア判定が参照する値のため、
+ * 実フィールド `is_discount_work`（実測150件中78件がtrue）から正しくマッピングする。
+ * `isSoldOut` は実APIに信頼できる直接対応フィールドが無いため undefined のまま。
  */
-function toSalesStatus(raw: DLsiteApiResponse): SalesStatus | undefined {
-	if (!raw.sales_status) return undefined;
-
+function toSalesStatus(raw: DLsiteApiResponse): SalesStatus {
 	return {
-		isSale: raw.sales_status.is_sale,
-		onSale: raw.sales_status.on_sale,
-		isDiscount: raw.sales_status.is_discount,
-		isPointup: raw.sales_status.is_pointup,
-		isFree: raw.sales_status.is_free,
-		isRental: raw.sales_status.is_rental,
-		isSoldOut: raw.sales_status.is_sold_out,
-		isReserveWork: raw.sales_status.is_reserve_work,
-		isReservable: raw.sales_status.is_reservable,
-		isTimesale: raw.sales_status.is_timesale,
-		dlsiteplayWork: raw.sales_status.dlsiteplay_work,
+		isSale: raw.is_discount_work,
+		onSale: raw.on_sale,
+		isDiscount: raw.is_discount_work,
+		isPointup: raw.is_title_pointup ?? undefined,
+		isFree: raw.free,
+		isRental: raw.is_rental_work,
+		isSoldOut: undefined,
+		isReserveWork: raw.is_reserve_work,
+		isReservable: raw.is_reservable,
+		isTimesale: raw.is_timesale_work,
+		dlsiteplayWork: raw.is_dlsiteplay_work,
 	};
 }
 

--- a/apps/functions/src/services/mappers/work-mapper.ts
+++ b/apps/functions/src/services/mappers/work-mapper.ts
@@ -407,6 +407,13 @@ function formatDateDisplay(dateStr: string): string | undefined {
  * `isSale`（セール中判定）は work-tiering.ts の volatile ティア判定が参照する値のため、
  * 実フィールド `is_discount_work`（実測150件中78件がtrue）から正しくマッピングする。
  * `isSoldOut` は実APIに信頼できる直接対応フィールドが無いため undefined のまま。
+ *
+ * `isSale`/`isDiscount` は同一フィールド `is_discount_work` から求めており実質同義（意図的）。
+ * `isTimesale`（タイムセール）・`isReserveWork`（予約）起因の価格変動は `isSale` に含めない。
+ * 実測150件では `is_timesale_work`/`is_limit_sales` が全件 false で、volatile ティア判定
+ * （work-tiering.ts の `salesStatus?.isSale === true`）への実害は無い。DLsite の実APIには
+ * 「一般的なセール中」を示す独立フィールドが無く、現状 `is_discount_work` が最も広く
+ * カバーする信号のため、これを唯一のソースとして採用している。
  */
 function toSalesStatus(raw: DLsiteApiResponse): SalesStatus {
 	return {

--- a/apps/functions/src/tools/backfill-missing-videos.ts
+++ b/apps/functions/src/tools/backfill-missing-videos.ts
@@ -1,0 +1,118 @@
+/**
+ * 未取込動画の backfill ツール（SPR-263）
+ *
+ * 旧 discovery（search.list、インデックス不完全）時代に一度も Firestore へ
+ * 取り込まれなかった公開動画5件を、videos.list で ID 指定取得して
+ * 本番の書き込み経路（saveVideosToFirestore、merge:true）にそのまま渡す。
+ * 新しい書き込みパスは増やさない（backfill-video-status.ts と同型）。
+ *
+ * 対象IDは SPR-230 の週次フルスイープ初回発火（2026-07-12）で検出された
+ * 「uploadsPlaylistのみに存在する件数」と一致する固定リスト。
+ */
+
+import type { youtube_v3 } from "googleapis";
+import {
+	fetchChannelPlaylists,
+	fetchPlaylistItems,
+	fetchVideoDetails,
+	initializeYouTubeClient,
+} from "../services/youtube/youtube-api";
+import { getKnownVideoIdsSet, saveVideosToFirestore } from "../services/youtube/youtube-firestore";
+import { SUZUKA_MINASE_CHANNEL_ID } from "../shared/common";
+import * as logger from "../shared/logger";
+
+/** SPR-230 週次フルスイープで検出された未取込動画ID（固定リスト） */
+export const MISSING_VIDEO_IDS = [
+	"pbYmFamK9lE",
+	"AFc0vAj__dA",
+	"FM9Z0l7sT44",
+	"gLYSr3MlXyk",
+	"J_Whs7Lf76c",
+] as const;
+
+/**
+ * buildPlaylistVideoMapping（youtube.ts、非 export）と同じロジックの再計算。
+ * 対象動画に限定せずチャンネル全体を走査する（既存の毎時クロールと同一コスト）。
+ */
+async function buildPlaylistVideoMapping(
+	youtube: youtube_v3.Youtube,
+): Promise<Map<string, string[]>> {
+	const videoPlaylistMap = new Map<string, string[]>();
+	const playlists = await fetchChannelPlaylists(youtube, SUZUKA_MINASE_CHANNEL_ID);
+	logger.info(`${playlists.length}個のプレイリストを取得しました`);
+
+	for (const playlist of playlists) {
+		try {
+			const videoIds = await fetchPlaylistItems(youtube, playlist.id);
+			for (const videoId of videoIds) {
+				const current = videoPlaylistMap.get(videoId) || [];
+				if (!current.includes(playlist.title)) {
+					current.push(playlist.title);
+				}
+				videoPlaylistMap.set(videoId, current);
+			}
+		} catch (_error) {
+			logger.warn(`プレイリスト「${playlist.title}」の動画取得に失敗`);
+		}
+	}
+	return videoPlaylistMap;
+}
+
+export async function backfillMissingVideos(): Promise<void> {
+	const targetIds = [...MISSING_VIDEO_IDS];
+
+	const knownIds = await getKnownVideoIdsSet(targetIds);
+	const alreadyKnown = targetIds.filter((id) => knownIds.has(id));
+	if (alreadyKnown.length > 0) {
+		logger.info(`既に取り込み済みのためスキップ: ${alreadyKnown.length}件`, { alreadyKnown });
+	}
+	const missingIds = targetIds.filter((id) => !knownIds.has(id));
+	logger.info(`backfill 対象: ${missingIds.length}件`, { missingIds });
+
+	if (missingIds.length === 0) {
+		logger.info("backfill 対象なし。終了します");
+		return;
+	}
+
+	const [youtube, initError] = initializeYouTubeClient();
+	if (initError || !youtube) {
+		logger.error("YouTube クライアント初期化に失敗しました", { initError });
+		throw new Error(initError?.error || "YouTube クライアント初期化に失敗しました");
+	}
+
+	const playlistMap = await buildPlaylistVideoMapping(youtube);
+	const videoDetails = await fetchVideoDetails(youtube, missingIds);
+	logger.info(`videos.list で ${videoDetails.length}/${missingIds.length} 件を取得`);
+
+	const foundIds = new Set(videoDetails.map((v) => v.id).filter((id): id is string => !!id));
+	const notFound = missingIds.filter((id) => !foundIds.has(id));
+	if (notFound.length > 0) {
+		logger.warn("videos.list で見つからなかった ID（非公開化・削除の可能性）", { notFound });
+	}
+
+	const videosWithTags = videoDetails.map((video) => {
+		if (!video.id) return video;
+		const playlistTags = playlistMap.get(video.id) || [];
+		return { ...video, _playlistTags: playlistTags };
+	});
+
+	const savedCount = await saveVideosToFirestore(videosWithTags);
+	logger.info(`保存完了: ${savedCount}件`);
+
+	// 検証: 対象IDが取り込まれたか再確認
+	const finalKnown = await getKnownVideoIdsSet(missingIds);
+	const stillMissing = missingIds.filter((id) => !finalKnown.has(id));
+	logger.info(`backfill 後の残存: ${stillMissing.length}件`, { stillMissing });
+}
+
+if (require.main === module) {
+	backfillMissingVideos()
+		.then(() => {
+			logger.info("backfill-missing-videos 完了");
+			process.exit(0);
+		})
+		.catch((error) => {
+			logger.error("backfill-missing-videos エラー:", error);
+			process.exit(1);
+		});
+}

--- a/packages/shared-types/src/api-schemas/dlsite-raw.ts
+++ b/packages/shared-types/src/api-schemas/dlsite-raw.ts
@@ -36,6 +36,18 @@ export const DLsiteRawWork = z.object({
 	image_thum: z.any().optional(),
 	srcset: z.string().optional(),
 	image_samples: z.array(z.any()).optional(),
+
+	// === 販売状態（フラット・実測フィールド。SPR-264: `sales_status`ネストは実APIに存在しない） ===
+	is_discount_work: z.boolean().optional(),
+	is_timesale_work: z.boolean().optional(),
+	is_limit_sales: z.boolean().optional(),
+	is_rental_work: z.boolean().optional(),
+	is_reserve_work: z.boolean().optional(),
+	is_reservable: z.boolean().optional(),
+	is_dlsiteplay_work: z.boolean().optional(),
+	is_title_pointup: z.boolean().nullable().optional(),
+	free: z.boolean().optional(),
+	free_only: z.boolean().optional(),
 });
 
 // === 評価情報 ===
@@ -127,21 +139,6 @@ export const DLsiteRawRank = z.object({
 
 export const DLsiteRawRanks = z.array(DLsiteRawRank);
 
-// === 販売状態 ===
-export const DLsiteRawSalesStatus = z.object({
-	is_sale: z.boolean().optional(),
-	on_sale: z.number().optional(),
-	is_discount: z.boolean().optional(),
-	is_pointup: z.boolean().optional(),
-	is_free: z.boolean().optional(),
-	is_rental: z.boolean().optional(),
-	is_sold_out: z.boolean().optional(),
-	is_reserve_work: z.boolean().optional(),
-	is_reservable: z.boolean().optional(),
-	is_timesale: z.boolean().optional(),
-	dlsiteplay_work: z.boolean().optional(),
-});
-
 // === クリエイター情報（creaters API） ===
 export const DLsiteRawCreater = z.object({
 	id: z.string(),
@@ -175,8 +172,6 @@ export const DLsiteApiResponse = z.object({
 	language_editions: DLsiteRawLanguageEditions.optional(),
 	// ランキング
 	rank: DLsiteRawRanks.optional(),
-	// 販売状態
-	sales_status: DLsiteRawSalesStatus.optional(),
 	// その他
 	default_point_rate: z.number().optional(),
 	// クリエイター情報（creaters APIから）


### PR DESCRIPTION
## Summary
- SPR-263: YouTube未取込動画5件のバックフィルツールを追加・本番実行済み（対象5件とも取り込み完了・残存0件確認）
- SPR-264: `work-mapper.ts`の`toSalesStatus`が実APIに存在しないネストフィールド`sales_status`を参照しており、`salesStatus`が常に`undefined`になっていた不具合を修正。実測150件中78件（52%）がセール中だったが検知できていなかった。これによりSPR-229のvolatileティア判定（セール中の旧作を毎run取得対象にする分岐）が常にfalseで機能していなかった問題も解消される。

## Test plan
- [x] `pnpm verify`（lint:docs/lint:tokens/lint/typecheck/test）全体green確認済み
- [x] `work-mapper.test.ts`にSPR-264のマッピング修正を検証するテストケースを追加
- [x] SPR-263のbackfillツールは本番実行済み（`tools:backfill-missing-videos`）・対象5件の取り込み完了と残存0件を確認済み
- [x] Linear SPR-262（重複クローズ漏れ）・SPR-263・SPR-264をそれぞれDoneにクローズ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)