### PR TITLE
refactor(functions): data-integrity endpointを薄いハンドラ+orchestrator構成へ再配置 (SPR-231 段階④・最終)

### DIFF
--- a/apps/functions/biome.json
+++ b/apps/functions/biome.json
@@ -82,7 +82,7 @@
 			}
 		},
 		{
-			"includes": ["**/data-integrity-check.ts", "**/video-mapper.ts"],
+			"includes": ["**/integrity-checks.ts", "**/video-mapper.ts"],
 			"linter": {
 				"rules": {
 					"complexity": {

--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -14,7 +14,7 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
-		"test:integration": "vitest run --coverage.enabled=false src/endpoints/__tests__/data-integrity-check.integration.test.ts",
+		"test:integration": "vitest run --coverage.enabled=false src/endpoints/data-integrity/__tests__/check-data-integrity.integration.test.ts",
 		"seed:dump": "dotenv -e .env -- tsx src/tools/firestore-local/dump.ts",
 		"seed:load": "tsx src/tools/firestore-local/seed.ts",
 		"check:region-equivalence": "dotenv -e .env -- tsx src/tools/core/region-equivalence-check.ts",

--- a/apps/functions/src/endpoints/data-integrity/__tests__/check-data-integrity.integration.test.ts
+++ b/apps/functions/src/endpoints/data-integrity/__tests__/check-data-integrity.integration.test.ts
@@ -17,7 +17,7 @@
 
 import type { Firestore } from "@google-cloud/firestore";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import type { runIntegrityCheck as RunIntegrityCheck } from "../data-integrity-check";
+import type { runIntegrityCheck as RunIntegrityCheck } from "../run-integrity-check";
 
 const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST;
 const RUN = Boolean(process.env.RUN_INTEGRATION_TESTS) && Boolean(EMULATOR_HOST);
@@ -57,10 +57,10 @@ describe.skipIf(!RUN)("checkDataIntegrity (integration / Firestore Emulator)", (
 		process.env.ALLOW_TEST_FIRESTORE = "true";
 		process.env.GOOGLE_CLOUD_PROJECT = PROJECT_ID;
 
-		const firestoreModule = await import("../../infrastructure/database/firestore");
+		const firestoreModule = await import("../../../infrastructure/database/firestore");
 		getFirestore = firestoreModule.getFirestore;
 		resetFirestoreInstance = firestoreModule.resetFirestoreInstance;
-		const dicModule = await import("../data-integrity-check");
+		const dicModule = await import("../run-integrity-check");
 		runIntegrityCheck = dicModule.runIntegrityCheck;
 		batchLimit = dicModule.FIRESTORE_BATCH_LIMIT;
 	});

--- a/apps/functions/src/endpoints/data-integrity/__tests__/check-data-integrity.test.ts
+++ b/apps/functions/src/endpoints/data-integrity/__tests__/check-data-integrity.test.ts
@@ -6,7 +6,7 @@ import type { CloudEvent } from "@google-cloud/functions-framework";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 // Firestoreモック
-vi.mock("../../infrastructure/database/firestore", () => {
+vi.mock("../../../infrastructure/database/firestore", () => {
 	const mockCollection = vi.fn();
 	const mockBatch = vi.fn();
 
@@ -24,15 +24,16 @@ vi.mock("../../infrastructure/database/firestore", () => {
 });
 
 // ロガーモック
-vi.mock("../../shared/logger", () => ({
+vi.mock("../../../shared/logger", () => ({
 	info: vi.fn(),
 	warn: vi.fn(),
 	error: vi.fn(),
 }));
 
-import firestore from "../../infrastructure/database/firestore";
+import firestore from "../../../infrastructure/database/firestore";
 // テスト対象をインポート（モックの後）
-import { checkDataIntegrity, runIntegrityCheck } from "../data-integrity-check";
+import { checkDataIntegrity } from "../check-data-integrity";
+import { runIntegrityCheck } from "../run-integrity-check";
 
 // モック関数をvitestから取得
 const mockCollection = vi.mocked(firestore.collection) as unknown as Mock<

--- a/apps/functions/src/endpoints/data-integrity/check-data-integrity.ts
+++ b/apps/functions/src/endpoints/data-integrity/check-data-integrity.ts
@@ -1,0 +1,36 @@
+/**
+ * データ整合性検証エンドポイント（薄いハンドラ）
+ *
+ * CloudEvent の受領 → オーケストレータ呼び出し → 結果ログのみを担う。
+ * 本処理は run-integrity-check.ts の `runIntegrityCheck`。
+ */
+
+import type { CloudEvent } from "@google-cloud/functions-framework";
+import * as logger from "../../shared/logger";
+import { runIntegrityCheck } from "./run-integrity-check";
+
+/**
+ * Cloud Functions エントリーポイント
+ *
+ * 本番スケジュール実行用。常に dryRun=false（修正を書き込む）。
+ */
+export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<void> {
+	logger.info("データ整合性チェックを開始", { eventType: event.type });
+
+	try {
+		const result = await runIntegrityCheck();
+
+		logger.info("データ整合性チェック完了", {
+			totalChecked:
+				result.checks.circleWorkCounts.checked +
+				result.checks.orphanedCreators.checked +
+				result.checks.workCircleConsistency.checked,
+			totalIssues: result.totalIssues,
+			totalFixed: result.totalFixed,
+			executionTimeMs: result.executionTimeMs,
+		});
+	} catch (error) {
+		logger.error("データ整合性チェックエラー", { error });
+		throw error;
+	}
+}

--- a/apps/functions/src/endpoints/data-integrity/integrity-checks.ts
+++ b/apps/functions/src/endpoints/data-integrity/integrity-checks.ts
@@ -1,30 +1,22 @@
 /**
- * データ整合性検証エンドポイント
+ * データ整合性検証: 4種の検査・修復関数
  *
- * 週次で実行されるデータ整合性チェック機能
  * - CircleのworkIds配列の整合性
  * - 孤立したCreatorマッピングのクリーンアップ
  * - Work-Circle相互参照の整合性
+ * - Creator-Work関連の復元
  *
- * dryRun（report-only）モード:
- *   集計・検出は通常どおり行い「修正したであろう件数」をカウントするが、
- *   Firestore への書き込み（batch.commit / 結果保存）は一切行わない。
- *   本番データを汚さずに「整合性関数が何を直すか」を確認するための観測専用モード。
+ * 実行順序と結果集計はオーケストレータ（run-integrity-check.ts）が担う。
  */
 
 import type { DocumentReference, WriteBatch } from "@google-cloud/firestore";
-import type { CloudEvent } from "@google-cloud/functions-framework";
 import type { CreatorType, CreatorWorkRelation } from "@suzumina.click/shared-types";
-import firestore, { Timestamp } from "../infrastructure/database/firestore";
+import firestore, { Timestamp } from "../../infrastructure/database/firestore";
 import {
 	extractCreatorMappingsFromWorkDocument,
 	recomputeCreatorStats,
-} from "../services/dlsite/creator-firestore";
-import * as logger from "../shared/logger";
-
-// メタデータ保存用の定数
-const INTEGRITY_CHECK_COLLECTION = "dlsiteMetadata";
-const INTEGRITY_CHECK_DOC_ID = "dataIntegrityCheck";
+} from "../../services/dlsite/creator-firestore";
+import * as logger from "../../shared/logger";
 
 // Firestoreバッチ操作の制限値（500より少し余裕を持たせた値）
 // 分割コミットの境界。テストはこの値+1で分割パスを確実に踏むため export する。
@@ -40,17 +32,6 @@ export const FIRESTORE_BATCH_LIMIT = 400;
 async function commitAndRenew(batch: WriteBatch): Promise<WriteBatch> {
 	await batch.commit();
 	return firestore.batch();
-}
-
-/**
- * 整合性チェックの実行オプション
- */
-export interface IntegrityCheckOptions {
-	/**
-	 * true の場合、検出・集計のみ行い Firestore への書き込みを一切行わない（report-only）。
-	 * 既定は false（＝従来どおり修正を書き込む）。本番スケジュール実行は false。
-	 */
-	dryRun?: boolean;
 }
 
 /**
@@ -90,7 +71,10 @@ export interface IntegrityCheckResult {
 /**
  * CircleのworkIds配列の整合性をチェック
  */
-async function checkCircleWorkCounts(result: IntegrityCheckResult, dryRun: boolean): Promise<void> {
+export async function checkCircleWorkCounts(
+	result: IntegrityCheckResult,
+	dryRun: boolean,
+): Promise<void> {
 	logger.info("CircleのworkIds配列の整合性チェックを開始");
 
 	const circlesSnapshot = await firestore.collection("circles").get();
@@ -171,7 +155,10 @@ async function checkCircleWorkCounts(result: IntegrityCheckResult, dryRun: boole
 /**
  * 孤立したCreatorマッピングをチェック
  */
-async function checkOrphanedCreators(result: IntegrityCheckResult, dryRun: boolean): Promise<void> {
+export async function checkOrphanedCreators(
+	result: IntegrityCheckResult,
+	dryRun: boolean,
+): Promise<void> {
 	logger.info("孤立したCreatorマッピングのチェックを開始");
 
 	const creatorsSnapshot = await firestore.collection("creators").get();
@@ -335,7 +322,7 @@ async function commitBatchIfNeeded(
 /**
  * 削除されたCreator-Work関連を復元
  */
-async function restoreCreatorWorkRelations(
+export async function restoreCreatorWorkRelations(
 	result: IntegrityCheckResult,
 	dryRun: boolean,
 ): Promise<void> {
@@ -425,7 +412,7 @@ async function restoreCreatorWorkRelations(
 /**
  * Work-Circle相互参照の整合性をチェック
  */
-async function checkWorkCircleConsistency(
+export async function checkWorkCircleConsistency(
 	result: IntegrityCheckResult,
 	dryRun: boolean,
 ): Promise<void> {
@@ -488,137 +475,4 @@ async function checkWorkCircleConsistency(
 	logger.info(
 		`Work-Circle整合性チェック完了: ${result.checks.workCircleConsistency.checked}件チェック、${result.checks.workCircleConsistency.fixed}件${dryRun ? "要修正" : "修正"}`,
 	);
-}
-
-/**
- * 整合性チェック結果を保存
- */
-async function saveIntegrityCheckResult(result: IntegrityCheckResult): Promise<void> {
-	const docRef = firestore.collection(INTEGRITY_CHECK_COLLECTION).doc(INTEGRITY_CHECK_DOC_ID);
-
-	// 最新の結果を保存
-	await docRef.set(
-		{
-			latest: result,
-			lastCheckedAt: Timestamp.now(),
-			updatedAt: Timestamp.now(),
-		},
-		{ merge: true },
-	);
-
-	// 履歴として保存（最大10件保持）
-	const historyRef = docRef.collection("history").doc(result.timestamp);
-	await historyRef.set(result);
-
-	// 古い履歴を削除
-	const historySnapshot = await docRef
-		.collection("history")
-		.orderBy("timestamp", "desc")
-		.limit(11)
-		.get();
-
-	if (historySnapshot.size > 10) {
-		const batch = firestore.batch();
-		historySnapshot.docs.slice(10).forEach((doc) => {
-			batch.delete(doc.ref);
-		});
-		await batch.commit();
-	}
-}
-
-/**
- * 整合性チェックの本体ロジック
- *
- * 4種の検査（Circle workIds / 孤立Creator / Work-Circle / Creator-Work復元）を実行し、
- * 結果を返す。dryRun=false（既定）の場合のみ Firestore へ修正と結果を書き込む。
- *
- * Cloud Functions ハンドラ（{@link checkDataIntegrity}）からも、
- * ローカル手動実行・インテグレーションテストからも共通で呼ばれる正本。
- *
- * @param options.dryRun true で書き込みを一切行わない観測専用モード
- * @returns 検査結果（dryRun でも「要修正件数」を含む）
- */
-export async function runIntegrityCheck(
-	options: IntegrityCheckOptions = {},
-): Promise<IntegrityCheckResult> {
-	const dryRun = options.dryRun ?? false;
-	const startTime = Date.now();
-
-	const result: IntegrityCheckResult = {
-		timestamp: new Date().toISOString(),
-		dryRun,
-		checks: {
-			circleWorkCounts: { checked: 0, mismatches: 0, fixed: 0 },
-			orphanedCreators: { checked: 0, found: 0, cleaned: 0 },
-			workCircleConsistency: { checked: 0, mismatches: 0, fixed: 0 },
-		},
-		totalIssues: 0,
-		totalFixed: 0,
-		executionTimeMs: 0,
-	};
-
-	// 1. CircleのworkIds配列の整合性チェック
-	await checkCircleWorkCounts(result, dryRun);
-
-	// 2. 孤立したCreatorマッピングのクリーンアップ
-	await checkOrphanedCreators(result, dryRun);
-
-	// 3. Work-Circle相互参照の整合性
-	await checkWorkCircleConsistency(result, dryRun);
-
-	// 4. Creator-Work関連の復元（削除されたデータの回復）
-	await restoreCreatorWorkRelations(result, dryRun);
-
-	// 総計を計算
-	result.totalIssues =
-		result.checks.circleWorkCounts.mismatches +
-		result.checks.orphanedCreators.found +
-		result.checks.workCircleConsistency.mismatches;
-
-	result.totalFixed =
-		result.checks.circleWorkCounts.fixed +
-		result.checks.orphanedCreators.cleaned +
-		result.checks.workCircleConsistency.fixed +
-		(result.checks.creatorWorkRestore?.restored || 0) +
-		(result.checks.creatorWorkRestore?.creatorsCreated || 0);
-
-	result.executionTimeMs = Date.now() - startTime;
-
-	// 結果を保存（dryRun では書き込まない）
-	if (dryRun) {
-		logger.info("dry-run: 書き込みをスキップしました（検出のみ）", {
-			totalIssues: result.totalIssues,
-			wouldFix: result.totalFixed,
-		});
-	} else {
-		await saveIntegrityCheckResult(result);
-	}
-
-	return result;
-}
-
-/**
- * Cloud Functions エントリーポイント
- *
- * 本番スケジュール実行用。常に dryRun=false（修正を書き込む）。
- */
-export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<void> {
-	logger.info("データ整合性チェックを開始", { eventType: event.type });
-
-	try {
-		const result = await runIntegrityCheck();
-
-		logger.info("データ整合性チェック完了", {
-			totalChecked:
-				result.checks.circleWorkCounts.checked +
-				result.checks.orphanedCreators.checked +
-				result.checks.workCircleConsistency.checked,
-			totalIssues: result.totalIssues,
-			totalFixed: result.totalFixed,
-			executionTimeMs: result.executionTimeMs,
-		});
-	} catch (error) {
-		logger.error("データ整合性チェックエラー", { error });
-		throw error;
-	}
 }

--- a/apps/functions/src/endpoints/data-integrity/run-integrity-check.ts
+++ b/apps/functions/src/endpoints/data-integrity/run-integrity-check.ts
@@ -1,0 +1,147 @@
+/**
+ * データ整合性検証: オーケストレータ（この関数が run の本処理）
+ *
+ * 週次で実行されるデータ整合性チェック機能。4種の検査（integrity-checks.ts）を
+ * 順に実行し、結果を集計して保存する。
+ *
+ * dryRun（report-only）モード:
+ *   集計・検出は通常どおり行い「修正したであろう件数」をカウントするが、
+ *   Firestore への書き込み（batch.commit / 結果保存）は一切行わない。
+ *   本番データを汚さずに「整合性関数が何を直すか」を確認するための観測専用モード。
+ */
+
+import firestore, { Timestamp } from "../../infrastructure/database/firestore";
+import * as logger from "../../shared/logger";
+import {
+	checkCircleWorkCounts,
+	checkOrphanedCreators,
+	checkWorkCircleConsistency,
+	type IntegrityCheckResult,
+	restoreCreatorWorkRelations,
+} from "./integrity-checks";
+
+// ローカル手動実行（tools/core）・インテグレーションテストが単一のimport元で済むよう、
+// 検査側の公開シンボルをここから再エクスポートする（本ファイルが公開の正面玄関）。
+export { FIRESTORE_BATCH_LIMIT, type IntegrityCheckResult } from "./integrity-checks";
+
+// メタデータ保存用の定数
+const INTEGRITY_CHECK_COLLECTION = "dlsiteMetadata";
+const INTEGRITY_CHECK_DOC_ID = "dataIntegrityCheck";
+
+/**
+ * 整合性チェックの実行オプション
+ */
+export interface IntegrityCheckOptions {
+	/**
+	 * true の場合、検出・集計のみ行い Firestore への書き込みを一切行わない（report-only）。
+	 * 既定は false（＝従来どおり修正を書き込む）。本番スケジュール実行は false。
+	 */
+	dryRun?: boolean;
+}
+
+/**
+ * 整合性チェック結果を保存
+ */
+async function saveIntegrityCheckResult(result: IntegrityCheckResult): Promise<void> {
+	const docRef = firestore.collection(INTEGRITY_CHECK_COLLECTION).doc(INTEGRITY_CHECK_DOC_ID);
+
+	// 最新の結果を保存
+	await docRef.set(
+		{
+			latest: result,
+			lastCheckedAt: Timestamp.now(),
+			updatedAt: Timestamp.now(),
+		},
+		{ merge: true },
+	);
+
+	// 履歴として保存（最大10件保持）
+	const historyRef = docRef.collection("history").doc(result.timestamp);
+	await historyRef.set(result);
+
+	// 古い履歴を削除
+	const historySnapshot = await docRef
+		.collection("history")
+		.orderBy("timestamp", "desc")
+		.limit(11)
+		.get();
+
+	if (historySnapshot.size > 10) {
+		const batch = firestore.batch();
+		historySnapshot.docs.slice(10).forEach((doc) => {
+			batch.delete(doc.ref);
+		});
+		await batch.commit();
+	}
+}
+
+/**
+ * 整合性チェックの本体ロジック
+ *
+ * 4種の検査（Circle workIds / 孤立Creator / Work-Circle / Creator-Work復元）を実行し、
+ * 結果を返す。dryRun=false（既定）の場合のみ Firestore へ修正と結果を書き込む。
+ *
+ * Cloud Functions ハンドラ（check-data-integrity.ts の `checkDataIntegrity`）からも、
+ * ローカル手動実行・インテグレーションテストからも共通で呼ばれる正本。
+ *
+ * @param options.dryRun true で書き込みを一切行わない観測専用モード
+ * @returns 検査結果（dryRun でも「要修正件数」を含む）
+ */
+export async function runIntegrityCheck(
+	options: IntegrityCheckOptions = {},
+): Promise<IntegrityCheckResult> {
+	const dryRun = options.dryRun ?? false;
+	const startTime = Date.now();
+
+	const result: IntegrityCheckResult = {
+		timestamp: new Date().toISOString(),
+		dryRun,
+		checks: {
+			circleWorkCounts: { checked: 0, mismatches: 0, fixed: 0 },
+			orphanedCreators: { checked: 0, found: 0, cleaned: 0 },
+			workCircleConsistency: { checked: 0, mismatches: 0, fixed: 0 },
+		},
+		totalIssues: 0,
+		totalFixed: 0,
+		executionTimeMs: 0,
+	};
+
+	// 1. CircleのworkIds配列の整合性チェック
+	await checkCircleWorkCounts(result, dryRun);
+
+	// 2. 孤立したCreatorマッピングのクリーンアップ
+	await checkOrphanedCreators(result, dryRun);
+
+	// 3. Work-Circle相互参照の整合性
+	await checkWorkCircleConsistency(result, dryRun);
+
+	// 4. Creator-Work関連の復元（削除されたデータの回復）
+	await restoreCreatorWorkRelations(result, dryRun);
+
+	// 総計を計算
+	result.totalIssues =
+		result.checks.circleWorkCounts.mismatches +
+		result.checks.orphanedCreators.found +
+		result.checks.workCircleConsistency.mismatches;
+
+	result.totalFixed =
+		result.checks.circleWorkCounts.fixed +
+		result.checks.orphanedCreators.cleaned +
+		result.checks.workCircleConsistency.fixed +
+		(result.checks.creatorWorkRestore?.restored || 0) +
+		(result.checks.creatorWorkRestore?.creatorsCreated || 0);
+
+	result.executionTimeMs = Date.now() - startTime;
+
+	// 結果を保存（dryRun では書き込まない）
+	if (dryRun) {
+		logger.info("dry-run: 書き込みをスキップしました（検出のみ）", {
+			totalIssues: result.totalIssues,
+			wouldFix: result.totalFixed,
+		});
+	} else {
+		await saveIntegrityCheckResult(result);
+	}
+
+	return result;
+}

--- a/apps/functions/src/endpoints/index.ts
+++ b/apps/functions/src/endpoints/index.ts
@@ -12,7 +12,7 @@ import * as functions from "@google-cloud/functions-framework";
 import * as logger from "../shared/logger";
 import type { MessagePublishedData } from "../shared/pubsub-utils";
 // 各モジュールから関数をインポート（統合アーキテクチャ）
-import { checkDataIntegrity } from "./data-integrity-check";
+import { checkDataIntegrity } from "./data-integrity/check-data-integrity";
 import { fetchDLsiteUnifiedData } from "./dlsite/fetch-dlsite-unified-data";
 import { fetchYouTubeVideos } from "./youtube/fetch-youtube-videos";
 

--- a/apps/functions/src/tools/core/run-data-integrity-check.ts
+++ b/apps/functions/src/tools/core/run-data-integrity-check.ts
@@ -15,7 +15,10 @@
  *   - 未設定 → ADC で本番 Firestore（dry-run 推奨）
  */
 
-import { type IntegrityCheckResult, runIntegrityCheck } from "../../endpoints/data-integrity-check";
+import {
+	type IntegrityCheckResult,
+	runIntegrityCheck,
+} from "../../endpoints/data-integrity/run-integrity-check";
 import * as logger from "../../shared/logger";
 
 function printReport(result: IntegrityCheckResult): void {

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -21,7 +21,7 @@
 | `contacts` | お問い合わせ（通知の正は Resend メール = [email.ts](../../apps/web/src/lib/email.ts)。Firestore は送信記録のアーカイブで読み手なし） | 自動生成 ID | [contact.ts](../../packages/shared-types/src/entities/contact.ts) `FirestoreContactData` | Server Actions |
 | `ba_user` / `ba_session` / `ba_account` | better-auth の認証データ（認証の正本） | better-auth 採番 | 書き込み元 [firestore-adapter.ts](../../apps/web/src/lib/better-auth/firestore-adapter.ts)（better-auth 標準モデル・prefix `ba_`） | better-auth |
 | `youtubeMetadata` | YouTube 取得処理のメタデータ | `fetch_metadata` | 書き込み元 [fetch-metadata.ts](../../apps/functions/src/endpoints/youtube/fetch-metadata.ts)（`FetchMetadata`） | Cloud Functions |
-| `dlsiteMetadata` | DLsite 収集・整合性チェックのメタデータ | `unified_data_collection_metadata` / `dataIntegrityCheck` | 書き込み元 Cloud Function（[dlsite](../../apps/functions/src/endpoints/dlsite/collection-metadata.ts) / [integrity](../../apps/functions/src/endpoints/data-integrity-check.ts)） | Cloud Functions |
+| `dlsiteMetadata` | DLsite 収集・整合性チェックのメタデータ | `unified_data_collection_metadata` / `dataIntegrityCheck` | 書き込み元 Cloud Function（[dlsite](../../apps/functions/src/endpoints/dlsite/collection-metadata.ts) / [integrity](../../apps/functions/src/endpoints/data-integrity/run-integrity-check.ts)） | Cloud Functions |
 
 > **クリエイター ⇔ 作品の関連はルートコレクションではない**: 旧記載の `creatorWorkMappings` は存在せず、実体は `creators/{creatorId}/works` サブコレクション（下表）。
 > **認証の正本は `ba_*`**: `users` はアプリプロファイル（Discord ID キー）。`ba_user` はログイン時に better-auth が作成するため `users` と件数は一致しない。`_firestore_rules` はシステム生成の内部コレクションで台帳管理外。
@@ -35,7 +35,7 @@
 | `users/{userId}/likes` / `…/dislikes` | 音声ボタンの高評価 / 低評価 | 音声ボタン ID | 書き込み元 [reaction-toggle.ts](../../apps/web/src/actions/reaction-toggle.ts)（`audioButtonId` + `createdAt` 最小スキーマ） |
 | `users/{userId}/top10` | 10 選ランキング | `ranking` | [work-evaluation.ts](../../packages/shared-types/src/entities/work-evaluation.ts) `UserTop10List` |
 | `works/{workId}/priceHistory` | 価格履歴（全履歴・多通貨） | `YYYY-MM-DD` | [price-history.ts](../../packages/shared-types/src/utilities/price-history.ts) `PriceHistoryDocument` |
-| `dlsiteMetadata/dataIntegrityCheck/history` | 整合性チェック実行履歴（最大 10 件） | 実行日時 ISO | 書き込み元 [Cloud Function](../../apps/functions/src/endpoints/data-integrity-check.ts) |
+| `dlsiteMetadata/dataIntegrityCheck/history` | 整合性チェック実行履歴（最大 10 件） | 実行日時 ISO | 書き込み元 [Cloud Function](../../apps/functions/src/endpoints/data-integrity/run-integrity-check.ts) |
 
 > **削除済み**: `dlsite_timeseries_raw` / `dlsite_timeseries_daily`（統合アーキテクチャへ移行。価格履歴の後継は
 > `works/{workId}/priceHistory`）。`favorites` は最小スキーマ（`audioButtonId` + `addedAt`）で、表示時に `audioButtons` を都度 join する。
@@ -65,7 +65,7 @@ cron の正本は Terraform の Cloud Scheduler（[`scheduler.tf`](../../terrafo
 
 - `30 * * * *` → [`fetchYouTubeVideos`](../../apps/functions/src/endpoints/youtube/fetch-youtube-videos.ts) → `videos` / `youtubeMetadata`
 - `3 */2 * * *`（2 時間ごと）→ [`fetchDLsiteUnifiedData`](../../apps/functions/src/endpoints/dlsite/fetch-dlsite-unified-data.ts) → `works` / `circles` / `creators`（+ `creators/{id}/works`） / `works/{workId}/priceHistory` / `dlsiteMetadata`
-- `0 3 * * 0`（日曜 3:00 JST）→ [`checkDataIntegrity`](../../apps/functions/src/endpoints/data-integrity-check.ts) → `dlsiteMetadata/dataIntegrityCheck`（+ `history`）
+- `0 3 * * 0`（日曜 3:00 JST）→ [`checkDataIntegrity`](../../apps/functions/src/endpoints/data-integrity/check-data-integrity.ts) → `dlsiteMetadata/dataIntegrityCheck`（+ `history`）
   - Circle workIds / 孤立 Creator マッピング / Work-Circle 整合を**事後修復**。
     非正規化を増やすとこの cron の負債が増える（CLAUDE.md 軸1）。
 - 書き込みは Firestore の 500 件バッチ制限に従いチャンク分割する。


### PR DESCRIPTION
## Summary
SPR-231 の最終段階④。624行の `data-integrity-check.ts` を `endpoints/data-integrity/` の3ファイルへ分割する。**整合性 cron（One-Way Door 領域）のため、4検査関数のロジック・ログ文言・定数値は一字も変えない逐語移動**（git はテストを 97-98%・検査関数本体を 70% rename として検出）。

| ファイル | 責務 |
|---|---|
| `check-data-integrity.ts` | 薄いハンドラ（CloudEvent 受領 → orchestrator 呼び出し → 結果ログ） |
| `run-integrity-check.ts` | オーケストレータ（4検査の実行順序・結果集計・保存）。tools/テストの単一 import 元として `FIRESTORE_BATCH_LIMIT` / `IntegrityCheckResult` を再エクスポート |
| `integrity-checks.ts` | 4種の検査・修復関数（Circle workIds / 孤立Creator / Work-Circle / Creator-Work復元）＋分割コミットヘルパ |

- リネームなし。Cloud Functions 登録名 `checkDataIntegrity` は不変
- 追従: `endpoints/index.ts` import 1行 / `tools/core/run-data-integrity-check.ts` import 1行 / `package.json` の `test:integration` パス（CI は `pnpm test:integration` のスクリプト名経由のため workflow 変更不要） / `biome.json` の認知的複雑度除外 glob（検査関数の移動先 `integrity-checks.ts` へ） / `database-schema.md` リンク3箇所（lint:docs green）

## 挙動不変の検証
- [x] `pnpm verify` 全体 green（exit 0・functions 481件）
- [x] **既存テストのアサーション無変更**: ユニット/インテグレーションテストとも差分は import パス（深さ+分割後の import 元）のみ
- [x] 4検査関数・`runIntegrityCheck`・`saveIntegrityCheckResult`・ハンドラの本文は逐語移動（`git diff --color-moved` で確認可能）

## SPR-231 全体の完了
本 PR のマージで SPR-231 の計画（①共通ユーティリティ → ②dlsite → search撤去 → ③youtube → ④data-integrity）が全段階完了。3 endpoint すべてが「薄いハンドラ + named orchestrator + 責務別ファイル」の統一構成になる。

## 関連
- Linear: SPR-231 / 先行: #850 #851 #852 #853 #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)