### PR TITLE
refactor(functions): run metadata骨格をshared/run-metadataへ集約 (SPR-231 段階①)

### DIFF
--- a/apps/functions/src/endpoints/dlsite-individual-info-api.ts
+++ b/apps/functions/src/endpoints/dlsite-individual-info-api.ts
@@ -11,7 +11,7 @@ import type {
 	DLsiteApiResponse,
 	WorkDocument,
 } from "@suzumina.click/shared-types";
-import firestore, { Timestamp } from "../infrastructure/database/firestore";
+import { Timestamp } from "../infrastructure/database/firestore";
 import { recomputeCreatorStats } from "../services/dlsite/creator-firestore";
 import {
 	resetCreatorRecomputeQueue,
@@ -41,6 +41,7 @@ import { chunkArray } from "../shared/array-utils";
 import { withClearedUndefined } from "../shared/firestore-write";
 import * as logger from "../shared/logger";
 import { decodePubsubMode, type MessagePublishedData } from "../shared/pubsub-utils";
+import { createRunMetadataStore } from "../shared/run-metadata";
 
 /**
  * SPR-229 Stage②: ティア差分によるdue-setフィルタの有効/無効フラグ。
@@ -90,37 +91,36 @@ interface BatchProcessingInfo {
 }
 
 /**
- * 統合データ収集メタデータの取得または初期化
+ * 統合データ収集メタデータのストア（SPR-231: 骨格は shared/run-metadata に集約）
+ *
+ * update 時は undefined フィールドを FieldValue.delete() へ変換してから書き込む。
+ * ignoreUndefinedProperties 環境では undefined がスキップされ旧値が残る（sticky）ため、
+ * メタデータをクリア可能にする（`withClearedUndefined` 参照）。
  */
-async function getOrCreateUnifiedMetadata(): Promise<CollectionMetadata> {
-	const metadataRef = firestore.collection(METADATA_COLLECTION).doc(UNIFIED_METADATA_DOC_ID);
-	const doc = await metadataRef.get();
-
-	if (doc.exists) {
-		return doc.data() as CollectionMetadata;
-	}
-
-	const initialMetadata: CollectionMetadata = {
+const unifiedMetadataStore = createRunMetadataStore<CollectionMetadata>({
+	collection: METADATA_COLLECTION,
+	docId: UNIFIED_METADATA_DOC_ID,
+	createInitial: () => ({
 		lastFetchedAt: Timestamp.now(),
 		isInProgress: false,
 		unifiedSystemStarted: Timestamp.now(),
 		migrationVersion: "v2",
-	};
+	}),
+	sanitizeUpdate: withClearedUndefined,
+});
 
-	await metadataRef.set(initialMetadata);
-	return initialMetadata;
+/**
+ * 統合データ収集メタデータの取得または初期化
+ */
+async function getOrCreateUnifiedMetadata(): Promise<CollectionMetadata> {
+	return unifiedMetadataStore.getOrCreate();
 }
 
 /**
  * 統合データ収集メタデータの更新
- *
- * undefined フィールドは FieldValue.delete() へ変換してから書き込む。
- * ignoreUndefinedProperties 環境では undefined がスキップされ旧値が残る（sticky）ため、
- * メタデータをクリア可能にする（`withClearedUndefined` 参照）。
  */
 async function updateUnifiedMetadata(update: Partial<CollectionMetadata>): Promise<void> {
-	const metadataRef = firestore.collection(METADATA_COLLECTION).doc(UNIFIED_METADATA_DOC_ID);
-	await metadataRef.update(withClearedUndefined(update));
+	await unifiedMetadataStore.update(update);
 }
 
 /**

--- a/apps/functions/src/endpoints/youtube.ts
+++ b/apps/functions/src/endpoints/youtube.ts
@@ -26,6 +26,7 @@ import {
 import { SUZUKA_MINASE_CHANNEL_ID } from "../shared/common";
 import * as logger from "../shared/logger";
 import { decodePubsubMode, type MessagePublishedData } from "../shared/pubsub-utils";
+import { createRunMetadataStore } from "../shared/run-metadata";
 
 // メタデータ保存用のドキュメントID
 const METADATA_DOC_ID = "fetch_metadata";
@@ -104,24 +105,45 @@ interface FetchResult {
 }
 
 /**
+ * メタデータのストア（SPR-231: 骨格は shared/run-metadata に集約）
+ *
+ * update 時は undefined 値を null に変換し、lastFetchedAt を常時注入する（現行挙動の温存）。
+ * dlsite 側（undefined → FieldValue.delete()）との非対称は意図的に統一しない
+ * （Firestore に残る値が変わる＝挙動変更のため。shared/run-metadata.ts 参照）。
+ */
+const fetchMetadataStore = createRunMetadataStore<FetchMetadata>({
+	collection: METADATA_COLLECTION,
+	docId: METADATA_DOC_ID,
+	createInitial: () => ({
+		lastFetchedAt: Timestamp.now(),
+		isInProgress: false,
+	}),
+	sanitizeUpdate: (updates) => {
+		// undefined値を持つプロパティをnullに変換する（テストに合わせるため）
+		const sanitizedUpdates: Record<string, Timestamp | boolean | string | null> = {
+			lastFetchedAt: Timestamp.now(), // 常に最終実行時間を更新
+		};
+
+		// updatesの各プロパティをチェックし、undefined値をnullに変換
+		// lastFetchedAtは常に上記で設定した値を使用するため、処理から除外する
+		for (const [key, value] of Object.entries(updates)) {
+			if (key !== "lastFetchedAt") {
+				// lastFetchedAtは上書きしない
+				// undefinedの場合はnullを設定（テスト互換性のため）
+				sanitizedUpdates[key] = value === undefined ? null : value;
+			}
+		}
+		return sanitizedUpdates;
+	},
+});
+
+/**
  * メタデータの取得または初期化
  *
  * @returns Promise<FetchMetadata> - 取得または初期化されたメタデータ
  */
 async function getOrCreateMetadata(): Promise<FetchMetadata> {
-	const metadataRef = firestore.collection(METADATA_COLLECTION).doc(METADATA_DOC_ID);
-	const doc = await metadataRef.get();
-
-	if (doc.exists) {
-		return doc.data() as FetchMetadata;
-	}
-	// 初期メタデータの作成
-	const initialMetadata: FetchMetadata = {
-		lastFetchedAt: Timestamp.now(),
-		isInProgress: false,
-	};
-	await metadataRef.set(initialMetadata);
-	return initialMetadata;
+	return fetchMetadataStore.getOrCreate();
 }
 
 /**
@@ -131,25 +153,7 @@ async function getOrCreateMetadata(): Promise<FetchMetadata> {
  * @returns Promise<void>
  */
 async function updateMetadata(updates: Partial<FetchMetadata>): Promise<void> {
-	const metadataRef = firestore.collection(METADATA_COLLECTION).doc(METADATA_DOC_ID);
-
-	// undefined値を持つプロパティをnullに変換する（テストに合わせるため）
-	const sanitizedUpdates: Record<string, Timestamp | boolean | string | null> = {
-		lastFetchedAt: Timestamp.now(), // 常に最終実行時間を更新
-	};
-
-	// updatesの各プロパティをチェックし、undefined値をnullに変換
-	// lastFetchedAtは常に上記で設定した値を使用するため、処理から除外する
-	for (const [key, value] of Object.entries(updates)) {
-		if (key !== "lastFetchedAt") {
-			// lastFetchedAtは上書きしない
-			// undefinedの場合はnullを設定（テスト互換性のため）
-			sanitizedUpdates[key] = value === undefined ? null : value;
-		}
-	}
-
-	// 有効な更新データをFirestoreに送信
-	await metadataRef.update(sanitizedUpdates);
+	await fetchMetadataStore.update(updates);
 }
 
 // 注：initializeYouTubeClientはutils/youtube-apiから利用

--- a/apps/functions/src/shared/__tests__/run-metadata.test.ts
+++ b/apps/functions/src/shared/__tests__/run-metadata.test.ts
@@ -1,0 +1,109 @@
+/**
+ * run-metadata.ts のテスト（SPR-231 段階①）
+ *
+ * get-or-create の骨格と sanitizeUpdate 注入の等価性を検証する。
+ * endpoint 側の挙動不変は endpoints/__tests__ の既存テスト（アサーション無変更）が担保する。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../infrastructure/database/firestore", () => {
+	const updateMock = vi.fn().mockResolvedValue(undefined);
+	const getMock = vi.fn().mockResolvedValue({ exists: false });
+	const setMock = vi.fn().mockResolvedValue(undefined);
+	const docMock = vi.fn(() => ({ update: updateMock, get: getMock, set: setMock }));
+	const collection = vi.fn(() => ({ doc: docMock }));
+
+	return {
+		default: { collection },
+		__updateMock: updateMock,
+		__getMock: getMock,
+		__setMock: setMock,
+		__docMock: docMock,
+		__collectionMock: collection,
+	};
+});
+
+const { createRunMetadataStore } = await import("../run-metadata");
+const firestoreMock = (await import("../../infrastructure/database/firestore")) as unknown as {
+	__updateMock: ReturnType<typeof vi.fn>;
+	__getMock: ReturnType<typeof vi.fn>;
+	__setMock: ReturnType<typeof vi.fn>;
+	__docMock: ReturnType<typeof vi.fn>;
+	__collectionMock: ReturnType<typeof vi.fn>;
+};
+
+interface TestMetadata {
+	isInProgress: boolean;
+	note?: string;
+}
+
+function makeStore(sanitizeUpdate = (u: Partial<TestMetadata>) => ({ ...u })) {
+	return createRunMetadataStore<TestMetadata>({
+		collection: "testMetadata",
+		docId: "test_doc",
+		createInitial: () => ({ isInProgress: false }),
+		sanitizeUpdate,
+	});
+}
+
+describe("createRunMetadataStore", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		firestoreMock.__getMock.mockResolvedValue({ exists: false });
+	});
+
+	describe("getOrCreate", () => {
+		it("doc が存在する場合はその data を返し、set は呼ばない", async () => {
+			const existing = { isInProgress: true, note: "existing" };
+			firestoreMock.__getMock.mockResolvedValue({ exists: true, data: () => existing });
+
+			const result = await makeStore().getOrCreate();
+
+			expect(result).toEqual(existing);
+			expect(firestoreMock.__setMock).not.toHaveBeenCalled();
+		});
+
+		it("doc が不在の場合は初期値を set して返す", async () => {
+			const result = await makeStore().getOrCreate();
+
+			expect(result).toEqual({ isInProgress: false });
+			expect(firestoreMock.__setMock).toHaveBeenCalledWith({ isInProgress: false });
+		});
+
+		it("指定した collection / docId を参照する", async () => {
+			await makeStore().getOrCreate();
+
+			expect(firestoreMock.__collectionMock).toHaveBeenCalledWith("testMetadata");
+			expect(firestoreMock.__docMock).toHaveBeenCalledWith("test_doc");
+		});
+
+		it("createInitial は doc 存在時には評価されない（遅延評価）", async () => {
+			firestoreMock.__getMock.mockResolvedValue({ exists: true, data: () => ({}) });
+			const createInitial = vi.fn(() => ({ isInProgress: false }));
+
+			await createRunMetadataStore<TestMetadata>({
+				collection: "testMetadata",
+				docId: "test_doc",
+				createInitial,
+				sanitizeUpdate: (u) => ({ ...u }),
+			}).getOrCreate();
+
+			expect(createInitial).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("update", () => {
+		it("sanitizeUpdate を通した結果で update する", async () => {
+			const sanitize = vi.fn((u: Partial<TestMetadata>) => ({ ...u, sanitized: true }));
+
+			await makeStore(sanitize).update({ isInProgress: true });
+
+			expect(sanitize).toHaveBeenCalledWith({ isInProgress: true });
+			expect(firestoreMock.__updateMock).toHaveBeenCalledWith({
+				isInProgress: true,
+				sanitized: true,
+			});
+		});
+	});
+});

--- a/apps/functions/src/shared/run-metadata.ts
+++ b/apps/functions/src/shared/run-metadata.ts
@@ -1,0 +1,56 @@
+/**
+ * 定期実行関数の run metadata ストア（SPR-231 段階①）
+ *
+ * dlsite / youtube の定期実行関数が持つ「メタデータ doc の get-or-create + update」の
+ * 骨格（get → exists ? data : set(initial)）は完全同一だったため、ここに集約する。
+ *
+ * 一方で update 時のサニタイズ戦略は endpoint ごとに非対称で、これは統一しない:
+ * - dlsite: undefined を FieldValue.delete() に変換（フィールドを実際に削除）
+ * - youtube: undefined を null に変換し、lastFetchedAt を常時注入（フィールドは残る）
+ * この差は Firestore に残る値の差＝挙動そのものであるため、統一は挙動変更（SPR-231 の対象外）。
+ * サニタイズは `sanitizeUpdate` として呼び出し側から注入し、各 endpoint の現行挙動を温存する。
+ */
+
+import firestore from "../infrastructure/database/firestore";
+
+export interface RunMetadataStore<T extends object> {
+	/** メタデータ doc を取得し、存在しなければ初期値で作成して返す */
+	getOrCreate(): Promise<T>;
+	/** sanitizeUpdate を通した部分更新を適用する */
+	update(updates: Partial<T>): Promise<void>;
+}
+
+/**
+ * メタデータ doc への get-or-create / update を提供するストアを作る
+ *
+ * doc 参照は呼び出しの都度組み立てる（モジュール読み込み時に固定しない）。
+ * テストが firestore モックを beforeEach でリセットする前提と、現行実装の
+ * 呼び出しパターン（各関数内で collection().doc() を構築）を両方保つため。
+ */
+export function createRunMetadataStore<T extends object>(options: {
+	/** メタデータ doc のコレクション名（例: "dlsiteMetadata"） */
+	collection: string;
+	/** メタデータ doc の ID */
+	docId: string;
+	/** doc 不在時にのみ評価される初期値の生成（Timestamp.now() を含むため遅延評価） */
+	createInitial: () => T;
+	/** update 前の変換。endpoint ごとの undefined の扱い（delete vs null）をここで温存する */
+	sanitizeUpdate: (updates: Partial<T>) => Record<string, unknown>;
+}): RunMetadataStore<T> {
+	const metadataRef = () => firestore.collection(options.collection).doc(options.docId);
+
+	return {
+		async getOrCreate(): Promise<T> {
+			const doc = await metadataRef().get();
+			if (doc.exists) {
+				return doc.data() as T;
+			}
+			const initial = options.createInitial();
+			await metadataRef().set(initial);
+			return initial;
+		},
+		async update(updates: Partial<T>): Promise<void> {
+			await metadataRef().update(options.sanitizeUpdate(updates));
+		},
+	};
+}


### PR DESCRIPTION
## Summary
SPR-231（Cloud Run Functions保守性向上）の段階①。dlsite/youtube両endpointで完全同一だったメタデータdocのget-or-create + update骨格を `shared/run-metadata.ts` の `createRunMetadataStore<T>` に集約する。**ファイル移動なし・挙動不変**。

- サニタイズ戦略の非対称（dlsite=undefined→`FieldValue.delete()` / youtube=undefined→null + `lastFetchedAt`常時注入）は**統一せず**`sanitizeUpdate`関数注入で温存（Firestoreに残る値の差＝挙動そのもののため。統一は挙動変更＝本Issueの対象外）
- 既存関数名（`getOrCreateUnifiedMetadata`/`updateUnifiedMetadata`/`getOrCreateMetadata`/`updateMetadata`）は薄いラッパとして残存
- doc参照は呼び出し都度組み立て（遅延評価）で現行の`collection().doc()`呼び出しパターンを維持
- youtube の `getCachedUploadsPlaylistId`（読むだけ・作らない意図的な素の読み取り）はstore対象外のまま
- dlsite endpoint の `firestore` default import はmetadata関数でしか使われていなかったため削除（`Timestamp`のみ残存）

## 挙動不変の検証
- [x] `pnpm verify` 全体green（exit 0）
- [x] **既存endpointテストのアサーション無変更で488件全通過**（`endpoints/__tests__/` への差分0行＝挙動不変の合格条件）
- [x] `shared/__tests__/run-metadata.test.ts` を新規追加（get-or-create骨格・sanitize注入・遅延評価の検証）

## 関連
- Linear: SPR-231（構造案は2026-07-05設計コメント参照）
- 後続: 段階②（dlsite再配置）→ search経路撤去 → 段階③（youtube再配置）→ 段階④（data-integrity再配置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)