### PR TITLE
refactor(functions): dlsite endpointを薄いハンドラ+orchestrator構成へ再配置 (SPR-231 段階②)

### DIFF
--- a/apps/functions/src/endpoints/__tests__/index.test.ts
+++ b/apps/functions/src/endpoints/__tests__/index.test.ts
@@ -12,7 +12,7 @@ vi.mock("../youtube", () => ({
 	fetchYouTubeVideos: vi.fn(),
 }));
 
-vi.mock("../dlsite-individual-info-api", () => ({
+vi.mock("../dlsite/fetch-dlsite-unified-data", () => ({
 	fetchDLsiteUnifiedData: vi.fn(),
 }));
 

--- a/apps/functions/src/endpoints/__tests__/youtube.test.ts
+++ b/apps/functions/src/endpoints/__tests__/youtube.test.ts
@@ -2,7 +2,7 @@
  * youtube.ts のテスト（SPR-230: discoveryモード切替・early-stop・週次フルスイープ 中心）
  *
  * サービス層（youtube-api.ts / youtube-firestore.ts）はモックし、
- * dlsite-individual-info-api.test.tsと同様のパターンでエンドポイントの分岐を検証する。
+ * dlsite/fetch-dlsite-unified-data.test.tsと同様のパターンでエンドポイントの分岐を検証する。
  */
 
 import type { youtube_v3 } from "googleapis";

--- a/apps/functions/src/endpoints/dlsite/__tests__/fetch-dlsite-unified-data.test.ts
+++ b/apps/functions/src/endpoints/dlsite/__tests__/fetch-dlsite-unified-data.test.ts
@@ -1,5 +1,5 @@
 /**
- * dlsite-individual-info-api.ts のテスト（SPR-229: computeDueWorkIds / resolveCycleInfo /
+ * DLsite 統合データ収集エンドポイントのテスト（SPR-229: computeDueWorkIds / resolveCycleInfo /
  * fetchDLsiteUnifiedData 中心）
  *
  * レビュー指摘（この専用エンドポイントに直接のテストが無い）への対応。
@@ -15,7 +15,7 @@ import type {
 } from "@suzumina.click/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../infrastructure/database/firestore", () => {
+vi.mock("../../../infrastructure/database/firestore", () => {
 	const updateMock = vi.fn().mockResolvedValue(undefined);
 	const getMock = vi.fn().mockResolvedValue({ exists: false });
 	const docRef = { update: updateMock, get: getMock, create: vi.fn() };
@@ -29,62 +29,61 @@ vi.mock("../../infrastructure/database/firestore", () => {
 	};
 });
 
-vi.mock("../../services/price-history", () => ({
+vi.mock("../../../services/price-history", () => ({
 	bulkCheckPriceHistoryExistsToday: vi.fn().mockResolvedValue(new Set()),
 	getJSTDate: vi.fn(() => "2026-07-05"),
 	savePriceHistory: vi.fn(),
 }));
 
-vi.mock("../../services/dlsite/work-id-collector", () => ({
+vi.mock("../../../services/dlsite/work-id-collector", () => ({
 	collectWorkIdsForProduction: vi.fn(),
 }));
 
-vi.mock("../../services/dlsite/dlsite-firestore", () => ({
+vi.mock("../../../services/dlsite/dlsite-firestore", () => ({
 	getExistingWorksMap: vi.fn().mockResolvedValue(new Map()),
 }));
 
-vi.mock("../../services/dlsite/individual-info-api-client", () => ({
+vi.mock("../../../services/dlsite/individual-info-api-client", () => ({
 	batchFetchIndividualInfo: vi.fn(),
 }));
 
-vi.mock("../../services/dlsite/unified-data-processor", () => ({
+vi.mock("../../../services/dlsite/unified-data-processor", () => ({
 	processBatchUnifiedDLsiteData: vi.fn(),
 }));
 
-vi.mock("../../services/dlsite/creator-firestore", () => ({
+vi.mock("../../../services/dlsite/creator-firestore", () => ({
 	recomputeCreatorStats: vi.fn(),
 }));
 
-vi.mock("../../services/dlsite/creator-recompute-queue", () => ({
+vi.mock("../../../services/dlsite/creator-recompute-queue", () => ({
 	resetCreatorRecomputeQueue: vi.fn(),
 	takeQueuedCreators: vi.fn(() => []),
 }));
 
-vi.mock("../../services/dlsite/dlsite-read-metrics", () => ({
+vi.mock("../../../services/dlsite/dlsite-read-metrics", () => ({
 	resetDlsiteReadMetrics: vi.fn(),
 	getDlsiteReadMetrics: vi.fn(() => ({})),
 }));
 
-vi.mock("../../shared/logger", () => ({
+vi.mock("../../../shared/logger", () => ({
 	debug: vi.fn(),
 	info: vi.fn(),
 	warn: vi.fn(),
 	error: vi.fn(),
 }));
 
-const { computeDueWorkIds, resolveCycleInfo, fetchDLsiteUnifiedData } = await import(
-	"../dlsite-individual-info-api"
-);
-const { bulkCheckPriceHistoryExistsToday } = await import("../../services/price-history");
-const { collectWorkIdsForProduction } = await import("../../services/dlsite/work-id-collector");
-const { getExistingWorksMap } = await import("../../services/dlsite/dlsite-firestore");
+const { fetchDLsiteUnifiedData } = await import("../fetch-dlsite-unified-data");
+const { computeDueWorkIds, resolveCycleInfo } = await import("../run-unified-data-collection");
+const { bulkCheckPriceHistoryExistsToday } = await import("../../../services/price-history");
+const { collectWorkIdsForProduction } = await import("../../../services/dlsite/work-id-collector");
+const { getExistingWorksMap } = await import("../../../services/dlsite/dlsite-firestore");
 const { batchFetchIndividualInfo } = await import(
-	"../../services/dlsite/individual-info-api-client"
+	"../../../services/dlsite/individual-info-api-client"
 );
 const { processBatchUnifiedDLsiteData } = await import(
-	"../../services/dlsite/unified-data-processor"
+	"../../../services/dlsite/unified-data-processor"
 );
-const firestoreMock = vi.mocked(await import("../../infrastructure/database/firestore"));
+const firestoreMock = vi.mocked(await import("../../../infrastructure/database/firestore"));
 const updateMock = (firestoreMock as unknown as { __updateMock: ReturnType<typeof vi.fn> })
 	.__updateMock;
 const getMetadataMock = (firestoreMock as unknown as { __getMock: ReturnType<typeof vi.fn> })

--- a/apps/functions/src/endpoints/dlsite/collection-metadata.ts
+++ b/apps/functions/src/endpoints/dlsite/collection-metadata.ts
@@ -1,0 +1,159 @@
+/**
+ * DLsite 統合データ収集: run metadata と継続 cursor のライフサイクル
+ *
+ * メタデータ doc（dlsiteMetadata/unified_data_collection_metadata）の取得/更新と、
+ * 継続 cursor（batchProcessingMode/currentBatch/allWorkIds）の読み取り・初期化・完了クリアを担う。
+ * バッチループ中の cursor 逐次更新はオーケストレータ（run-unified-data-collection.ts）が行う。
+ */
+
+import type { CollectionMetadata } from "@suzumina.click/shared-types";
+import { Timestamp } from "../../infrastructure/database/firestore";
+import { withClearedUndefined } from "../../shared/firestore-write";
+import * as logger from "../../shared/logger";
+import { createRunMetadataStore } from "../../shared/run-metadata";
+import { BATCH_SIZE, MAX_EXECUTION_TIME } from "./process-batch";
+
+// 統合メタデータ保存用の定数
+const UNIFIED_METADATA_DOC_ID = "unified_data_collection_metadata";
+const METADATA_COLLECTION = "dlsiteMetadata";
+
+/**
+ * 統合データ収集メタデータのストア（SPR-231: 骨格は shared/run-metadata に集約）
+ *
+ * update 時は undefined フィールドを FieldValue.delete() へ変換してから書き込む。
+ * ignoreUndefinedProperties 環境では undefined がスキップされ旧値が残る（sticky）ため、
+ * メタデータをクリア可能にする（`withClearedUndefined` 参照）。
+ */
+const unifiedMetadataStore = createRunMetadataStore<CollectionMetadata>({
+	collection: METADATA_COLLECTION,
+	docId: UNIFIED_METADATA_DOC_ID,
+	createInitial: () => ({
+		lastFetchedAt: Timestamp.now(),
+		isInProgress: false,
+		unifiedSystemStarted: Timestamp.now(),
+		migrationVersion: "v2",
+	}),
+	sanitizeUpdate: withClearedUndefined,
+});
+
+/**
+ * 統合データ収集メタデータの取得または初期化
+ */
+export async function getOrCreateUnifiedMetadata(): Promise<CollectionMetadata> {
+	return unifiedMetadataStore.getOrCreate();
+}
+
+/**
+ * 統合データ収集メタデータの更新
+ */
+export async function updateUnifiedMetadata(update: Partial<CollectionMetadata>): Promise<void> {
+	await unifiedMetadataStore.update(update);
+}
+
+/**
+ * バッチ処理の継続情報を取得
+ */
+export function getContinuationInfo(
+	metadata: CollectionMetadata,
+): { isContinuation: true; allWorkIds: string[]; startBatch: number } | { isContinuation: false } {
+	if (
+		metadata.batchProcessingMode &&
+		metadata.allWorkIds &&
+		metadata.currentBatch !== undefined &&
+		metadata.totalBatches !== undefined
+	) {
+		// currentBatchがtotalBatchesに達している場合は新規処理として扱う
+		if ((metadata.currentBatch ?? 0) >= metadata.totalBatches) {
+			logger.info("前回の処理は完了済み。新規処理として開始します", {
+				currentBatch: metadata.currentBatch,
+				totalBatches: metadata.totalBatches,
+			});
+			return { isContinuation: false as const };
+		}
+
+		logger.info("バッチ処理を継続します", {
+			currentBatch: metadata.currentBatch,
+			totalBatches: metadata.totalBatches,
+			allWorkIdsLength: metadata.allWorkIds?.length || 0,
+		});
+
+		return {
+			isContinuation: true as const,
+			allWorkIds: metadata.allWorkIds,
+			startBatch: metadata.currentBatch,
+		};
+	}
+
+	return { isContinuation: false as const };
+}
+
+/**
+ * 新規バッチ処理を初期化
+ *
+ * @param tierBreakdown SPR-229: このサイクルのティア別内訳（観測用。省略時=ティアリング無効）
+ * @param isFullSweepCycle SPR-229: 週次フルスイープ実行かどうか
+ * @param fullSweepWouldSkipWorkIds SPR-229: 週次フルスイープ時、通常runならスキップされていた作品ID（取りこぼし検知用）
+ */
+export async function initializeNewBatchProcessing(
+	allWorkIds: string[],
+	batches: string[][],
+	tierBreakdown?: CollectionMetadata["tierBreakdown"],
+	isFullSweepCycle = false,
+	fullSweepWouldSkipWorkIds?: string[],
+): Promise<void> {
+	logger.info(
+		`新規バッチ処理開始: 総作品数=${allWorkIds.length}, バッチ数=${batches.length}, バッチサイズ=${BATCH_SIZE}`,
+	);
+	logger.info(
+		`処理時間制限: ${MAX_EXECUTION_TIME / 1000}秒, 予想処理時間: ${batches.length * 30}秒（30秒/バッチ）`,
+	);
+
+	await updateUnifiedMetadata({
+		isInProgress: true,
+		batchProcessingMode: true,
+		allWorkIds,
+		totalBatches: batches.length,
+		currentBatch: 0,
+		totalWorks: allWorkIds.length,
+		processedWorks: 0,
+		basicDataUpdated: 0,
+		completedBatches: [],
+		lastError: undefined,
+		currentBatchStartTime: Timestamp.now(),
+		migrationVersion: "v2",
+		tierBreakdown,
+		isFullSweepCycle,
+		fullSweepWouldSkipWorkIds: isFullSweepCycle ? fullSweepWouldSkipWorkIds : undefined,
+		// SPR-229: 新規サイクル開始時点で pending 状態は解消済み（effectiveFullSweep に
+		// 反映済み、または今回対象外）のため必ずクリアする。
+		pendingFullSweep: undefined,
+	});
+}
+
+/**
+ * 処理完了時のメタデータ更新
+ */
+export async function finalizeCompletedProcessing(
+	allWorkIds: string[],
+	totalUpdated: number,
+): Promise<void> {
+	logger.info("全バッチ処理完了", {
+		totalWorks: allWorkIds.length,
+		totalUpdated,
+	});
+
+	await updateUnifiedMetadata({
+		isInProgress: false,
+		lastSuccessfulCompleteFetch: Timestamp.now(),
+		lastFetchedAt: Timestamp.now(),
+		batchProcessingMode: false,
+		currentBatch: undefined,
+		totalBatches: undefined,
+		allWorkIds: undefined,
+		completedBatches: undefined,
+		// SPR-229: サイクル終了時にティア/週次フルスイープ関連の一時フィールドをクリアする
+		tierBreakdown: undefined,
+		isFullSweepCycle: undefined,
+		fullSweepWouldSkipWorkIds: undefined,
+	});
+}

--- a/apps/functions/src/endpoints/dlsite/fetch-dlsite-unified-data.ts
+++ b/apps/functions/src/endpoints/dlsite/fetch-dlsite-unified-data.ts
@@ -1,0 +1,53 @@
+/**
+ * DLsite 統合データ収集エンドポイント（薄いハンドラ）
+ *
+ * CloudEvent の unwrap（mode 判定）→ オーケストレータ呼び出し → 結果ログのみを担う。
+ * 本処理は run-unified-data-collection.ts の `runUnifiedDataCollection`。
+ */
+
+import type { CloudEvent } from "@google-cloud/functions-framework";
+import { Timestamp } from "../../infrastructure/database/firestore";
+import * as logger from "../../shared/logger";
+import { decodePubsubMode, type MessagePublishedData } from "../../shared/pubsub-utils";
+import { updateUnifiedMetadata } from "./collection-metadata";
+import { runUnifiedDataCollection } from "./run-unified-data-collection";
+
+/**
+ * Cloud Functions エントリーポイント
+ */
+export async function fetchDLsiteUnifiedData(
+	event: CloudEvent<MessagePublishedData>,
+): Promise<void> {
+	const mode = decodePubsubMode(event.data);
+	const isWeeklyFullSweep = mode === "weekly_full_sweep";
+
+	logger.info("統合データ収集開始", {
+		eventType: event.type,
+		mode,
+		週次フルスイープ: isWeeklyFullSweep,
+		timestamp: new Date().toISOString(),
+		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+	});
+
+	try {
+		const result = await runUnifiedDataCollection(isWeeklyFullSweep);
+
+		if (result.error) {
+			logger.error(`統合データ収集エラー: ${result.error}`);
+		} else {
+			logger.info("統合データ収集完了", {
+				更新作品数: result.basicDataUpdated,
+				API呼び出し数: result.apiCallCount,
+				統合完了: result.unificationComplete,
+			});
+		}
+	} catch (error) {
+		logger.error("予期しないエラー:", error);
+
+		await updateUnifiedMetadata({
+			isInProgress: false,
+			lastError: error instanceof Error ? error.message : "不明なエラー",
+			lastFetchedAt: Timestamp.now(),
+		});
+	}
+}

--- a/apps/functions/src/endpoints/dlsite/process-batch.ts
+++ b/apps/functions/src/endpoints/dlsite/process-batch.ts
@@ -1,0 +1,279 @@
+/**
+ * DLsite 統合データ収集: 1バッチ分の実行と集計/ログヘルパ
+ *
+ * Individual Info API のバッチ呼び出し → 統合処理 → 結果集計までを担う。
+ * メタデータ/cursor には触れない（それは collection-metadata.ts / オーケストレータの責務）。
+ */
+
+import type { DLsiteApiResponse, WorkDocument } from "@suzumina.click/shared-types";
+import type { Timestamp } from "../../infrastructure/database/firestore";
+import { batchFetchIndividualInfo } from "../../services/dlsite/individual-info-api-client";
+import {
+	type ProcessingResult,
+	processBatchUnifiedDLsiteData,
+} from "../../services/dlsite/unified-data-processor";
+import * as logger from "../../shared/logger";
+
+// バッチ処理設定
+const MAX_CONCURRENT_API_REQUESTS = 5; // 6 → 3 → 5（バッチ処理を効率化: 50件を10回の並列処理で実行）
+const API_REQUEST_DELAY = 400;
+export const BATCH_SIZE = 50; // 100 → 50に削減（エラー率低下とタイムアウト回避）
+export const MAX_EXECUTION_TIME = 270000; // 4.5分（Cloud Functions 5分タイムアウトより短く設定）
+
+/**
+ * 統合処理結果の型定義
+ */
+export interface UnifiedFetchResult {
+	workCount: number;
+	apiCallCount: number;
+	basicDataUpdated: number;
+	error?: string;
+	unificationComplete?: boolean;
+}
+
+/**
+ * バッチ処理情報の型定義
+ */
+export interface BatchProcessingInfo {
+	batchNumber: number;
+	totalBatches: number;
+	workIds: string[];
+	startTime: Timestamp;
+	existingWorksMap?: Map<string, WorkDocument>;
+	/** SPR-229: 週次フルスイープ時、通常runならstableとしてスキップされていたはずの作品ID（取りこぼし検知用） */
+	wouldSkipStableIds?: Set<string>;
+}
+
+/**
+ * APIレスポンスがない場合のエラーレスポンスを作成
+ */
+function createNoResponseResult(workIdsLength: number): UnifiedFetchResult {
+	return {
+		workCount: 0,
+		apiCallCount: workIdsLength,
+		basicDataUpdated: 0,
+		error: "APIレスポンスなし",
+	};
+}
+
+/**
+ * 成功した処理結果をカウント
+ */
+function countSuccessfulUpdates(result: ProcessingResult) {
+	if (!result.success || !result.updates) {
+		return { work: 0, circle: 0, creator: 0, priceHistory: 0 };
+	}
+
+	return {
+		work: result.updates.work ? 1 : 0,
+		circle: result.updates.circle ? 1 : 0,
+		creator: result.updates.creators ? 1 : 0,
+		priceHistory: result.updates.priceHistory ? 1 : 0,
+	};
+}
+
+/**
+ * 処理結果を集計
+ */
+function aggregateProcessingResults(processingResults: ProcessingResult[]): {
+	workUpdated: number;
+	circleUpdated: number;
+	creatorUpdated: number;
+	priceHistoryUpdated: number;
+	errors: string[];
+} {
+	let workUpdated = 0;
+	let circleUpdated = 0;
+	let creatorUpdated = 0;
+	let priceHistoryUpdated = 0;
+	const errors: string[] = [];
+
+	for (const result of processingResults) {
+		const counts = countSuccessfulUpdates(result);
+		workUpdated += counts.work;
+		circleUpdated += counts.circle;
+		creatorUpdated += counts.creator;
+		priceHistoryUpdated += counts.priceHistory;
+
+		if (result.errors?.length > 0) {
+			errors.push(...result.errors);
+		}
+	}
+
+	return {
+		workUpdated,
+		circleUpdated,
+		creatorUpdated,
+		priceHistoryUpdated,
+		errors,
+	};
+}
+
+/**
+ * バッチ処理結果をUnifiedFetchResult形式に変換
+ */
+function createBatchResult(
+	aggregatedResults: {
+		workUpdated: number;
+		circleUpdated: number;
+		creatorUpdated: number;
+		errors: string[];
+	},
+	workIdsLength: number,
+): UnifiedFetchResult {
+	return {
+		workCount: aggregatedResults.workUpdated,
+		apiCallCount: workIdsLength,
+		basicDataUpdated: aggregatedResults.workUpdated,
+		unificationComplete: aggregatedResults.errors.length === 0,
+	};
+}
+
+/**
+ * API呼び出しの失敗をログ出力
+ */
+function logApiFailures(batchNumber: number, failedWorkIds: string[]): void {
+	if (failedWorkIds.length > 0) {
+		logger.warn(`バッチ ${batchNumber}: ${failedWorkIds.length}件の取得失敗`);
+		logger.debug(
+			`失敗ID一覧: ${failedWorkIds.slice(0, 10).join(", ")}${failedWorkIds.length > 10 ? "..." : ""}`,
+		);
+	}
+}
+
+/**
+ * 価格履歴の保存状況をデバッグログ出力
+ */
+function logPriceHistoryDebug(
+	batchNumber: number,
+	priceHistoryUpdated: number,
+	apiResponses: DLsiteApiResponse[],
+	existingWorksMap?: Map<string, WorkDocument>,
+): void {
+	if (priceHistoryUpdated === 0 && apiResponses.length > 0) {
+		logger.warn(`[DEBUG] バッチ ${batchNumber}: 価格履歴が1件も保存されませんでした`);
+		logger.warn(`[DEBUG] 現在時刻: ${new Date().toISOString()}`);
+		logger.warn(
+			`[DEBUG] JST時刻: ${new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}`,
+		);
+		// 既存作品の状態を確認
+		const sampleWorkId = apiResponses[0]?.workno;
+		if (sampleWorkId && existingWorksMap) {
+			const existingWork = existingWorksMap.get(sampleWorkId);
+			logger.warn(
+				`[DEBUG] サンプル作品 ${sampleWorkId} の既存データ: ${existingWork ? "あり" : "なし"}`,
+			);
+		}
+	}
+}
+
+/**
+ * バッチ処理の結果をログ出力
+ */
+function logBatchComplete(
+	batchNumber: number,
+	workIdsLength: number,
+	apiDataMapSize: number,
+	aggregatedResults: ReturnType<typeof aggregateProcessingResults>,
+): void {
+	logger.info(`バッチ ${batchNumber}: 統合処理完了`, {
+		入力: workIdsLength,
+		API成功: apiDataMapSize,
+		Work更新: aggregatedResults.workUpdated,
+		Circle更新: aggregatedResults.circleUpdated,
+		Creator更新: aggregatedResults.creatorUpdated,
+		価格履歴: aggregatedResults.priceHistoryUpdated,
+		エラー数: aggregatedResults.errors.length,
+	});
+}
+
+/**
+ * SPR-229: 週次フルスイープの取りこぼし検知ログ
+ *
+ * `wouldSkipStableIds`（通常runならstableとしてスキップされていたはずの作品）のうち、
+ * 実際にWorkの変化が検出された件数を出す。0件が理想（stableの90日窓が妥当であることの裏付け）。
+ * 非0が続く場合はStage③で`VOLATILE_RELEASE_WINDOW_DAYS`の見直しを検討する。
+ */
+function logFullSweepMissedChanges(
+	batchNumber: number,
+	processingResults: ProcessingResult[],
+	wouldSkipStableIds: Set<string> | undefined,
+): void {
+	if (!wouldSkipStableIds || wouldSkipStableIds.size === 0) {
+		return;
+	}
+
+	const targeted = processingResults.filter((r) => wouldSkipStableIds.has(r.workId));
+	const missed = targeted.filter((r) => r.updates.work);
+
+	logger.info(`バッチ ${batchNumber}: 週次フルスイープ取りこぼし検知`, {
+		stable想定件数: targeted.length,
+		変化検出件数: missed.length,
+		...(missed.length > 0 && { 変化検出workIds: missed.map((r) => r.workId) }),
+	});
+}
+
+/**
+ * バッチ処理実行
+ */
+export async function processBatch(batchInfo: BatchProcessingInfo): Promise<UnifiedFetchResult> {
+	const { batchNumber, totalBatches, workIds, existingWorksMap, wouldSkipStableIds } = batchInfo;
+
+	logger.info(`バッチ ${batchNumber}/${totalBatches} 処理開始: ${workIds.length}件`);
+
+	try {
+		// 1. Individual Info API 呼び出し（バッチ）
+		const { results: apiDataMap, failedWorkIds } = await batchFetchIndividualInfo(workIds, {
+			maxConcurrent: MAX_CONCURRENT_API_REQUESTS,
+			batchDelay: API_REQUEST_DELAY,
+		});
+
+		if (apiDataMap.size === 0) {
+			logger.warn(`バッチ ${batchNumber}: APIレスポンスなし`);
+			return createNoResponseResult(workIds.length);
+		}
+
+		// 失敗作品のログ
+		logApiFailures(batchNumber, failedWorkIds);
+
+		const apiResponses = Array.from(apiDataMap.values());
+
+		// デバッグ: API取得数とデータ内容を確認
+		logger.info(`[DEBUG] バッチ ${batchNumber}: API取得成功数=${apiResponses.length}`);
+		if (apiResponses.length > 0 && apiResponses[0]) {
+			logger.info(`[DEBUG] サンプルworkno: ${apiResponses[0].workno}`);
+		}
+
+		// 2. 新しい統合処理を使用
+		const processingResults = await processBatchUnifiedDLsiteData(apiResponses, {
+			skipPriceHistory: false, // 価格履歴も含めて全て更新
+			forceUpdate: false, // 差分チェックあり
+			existingWorksMap, // 既存作品マップを渡す
+		});
+
+		// 3. 結果の集計
+		const aggregatedResults = aggregateProcessingResults(processingResults);
+
+		// デバッグ: 価格履歴保存の詳細
+		logPriceHistoryDebug(
+			batchNumber,
+			aggregatedResults.priceHistoryUpdated,
+			apiResponses,
+			existingWorksMap,
+		);
+
+		// ログ出力
+		logBatchComplete(batchNumber, workIds.length, apiDataMap.size, aggregatedResults);
+		logFullSweepMissedChanges(batchNumber, processingResults, wouldSkipStableIds);
+
+		return createBatchResult(aggregatedResults, workIds.length);
+	} catch (error) {
+		logger.error(`バッチ ${batchNumber} 処理エラー:`, { error });
+		return {
+			workCount: 0,
+			apiCallCount: workIds.length,
+			basicDataUpdated: 0,
+			error: error instanceof Error ? error.message : "不明なエラー",
+		};
+	}
+}

--- a/apps/functions/src/endpoints/dlsite/run-unified-data-collection.ts
+++ b/apps/functions/src/endpoints/dlsite/run-unified-data-collection.ts
@@ -1,47 +1,49 @@
 /**
- * DLsite 統合データ収集エンドポイント
+ * DLsite 統合データ収集: オーケストレータ（この関数群が run の本処理）
  *
- * 新しいshared-types構造と薄いマッパーを使用したバージョン
- * レガシーフィールドを段階的に削除
+ * サイクル解決（継続 or 新規・due-set 計算・fast-lane 並べ替え）→ バッチループ →
+ * 完了処理 → creator recompute drain の流れを組み立てる。
+ * ハンドラ（fetch-dlsite-unified-data.ts）から `runUnifiedDataCollection` が呼ばれる。
  */
 
-import type { CloudEvent } from "@google-cloud/functions-framework";
-import type {
-	CollectionMetadata,
-	DLsiteApiResponse,
-	WorkDocument,
-} from "@suzumina.click/shared-types";
-import { Timestamp } from "../infrastructure/database/firestore";
-import { recomputeCreatorStats } from "../services/dlsite/creator-firestore";
+import type { CollectionMetadata, WorkDocument } from "@suzumina.click/shared-types";
+import { Timestamp } from "../../infrastructure/database/firestore";
+import { recomputeCreatorStats } from "../../services/dlsite/creator-firestore";
 import {
 	resetCreatorRecomputeQueue,
 	takeQueuedCreators,
-} from "../services/dlsite/creator-recompute-queue";
-import { getExistingWorksMap } from "../services/dlsite/dlsite-firestore";
+} from "../../services/dlsite/creator-recompute-queue";
+import { getExistingWorksMap } from "../../services/dlsite/dlsite-firestore";
 import {
 	getDlsiteReadMetrics,
 	resetDlsiteReadMetrics,
-} from "../services/dlsite/dlsite-read-metrics";
-import { batchFetchIndividualInfo } from "../services/dlsite/individual-info-api-client";
-import {
-	type ProcessingResult,
-	processBatchUnifiedDLsiteData,
-} from "../services/dlsite/unified-data-processor";
-import { collectWorkIdsForProduction } from "../services/dlsite/work-id-collector";
-import { orderNewWorksFirst } from "../services/dlsite/work-ordering";
+} from "../../services/dlsite/dlsite-read-metrics";
+import { collectWorkIdsForProduction } from "../../services/dlsite/work-id-collector";
+import { orderNewWorksFirst } from "../../services/dlsite/work-ordering";
 import {
 	classifyAndFilterStableTier,
 	classifyWorkTiers,
 	getStableCandidateIds,
 	type TieredWorkIds,
 	toDueWorkIds,
-} from "../services/dlsite/work-tiering";
-import { bulkCheckPriceHistoryExistsToday, getJSTDate } from "../services/price-history";
-import { chunkArray } from "../shared/array-utils";
-import { withClearedUndefined } from "../shared/firestore-write";
-import * as logger from "../shared/logger";
-import { decodePubsubMode, type MessagePublishedData } from "../shared/pubsub-utils";
-import { createRunMetadataStore } from "../shared/run-metadata";
+} from "../../services/dlsite/work-tiering";
+import { bulkCheckPriceHistoryExistsToday, getJSTDate } from "../../services/price-history";
+import { chunkArray } from "../../shared/array-utils";
+import * as logger from "../../shared/logger";
+import {
+	finalizeCompletedProcessing,
+	getContinuationInfo,
+	getOrCreateUnifiedMetadata,
+	initializeNewBatchProcessing,
+	updateUnifiedMetadata,
+} from "./collection-metadata";
+import {
+	BATCH_SIZE,
+	type BatchProcessingInfo,
+	MAX_EXECUTION_TIME,
+	processBatch,
+	type UnifiedFetchResult,
+} from "./process-batch";
 
 /**
  * SPR-229 Stage②: ティア差分によるdue-setフィルタの有効/無効フラグ。
@@ -52,389 +54,6 @@ import { createRunMetadataStore } from "../shared/run-metadata";
  */
 function isTierFilteringEnabled(): boolean {
 	return process.env.DLSITE_TIER_FILTERING_ENABLED !== "false";
-}
-
-// 統合メタデータ保存用の定数
-const UNIFIED_METADATA_DOC_ID = "unified_data_collection_metadata";
-const METADATA_COLLECTION = "dlsiteMetadata";
-
-// バッチ処理設定
-const MAX_CONCURRENT_API_REQUESTS = 5; // 6 → 3 → 5（バッチ処理を効率化: 50件を10回の並列処理で実行）
-const API_REQUEST_DELAY = 400;
-const BATCH_SIZE = 50; // 100 → 50に削減（エラー率低下とタイムアウト回避）
-const MAX_EXECUTION_TIME = 270000; // 4.5分（Cloud Functions 5分タイムアウトより短く設定）
-
-// Note: CollectionMetadata type is now imported from @suzumina.click/shared-types
-
-/**
- * 統合処理結果の型定義
- */
-interface UnifiedFetchResult {
-	workCount: number;
-	apiCallCount: number;
-	basicDataUpdated: number;
-	error?: string;
-	unificationComplete?: boolean;
-}
-
-/**
- * バッチ処理情報の型定義
- */
-interface BatchProcessingInfo {
-	batchNumber: number;
-	totalBatches: number;
-	workIds: string[];
-	startTime: Timestamp;
-	existingWorksMap?: Map<string, WorkDocument>;
-	/** SPR-229: 週次フルスイープ時、通常runならstableとしてスキップされていたはずの作品ID（取りこぼし検知用） */
-	wouldSkipStableIds?: Set<string>;
-}
-
-/**
- * 統合データ収集メタデータのストア（SPR-231: 骨格は shared/run-metadata に集約）
- *
- * update 時は undefined フィールドを FieldValue.delete() へ変換してから書き込む。
- * ignoreUndefinedProperties 環境では undefined がスキップされ旧値が残る（sticky）ため、
- * メタデータをクリア可能にする（`withClearedUndefined` 参照）。
- */
-const unifiedMetadataStore = createRunMetadataStore<CollectionMetadata>({
-	collection: METADATA_COLLECTION,
-	docId: UNIFIED_METADATA_DOC_ID,
-	createInitial: () => ({
-		lastFetchedAt: Timestamp.now(),
-		isInProgress: false,
-		unifiedSystemStarted: Timestamp.now(),
-		migrationVersion: "v2",
-	}),
-	sanitizeUpdate: withClearedUndefined,
-});
-
-/**
- * 統合データ収集メタデータの取得または初期化
- */
-async function getOrCreateUnifiedMetadata(): Promise<CollectionMetadata> {
-	return unifiedMetadataStore.getOrCreate();
-}
-
-/**
- * 統合データ収集メタデータの更新
- */
-async function updateUnifiedMetadata(update: Partial<CollectionMetadata>): Promise<void> {
-	await unifiedMetadataStore.update(update);
-}
-
-/**
- * APIレスポンスがない場合のエラーレスポンスを作成
- */
-function createNoResponseResult(workIdsLength: number): UnifiedFetchResult {
-	return {
-		workCount: 0,
-		apiCallCount: workIdsLength,
-		basicDataUpdated: 0,
-		error: "APIレスポンスなし",
-	};
-}
-
-/**
- * 成功した処理結果をカウント
- */
-function countSuccessfulUpdates(result: ProcessingResult) {
-	if (!result.success || !result.updates) {
-		return { work: 0, circle: 0, creator: 0, priceHistory: 0 };
-	}
-
-	return {
-		work: result.updates.work ? 1 : 0,
-		circle: result.updates.circle ? 1 : 0,
-		creator: result.updates.creators ? 1 : 0,
-		priceHistory: result.updates.priceHistory ? 1 : 0,
-	};
-}
-
-/**
- * 処理結果を集計
- */
-function aggregateProcessingResults(processingResults: ProcessingResult[]): {
-	workUpdated: number;
-	circleUpdated: number;
-	creatorUpdated: number;
-	priceHistoryUpdated: number;
-	errors: string[];
-} {
-	let workUpdated = 0;
-	let circleUpdated = 0;
-	let creatorUpdated = 0;
-	let priceHistoryUpdated = 0;
-	const errors: string[] = [];
-
-	for (const result of processingResults) {
-		const counts = countSuccessfulUpdates(result);
-		workUpdated += counts.work;
-		circleUpdated += counts.circle;
-		creatorUpdated += counts.creator;
-		priceHistoryUpdated += counts.priceHistory;
-
-		if (result.errors?.length > 0) {
-			errors.push(...result.errors);
-		}
-	}
-
-	return {
-		workUpdated,
-		circleUpdated,
-		creatorUpdated,
-		priceHistoryUpdated,
-		errors,
-	};
-}
-
-/**
- * バッチ処理結果をUnifiedFetchResult形式に変換
- */
-function createBatchResult(
-	aggregatedResults: {
-		workUpdated: number;
-		circleUpdated: number;
-		creatorUpdated: number;
-		errors: string[];
-	},
-	workIdsLength: number,
-): UnifiedFetchResult {
-	return {
-		workCount: aggregatedResults.workUpdated,
-		apiCallCount: workIdsLength,
-		basicDataUpdated: aggregatedResults.workUpdated,
-		unificationComplete: aggregatedResults.errors.length === 0,
-	};
-}
-
-/**
- * API呼び出しの失敗をログ出力
- */
-function logApiFailures(batchNumber: number, failedWorkIds: string[]): void {
-	if (failedWorkIds.length > 0) {
-		logger.warn(`バッチ ${batchNumber}: ${failedWorkIds.length}件の取得失敗`);
-		logger.debug(
-			`失敗ID一覧: ${failedWorkIds.slice(0, 10).join(", ")}${failedWorkIds.length > 10 ? "..." : ""}`,
-		);
-	}
-}
-
-/**
- * 価格履歴の保存状況をデバッグログ出力
- */
-function logPriceHistoryDebug(
-	batchNumber: number,
-	priceHistoryUpdated: number,
-	apiResponses: DLsiteApiResponse[],
-	existingWorksMap?: Map<string, WorkDocument>,
-): void {
-	if (priceHistoryUpdated === 0 && apiResponses.length > 0) {
-		logger.warn(`[DEBUG] バッチ ${batchNumber}: 価格履歴が1件も保存されませんでした`);
-		logger.warn(`[DEBUG] 現在時刻: ${new Date().toISOString()}`);
-		logger.warn(
-			`[DEBUG] JST時刻: ${new Date().toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })}`,
-		);
-		// 既存作品の状態を確認
-		const sampleWorkId = apiResponses[0]?.workno;
-		if (sampleWorkId && existingWorksMap) {
-			const existingWork = existingWorksMap.get(sampleWorkId);
-			logger.warn(
-				`[DEBUG] サンプル作品 ${sampleWorkId} の既存データ: ${existingWork ? "あり" : "なし"}`,
-			);
-		}
-	}
-}
-
-/**
- * バッチ処理の結果をログ出力
- */
-function logBatchComplete(
-	batchNumber: number,
-	workIdsLength: number,
-	apiDataMapSize: number,
-	aggregatedResults: ReturnType<typeof aggregateProcessingResults>,
-): void {
-	logger.info(`バッチ ${batchNumber}: 統合処理完了`, {
-		入力: workIdsLength,
-		API成功: apiDataMapSize,
-		Work更新: aggregatedResults.workUpdated,
-		Circle更新: aggregatedResults.circleUpdated,
-		Creator更新: aggregatedResults.creatorUpdated,
-		価格履歴: aggregatedResults.priceHistoryUpdated,
-		エラー数: aggregatedResults.errors.length,
-	});
-}
-
-/**
- * SPR-229: 週次フルスイープの取りこぼし検知ログ
- *
- * `wouldSkipStableIds`（通常runならstableとしてスキップされていたはずの作品）のうち、
- * 実際にWorkの変化が検出された件数を出す。0件が理想（stableの90日窓が妥当であることの裏付け）。
- * 非0が続く場合はStage③で`VOLATILE_RELEASE_WINDOW_DAYS`の見直しを検討する。
- */
-function logFullSweepMissedChanges(
-	batchNumber: number,
-	processingResults: ProcessingResult[],
-	wouldSkipStableIds: Set<string> | undefined,
-): void {
-	if (!wouldSkipStableIds || wouldSkipStableIds.size === 0) {
-		return;
-	}
-
-	const targeted = processingResults.filter((r) => wouldSkipStableIds.has(r.workId));
-	const missed = targeted.filter((r) => r.updates.work);
-
-	logger.info(`バッチ ${batchNumber}: 週次フルスイープ取りこぼし検知`, {
-		stable想定件数: targeted.length,
-		変化検出件数: missed.length,
-		...(missed.length > 0 && { 変化検出workIds: missed.map((r) => r.workId) }),
-	});
-}
-
-/**
- * バッチ処理実行
- */
-async function processBatch(batchInfo: BatchProcessingInfo): Promise<UnifiedFetchResult> {
-	const { batchNumber, totalBatches, workIds, existingWorksMap, wouldSkipStableIds } = batchInfo;
-
-	logger.info(`バッチ ${batchNumber}/${totalBatches} 処理開始: ${workIds.length}件`);
-
-	try {
-		// 1. Individual Info API 呼び出し（バッチ）
-		const { results: apiDataMap, failedWorkIds } = await batchFetchIndividualInfo(workIds, {
-			maxConcurrent: MAX_CONCURRENT_API_REQUESTS,
-			batchDelay: API_REQUEST_DELAY,
-		});
-
-		if (apiDataMap.size === 0) {
-			logger.warn(`バッチ ${batchNumber}: APIレスポンスなし`);
-			return createNoResponseResult(workIds.length);
-		}
-
-		// 失敗作品のログ
-		logApiFailures(batchNumber, failedWorkIds);
-
-		const apiResponses = Array.from(apiDataMap.values());
-
-		// デバッグ: API取得数とデータ内容を確認
-		logger.info(`[DEBUG] バッチ ${batchNumber}: API取得成功数=${apiResponses.length}`);
-		if (apiResponses.length > 0 && apiResponses[0]) {
-			logger.info(`[DEBUG] サンプルworkno: ${apiResponses[0].workno}`);
-		}
-
-		// 2. 新しい統合処理を使用
-		const processingResults = await processBatchUnifiedDLsiteData(apiResponses, {
-			skipPriceHistory: false, // 価格履歴も含めて全て更新
-			forceUpdate: false, // 差分チェックあり
-			existingWorksMap, // 既存作品マップを渡す
-		});
-
-		// 3. 結果の集計
-		const aggregatedResults = aggregateProcessingResults(processingResults);
-
-		// デバッグ: 価格履歴保存の詳細
-		logPriceHistoryDebug(
-			batchNumber,
-			aggregatedResults.priceHistoryUpdated,
-			apiResponses,
-			existingWorksMap,
-		);
-
-		// ログ出力
-		logBatchComplete(batchNumber, workIds.length, apiDataMap.size, aggregatedResults);
-		logFullSweepMissedChanges(batchNumber, processingResults, wouldSkipStableIds);
-
-		return createBatchResult(aggregatedResults, workIds.length);
-	} catch (error) {
-		logger.error(`バッチ ${batchNumber} 処理エラー:`, { error });
-		return {
-			workCount: 0,
-			apiCallCount: workIds.length,
-			basicDataUpdated: 0,
-			error: error instanceof Error ? error.message : "不明なエラー",
-		};
-	}
-}
-
-/**
- * バッチ処理の継続情報を取得
- */
-function getContinuationInfo(
-	metadata: CollectionMetadata,
-): { isContinuation: true; allWorkIds: string[]; startBatch: number } | { isContinuation: false } {
-	if (
-		metadata.batchProcessingMode &&
-		metadata.allWorkIds &&
-		metadata.currentBatch !== undefined &&
-		metadata.totalBatches !== undefined
-	) {
-		// currentBatchがtotalBatchesに達している場合は新規処理として扱う
-		if ((metadata.currentBatch ?? 0) >= metadata.totalBatches) {
-			logger.info("前回の処理は完了済み。新規処理として開始します", {
-				currentBatch: metadata.currentBatch,
-				totalBatches: metadata.totalBatches,
-			});
-			return { isContinuation: false as const };
-		}
-
-		logger.info("バッチ処理を継続します", {
-			currentBatch: metadata.currentBatch,
-			totalBatches: metadata.totalBatches,
-			allWorkIdsLength: metadata.allWorkIds?.length || 0,
-		});
-
-		return {
-			isContinuation: true as const,
-			allWorkIds: metadata.allWorkIds,
-			startBatch: metadata.currentBatch,
-		};
-	}
-
-	return { isContinuation: false as const };
-}
-
-/**
- * 新規バッチ処理を初期化
- *
- * @param tierBreakdown SPR-229: このサイクルのティア別内訳（観測用。省略時=ティアリング無効）
- * @param isFullSweepCycle SPR-229: 週次フルスイープ実行かどうか
- * @param fullSweepWouldSkipWorkIds SPR-229: 週次フルスイープ時、通常runならスキップされていた作品ID（取りこぼし検知用）
- */
-async function initializeNewBatchProcessing(
-	allWorkIds: string[],
-	batches: string[][],
-	tierBreakdown?: CollectionMetadata["tierBreakdown"],
-	isFullSweepCycle = false,
-	fullSweepWouldSkipWorkIds?: string[],
-): Promise<void> {
-	logger.info(
-		`新規バッチ処理開始: 総作品数=${allWorkIds.length}, バッチ数=${batches.length}, バッチサイズ=${BATCH_SIZE}`,
-	);
-	logger.info(
-		`処理時間制限: ${MAX_EXECUTION_TIME / 1000}秒, 予想処理時間: ${batches.length * 30}秒（30秒/バッチ）`,
-	);
-
-	await updateUnifiedMetadata({
-		isInProgress: true,
-		batchProcessingMode: true,
-		allWorkIds,
-		totalBatches: batches.length,
-		currentBatch: 0,
-		totalWorks: allWorkIds.length,
-		processedWorks: 0,
-		basicDataUpdated: 0,
-		completedBatches: [],
-		lastError: undefined,
-		currentBatchStartTime: Timestamp.now(),
-		migrationVersion: "v2",
-		tierBreakdown,
-		isFullSweepCycle,
-		fullSweepWouldSkipWorkIds: isFullSweepCycle ? fullSweepWouldSkipWorkIds : undefined,
-		// SPR-229: 新規サイクル開始時点で pending 状態は解消済み（effectiveFullSweep に
-		// 反映済み、または今回対象外）のため必ずクリアする。
-		pendingFullSweep: undefined,
-	});
 }
 
 /**
@@ -580,34 +199,6 @@ async function executeBatchLoop(
 	}
 
 	return { totalUpdated, totalApiCalls, completedBatches, allBatchesCompleted };
-}
-
-/**
- * 処理完了時のメタデータ更新
- */
-async function finalizeCompletedProcessing(
-	allWorkIds: string[],
-	totalUpdated: number,
-): Promise<void> {
-	logger.info("全バッチ処理完了", {
-		totalWorks: allWorkIds.length,
-		totalUpdated,
-	});
-
-	await updateUnifiedMetadata({
-		isInProgress: false,
-		lastSuccessfulCompleteFetch: Timestamp.now(),
-		lastFetchedAt: Timestamp.now(),
-		batchProcessingMode: false,
-		currentBatch: undefined,
-		totalBatches: undefined,
-		allWorkIds: undefined,
-		completedBatches: undefined,
-		// SPR-229: サイクル終了時にティア/週次フルスイープ関連の一時フィールドをクリアする
-		tierBreakdown: undefined,
-		isFullSweepCycle: undefined,
-		fullSweepWouldSkipWorkIds: undefined,
-	});
 }
 
 /**
@@ -799,7 +390,9 @@ export async function resolveCycleInfo(
  *
  * @param forceFullSweep SPR-229 Stage②: 週次フルスイープ実行時 true（ティア差分を無視して全件を対象にする）
  */
-async function executeUnifiedDataCollection(forceFullSweep = false): Promise<UnifiedFetchResult> {
+export async function runUnifiedDataCollection(
+	forceFullSweep = false,
+): Promise<UnifiedFetchResult> {
 	// SPR-225 Stage 0/P0: dlsite 同期 reads の内訳をこの run の分だけ計測する（挙動は変えない）。
 	resetDlsiteReadMetrics();
 	// SPR-225 Stage 1: 変更 creator の recompute キューを run 開始でクリアする。
@@ -887,45 +480,5 @@ async function executeUnifiedDataCollection(forceFullSweep = false): Promise<Uni
 		// creator-sync / recompute を網羅）。recompute(drain) の読み取りも計上するため recompute の
 		// 後に出す。Cloud Monitoring の絞り込みキーにするため、メッセージは Stage を含めない恒久キー。
 		logger.info("dlsite reads計測(run)", { ...getDlsiteReadMetrics() });
-	}
-}
-
-/**
- * Cloud Functions エントリーポイント
- */
-export async function fetchDLsiteUnifiedData(
-	event: CloudEvent<MessagePublishedData>,
-): Promise<void> {
-	const mode = decodePubsubMode(event.data);
-	const isWeeklyFullSweep = mode === "weekly_full_sweep";
-
-	logger.info("統合データ収集開始", {
-		eventType: event.type,
-		mode,
-		週次フルスイープ: isWeeklyFullSweep,
-		timestamp: new Date().toISOString(),
-		timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-	});
-
-	try {
-		const result = await executeUnifiedDataCollection(isWeeklyFullSweep);
-
-		if (result.error) {
-			logger.error(`統合データ収集エラー: ${result.error}`);
-		} else {
-			logger.info("統合データ収集完了", {
-				更新作品数: result.basicDataUpdated,
-				API呼び出し数: result.apiCallCount,
-				統合完了: result.unificationComplete,
-			});
-		}
-	} catch (error) {
-		logger.error("予期しないエラー:", error);
-
-		await updateUnifiedMetadata({
-			isInProgress: false,
-			lastError: error instanceof Error ? error.message : "不明なエラー",
-			lastFetchedAt: Timestamp.now(),
-		});
 	}
 }

--- a/apps/functions/src/endpoints/index.ts
+++ b/apps/functions/src/endpoints/index.ts
@@ -13,7 +13,7 @@ import * as logger from "../shared/logger";
 import type { MessagePublishedData } from "../shared/pubsub-utils";
 // 各モジュールから関数をインポート（統合アーキテクチャ）
 import { checkDataIntegrity } from "./data-integrity-check";
-import { fetchDLsiteUnifiedData } from "./dlsite-individual-info-api";
+import { fetchDLsiteUnifiedData } from "./dlsite/fetch-dlsite-unified-data";
 import { fetchYouTubeVideos } from "./youtube";
 
 /**

--- a/apps/functions/src/services/dlsite/work-id-collector.ts
+++ b/apps/functions/src/services/dlsite/work-id-collector.ts
@@ -260,7 +260,7 @@ export async function collectAllWorkIds(
 
 /**
  * Cloud Functions用の効率的作品ID収集
- * dlsite-individual-info-api.ts の getAllWorkIds() に対応
+ * endpoints/dlsite の新規サイクル準備（prepareNewBatchProcessing）から呼ばれる
  */
 export async function collectWorkIdsForProduction(): Promise<string[]> {
 	const result = await collectAllWorkIds({

--- a/apps/functions/src/services/dlsite/work-tiering.ts
+++ b/apps/functions/src/services/dlsite/work-tiering.ts
@@ -5,7 +5,7 @@
  * 作品ID（due-set）を絞り込む。ティア判定は既に取得済みの existingWorksMap のみを見て行い、
  * 追加の Firestore 読み取りは発生しない。stable ティアのみ、当日分 priceHistory が
  * 存在するかどうかで実際の取得要否（due）を決める（この Firestore 読み取り自体は
- * 呼び出し側であらかじめバルク確認した結果を Set として受け取る。cf. dlsite-individual-info-api.ts）。
+ * 呼び出し側であらかじめバルク確認した結果を Set として受け取る。cf. endpoints/dlsite/run-unified-data-collection.ts）。
  */
 
 import type { WorkDocument } from "@suzumina.click/shared-types";
@@ -83,7 +83,7 @@ export function classifyWorkTiers(
 /**
  * stable候補（= new/volatile以外）の作品IDを抽出する
  *
- * 呼び出し側（dlsite-individual-info-api.ts）はこの結果に対してのみ
+ * 呼び出し側（endpoints/dlsite/run-unified-data-collection.ts）はこの結果に対してのみ
  * `priceHistory/{today}` の存在確認をバルクで行う（stable候補以外は対象外にすることで
  * 無駄な読み取りを避ける）。
  *

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -21,7 +21,7 @@
 | `contacts` | お問い合わせ（通知の正は Resend メール = [email.ts](../../apps/web/src/lib/email.ts)。Firestore は送信記録のアーカイブで読み手なし） | 自動生成 ID | [contact.ts](../../packages/shared-types/src/entities/contact.ts) `FirestoreContactData` | Server Actions |
 | `ba_user` / `ba_session` / `ba_account` | better-auth の認証データ（認証の正本） | better-auth 採番 | 書き込み元 [firestore-adapter.ts](../../apps/web/src/lib/better-auth/firestore-adapter.ts)（better-auth 標準モデル・prefix `ba_`） | better-auth |
 | `youtubeMetadata` | YouTube 取得処理のメタデータ | `fetch_metadata` | 書き込み元 [youtube.ts](../../apps/functions/src/endpoints/youtube.ts)（内部型 `FetchMetadata`・非 export） | Cloud Functions |
-| `dlsiteMetadata` | DLsite 収集・整合性チェックのメタデータ | `unified_data_collection_metadata` / `dataIntegrityCheck` | 書き込み元 Cloud Function（[dlsite](../../apps/functions/src/endpoints/dlsite-individual-info-api.ts) / [integrity](../../apps/functions/src/endpoints/data-integrity-check.ts)） | Cloud Functions |
+| `dlsiteMetadata` | DLsite 収集・整合性チェックのメタデータ | `unified_data_collection_metadata` / `dataIntegrityCheck` | 書き込み元 Cloud Function（[dlsite](../../apps/functions/src/endpoints/dlsite/collection-metadata.ts) / [integrity](../../apps/functions/src/endpoints/data-integrity-check.ts)） | Cloud Functions |
 
 > **クリエイター ⇔ 作品の関連はルートコレクションではない**: 旧記載の `creatorWorkMappings` は存在せず、実体は `creators/{creatorId}/works` サブコレクション（下表）。
 > **認証の正本は `ba_*`**: `users` はアプリプロファイル（Discord ID キー）。`ba_user` はログイン時に better-auth が作成するため `users` と件数は一致しない。`_firestore_rules` はシステム生成の内部コレクションで台帳管理外。
@@ -64,7 +64,7 @@ cron の正本は Terraform の Cloud Scheduler（[`scheduler.tf`](../../terrafo
 [`function_data_integrity_check.tf`](../../terraform/function_data_integrity_check.tf)）。
 
 - `30 * * * *` → [`fetchYouTubeVideos`](../../apps/functions/src/endpoints/youtube.ts) → `videos` / `youtubeMetadata`
-- `3 */2 * * *`（2 時間ごと）→ [`fetchDLsiteUnifiedData`](../../apps/functions/src/endpoints/dlsite-individual-info-api.ts) → `works` / `circles` / `creators`（+ `creators/{id}/works`） / `works/{workId}/priceHistory` / `dlsiteMetadata`
+- `3 */2 * * *`（2 時間ごと）→ [`fetchDLsiteUnifiedData`](../../apps/functions/src/endpoints/dlsite/fetch-dlsite-unified-data.ts) → `works` / `circles` / `creators`（+ `creators/{id}/works`） / `works/{workId}/priceHistory` / `dlsiteMetadata`
 - `0 3 * * 0`（日曜 3:00 JST）→ [`checkDataIntegrity`](../../apps/functions/src/endpoints/data-integrity-check.ts) → `dlsiteMetadata/dataIntegrityCheck`（+ `history`）
   - Circle workIds / 孤立 Creator マッピング / Work-Circle 整合を**事後修復**。
     非正規化を増やすとこの cron の負債が増える（CLAUDE.md 軸1）。

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -168,7 +168,7 @@ resource "google_monitoring_alert_policy" "dlsite_no_data_fetched" {
 }
 
 # DLsite関数のプラットフォーム障害アラート（OOM・タイムアウト・クラッシュ）
-# エントリポイント（dlsite-individual-info-api.ts の fetchDLsiteUnifiedData）は catch-all で
+# エントリポイント（endpoints/dlsite/fetch-dlsite-unified-data.ts の fetchDLsiteUnifiedData）は catch-all で
 # 例外を ERROR ログ化して正常終了（2xx）するため、アプリレベルの失敗はここでは 5xx にならず
 # dlsite_error_count 側が検知する。この alert はプロセスが応答を返せなかったケース
 # （プラットフォームによる強制終了）専用（役割分担・SPR-234）。
@@ -229,7 +229,7 @@ resource "google_monitoring_alert_policy" "dlsite_function_failure" {
 # ログベースメトリクス - バッチ全滅（Individual Info API 全面停止の兆候）
 # per-work の一時エラーは dlsite_error_count から除外しているため、「全 work が取得失敗する
 # 全面停止」はこのメトリクスが検知の正本（役割分担・SPR-234）。バッチ内 50件全てが失敗すると
-# processBatch が「バッチ N: APIレスポンスなし」を WARN 出力する（dlsite-individual-info-api.ts）。
+# processBatch が「バッチ N: APIレスポンスなし」を WARN 出力する（endpoints/dlsite/process-batch.ts）。
 # 平常時は発生しない（過去30日で0件・2026-07-04 実測）ため閾値は >0 でノイズにならない。
 resource "google_logging_metric" "dlsite_api_batch_all_failed" {
   name    = "dlsite_api_batch_all_failed"


### PR DESCRIPTION
## Summary
SPR-231 段階②。931行に肥大していた `dlsite-individual-info-api.ts` を `endpoints/dlsite/` の4ファイルへ分割し、「この関数の本処理はどこか」を一目で分かるようにする。**挙動不変・移動中心**（git はテストを 90%・本体を 54% rename として検出）。

| ファイル | 責務 |
|---|---|
| `fetch-dlsite-unified-data.ts` | 薄いハンドラ（CloudEvent unwrap → orchestrator 呼び出し → 結果ログ） |
| `run-unified-data-collection.ts` | オーケストレータ（サイクル解決 → バッチループ → 完了処理 → creator recompute drain） |
| `collection-metadata.ts` | run metadata + 継続 cursor のライフサイクル（store・継続判定・初期化・完了クリア） |
| `process-batch.ts` | 1バッチ分の実行（API バッチ呼び出し → 統合処理 → 集計/ログ） |

- リネームは `executeUnifiedDataCollection`→`runUnifiedDataCollection` の**1件のみ**（youtube.ts に既にある `runWeeklyFullSweep`/`runNormalFetchAndSave` の `run-*` 規約に整合）
- **ハンドラのエクスポート名（Cloud Functions 登録名）`fetchDLsiteUnifiedData` は不変**（terraform/deploy と結合しているため）
- `endpoints/index.ts` は import パス1行変更のみ（esbuild エントリ不変）
- 旧ファイル名を参照していたコメント（work-tiering / work-id-collector / index.test / youtube.test）と docs リンク（`database-schema.md`・**lint:docs が自動検出**）も追従

## 挙動不変の検証
- [x] `pnpm verify` 全体 green（exit 0）
- [x] **既存テストのアサーション無変更**: テストファイルの差分39行は import パス深さ（`../../`→`../../../`）と endpoint import の分割（handler / orchestrator が別ファイル化したため）のみ
- [x] `git diff --color-moved` で移動と編集を分離確認（編集は import 文・リネーム1件・各ファイル冒頭の役割 JSDoc のみ）

## 関連
- Linear: SPR-231（構造案 2026-07-05 設計コメントどおり）
- 先行: #850（段階①）/ #851（TOCTOU 修正）
- 後続: search.list 経路撤去 → 段階③（youtube 再配置）→ 段階④（data-integrity 再配置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)