### PR TITLE
feat(web): 動画ユーザータグ編集のGA4計装を追加（利用実態の判別用）

### DIFF
--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
@@ -231,6 +231,25 @@ describe("VideoUserTagEditor", () => {
 			});
 		});
 
+		it("open と save は同じ video_id を載せる（GA4 で突き合わせられること）", async () => {
+			// save 側は VideoTagEditor から返る videoId を使うため open 側（video.videoId）とは
+			// 変数系統が異なる。実体は同じ prop の往復だが、将来 VideoTagEditor が別の id を
+			// 返すようになると計測が静かに突き合わせ不能になるため、ここで不変条件を固定する。
+			mockUseSession(loggedIn);
+			(updateUserTagsAction as any).mockResolvedValue({ success: true });
+			render(<VideoUserTagEditor video={createVideo()} />);
+
+			fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+			fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+			await waitFor(() => {
+				expect(trackUserTagSave).toHaveBeenCalled();
+			});
+			const openVideoId = vi.mocked(trackUserTagEditOpen).mock.calls[0]?.[0];
+			const saveVideoId = vi.mocked(trackUserTagSave).mock.calls[0]?.[0];
+			expect(saveVideoId).toBe(openVideoId);
+		});
+
 		it("保存失敗時は user_tag_save を送らない（open との差分が失敗を表す）", async () => {
 			mockUseSession(loggedIn);
 			(updateUserTagsAction as any).mockResolvedValue({

--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-user-tag-editor.test.tsx
@@ -2,6 +2,7 @@ import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { updateUserTagsAction } from "@/actions/user-tags";
+import { trackUserTagEditOpen, trackUserTagSave } from "@/lib/analytics/events";
 import { buildTagSearchHref } from "@/lib/tag-search";
 import { mockUseSession } from "@/test-utils/auth";
 import { VideoUserTagEditor } from "../video-user-tag-editor";
@@ -10,6 +11,12 @@ vi.mock("@/lib/auth/client");
 
 vi.mock("@/actions/user-tags", () => ({
 	updateUserTagsAction: vi.fn(),
+}));
+
+// SPR-273 の修正後、この機能が実際に使われるかを測る計装（GA4）の発火を検証する
+vi.mock("@/lib/analytics/events", () => ({
+	trackUserTagEditOpen: vi.fn(),
+	trackUserTagSave: vi.fn(),
 }));
 
 // router.push / router.refresh の副作用を検証するため next/navigation をローカルでモックして捕捉する
@@ -198,6 +205,48 @@ describe("VideoUserTagEditor", () => {
 
 		fireEvent.click(screen.getByRole("button", { name: /編集/ }));
 		expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
+	});
+
+	describe("利用実態の計測（GA4）", () => {
+		it("編集ボタンで user_tag_edit_open を送る", () => {
+			mockUseSession(loggedIn);
+			render(<VideoUserTagEditor video={createVideo()} />);
+
+			fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+
+			expect(trackUserTagEditOpen).toHaveBeenCalledWith("abc123");
+		});
+
+		it("保存成功時のみ user_tag_save をタグ数付きで送る", async () => {
+			mockUseSession(loggedIn);
+			(updateUserTagsAction as any).mockResolvedValue({ success: true });
+			render(<VideoUserTagEditor video={createVideo()} />);
+
+			fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+			fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+			await waitFor(() => {
+				// スタブは ["new-tag"] を渡すのでタグ数は1
+				expect(trackUserTagSave).toHaveBeenCalledWith("abc123", 1);
+			});
+		});
+
+		it("保存失敗時は user_tag_save を送らない（open との差分が失敗を表す）", async () => {
+			mockUseSession(loggedIn);
+			(updateUserTagsAction as any).mockResolvedValue({
+				success: false,
+				error: "権限がありません",
+			});
+			render(<VideoUserTagEditor video={createVideo()} />);
+
+			fireEvent.click(screen.getByRole("button", { name: /編集/ }));
+			fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+			await waitFor(() => {
+				expect(updateResult.value).toEqual({ success: false, error: "権限がありません" });
+			});
+			expect(trackUserTagSave).not.toHaveBeenCalled();
+		});
 	});
 
 	it("タグクリックで buildTagSearchHref の URL に router.push する", () => {

--- a/apps/web/src/app/videos/[videoId]/components/video-user-tag-editor.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/video-user-tag-editor.tsx
@@ -14,6 +14,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { updateUserTagsAction } from "@/actions/user-tags";
 import { VideoTagEditor } from "@/components/video/video-tag-editor";
+import { trackUserTagEditOpen, trackUserTagSave } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
 import { buildTagSearchHref } from "@/lib/tag-search";
 
@@ -38,6 +39,8 @@ export function VideoUserTagEditor({ video }: VideoUserTagEditorProps) {
 				});
 
 				if (result.success) {
+					// 保存成功のみ計上する（失敗は user_tag_edit_open との差分として現れる）
+					trackUserTagSave(videoId, tags.length);
 					// 成功時はページをリフレッシュして最新データを取得
 					router.refresh();
 					setIsEditingUserTags(false);
@@ -56,6 +59,12 @@ export function VideoUserTagEditor({ video }: VideoUserTagEditorProps) {
 		},
 		[router],
 	);
+
+	/** 編集モードへ入る。open と save の差が「編集を試みたが保存に至らなかった」を表す */
+	const handleStartEditing = useCallback(() => {
+		trackUserTagEditOpen(video.videoId);
+		setIsEditingUserTags(true);
+	}, [video.videoId]);
 
 	// 編集権限チェック: 認証済みユーザーのみ編集可能
 	const canEdit = !!user?.discordId;
@@ -93,7 +102,7 @@ export function VideoUserTagEditor({ video }: VideoUserTagEditorProps) {
 					<div className="flex items-center justify-between mb-4">
 						<h4 className="text-lg font-semibold">みんなのタグ編集</h4>
 						{!isEditingUserTags && (
-							<Button variant="outline" size="sm" onClick={() => setIsEditingUserTags(true)}>
+							<Button variant="outline" size="sm" onClick={handleStartEditing}>
 								<Edit className="h-4 w-4 mr-2" />
 								編集
 							</Button>

--- a/apps/web/src/lib/analytics/__tests__/events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/events.test.ts
@@ -11,6 +11,8 @@ import {
 	trackPlayButton,
 	trackSuggestionApply,
 	trackSuggestionGenerate,
+	trackUserTagEditOpen,
+	trackUserTagSave,
 } from "../events";
 
 const gtag = vi.fn();
@@ -147,5 +149,38 @@ describe("GA4 カスタムイベント語彙 (SPR-149)", () => {
 			video_id: "vid00000001",
 			target: "tag",
 		});
+	});
+
+	// SPR-273 の修正後、ユーザータグ機能が実際に使われるかを測るための計装。
+	// open と save の差で「気づかれていない」と「試したが保存に至らない」を区別する。
+	it("user_tag_edit_open: 編集開始を video_id 付きで送る", () => {
+		grantAnalyticsConsent();
+		trackUserTagEditOpen("vid00000001");
+
+		expect(gtag).toHaveBeenCalledWith("event", "user_tag_edit_open", {
+			video_id: "vid00000001",
+		});
+	});
+
+	it("user_tag_save: タグ数を添えて送る（0件＝全削除も区別できる）", () => {
+		grantAnalyticsConsent();
+		trackUserTagSave("vid00000001", 3);
+		trackUserTagSave("vid00000002", 0);
+
+		expect(gtag).toHaveBeenCalledWith("event", "user_tag_save", {
+			video_id: "vid00000001",
+			tag_count: 3,
+		});
+		expect(gtag).toHaveBeenCalledWith("event", "user_tag_save", {
+			video_id: "vid00000002",
+			tag_count: 0,
+		});
+	});
+
+	it("consent 未取得ならタグ編集イベントも送らない", () => {
+		trackUserTagEditOpen("vid00000001");
+		trackUserTagSave("vid00000001", 1);
+
+		expect(gtag).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -100,3 +100,24 @@ export function trackLoginSuccess(provider: string): void {
 export function trackLoginError(reason: string): void {
 	sendGoogleAnalyticsEvent("login_error", { reason: reason.slice(0, MAX_PARAM_LENGTH) });
 }
+
+/**
+ * 動画のユーザータグ編集ファネル: 編集モードに入った（SPR-273 の修正後に利用実態を測るため）。
+ *
+ * この機能は長らく壊れており（保存先とUIの読み出し先が別フィールド・cron が空配列で上書き）、
+ * Firestore 上の userTags は全件空だった。そのため「データが無い＝使われていない」とは言えず、
+ * 「気づかれていない」のか「使われた上で定着しない」のかを区別できる行動データが要る。
+ * open と save の差がその判別材料になる。
+ */
+export function trackUserTagEditOpen(videoId: string): void {
+	sendGoogleAnalyticsEvent("user_tag_edit_open", { video_id: videoId });
+}
+
+/**
+ * 動画のユーザータグ編集ファネル: 保存した。
+ *
+ * @param tagCount 保存後のタグ数。0 は「全タグを削除した」を意味し、追加と区別して見たい
+ */
+export function trackUserTagSave(videoId: string, tagCount: number): void {
+	sendGoogleAnalyticsEvent("user_tag_save", { video_id: videoId, tag_count: tagCount });
+}


### PR DESCRIPTION
## Summary
SPR-273 でユーザータグ機能の二重の欠陥を修正したが、**修正後にこの機能を残すか畳むかを判断する材料が無い**ため、行動データを取る計装を入れる。

### なぜ Firestore では判断できないか
「Firestore の userTags が全件空だから、ユーザーは playlistTags で満足していて userTags は不要なのでは」という見立ては成立しない。**機能が壊れていた**（保存先とUIの読み出し先が別フィールド・cron が空配列で上書き）ため、試された痕跡ごと消えている。Firestore は現在状態しか持たず、`0件` はバグで完全に説明がつくのでユーザー意図の情報を含まない。

参考までに、Firestore から取れる周辺データはむしろ逆を示唆していた:

| | ユニークタグ数 | 付与率 | 性質 |
|---|---|---|---|
| videos の playlistTags | 15種 / 平均1.37個 | 97.2% | 🎮ゲーム💗 / ⭐雑談💗 ＝**配信の種別** |
| audioButtons の tags（動く機能） | 22種 | **100%** | 名言・迷言 / 返事・リアクション ＝**中身の記述** |

粒度が違うので代替関係になく、かつ「動くタグ機能は全件使われている」ため「このコミュニティはタグを付けない」とは言えない。

## 追加したイベント
- `user_tag_edit_open`（`video_id`）: 編集モードに入った
- `user_tag_save`（`video_id`, `tag_count`）: **保存成功時のみ**。`tag_count=0` は全削除を表し追加と区別できる

**open と save の差**が「気づかれていない」と「試したが保存に至らない／定着しない」の判別材料になる。

イベント語彙は既存どおり `lib/analytics/events.ts` に集約し、送信は consent ゲート内蔵の `sendGoogleAnalyticsEvent` を経由（呼び出し側に文字列を組ませない＝計測語彙のドリフト防止）。既存の `login_start` / `suggestion_apply` 等と同じ形。

## Test plan
- [x] `pnpm verify` 全体 green（web 1101件）
- [x] テスト5件追加（events 3件: パラメータ形・consent ゲート / コンポーネント配線 2件: open 発火・保存成功時のみ save）
- [x] **配線の実効性を確認**: 計装呼び出しを外すとコンポーネント側テスト2件が fail し、復元で green に戻ることを確認

ブラウザでの実地確認は Discord 認証が必要な画面のため未実施。代わりに配線をコンポーネントテストで直接カバーしている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)