### PR TITLE
docs(functions): totalCheckedがcreatorWorkRestoreを加算しない理由を明記 (SPR-270)

### DIFF
--- a/apps/functions/src/endpoints/data-integrity/check-data-integrity.ts
+++ b/apps/functions/src/endpoints/data-integrity/check-data-integrity.ts
@@ -21,6 +21,13 @@ export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<vo
 		const result = await runIntegrityCheck();
 
 		logger.info("データ整合性チェック完了", {
+			// totalChecked は「走査した doc 数」をコレクション単位で数える（circles + creators + works）。
+			// 4つ目の検査 creatorWorkRestore.checked を足さないのは意図的: これは
+			// workCircleConsistency と同じ works コレクションを再走査した件数で、加算すると
+			// works が二重計上になる（実測 2026-07-18: circles 383 + creators 1,178 + works 2,114
+			// = 3,675。足すと 5,789 になり実態と乖離する）。
+			// creatorWorkRestore の「成果」は totalFixed 側に restored/creatorsCreated として
+			// 計上済みなので、この検査がサマリから漏れているわけではない（SPR-270）。
 			totalChecked:
 				result.checks.circleWorkCounts.checked +
 				result.checks.orphanedCreators.checked +

--- a/apps/functions/src/endpoints/data-integrity/check-data-integrity.ts
+++ b/apps/functions/src/endpoints/data-integrity/check-data-integrity.ts
@@ -22,10 +22,10 @@ export async function checkDataIntegrity(event: CloudEvent<unknown>): Promise<vo
 
 		logger.info("データ整合性チェック完了", {
 			// totalChecked は「走査した doc 数」をコレクション単位で数える（circles + creators + works）。
-			// 4つ目の検査 creatorWorkRestore.checked を足さないのは意図的: これは
-			// workCircleConsistency と同じ works コレクションを再走査した件数で、加算すると
-			// works が二重計上になる（実測 2026-07-18: circles 383 + creators 1,178 + works 2,114
-			// = 3,675。足すと 5,789 になり実態と乖離する）。
+			// 4つ目の検査 creatorWorkRestore.checked を足さないのは意図的:
+			// `creatorWorkRestore.checked` と `workCircleConsistency.checked` は
+			// **どちらも works 全件の件数で常に同値**（両者とも collection("works") を走査する）。
+			// したがって加算すると works が必ず二重計上になる（件数の多寡によらず成立する）。
 			// creatorWorkRestore の「成果」は totalFixed 側に restored/creatorsCreated として
 			// 計上済みなので、この検査がサマリから漏れているわけではない（SPR-270）。
 			totalChecked:

--- a/docs/decisions/architecture/ADR-013-cloud-functions-endpoint-architecture.md
+++ b/docs/decisions/architecture/ADR-013-cloud-functions-endpoint-architecture.md
@@ -98,7 +98,7 @@ export function createRunMetadataStore<T extends object>(options: {
 
 ### 良くない点・残課題
 
-- （解決済み・記録として残す）`checkDataIntegrity` の `totalChecked` が `creatorWorkRestore.checked` を含まない点を「欠落」として SPR-270 に起票したが、調査の結果**現状が正しい実装**と判明した。`creatorWorkRestore` は `workCircleConsistency` と同じ `works` コレクションを再走査しており、加算すると works が二重計上になる（実測: circles 383 + creators 1,178 + works 2,114 = 3,675。足すと 5,789）。当該検査の成果は `totalFixed` 側に計上済みでサマリから漏れてもいない。同じ誤解の再発を防ぐため、理由をコード側コメントに明記した（SPR-270 は Won't Fix でクローズ）。
+- （解決済み・記録として残す）`checkDataIntegrity` の `totalChecked` が `creatorWorkRestore.checked` を含まない点を「欠落」として SPR-270 に起票したが、調査の結果**現状が正しい実装**と判明した。`creatorWorkRestore.checked` と `workCircleConsistency.checked` はどちらも `works` 全件の件数で**常に同値**のため、加算すると works が必ず二重計上になる（件数によらず成立）。当該検査の成果は `totalFixed` 側に計上済みでサマリから漏れてもいない。判断の根拠にした実測値は 2026-07-18 時点で circles 383 + creators 1,178 + works 2,114 = 3,675（ログの `totalChecked` と一致・加算すると 5,789）。同じ誤解の再発を防ぐため、理由をコード側コメントに明記した（SPR-270 は Won't Fix でクローズ）。
 
 ## 参考
 

--- a/docs/decisions/architecture/ADR-013-cloud-functions-endpoint-architecture.md
+++ b/docs/decisions/architecture/ADR-013-cloud-functions-endpoint-architecture.md
@@ -98,7 +98,7 @@ export function createRunMetadataStore<T extends object>(options: {
 
 ### 良くない点・残課題
 
-- `checkDataIntegrity` の `totalChecked` 集計ログが `creatorWorkRestore.checked` を含んでいない（分割前から存在する欠落・実害なし・SPR-270 として別途起票）。
+- （解決済み・記録として残す）`checkDataIntegrity` の `totalChecked` が `creatorWorkRestore.checked` を含まない点を「欠落」として SPR-270 に起票したが、調査の結果**現状が正しい実装**と判明した。`creatorWorkRestore` は `workCircleConsistency` と同じ `works` コレクションを再走査しており、加算すると works が二重計上になる（実測: circles 383 + creators 1,178 + works 2,114 = 3,675。足すと 5,789）。当該検査の成果は `totalFixed` 側に計上済みでサマリから漏れてもいない。同じ誤解の再発を防ぐため、理由をコード側コメントに明記した（SPR-270 は Won't Fix でクローズ）。
 
 ## 参考
 


### PR DESCRIPTION
## Summary
SPR-270 は「`checkDataIntegrity` の `totalChecked` から `creatorWorkRestore.checked` が漏れている」として起票したが、**本番実数で調査した結果、現状が正しい実装と判明したため加算しない**。挙動は変更せず、同じ誤解の再発を防ぐ形で決着させる。

## 調査結果（本番実測 2026-07-18）

| 検査 | 対象コレクション | 件数 |
|---|---|---|
| `circleWorkCounts` | circles | 383 |
| `orphanedCreators` | creators | 1,178 |
| `workCircleConsistency` | **works** | 2,114 |
| `creatorWorkRestore` | **works（同一を再走査）** | 2,114 |

- ログの `totalChecked=3675` は `383 + 1,178 + 2,114` と完全一致
- 起票時の想定どおり加算すると **5,789** になり、`works` を二重計上して実態と乖離する
- さらに `totalFixed` は既に `creatorWorkRestore.restored + creatorsCreated` を含んでおり、**この検査の成果はサマリから漏れていない**（漏れているのは重複する `checked` のみ）

つまり `totalChecked` は「走査した doc 数をコレクション単位で数える」という一貫した定義になっており、4つ目を足さないのは正しい。

## 変更内容
- `check-data-integrity.ts`: なぜ加算しないのかを実測値つきでコメント化（コードは無変更）
- `ADR-013`: 「残課題」に欠落として記載していた項目を、調査結果に基づき訂正

## Test plan
- [x] `pnpm verify` 全体 green（exit 0・functions 481件）
- [x] `pnpm lint:docs` green
- [x] 挙動変更なし（ログ出力値・ロジックとも一切変えていない）

## 注意
`checkDataIntegrity`（整合性 cron）配下のファイルのため形式上 One-Way Door 領域。ただし本 PR はコメントとドキュメントのみで、実行されるコードは1文字も変わっていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)