### PR TITLE
fix(web): 同意直後の page_view を送らず landing page が全欠落する不具合を修正

### DIFF
--- a/apps/web/src/components/analytics/__tests__/page-view-tracker.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/page-view-tracker.test.tsx
@@ -1,0 +1,93 @@
+import { act, render } from "@testing-library/react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as consent from "@/lib/consent/google-consent-mode";
+import { PageViewTracker } from "../page-view-tracker";
+
+vi.mock("next/navigation");
+
+function setRoute(pathname: string, query = "") {
+	vi.mocked(usePathname).mockReturnValue(pathname);
+	vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams(query) as never);
+}
+
+/** 同意状態を模す。granted=true のときだけ実送信が成功したことにする */
+function mockPageView(granted: boolean) {
+	return vi.spyOn(consent, "sendGoogleAnalyticsPageView").mockReturnValue(granted);
+}
+
+function dispatchConsentUpdate() {
+	act(() => {
+		window.dispatchEvent(new CustomEvent("consentUpdate", { detail: { analytics: true } }));
+	});
+}
+
+beforeEach(() => {
+	setRoute("/buttons");
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("PageViewTracker", () => {
+	it("同意済みならマウント時に現在の URL を送る", () => {
+		const spy = mockPageView(true);
+
+		render(<PageViewTracker />);
+
+		expect(spy).toHaveBeenCalledExactlyOnceWith("/buttons");
+	});
+
+	it("クエリつきの URL は pathname?query の形で送る", () => {
+		const spy = mockPageView(true);
+		setRoute("/works", "page=2&sort=new");
+
+		render(<PageViewTracker />);
+
+		expect(spy).toHaveBeenCalledExactlyOnceWith("/works?page=2&sort=new");
+	});
+
+	it("未同意のロードは送らず、同意反映後にその時開いているページを送る", () => {
+		const spy = mockPageView(false);
+
+		render(<PageViewTracker />);
+		expect(spy).toHaveBeenCalledTimes(1); // 呼びはするが送信されない（同意ゲート内で no-op）
+
+		spy.mockReturnValue(true);
+		dispatchConsentUpdate();
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(spy).toHaveBeenLastCalledWith("/buttons");
+	});
+
+	it("同意反映後、同じページの consentUpdate 再発火では二重に送らない", () => {
+		const spy = mockPageView(false);
+		render(<PageViewTracker />);
+
+		spy.mockReturnValue(true);
+		dispatchConsentUpdate();
+		dispatchConsentUpdate();
+
+		expect(spy).toHaveBeenCalledTimes(2); // 初回ロード分 + 同意反映分のみ
+	});
+
+	it("同意済みで送信済みのページでは consentUpdate に反応しない", () => {
+		const spy = mockPageView(true);
+		render(<PageViewTracker />);
+
+		dispatchConsentUpdate();
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("遷移すれば新しい URL を送る", () => {
+		const spy = mockPageView(true);
+		const { rerender } = render(<PageViewTracker />);
+
+		setRoute("/works");
+		rerender(<PageViewTracker />);
+
+		expect(spy).toHaveBeenNthCalledWith(2, "/works");
+	});
+});

--- a/apps/web/src/components/analytics/page-view-tracker.tsx
+++ b/apps/web/src/components/analytics/page-view-tracker.tsx
@@ -1,24 +1,46 @@
 "use client";
 
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { sendGoogleAnalyticsPageView } from "@/lib/consent/google-consent-mode";
 
 /**
  * Client-side page view tracker for Google Analytics
  * Respects user consent preferences
+ *
+ * GA 本体は send_page_view: false のため page view の送信元はここだけ。同意前のロードでは
+ * 送信できないので、バナー/設定パネルの同意反映（consentUpdate）を待って、その時点で
+ * 開いているページ分を送る。これが無いと同意した訪問の初回ページが永久に欠落し、
+ * GA4 の landingPage が (not set)・PV がユーザー数を下回る壊れた指標になる。
  */
 export function PageViewTracker() {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
+	const query = searchParams?.toString();
+	const url = pathname ? (query ? `${pathname}?${query}` : pathname) : null;
+
+	/** 送信済みの URL。同意トグルの往復や設定パネルからの再同意で二重計上しないための印 */
+	const sentUrl = useRef<string | null>(null);
+
+	// 送信できたときだけ印を付ける（同意前の no-op を「送信済み」にすると再送の機会を失う）
+	const sendOnce = useCallback((target: string): boolean => {
+		if (sentUrl.current === target) return true;
+		const sent = sendGoogleAnalyticsPageView(target);
+		if (sent) sentUrl.current = target;
+		return sent;
+	}, []);
 
 	useEffect(() => {
-		// Send page view on route change
-		if (pathname) {
-			const url = searchParams?.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
-			sendGoogleAnalyticsPageView(url);
-		}
-	}, [pathname, searchParams]);
+		if (!url) return;
+		if (sendOnce(url)) return;
+
+		// 未同意。同意が反映された時点で、その時開いているページを送る
+		const handleConsentUpdate = () => {
+			sendOnce(url);
+		};
+		window.addEventListener("consentUpdate", handleConsentUpdate);
+		return () => window.removeEventListener("consentUpdate", handleConsentUpdate);
+	}, [url, sendOnce]);
 
 	// This component doesn't render anything
 	return null;

--- a/apps/web/src/lib/consent/google-consent-mode.ts
+++ b/apps/web/src/lib/consent/google-consent-mode.ts
@@ -140,24 +140,28 @@ export function resetAllConsent() {
 /**
  * Send a page view to Google Analytics
  * Only works if analytics consent is granted
+ *
+ * @returns 実際に送信したか。同意前のロードでは false を返すため、呼び出し側は
+ * 同意反映後に再送する判断ができる（未送信を「送信済み」と誤認すると landing page が欠ける）
  */
-export function sendGoogleAnalyticsPageView(url?: string) {
-	if (typeof window === "undefined" || !window.gtag) return;
+export function sendGoogleAnalyticsPageView(url?: string): boolean {
+	if (typeof window === "undefined" || !window.gtag) return false;
 
 	const consentState = getCurrentConsentState();
 	if (!consentState?.analytics) {
 		// Page view blocked - no consent
-		return;
+		return false;
 	}
 
 	const measurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
-	if (!measurementId) return;
+	if (!measurementId) return false;
 
 	window.gtag("config", measurementId, {
 		page_path: url || window.location.pathname,
 		page_title: document.title,
 		page_location: window.location.href,
 	});
+	return true;
 }
 
 /**


### PR DESCRIPTION
## 背景

GA4 の実データを取得して分析したところ、指標そのものが壊れていることが分かった。

- 90日で landingPage の **64%（122/191セッション）が `(not set)`**
- **PV がユーザー数を下回る**（トップページは activeUsers 29 に対し PV 8）
- 直近13日で session_start 45 に対し page_view 15

## 原因

GA 本体は `send_page_view: false`（`google-analytics-script.tsx`）なので page view の送信元は `PageViewTracker` だけ。しかし同意前のロードでは consent ゲートで no-op になり、**その後の同意反映（`consentUpdate`）を誰も listen していなかった**（dispatch は banner と設定パネルの2箇所にあるが listener はゼロ）。

結果、同意した訪問の初回ページ＝landing page が永久に失われていた。遷移すれば送られるため、直帰セッションは PV 0 として記録される。

## 変更

- `PageViewTracker`: 未送信なら `consentUpdate` を待って、その時開いているページ分を送る。送信済み URL の印で再同意時の二重計上を防ぐ
- `sendGoogleAnalyticsPageView`: 実際に送信したかを返す。同意前の no-op を「送信済み」と誤認すると再送の機会を失うため

同意していないユーザーの扱いは変えていない（送信しない）。プライバシーポリシー本文「明示的な同意がある場合のみ使用されます」を維持する。

## 検証

- `pnpm verify` EXIT=0 / テスト6件追加
- ローカル実機で `window.dataLayer` を実測:

| 操作 | 結果 |
|---|---|
| 未同意でロード | consent default のみ＝page_view なし |
| 「すべて許可」 | `config {page_path:"/"}` が発火（失われていた landing page） |
| 再度「すべて許可」 | config 0件（二重送信なし） |
| `/buttons` へ soft nav | `config {page_path:"/buttons"}` |

## 残課題（この PR の範囲外）

- **カスタムディメンション登録が0件**（Data API metadata 実測）＋ BigQuery export 未設定のため、`audio_button_id` / `from_draft` / `reason` 等のパラメータは送っていても集計できない。GA4 は登録以前のデータに遡及適用しないため早期の登録が必要。Admin API で作成を試みたが `ga4-reader@` が閲覧者のみで permission 拒否 → GA4 側で編集者権限の付与か手動登録が必要
- **SPR-149/267/148 のカスタムイベントは本番で1件も記録されていない**（同期間に自動計測の video_start は 33件/10ユーザー）。同意率が実質ゼロ（13日で consent_update 1件）のため、成功指標が構造的に測れていない
- **ポリシーと実装の不一致**: 現状は advanced consent mode（GA タグを常にロードし default を denied）で、非同意ユーザーの `session_start` / `scroll` / `video_start` は既に GA4 に記録されている。ポリシー本文と実態のどちらに寄せるか要判断

Two-Way Door（表示に影響せず、戻せる範囲の計測修正）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)