### PR TITLE
fix(functions): run metadataのgetOrCreateを原子的create()にしTOCTOUを解消 (SPR-231 フォローアップ)

### DIFF
--- a/apps/functions/src/endpoints/__tests__/dlsite-individual-info-api.test.ts
+++ b/apps/functions/src/endpoints/__tests__/dlsite-individual-info-api.test.ts
@@ -18,7 +18,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../infrastructure/database/firestore", () => {
 	const updateMock = vi.fn().mockResolvedValue(undefined);
 	const getMock = vi.fn().mockResolvedValue({ exists: false });
-	const docRef = { update: updateMock, get: getMock, set: vi.fn() };
+	const docRef = { update: updateMock, get: getMock, create: vi.fn() };
 	const collection = vi.fn(() => ({ doc: vi.fn(() => docRef) }));
 
 	return {

--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -11,8 +11,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../infrastructure/database/firestore", () => {
 	const updateMock = vi.fn().mockResolvedValue(undefined);
 	const getMock = vi.fn().mockResolvedValue({ exists: false });
-	const setMock = vi.fn().mockResolvedValue(undefined);
-	const docRef = { update: updateMock, get: getMock, set: setMock };
+	const createMock = vi.fn().mockResolvedValue(undefined);
+	const docRef = { update: updateMock, get: getMock, create: createMock };
 	const collection = vi.fn(() => ({ doc: vi.fn(() => docRef) }));
 
 	return {
@@ -20,7 +20,7 @@ vi.mock("../../infrastructure/database/firestore", () => {
 		Timestamp: { now: vi.fn(() => ({ seconds: 0, nanoseconds: 0 })) },
 		__updateMock: updateMock,
 		__getMock: getMock,
-		__setMock: setMock,
+		__createMock: createMock,
 	};
 });
 
@@ -63,8 +63,8 @@ const updateMock = (firestoreMock as unknown as { __updateMock: ReturnType<typeo
 	.__updateMock;
 const getMetadataMock = (firestoreMock as unknown as { __getMock: ReturnType<typeof vi.fn> })
 	.__getMock;
-const setMetadataMock = (firestoreMock as unknown as { __setMock: ReturnType<typeof vi.fn> })
-	.__setMock;
+const createMetadataMock = (firestoreMock as unknown as { __createMock: ReturnType<typeof vi.fn> })
+	.__createMock;
 
 const dummyClient = {} as youtube_v3.Youtube;
 
@@ -495,7 +495,7 @@ describe("fetchYouTubeVideos: 配信中/配信予定の高速反映（mode=fast_
 		// 共有メタデータを更新しないため実行される（= ロック起因のupdateも発生しない）
 		expect(youtubeFirestore.saveVideosToFirestore).toHaveBeenCalled();
 		expect(updateMock).not.toHaveBeenCalled();
-		expect(setMetadataMock).not.toHaveBeenCalled();
+		expect(createMetadataMock).not.toHaveBeenCalled();
 	});
 
 	describe("discoveryモード=playlist時の軽量新着発見", () => {
@@ -532,7 +532,7 @@ describe("fetchYouTubeVideos: 配信中/配信予定の高速反映（mode=fast_
 			expect(calledIds).toHaveLength(2);
 			expect(youtubeFirestore.saveVideosToFirestore).toHaveBeenCalled();
 			expect(updateMock).not.toHaveBeenCalled();
-			expect(setMetadataMock).not.toHaveBeenCalled();
+			expect(createMetadataMock).not.toHaveBeenCalled();
 		});
 
 		it("uploads playlist IDが未キャッシュなら新着発見をスキップする（メタデータは書き込まない）", async () => {
@@ -548,8 +548,8 @@ describe("fetchYouTubeVideos: 配信中/配信予定の高速反映（mode=fast_
 			expect(youtubeApi.fetchUploadsPlaylistPage).not.toHaveBeenCalled();
 			expect(updateMock).not.toHaveBeenCalled();
 			// 所見対応: FetchMetadataドキュメントが存在しない場合でも
-			// getCachedUploadsPlaylistIdは新規作成(set)しない（読み取り専用）
-			expect(setMetadataMock).not.toHaveBeenCalled();
+			// getCachedUploadsPlaylistIdは新規作成(create)しない（読み取り専用）
+			expect(createMetadataMock).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/apps/functions/src/shared/__tests__/run-metadata.test.ts
+++ b/apps/functions/src/shared/__tests__/run-metadata.test.ts
@@ -113,6 +113,18 @@ describe("createRunMetadataStore", () => {
 			expect(firestoreMock.__getMock).toHaveBeenCalledTimes(2);
 		});
 
+		it("ALREADY_EXISTS 後の再取得でも doc 不在なら元のエラーを throw する（握りつぶさない）", async () => {
+			// 勝者が作成直後に削除した等の異常事態。黙って初期値を返すと「作成済み」と
+			// 誤認させるため、大声で失敗して次の定期実行の自然リトライに任せるのが仕様。
+			firestoreMock.__getMock
+				.mockResolvedValueOnce({ exists: false })
+				.mockResolvedValueOnce({ exists: false });
+			firestoreMock.__createMock.mockRejectedValue(alreadyExistsError());
+
+			await expect(makeStore().getOrCreate()).rejects.toThrow("ALREADY_EXISTS");
+			expect(firestoreMock.__getMock).toHaveBeenCalledTimes(2);
+		});
+
 		it("create が ALREADY_EXISTS 以外のエラーで失敗したらそのまま throw する", async () => {
 			const error = Object.assign(new Error("7 PERMISSION_DENIED"), { code: 7 });
 			firestoreMock.__createMock.mockRejectedValue(error);

--- a/apps/functions/src/shared/__tests__/run-metadata.test.ts
+++ b/apps/functions/src/shared/__tests__/run-metadata.test.ts
@@ -1,8 +1,8 @@
 /**
- * run-metadata.ts のテスト（SPR-231 段階①）
+ * run-metadata.ts のテスト（SPR-231 段階①・TOCTOU対応）
  *
- * get-or-create の骨格と sanitizeUpdate 注入の等価性を検証する。
- * endpoint 側の挙動不変は endpoints/__tests__ の既存テスト（アサーション無変更）が担保する。
+ * get-or-create の骨格・sanitizeUpdate 注入・並行 create 競合（ALREADY_EXISTS）の
+ * 解決を検証する。endpoint 側の等価性は endpoints/__tests__ の既存テストが担保する。
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,15 +10,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../infrastructure/database/firestore", () => {
 	const updateMock = vi.fn().mockResolvedValue(undefined);
 	const getMock = vi.fn().mockResolvedValue({ exists: false });
-	const setMock = vi.fn().mockResolvedValue(undefined);
-	const docMock = vi.fn(() => ({ update: updateMock, get: getMock, set: setMock }));
+	const createMock = vi.fn().mockResolvedValue(undefined);
+	const docMock = vi.fn(() => ({ update: updateMock, get: getMock, create: createMock }));
 	const collection = vi.fn(() => ({ doc: docMock }));
 
 	return {
 		default: { collection },
 		__updateMock: updateMock,
 		__getMock: getMock,
-		__setMock: setMock,
+		__createMock: createMock,
 		__docMock: docMock,
 		__collectionMock: collection,
 	};
@@ -28,7 +28,7 @@ const { createRunMetadataStore } = await import("../run-metadata");
 const firestoreMock = (await import("../../infrastructure/database/firestore")) as unknown as {
 	__updateMock: ReturnType<typeof vi.fn>;
 	__getMock: ReturnType<typeof vi.fn>;
-	__setMock: ReturnType<typeof vi.fn>;
+	__createMock: ReturnType<typeof vi.fn>;
 	__docMock: ReturnType<typeof vi.fn>;
 	__collectionMock: ReturnType<typeof vi.fn>;
 };
@@ -47,28 +47,34 @@ function makeStore(sanitizeUpdate = (u: Partial<TestMetadata>) => ({ ...u })) {
 	});
 }
 
+/** gRPC ALREADY_EXISTS 相当のエラー（@google-cloud/firestore は code=6 を載せる） */
+function alreadyExistsError(): Error & { code: number } {
+	return Object.assign(new Error("6 ALREADY_EXISTS: Document already exists"), { code: 6 });
+}
+
 describe("createRunMetadataStore", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		firestoreMock.__getMock.mockResolvedValue({ exists: false });
+		firestoreMock.__createMock.mockResolvedValue(undefined);
 	});
 
 	describe("getOrCreate", () => {
-		it("doc が存在する場合はその data を返し、set は呼ばない", async () => {
+		it("doc が存在する場合はその data を返し、create は呼ばない", async () => {
 			const existing = { isInProgress: true, note: "existing" };
 			firestoreMock.__getMock.mockResolvedValue({ exists: true, data: () => existing });
 
 			const result = await makeStore().getOrCreate();
 
 			expect(result).toEqual(existing);
-			expect(firestoreMock.__setMock).not.toHaveBeenCalled();
+			expect(firestoreMock.__createMock).not.toHaveBeenCalled();
 		});
 
-		it("doc が不在の場合は初期値を set して返す", async () => {
+		it("doc が不在の場合は初期値を create して返す", async () => {
 			const result = await makeStore().getOrCreate();
 
 			expect(result).toEqual({ isInProgress: false });
-			expect(firestoreMock.__setMock).toHaveBeenCalledWith({ isInProgress: false });
+			expect(firestoreMock.__createMock).toHaveBeenCalledWith({ isInProgress: false });
 		});
 
 		it("指定した collection / docId を参照する", async () => {
@@ -90,6 +96,30 @@ describe("createRunMetadataStore", () => {
 			}).getOrCreate();
 
 			expect(createInitial).not.toHaveBeenCalled();
+		});
+
+		it("create が ALREADY_EXISTS で失敗したら勝者の doc を再取得して返す（TOCTOU 敗者側）", async () => {
+			const winner = { isInProgress: true, note: "winner" };
+			firestoreMock.__getMock
+				// 1回目の get: 不在（→ create を試みる）
+				.mockResolvedValueOnce({ exists: false })
+				// 敗者側の再取得: 並行呼び出しが作成済み
+				.mockResolvedValueOnce({ exists: true, data: () => winner });
+			firestoreMock.__createMock.mockRejectedValue(alreadyExistsError());
+
+			const result = await makeStore().getOrCreate();
+
+			expect(result).toEqual(winner);
+			expect(firestoreMock.__getMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("create が ALREADY_EXISTS 以外のエラーで失敗したらそのまま throw する", async () => {
+			const error = Object.assign(new Error("7 PERMISSION_DENIED"), { code: 7 });
+			firestoreMock.__createMock.mockRejectedValue(error);
+
+			await expect(makeStore().getOrCreate()).rejects.toThrow("PERMISSION_DENIED");
+			// 再取得は行わない（1回目の get のみ）
+			expect(firestoreMock.__getMock).toHaveBeenCalledTimes(1);
 		});
 	});
 

--- a/apps/functions/src/shared/run-metadata.ts
+++ b/apps/functions/src/shared/run-metadata.ts
@@ -2,7 +2,10 @@
  * 定期実行関数の run metadata ストア（SPR-231 段階①）
  *
  * dlsite / youtube の定期実行関数が持つ「メタデータ doc の get-or-create + update」の
- * 骨格（get → exists ? data : set(initial)）は完全同一だったため、ここに集約する。
+ * 骨格は完全同一だったため、ここに集約する。作成は create()（原子的・存在時は
+ * ALREADY_EXISTS）で行い、get→書き込み間の TOCTOU 競合は敗者側の再取得で解決する
+ * （#850 レビューのフォローアップ。本番では doc が恒久存在するため実害は無かったが、
+ * 集約を機に塞いだ）。
  *
  * 一方で update 時のサニタイズ戦略は endpoint ごとに非対称で、これは統一しない:
  * - dlsite: undefined を FieldValue.delete() に変換（フィールドを実際に削除）
@@ -12,6 +15,17 @@
  */
 
 import firestore from "../infrastructure/database/firestore";
+
+/** gRPC ステータスコード: ドキュメントが既に存在する（並行 create の敗者側が受け取る） */
+const GRPC_ALREADY_EXISTS = 6;
+
+function isAlreadyExistsError(error: unknown): boolean {
+	return (
+		typeof error === "object" &&
+		error !== null &&
+		(error as { code?: unknown }).code === GRPC_ALREADY_EXISTS
+	);
+}
 
 export interface RunMetadataStore<T extends object> {
 	/** メタデータ doc を取得し、存在しなければ初期値で作成して返す */
@@ -46,8 +60,21 @@ export function createRunMetadataStore<T extends object>(options: {
 				return doc.data() as T;
 			}
 			const initial = options.createInitial();
-			await metadataRef().set(initial);
-			return initial;
+			try {
+				// set() でなく create()（doc 存在時に ALREADY_EXISTS で失敗する原子的作成）を使い、
+				// get→set 間の TOCTOU（並行呼び出しの両者が「不在」を観測して二重作成する競合）を防ぐ
+				await metadataRef().create(initial);
+				return initial;
+			} catch (error) {
+				if (isAlreadyExistsError(error)) {
+					// 並行呼び出しが先に作成した（本呼び出しは競合の敗者）→ 勝者の doc を正として再取得
+					const winner = await metadataRef().get();
+					if (winner.exists) {
+						return winner.data() as T;
+					}
+				}
+				throw error;
+			}
 		},
 		async update(updates: Partial<T>): Promise<void> {
 			await metadataRef().update(options.sanitizeUpdate(updates));

--- a/apps/functions/src/shared/run-metadata.ts
+++ b/apps/functions/src/shared/run-metadata.ts
@@ -3,9 +3,7 @@
  *
  * dlsite / youtube の定期実行関数が持つ「メタデータ doc の get-or-create + update」の
  * 骨格は完全同一だったため、ここに集約する。作成は create()（原子的・存在時は
- * ALREADY_EXISTS）で行い、get→書き込み間の TOCTOU 競合は敗者側の再取得で解決する
- * （#850 レビューのフォローアップ。本番では doc が恒久存在するため実害は無かったが、
- * 集約を機に塞いだ）。
+ * ALREADY_EXISTS）で行い、get→書き込み間の TOCTOU 競合は敗者側の再取得で解決する。
  *
  * 一方で update 時のサニタイズ戦略は endpoint ごとに非対称で、これは統一しない:
  * - dlsite: undefined を FieldValue.delete() に変換（フィールドを実際に削除）


### PR DESCRIPTION
## Summary
PR #850のAIレビューで参考指摘された `getOrCreate` のTOCTOU（get→exists判定→set間の競合窓）を解消する。#850で骨格が `shared/run-metadata.ts` の1箇所に集約されたため、修正はこのファイルだけで完結する。

- `set()` → **`create()`**（doc存在時に `ALREADY_EXISTS` で失敗する原子的作成）に置換
- 敗者側は `ALREADY_EXISTS`（gRPC code=6）を捕捉し、**勝者のdocを再取得して返す**（自己解決・二重作成なし）
- それ以外のエラーはそのままthrow（従来どおり）
- トランザクションは不採用（この用途には過剰・ホットパス（doc存在時）は従来と同一の1 get で変化なし）

## 位置づけ
**本PRは挙動可視の変更**（Firestore呼び出しパターンが set→create に変わる）であり、#850の「既存アサーション無変更」契約の対象外として意図的に分離した独立PR。SPR-231の移動のみPR群（②〜④）とも分離してある。

なお本番ではメタデータdoc（`dlsiteMetadata`/`youtubeMetadata`）が恒久存在するためcreate分岐自体が実質到達不能で、実害は無かった（レビューでも blocker/major ではなく参考記載）。将来の新規環境・Emulator初回での正しさを固めるための修正。

## Test plan
- [x] `shared/__tests__/run-metadata.test.ts`: create成功・**ALREADY_EXISTS競合→勝者doc再取得**・他エラーrethrow・遅延評価を検証（+2件）
- [x] endpointテストのFirestoreモックを `create` 対応に更新（「fast_recheckは共有メタデータを作成しない」アサーション3件も create 基準へ）
- [x] `pnpm verify` 全体green（exit 0・functions 490件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)