### PR TITLE
feat(functions,terraform): YouTube関数の監視を整備しメモリ上限を引き上げ (SPR-235)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -197,6 +197,11 @@ jobs:
           declare -A deploy_pids
           
           # fetchYouTubeVideos
+          # メモリ 512Mi の理由（SPR-235・2026-07 実測）: 旧設定 256Mi では memory utilization が
+          # 常時 0.86〜1.00 で張り付き、2026-07-23 に OOM でインスタンスが強制終了した。
+          # SPR-266 の fast_recheck（15分毎）投入でインスタンスが常時ウォームになり、
+          # 毎時のコールドスタートによる暗黙のプロセスリサイクルが無くなったことで顕在化した
+          # （新インスタンス直後でも 0.86 と元々マージンが薄く、37時間で約 +19MiB 増加する）。
           gcloud functions deploy fetchYouTubeVideos \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
@@ -206,7 +211,7 @@ jobs:
             --region asia-northeast1 \
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --set-env-vars NODE_ENV=production,FUNCTION_SIGNATURE_TYPE=cloudevent,FUNCTION_TARGET=fetchYouTubeVideos \
-            --memory 256Mi \
+            --memory 512Mi \
             --timeout 540s \
             --max-instances 3 \
             --service-account fetch-youtube-videos-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \

--- a/apps/functions/src/endpoints/youtube/__tests__/fetch-youtube-videos.test.ts
+++ b/apps/functions/src/endpoints/youtube/__tests__/fetch-youtube-videos.test.ts
@@ -316,49 +316,89 @@ describe("fetchYouTubeVideos: 週次フルスイープ（mode=weekly_full_sweep�
 		expect(youtubeFirestore.getAllVideoIds).toHaveBeenCalled();
 	});
 
-	it("発見集合に差分がある場合はwarnログを出す（検知のみ・本処理は完了する）", async () => {
+	it("未保存の取りこぼしはalertフィールド付きwarnで出す（検知のみ・本処理は完了する・SPR-235）", async () => {
 		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
 			videoIds: ["v1"],
 			nextPageToken: undefined,
 		});
-		// Firestoreにはv2があるが、uploads playlist走査では見つからない → 差分あり
-		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v2"]));
+		// uploads playlistにv1があるがFirestoreは空 → 未保存＝真の取りこぼし
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set());
 
 		const result = await fetchYouTubeVideos(pubsubEvent({ mode: "weekly_full_sweep" }));
 
 		expect(logger.warn).toHaveBeenCalledWith(
-			expect.stringContaining("差分があります"),
-			expect.anything(),
+			expect.stringContaining("Firestoreに未保存"),
+			// alertフィールドは monitoring_youtube.tf のメトリクスが参照する契約
+			expect.objectContaining({ alert: "youtube_discovery_unsaved", 未保存件数: 1 }),
 		);
-		// 差分検出自体は本処理の完了を妨げない
+		// 取りこぼし検出自体は本処理の完了を妨げない
 		expect(result).toBeUndefined();
 	});
 
-	it("全走査がページ上限で打ち切られた場合はmissing判定をスキップして警告する（レビュー指摘対応）", async () => {
+	it("YouTube側で削除された動画（playlist不在）はINFOに留めアラート対象にしない（SPR-235）", async () => {
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockResolvedValue({
+			videoIds: ["v1"],
+			nextPageToken: undefined,
+		});
+		// Firestoreにはv1に加えv2があるが、uploads playlistには無い＝削除/非公開の残骸
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v1", "v2"]));
+
+		await fetchYouTubeVideos(pubsubEvent({ mode: "weekly_full_sweep" }));
+
+		expect(logger.info).toHaveBeenCalledWith(
+			expect.stringContaining("Firestoreにのみ存在する動画があります"),
+			expect.objectContaining({ playlist不在件数: 1 }),
+		);
+		// 常態の床のため、これ単独ではwarnを出さない（毎週の誤発火を避ける）
+		expect(logger.warn).not.toHaveBeenCalledWith(
+			expect.stringContaining("Firestoreに未保存"),
+			expect.anything(),
+		);
+	});
+
+	it("全走査がページ上限で打ち切られた場合はplaylist不在判定のみスキップする（未保存判定は有効・SPR-235）", async () => {
 		// 常にnextPageTokenありを返し続ける → fetchVideoIdsViaPlaylistFullがページ上限で打ち切られる
 		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockImplementation(async () => ({
 			videoIds: ["v1"],
 			nextPageToken: "more",
 		}));
-		// Firestoreには走査未到達分のv2がある想定（打ち切られなければmissing判定される状況）
+		// Firestoreには走査未到達分のv2がある想定（打ち切られなければplaylist不在判定される状況）
 		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set(["v1", "v2"]));
 
 		await fetchYouTubeVideos(pubsubEvent({ mode: "weekly_full_sweep" }));
 
 		// ページ上限打ち切りの警告が出る
 		expect(logger.warn).toHaveBeenCalledWith(
-			expect.stringContaining("ページ上限で打ち切られたため、今回はmissing判定をスキップします"),
+			expect.stringContaining(
+				"ページ上限で打ち切られたため、今回はplaylist不在判定をスキップします",
+			),
 			expect.anything(),
 		);
-		// missing判定はスキップされるため「差分があります」ログは出ない
-		expect(logger.warn).not.toHaveBeenCalledWith(
-			expect.stringContaining("差分があります"),
+		// playlist不在判定はスキップされるためINFOも出ない（未走査分の偽陽性を避ける）
+		expect(logger.info).not.toHaveBeenCalledWith(
+			expect.stringContaining("Firestoreにのみ存在する動画があります"),
 			expect.anything(),
 		);
 		// 一致ログも出ない（判定自体をスキップしているため）
 		expect(logger.info).not.toHaveBeenCalledWith(
 			expect.stringContaining("発見集合が一致しました"),
 			expect.anything(),
+		);
+	});
+
+	it("走査が打ち切られても未保存の取りこぼしは検知する（SPR-235）", async () => {
+		vi.mocked(youtubeApi.fetchUploadsPlaylistPage).mockImplementation(async () => ({
+			videoIds: ["v1"],
+			nextPageToken: "more",
+		}));
+		// 走査できた範囲のv1がFirestoreに無い＝打ち切りに関係なく真の取りこぼし
+		vi.mocked(youtubeFirestore.getAllVideoIds).mockResolvedValue(new Set());
+
+		await fetchYouTubeVideos(pubsubEvent({ mode: "weekly_full_sweep" }));
+
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("Firestoreに未保存"),
+			expect.objectContaining({ alert: "youtube_discovery_unsaved" }),
 		);
 	});
 

--- a/apps/functions/src/endpoints/youtube/video-discovery.ts
+++ b/apps/functions/src/endpoints/youtube/video-discovery.ts
@@ -131,14 +131,32 @@ async function fetchVideoIdsViaPlaylistFull(
 }
 
 /**
- * uploads playlist全走査の発見集合とFirestoreの既知集合を比較し、対称差をログ出力する
- * （週次フルスイープの取りこぼし検知）。比較自体が失敗しても本処理には影響させない
- * （ログのみ・例外を投げない）。ログの「SPR-230 shadow:」接頭辞は Cloud Logging の
- * 検索キーとして定着しているため互換維持する（shadowモード自体は撤去済み）。
+ * 週次フルスイープの取りこぼし検知アラート識別子
  *
- * ページ上限で全走査自体が打ち切られた場合（`truncated`）、未走査分は「Firestoreにあるが
- * playlist走査で見つからない」＝missing判定に必ず引っかかってしまい偽陽性になるため、
- * その回はmissing判定をスキップする（レビュー指摘対応）。
+ * SPR-235: terraform のログベースメトリクス（`youtube_discovery_unsaved`）が
+ * `jsonPayload.alert` でこの値を参照する＝監視の契約。変更する場合は
+ * terraform/monitoring_youtube.tf も同じPRで更新する。
+ */
+const DISCOVERY_UNSAVED_ALERT = "youtube_discovery_unsaved";
+
+/**
+ * uploads playlist全走査の発見集合とFirestoreの既知集合を比較し、差分をログ出力する
+ * （週次フルスイープの取りこぼし検知）。比較自体が失敗しても本処理には影響させない
+ * （ログのみ・例外を投げない）。
+ *
+ * SPR-235: 旧実装は両方向の差分を1本のWARNにまとめていたが、2つの差分は意味も緊急度も
+ * 異なるため分離した（まとめたままではアラート化できない）。
+ *   - **未保存**（uploads playlistにあるがFirestoreに無い）… 発見できているのに保存
+ *     されていない＝真の取りこぼし。WARN＋`alert`フィールドでアラート対象にする
+ *   - **playlist不在**（Firestoreにあるがuploads playlistに無い）… YouTube側で削除/
+ *     非公開になった旧動画の残骸。2026-07実測で3回のスイープとも同一の8件が出続ける
+ *     恒久的な床であり、アラート化すると毎週必ず鳴る（軸2の予測可能性を壊す）。
+ *     件数の推移だけ追えれば十分なのでINFOに留める
+ *
+ * ページ上限で全走査が打ち切られた場合（`truncated`）、未走査分は「Firestoreにあるが
+ * playlist走査で見つからない」＝playlist不在判定に必ず引っかかって偽陽性になるため、
+ * その回はplaylist不在判定のみスキップする。未保存判定は走査できた範囲の実在IDに対する
+ * 判定なので打ち切りの影響を受けず、そのまま有効（SPR-235で早期returnをやめた）。
  */
 export async function logDiscoveryComparison(
 	youtube: youtube_v3.Youtube,
@@ -150,15 +168,24 @@ export async function logDiscoveryComparison(
 			getAllVideoIds(),
 		]);
 		const playlistIdSet = new Set(playlistVideoIds);
-		const extraInPlaylist = playlistVideoIds.filter((id) => !knownIds.has(id));
+		const unsavedInFirestore = playlistVideoIds.filter((id) => !knownIds.has(id));
+
+		if (unsavedInFirestore.length > 0) {
+			logger.warn("uploads playlistにあるがFirestoreに未保存の動画を検出しました", {
+				alert: DISCOVERY_UNSAVED_ALERT,
+				未保存件数: unsavedInFirestore.length,
+				uploadsPlaylist走査件数: playlistVideoIds.length,
+				Firestore既知件数: knownIds.size,
+				未保存サンプル: unsavedInFirestore.slice(0, 10),
+			});
+		}
 
 		if (truncated) {
 			logger.warn(
-				"SPR-230 shadow: uploads playlist全走査がページ上限で打ち切られたため、今回はmissing判定をスキップします",
+				"uploads playlist全走査がページ上限で打ち切られたため、今回はplaylist不在判定をスキップします",
 				{
 					uploadsPlaylist走査件数: playlistVideoIds.length,
 					Firestore既知件数: knownIds.size,
-					uploadsPlaylistのみに存在する件数: extraInPlaylist.length,
 				},
 			);
 			return;
@@ -166,21 +193,22 @@ export async function logDiscoveryComparison(
 
 		const missingInPlaylist = [...knownIds].filter((id) => !playlistIdSet.has(id));
 
-		if (missingInPlaylist.length === 0 && extraInPlaylist.length === 0) {
-			logger.info("SPR-230 shadow: discovery方式の発見集合が一致しました", {
+		if (missingInPlaylist.length > 0) {
+			logger.info("Firestoreにのみ存在する動画があります（YouTube側で削除/非公開の可能性）", {
+				playlist不在件数: missingInPlaylist.length,
+				Firestore既知件数: knownIds.size,
+				playlist不在サンプル: missingInPlaylist.slice(0, 10),
+			});
+		}
+
+		if (missingInPlaylist.length === 0 && unsavedInFirestore.length === 0) {
+			logger.info("discovery方式の発見集合が一致しました", {
 				uploadsPlaylist件数: playlistVideoIds.length,
 				Firestore既知件数: knownIds.size,
 			});
-		} else {
-			logger.warn("SPR-230 shadow: discovery方式の発見集合に差分があります", {
-				uploadsPlaylistに無いFirestore既知件数: missingInPlaylist.length,
-				uploadsPlaylistのみに存在する件数: extraInPlaylist.length,
-				missingSample: missingInPlaylist.slice(0, 10),
-				extraSample: extraInPlaylist.slice(0, 10),
-			});
 		}
 	} catch (error) {
-		logger.warn("SPR-230 shadow: discovery方式の比較に失敗しました（本処理には影響しません）", {
+		logger.warn("discovery方式の比較に失敗しました（本処理には影響しません）", {
 			error: error instanceof Error ? error.message : String(error),
 		});
 	}

--- a/terraform/function_youtube_videos.tf
+++ b/terraform/function_youtube_videos.tf
@@ -22,7 +22,7 @@ locals {
 # Terraform では google_cloudfunctions2_function リソースを管理しない（ADR-009 / SPR-92）。
 #
 # spec の正本（deploy-functions.yml の gcloud functions deploy）:
-#   runtime=nodejs24 / memory=256Mi / timeout=540s / max-instances=3
+#   runtime=nodejs24 / memory=512Mi / timeout=540s / max-instances=3
 #   entry-point=fetchYouTubeVideos / trigger-topic=youtube-video-fetch-trigger
 #
 # デプロイ手順:

--- a/terraform/monitoring_youtube.tf
+++ b/terraform/monitoring_youtube.tf
@@ -1,0 +1,496 @@
+# YouTube関数専用のモニタリング設定（SPR-235・SPR-234 のDLsite監視を横展開）
+#
+# 注意（SPR-234 で確立した前提を踏襲）:
+#   - fetchYouTubeVideos は Gen2（Cloud Run 上で実行）のため、実行ログは
+#     resource.type="cloud_run_revision" + resource.labels.service_name="fetchyoutubevideos"
+#     （サービス名は小文字）で出力される。Gen1 形式（resource.type="cloud_function"）は一切マッチしない
+#   - 付加フィールド無しの logger 呼び出しは message が textPayload へ昇格するため、
+#     filter は jsonPayload.message / textPayload の両張りにする
+#
+# 実行構成（2026-07-25 実測）: 同一関数が3系統のスケジューラで起動する
+#   - hourly（通常run・毎時30分）              24 run/日
+#   - fast_recheck（15分毎・SPR-266）          96 run/日
+#   - weekly_full_sweep（日曜4:00 JST）        1 run/週
+#   合計 120 リクエスト/日・すべて 2xx（30日実測）
+#
+# ログ実態（直近30日・2026-07-25 集計）: severity>=WARNING は 4件のみ
+#   3件 discovery差分（週次フルスイープの度に出る常態・SPR-235でログを分離）
+#   1件 Memory limit exceeded（プラットフォーム発ERROR）
+# DLsite と違い per-item の常態ノイズが無いため、系統エラーは NOT 除外なしで張れる。
+
+# ログベースメトリクス - 系統エラー（catch-all）
+# 除外を一切置かない。30日で1件（OOM）のみ＝ノイズにならないことを実測で確認済み。
+# ここが拾う主なもの:
+#   - YouTube API 403（クォータ超過の本命シグナル）→「YouTube API 呼び出しエラー」
+#   - Entity変換失敗 / バッチ保存エラー / メタデータ取得失敗
+#   - プラットフォーム発の "Memory limit of N MiB exceeded"（jsonPayload を持たず
+#     textPayload にのみ出る。両張りが必要な実例）
+resource "google_logging_metric" "youtube_error_count" {
+  name    = "youtube_function_errors"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchyoutubevideos"
+    severity >= "ERROR"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "YouTube Function Errors"
+  }
+}
+
+resource "google_monitoring_alert_policy" "youtube_function_error" {
+  display_name = "YouTube Function Error Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "YouTube関数でエラーログ検出"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.youtube_error_count.id}\" resource.type=\"cloud_run_revision\""
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "60s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # YouTube関数のエラーログ検出
+
+    fetchYouTubeVideos で ERROR ログが出力されました。平常時は月1件程度のため、
+    発火したら実ログの確認が必要です。
+
+    ## 主な原因の切り分け
+    1. **YouTube API クォータ超過**: `YouTube API 呼び出しエラー` に 403 quotaExceeded が
+       含まれていないか。超過すると当日いっぱい動画更新が止まる（翌 0:00 PT にリセット）
+    2. **メモリ上限**: `Memory limit of N MiB exceeded` はプラットフォームによる
+       インスタンス強制終了。リクエスト自体は 2xx で完了するため 5xx アラートでは拾えない
+       （SPR-235 で 512Mi へ引き上げ済み。再発時は蓄積源の調査が必要）
+    3. **保存系**: `動画のEntity変換に失敗` / `バッチ保存エラー` は Firestore 書き込み側
+
+    ## ログ確認コマンド
+    ```bash
+    gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="fetchyoutubevideos" AND severity >= "ERROR"' --limit=20 --format=json
+    ```
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.youtube_error_count
+  ]
+}
+
+# ログベースメトリクス - 通常runの開始（無音障害検知用ハートビート）
+#
+# キーに使う「…の動画情報取得を開始します」は **通常run（mode=normal）でのみ**、かつ
+# 二重実行ロックのゲート（prepareExecution）を通過した後に出力される。この位置が重要で:
+#   - fast_recheck（96 run/日）では出ないため、hourly が止まったまま fast_recheck だけが
+#     生き残っている状態（＝統計ティア更新の停止）を隠さない
+#   - ロック競合スキップ（`前回の実行が完了していません`）が恒常化した場合もこのログは
+#     出ないため、cursor 詰まり相当の無音劣化を同じアラートで検知できる
+#     （SPR-235 の「lock 競合の対象化検討」は実測0件＋この性質により専用metricを作らない判断）
+resource "google_logging_metric" "youtube_run_started" {
+  name    = "youtube_run_started"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchyoutubevideos"
+    (jsonPayload.message:"の動画情報取得を開始します" OR textPayload:"の動画情報取得を開始します")
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "YouTube Run Started"
+  }
+}
+
+resource "google_monitoring_alert_policy" "youtube_run_absent" {
+  display_name = "YouTube Run Absent Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "通常runが3時間以上観測されない"
+
+    # 毎時実行に対し 3h（=3 run 欠け）で発火。1 run の一時的な欠けでは鳴らない。
+    #
+    # cross_series_reducer は必須（SPR-234 の偽陽性の真因）。Cloud Run の監視対象リソース
+    # ラベルには revision_name が含まれるため、集約しないと metric の時系列が revision ごとに
+    # 分かれ、デプロイで旧 revision の系列が更新停止 → duration 後に必ず誤発火する。
+    condition_absent {
+      filter   = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.youtube_run_started.id}\" resource.type=\"cloud_run_revision\""
+      duration = "10800s"
+
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_COUNT"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = ["resource.label.service_name"]
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # YouTube 通常runの途絶（3時間以上）
+
+    fetchYouTubeVideos の通常run開始ログが3時間以上観測されていません（正常時は毎時30分・
+    24回/日）。ログ自体が出ない障害のため、他の YouTube アラートは沈黙します。
+    動画の新着追加・統計（再生数等）の更新が止まっている状態です。
+
+    ## まず確認すること
+    実際に run が欠けているかを最優先で確認する:
+    ```bash
+    gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="fetchyoutubevideos" AND (jsonPayload.message:"の動画情報取得を開始します" OR textPayload:"の動画情報取得を開始します")' --freshness=1d --format="value(timestamp)" --order=asc
+    ```
+    毎時の時刻が埋まっていれば偽陽性（対応不要）。
+
+    ## 実際に欠けていた場合の原因
+    1. **二重実行ロックの詰まり**: `前回の実行が完了していません` が出続けていないか。
+       このログが出ている場合はロック解放漏れ（Firestore の fetchMetadata.isInProgress）
+    2. Cloud Scheduler 停止/削除: gcloud scheduler jobs describe fetch-youtube-videos-hourly --location=asia-northeast1
+    3. Pub/Sub topic・Eventarc trigger の破壊: gcloud eventarc triggers list --location=asia-northeast1
+    4. サービス消失/起動不能: gcloud run services describe fetchyoutubevideos --region=asia-northeast1
+
+    ## 復旧確認
+    手動トリガで1 run 流す: gcloud scheduler jobs run fetch-youtube-videos-hourly --location=asia-northeast1
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.youtube_run_started
+  ]
+}
+
+# YouTube関数のプラットフォーム障害アラート（5xx）
+#
+# エントリポイント（endpoints/youtube/fetch-youtube-videos.ts）は catch-all で例外を
+# ERROR ログ化して正常終了するため、アプリレベルの失敗は 5xx にならない（youtube_error_count が拾う）。
+# 加えて **OOM も 5xx にならない**点に注意: 2026-07-23 の Memory limit 事象では、
+# インスタンスが強制終了されたのは run 完了の約2分後（アイドル中）で、当日のリクエストは
+# 120件すべて 2xx だった。この alert はリクエスト処理中にプロセスが応答を返せなかった
+# ケース専用（30日実測で 0 件）。
+resource "google_monitoring_alert_policy" "youtube_function_failure" {
+  display_name = "YouTube Function Platform Failure (5xx)"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "プラットフォーム強制終了(5xx)を検出"
+
+    condition_threshold {
+      filter = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="fetchyoutubevideos"
+        metric.type="run.googleapis.com/request_count"
+        metric.labels.response_code_class="5xx"
+      EOT
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "60s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # YouTube関数のプラットフォーム障害（5xx）
+
+    fetchYouTubeVideos の呼び出しが 5xx で終了しました。エントリポイントは例外を catch して
+    正常終了するため、これはアプリ内エラーではなくリクエストタイムアウト・プロセスクラッシュ等、
+    プラットフォームが応答不能にしたケースを意味します。
+
+    ## 確認事項
+    1. Cloud Run のログ（service_name="fetchyoutubevideos"）で該当時刻の実行を確認
+    2. タイムアウト（540s）に達していないか。週次フルスイープ（日曜4:00 JST）は
+       uploads playlist の全ページ走査を行うため通常runより長い
+    3. 直近のデプロイ・依存更新の有無
+
+    ## 補足
+    OOM によるインスタンス強制終了はここでは検知できない（アイドル中に発生し、
+    リクエストは 2xx で完了するため）。そちらは「YouTube Function Error Alert」および
+    「YouTube Function Memory Pressure」で検知する。
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [google_monitoring_notification_channel.email]
+}
+
+# ログベースメトリクス - discovery取りこぼし（uploads playlistにあるがFirestoreに未保存）
+#
+# 週次フルスイープ（日曜4:00 JST）が uploads playlist の全走査とFirestore既知集合を突合する。
+# SPR-235: 旧実装は「Firestoreにあるがplaylistに無い」（＝YouTube側で削除/非公開になった
+# 旧動画の残骸。2026-07実測で3回のスイープとも同一の8件が出続ける恒久的な床）と、
+# 「playlistにあるがFirestoreに無い」（＝真の取りこぼし）を1本のWARNにまとめていたため、
+# そのままアラート化すると毎週必ず鳴る状態だった。コード側でログを分離し、後者だけを
+# `jsonPayload.alert` 付きで出すようにしたのでここで拾う（endpoints/youtube/video-discovery.ts）。
+resource "google_logging_metric" "youtube_discovery_unsaved" {
+  name    = "youtube_discovery_unsaved"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchyoutubevideos"
+    jsonPayload.alert="youtube_discovery_unsaved"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "YouTube Discovery Unsaved Videos"
+  }
+}
+
+resource "google_monitoring_alert_policy" "youtube_discovery_unsaved" {
+  display_name = "YouTube Discovery Unsaved Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "発見済みだが未保存の動画を検出"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.youtube_discovery_unsaved.id}\" resource.type=\"cloud_run_revision\""
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # YouTube discovery の取りこぼし（未保存動画）
+
+    週次フルスイープで、uploads playlist には存在するのに Firestore に保存されていない動画が
+    見つかりました。incremental discovery（early-stop）の取りこぼし、または保存側で
+    弾かれている可能性があります。放置するとその動画はサイトに永久に出ません。
+
+    ## 確認事項
+    1. 該当IDを特定: jsonPayload.alert="youtube_discovery_unsaved" の `未保存サンプル` を確認
+    2. 保存側で弾かれていないか: 同時刻の `許可されていないチャンネルの動画をスキップしました` /
+       `動画のEntity変換に失敗` / `動画にチャンネルIDがありません` を確認
+    3. 弾かれていない場合は discovery の early-stop がその動画を跨いだ可能性。
+       手動で週次フルスイープを流して再確認する:
+       gcloud scheduler jobs run fetch-youtube-videos-weekly-full-sweep --location=asia-northeast1
+
+    ## 鳴らないケース
+    「Firestore にあるが uploads playlist に無い」（YouTube側で削除/非公開になった旧動画）は
+    対象外で、INFO ログ `Firestoreにのみ存在する動画があります` に留めている（2026-07時点で
+    常時8件の恒久的な床のため、アラート化すると毎週誤発火する・SPR-235）。
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.youtube_discovery_unsaved
+  ]
+}
+
+# ログベースメトリクス - クォータ不足の早期警告
+#
+# SPR-230 で discovery を search.list(100 units) から uploads playlist(1 unit) へ移行した結果、
+# 消費は ~7,800 units/日 → 数百 units/日 に低下し、30日実測でクォータ関連の WARN/ERROR は 0件。
+# つまりこれは「異常の兆候」であって常態ではない＝閾値 >0 で成立する。
+#
+# 注意（このメトリクスの限界）: 判定元の YouTubeQuotaMonitor はインスタンス内メモリの
+# カウンタで、インスタンスの再起動・複数同時実行をまたいで合算されない（過小計上する）。
+# 実際の超過は YouTube API 側が 403 quotaExceeded を返し `YouTube API 呼び出しエラー`（ERROR）
+# として出るため、**超過検知の正本は youtube_error_count 側**。ここは早期警告に過ぎない。
+resource "google_logging_metric" "youtube_quota_shortage" {
+  name    = "youtube_quota_shortage"
+  project = var.gcp_project_id
+
+  filter = <<-EOT
+    resource.type="cloud_run_revision"
+    resource.labels.service_name="fetchyoutubevideos"
+    (
+      jsonPayload.message:"クォータが不足しています" OR textPayload:"クォータが不足しています"
+      OR jsonPayload.message:"クォータ不足" OR textPayload:"クォータ不足"
+      OR jsonPayload.message:"クォータ超過予測" OR textPayload:"クォータ超過予測"
+    )
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    display_name = "YouTube Quota Shortage"
+  }
+}
+
+resource "google_monitoring_alert_policy" "youtube_quota_shortage" {
+  display_name = "YouTube API Quota Shortage Alert"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "クォータ不足/超過予測を検出"
+
+    condition_threshold {
+      filter = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.youtube_quota_shortage.id}\" resource.type=\"cloud_run_revision\""
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "0s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # YouTube Data API クォータ不足の兆候
+
+    関数内のクォータ監視が「不足」または「超過予測」を報告しました。既定クォータは
+    10,000 units/日（0:00 PT リセット）で、SPR-230 以降の平常時消費は数百 units/日です。
+    平常時には出ないログのため、出た場合は消費構造が変わった可能性があります。
+
+    ## 確認事項
+    1. `YouTube API使用量詳細` ログで operation 別の消費を確認（どの呼び出しが増えたか）
+    2. discovery が uploads playlist 経由のままか（search.list は 1回=100 units）
+    3. playlist→videoマッピングの日次キャッシュが効いているか
+       （`playlist→videoマッピングのキャッシュを再利用します` が出ているか）
+    4. 新着が大量に出た日は一時的に増える（正常）。連日続く場合のみ調査対象
+
+    ## 注意
+    このアラートの判定元はインスタンス内メモリのカウンタのため過小計上する。実際の超過は
+    YouTube API の 403 として `YouTube API 呼び出しエラー`（ERROR）で観測され、
+    「YouTube Function Error Alert」側で発火する。
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [
+    google_monitoring_notification_channel.email,
+    google_logging_metric.youtube_quota_shortage
+  ]
+}
+
+# YouTube関数のメモリ逼迫アラート（OOM の予兆）
+#
+# SPR-235（2026-07 実測）: 256Mi 時代は memory utilization が常時 0.86〜1.00 に張り付き、
+# 2026-07-23 に OOM でインスタンスが強制終了した。SPR-266 の fast_recheck（15分毎）投入で
+# インスタンスが常時ウォームになり、毎時のコールドスタートによる暗黙のプロセスリサイクルが
+# 無くなったことで顕在化した（インスタンス起動 24-26回/日 → 1-9回/日）。
+# 同PRで 512Mi へ引き上げ済みのため、ベースラインは 0.45 前後まで下がる想定。
+#
+# 閾値 0.85・30分継続の根拠: 512Mi 化後のベースライン（~0.45）から十分離れており、
+# 実測の増加ペース（37時間で約 +19MiB ≒ 256Mi 換算 +7.6pt）なら OOM の数日前に発火する。
+# アイドル中の kill を事後に拾う youtube_error_count と違い、こちらは予兆で拾うのが役割。
+resource "google_monitoring_alert_policy" "youtube_memory_pressure" {
+  display_name = "YouTube Function Memory Pressure"
+  project      = var.gcp_project_id
+  combiner     = "OR"
+
+  conditions {
+    display_name = "メモリ使用率85%超が30分継続"
+
+    condition_threshold {
+      filter = <<-EOT
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="fetchyoutubevideos"
+        metric.type="run.googleapis.com/container/memory/utilizations"
+      EOT
+
+      # 分布メトリクスのため p99 で整列し、revision/インスタンス間は最大値で集約する
+      # （デプロイ直後の新旧混在で、逼迫している側の系列が平均に埋もれないように）。
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_PERCENTILE_99"
+        cross_series_reducer = "REDUCE_MAX"
+        group_by_fields      = ["resource.label.service_name"]
+      }
+
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0.85
+      duration        = "1800s"
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # YouTube関数のメモリ逼迫（OOM の予兆）
+
+    fetchYouTubeVideos のメモリ使用率が 85% を30分以上超えています。放置すると
+    プラットフォームがインスタンスを強制終了します（2026-07-23 に 256Mi で発生）。
+
+    ## 背景（SPR-235）
+    fast_recheck（15分毎）の投入でインスタンスが常時ウォームになり、run をまたぐメモリ蓄積が
+    毎時のコールドスタートでリサイクルされなくなった。実測の増加ペースは 37時間で約 +19MiB で、
+    デプロイ（インスタンス入れ替え）が2日以上無いと上限に到達する。
+
+    ## 確認事項
+    1. 現在の設定値を確認: gcloud run services describe fetchyoutubevideos --region=asia-northeast1 --format="value(spec.template.spec.containers[0].resources.limits.memory)"
+    2. 使用率の推移を確認（単調増加ならリーク性の蓄積、スパイクなら特定runの一時消費）
+    3. 直前の run で異常に多い件数を処理していないか（週次フルスイープ・大量の新着）
+
+    ## 対応
+    - 一時回避: 再デプロイでインスタンスを入れ替える（蓄積がリセットされる）
+    - 恒久: 蓄積源の特定が必要（512Mi 化しても増加ペースが同じなら数日で再到達する）。
+      調査は SPR-277 で追跡している
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  depends_on = [google_monitoring_notification_channel.email]
+}


### PR DESCRIPTION
## 概要

`fetchYouTubeVideos` は監視アラートが1本も無く、クォータ超過も無音障害も気づく手段が無かった（SPR-235）。SPR-234 の DLsite 監視の方法論を踏襲して整備する。

Linear: [SPR-235](https://linear.app/nothink/issue/SPR-235) / フォローアップ [SPR-277](https://linear.app/nothink/issue/SPR-277)

## 実測（直近30日・2026-07-25 集計）

起票時（2026-07-03）から前提が変わっているため、ログ集計をやり直してから設計した。

| 項目 | 実測 |
| --- | --- |
| severity>=WARNING | **30日で4件のみ**（discovery差分3・OOM 1） |
| クォータ関連 WARN/ERROR | **0件**（SPR-230 完了で ~7,800→数百 units/日） |
| 5xx | **0件**（120 req/日はすべて 2xx） |
| run 構成 | hourly 24 + fast_recheck 96 + 週次1（起票時の「24 run/日」から変化） |

DLsite と違い per-item の常態ノイズが無いため、系統エラーは NOT 除外なしで張れる。

## 変更内容

### 1. discovery 差分ログの分離（`video-discovery.ts`）

週次フルスイープの差分 WARN が2つの意味を1本にまとめており、**そのままではアラート化できなかった**。

| 差分 | 変更前 | 変更後 |
| --- | --- | --- |
| playlist にあるが Firestore に未保存＝真の取りこぼし | WARN（合算） | WARN + `alert: "youtube_discovery_unsaved"` |
| Firestore にあるが playlist に無い＝削除/非公開の残骸 | WARN（合算） | INFO に降格 |

後者は3回のスイープとも**同一の8件**が出続ける恒久的な床で（実データで削除済み動画と確認済み）、アラート化すると毎週必ず鳴る。SPR-271 の誤発火と同じ構図。

併せて、ページ上限による打ち切り時の早期 return をやめた。打ち切りが偽陽性を生むのは playlist 不在判定だけで、未保存判定は走査できた範囲の実在 ID に対する判定なので有効（従来は取りこぼしを検知しないまま抜けていた）。

### 2. メモリ上限 256Mi → 512Mi（`deploy-functions.yml`）

- 2026-07-23T13:32:10Z に `Memory limit of 256 MiB exceeded`（ERROR）でインスタンスが強制終了
- memory utilization p99 は30日通して **0.86〜1.00** に張り付き。OOM 直前は 0.9999 が3時間持続
- **kill されたのはアイドル中**（run 完了の2分後）で、リクエストは全て 2xx＝5xx アラートでは原理的に拾えない
- SPR-266 の fast_recheck 投入でインスタンスが常時ウォームになり（起動 24-26回/日 → 1-9回/日）、毎時のコールドスタートによる暗黙のプロセスリサイクルが無くなったことで顕在化した
- 蓄積は37時間で約 +19MiB の単調増加。**512Mi 化は猶予の延長にすぎず**、蓄積源の特定は SPR-277 で追跡

### 3. `terraform/monitoring_youtube.tf` 新設（アラート6本）

| アラート | 判定 |
| --- | --- |
| Function Error | `severity>=ERROR`（除外なし・30日1件） |
| Run Absent | 通常run開始ログの不在 3h。ロックゲート**通過後**のログをキーにしたためロック詰まりも同じアラートで検知 |
| Platform Failure (5xx) | `request_count` 5xx（OOM は拾えない旨を doc に明記） |
| Discovery Unsaved | `jsonPayload.alert="youtube_discovery_unsaved"` |
| Quota Shortage | 早期警告。超過検知の正本は 403→ERROR 側である旨を doc 化（判定元がインスタンス内メモリのカウンタで過小計上するため） |
| Memory Pressure | 使用率 >0.85 が30分継続 |

## 検証

- `pnpm verify` … 通過（exit 0）
- `terraform validate` / `terraform fmt` … 通過
- **各 filter を実ログで突合**（SPR-235 完了条件②）:
  - `youtube_function_errors` → 30日で1件ヒット（OOM）＝ `textPayload` 側マッチが機能
  - `youtube_run_started` → 直近1日でちょうど **24件**＝通常runのみ捕捉
  - `youtube_quota_shortage` → 0件＝閾値 >0 が成立
  - `youtube_discovery_unsaved` → 同一コールサイトが `jsonPayload` に構造化フィールドを出すことを既存ログで確認済み（新ログ自体はデプロイ後に発火確認）

## レビュー時の注意

- **One-Way Door 要素**: terraform/GCP インフラ・`.github/workflows` を含むため AI レビュー任せにせず要自己レビュー（CLAUDE.md のセルフマージ・ポリシー）
- **apply 順序**: マージ後、terraform apply と関数デプロイが並行する。512Mi 反映前は使用率 0.94 で Memory Pressure の条件を満たすが、duration 30分の猶予内に新インスタンス（~0.45）へ入れ替わるため発火しない見込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)