### PR TITLE
fix(functions,web): 動画のユーザータグが保存・表示されない二重の欠陥を修正 (SPR-273)

### DIFF
--- a/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
@@ -190,3 +190,31 @@ describe("VideoMapper（互換 API）", () => {
 		);
 	});
 });
+
+describe("userTags を省略した場合は書き込み対象にしない（SPR-273 回帰防止）", () => {
+	// userTags は web 側（ユーザー編集）が正本。YouTube 取り込みが既定値 [] を書くと
+	// merge:true でユーザーのタグを空で上書きしてしまう（[] は undefined と違い値として
+	// 存在するため ignoreUndefinedProperties では守られない）。
+	it("mapYouTubeToVideoPlainObject: 省略時は undefined のまま（[] にしない）", () => {
+		const v = mapYouTubeToVideoPlainObject(ytVideo(), ["pl"]);
+
+		expect(v?.tags?.userTags).toBeUndefined();
+		expect(v?.userTags).toBeUndefined();
+		// 同じ層の playlistTags / contentTags は従来どおり書き込む
+		expect(v?.tags?.playlistTags).toEqual(["pl"]);
+		expect(v?.tags?.contentTags).toEqual(["t1", "t2"]);
+	});
+
+	it("VideoMapper.fromYouTubeAPIWithTags: 第3引数省略時も undefined のまま", () => {
+		const v = VideoMapper.fromYouTubeAPIWithTags(ytVideo(), ["pl"]);
+
+		expect(v?.tags?.userTags).toBeUndefined();
+		expect(v?.userTags).toBeUndefined();
+	});
+
+	it("明示的に渡した場合は従来どおり反映する", () => {
+		const v = VideoMapper.fromYouTubeAPIWithTags(ytVideo(), ["pl"], ["u1"]);
+
+		expect(v?.tags?.userTags).toEqual(["u1"]);
+	});
+});

--- a/apps/functions/src/services/mappers/video-mapper.ts
+++ b/apps/functions/src/services/mappers/video-mapper.ts
@@ -65,7 +65,7 @@ function determineVideoType(
 export function mapYouTubeToVideoPlainObject(
 	youtubeVideo: youtube_v3.Schema$Video,
 	playlistTags: string[] = [],
-	userTags: string[] = [],
+	userTags?: string[],
 ): VideoPlainObject | null {
 	try {
 		// Validate required fields
@@ -136,6 +136,11 @@ export function mapYouTubeToVideoPlainObject(
 			// Use both new and old format for compatibility
 			tags: {
 				playlistTags,
+				// SPR-273: userTags は web 側（ユーザーが編集）が維持するもので YouTube 由来ではない。
+				// 既定値 [] を入れると merge:true でユーザーのタグを空で上書きしてしまう
+				// （[] は undefined と違い値として存在するため ignoreUndefinedProperties で守られない）。
+				// 呼び出し側が明示しない限り undefined のままにし、Firestore の既存値を温存する。
+				// audioButtonCount と同じ「web が正本のフィールドは YouTube 更新で書かない」方針。
 				userTags,
 				contentTags: snippet.tags || [],
 			},
@@ -192,7 +197,9 @@ export const VideoMapper = {
 	fromYouTubeAPIWithTags(
 		video: youtube_v3.Schema$Video,
 		playlistTags: string[] = [],
-		userTags: string[] = [],
+		// SPR-273: 既定値を [] にすると呼び出し側が省略しただけでユーザータグを消す。
+		// 省略時は undefined を伝播させ Firestore の既存値を温存する。
+		userTags?: string[],
 	): VideoPlainObject | null {
 		return mapYouTubeToVideoPlainObject(video, playlistTags, userTags);
 	},

--- a/apps/web/src/lib/__tests__/video-firestore.test.ts
+++ b/apps/web/src/lib/__tests__/video-firestore.test.ts
@@ -1,0 +1,87 @@
+/**
+ * video-firestore のユーザータグ読み書きテスト（SPR-273）
+ *
+ * ユーザータグの正本は `tags.userTags`（3層タグの1層）。読み手（一覧のタグ絞り込み・
+ * 動画カード・タグエディタ）はすべて `video.tags?.userTags` を見ているため、
+ * 書き込み先がトップレベル `userTags`（Legacy）だと保存しても表示されない。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getFirestore } from "../firestore";
+import { getVideoUserTags, updateVideoUserTags } from "../video-firestore";
+
+const mockCollection = vi.fn();
+const mockDoc = vi.fn();
+const mockGet = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("../firestore", () => ({
+	getFirestore: vi.fn(),
+}));
+
+vi.mock("../logger", () => ({
+	error: vi.fn(),
+	warn: vi.fn(),
+	info: vi.fn(),
+	debug: vi.fn(),
+}));
+
+describe("video-firestore: ユーザータグ", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(getFirestore).mockReturnValue({ collection: mockCollection } as never);
+		mockCollection.mockReturnValue({ doc: mockDoc });
+		mockDoc.mockReturnValue({ get: mockGet, update: mockUpdate });
+		mockUpdate.mockResolvedValue(undefined);
+	});
+
+	describe("updateVideoUserTags", () => {
+		it("正本である tags.userTags にドット記法で書き込む", async () => {
+			mockGet.mockResolvedValue({ exists: true });
+
+			const result = await updateVideoUserTags("v1", ["タグA", "タグB"]);
+
+			expect(result.success).toBe(true);
+			expect(mockUpdate).toHaveBeenCalledWith(
+				expect.objectContaining({ "tags.userTags": ["タグA", "タグB"] }),
+			);
+		});
+
+		it("tags マップ全体を置換しない（同じ層の playlistTags を巻き込まない）", async () => {
+			// `{ tags: { userTags } }` を渡すと update() は tags マップごと差し替えてしまい、
+			// playlistTags / contentTags が消える。ドット記法であることをここで固定する。
+			mockGet.mockResolvedValue({ exists: true });
+
+			await updateVideoUserTags("v1", ["タグA"]);
+
+			const written = mockUpdate.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(written).not.toHaveProperty("tags");
+		});
+
+		it("動画が存在しなければ更新しない", async () => {
+			mockGet.mockResolvedValue({ exists: false });
+
+			const result = await updateVideoUserTags("missing", ["タグA"]);
+
+			expect(result.success).toBe(false);
+			expect(mockUpdate).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("getVideoUserTags", () => {
+		it("tags.userTags から読む", async () => {
+			mockGet.mockResolvedValue({
+				exists: true,
+				data: () => ({ tags: { userTags: ["タグA"], playlistTags: ["PL"] } }),
+			});
+
+			expect(await getVideoUserTags("v1")).toEqual(["タグA"]);
+		});
+
+		it("未設定なら空配列を返す", async () => {
+			mockGet.mockResolvedValue({ exists: true, data: () => ({ tags: { playlistTags: ["PL"] } }) });
+
+			expect(await getVideoUserTags("v1")).toEqual([]);
+		});
+	});
+});

--- a/apps/web/src/lib/video-firestore.ts
+++ b/apps/web/src/lib/video-firestore.ts
@@ -71,9 +71,14 @@ export async function updateVideoUserTags(
 			};
 		}
 
-		// ユーザータグを更新
+		// SPR-273: 正本は `tags.userTags`（3層タグの1層）。読み手（一覧のタグ絞り込み・
+		// 動画カード・タグエディタ）はすべて `video.tags?.userTags` を見ており、
+		// 旧実装が書いていたトップレベル `userTags`（Legacy）は誰も読んでいなかったため
+		// 保存したタグが表示されない状態だった。
+		// ドット記法で書くこと: `{ tags: { userTags } }` だと update() は tags マップ全体を
+		// 置換し、同じ層の playlistTags/contentTags を消してしまう。
 		await videoRef.update({
-			userTags: userTags,
+			"tags.userTags": userTags,
 			updatedAt: new Date().toISOString(),
 		});
 
@@ -107,8 +112,9 @@ export async function getVideoUserTags(videoId: string): Promise<string[]> {
 			return [];
 		}
 
+		// SPR-273: 正本は `tags.userTags`。トップレベル `userTags` は Legacy で読み手がいない。
 		const data = videoDoc.data();
-		return data?.userTags || [];
+		return data?.tags?.userTags || [];
 	} catch (error) {
 		handleFirestoreError("getVideoUserTags", { videoId }, error);
 		return [];


### PR DESCRIPTION
## Summary
SPR-231 後の潜在バグ調査で発見。**独立した2つの欠陥が重なり、ユーザータグ機能が成立していなかった。**

本番 videos 573件を確認したところ `tags.userTags` / トップレベル `userTags` とも**全件が空**で、**復旧すべきデータは存在しない**（機能が一度も成立していなかったことの裏付け）。

### 欠陥1: YouTube cron がユーザータグを空配列で上書きしていた
`mapYouTubeToVideoPlainObject` の `userTags` 既定値が `[]` で、`youtube-firestore.ts` が第3引数を省略して呼ぶため常に `[]` が書かれていた。`[]` は `undefined` と違い**値として存在する**ため `ignoreUndefinedProperties` では守られず、`merge: true` で既存値を消す。SPR-261/262 の統計ティア化以降は全動画が定期的に書き換わるため、消失は偶発ではなく確定的だった。

→ 既定値を `undefined` にし、呼び出し側が明示しない限り書かない。すぐ隣の `audioButtonCount` と同じ「**web が正本のフィールドは YouTube 更新で書かない**」方針に揃えた。

### 欠陥2: 書き込み先と読み出し元のフィールドが違った
- web の書き込み: **トップレベル `userTags`**（Legacy）
- 読み手: 一覧のタグ絞り込み（`actions.ts`）・動画カード・タグエディタとも **`tags.userTags`**

`fromFirestore` は素のスプレッドで両者を橋渡ししないため、保存したタグはそもそも表示されなかった。

→ 正本を `tags.userTags`（3層タグの1層・読み手が見ている方）に統一。**ドット記法で書く**のが要点で、`{ tags: { userTags } }` だと `update()` が `tags` マップを丸ごと置換し、同じ層の `playlistTags` / `contentTags` を消してしまう。

## Test plan
- [x] `pnpm verify` 全体 green（exit 0・functions 488件 / web 1095件）
- [x] **回帰テスト8件を追加**（functions 3件: 省略時 undefined・明示時は反映 / web 5件: ドット記法・tags マップ非置換・読み出し元）
- [x] **テストの実効性を確認**: functions 側・web 側それぞれ修正を旧実装に戻すと該当テストが fail し、復元で全 green に戻ることを確認
- [x] 本番データで被害状況を確認（573件・両フィールドとも非空ゼロ＝データ復旧は不要）

## デプロイ後の挙動
既存ドキュメントの空の `userTags` / `tags.userTags` はそのまま残るが、以後 cron が上書きしなくなるため、ユーザーが保存したタグは保持され、読み手にも表示されるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)