### PR TITLE
docs: Issue トラッカーの正本が Linear であることを CLAUDE.md に明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,9 @@ PR は「やり直しが効くか」で自己マージ可否を分ける。AI �
 ## 2. プロジェクトの座標（事実）
 
 - **URL**: https://suzumina.click ／ Status: PRODUCTION READY
+- **Issue トラッカーの正本は Linear**（`nothink` workspace / **Sprints** チーム＝本文中の `SPR-*` / プロジェクト `suzumina.click`）。
+  Issue を起票・参照するときは Linear を使う。**GitHub Issues は #386 までで運用終了**（2026 年前半の遺物）。
+  MCP が未接続なら起票せず、内容を提示して人に渡す（`gh issue create` に流れない）
 - **構成**: pnpm monorepo — `apps/web`, `apps/functions`, `packages/shared-types`, `packages/ui`, `packages/typescript-config`
   （`apps/admin` は廃止。`/admin` 画面・admin/moderator ロールも SPR-164 で撤去＝ユーザーは認証/isActive のみで区別）
 - **技術スタック**: Next.js App Router + TypeScript + Tailwind CSS ／ Cloud Functions + Firestore ／


### PR DESCRIPTION
## 背景

GA4 調査のフォローアップ issue を、**運用終了済みの GitHub Issues に起票してしまった**（#868 / #869）。Linear の SPR-279 / SPR-280 へ移送し、GitHub 側は Linear への URL を残してクローズ済み。

## 原因

CLAUDE.md は `SPR-205` / `SPR-213` / `SPR-149` のような番号を本文中で頻繁に参照しているのに、**その番号がどこの何なのかを一度も書いていない**。

このファイルは「毎セッション効かせる能動ルールの唯一のソース」と自ら定義しており、§0 で「相手はステートレスな LLM／意図を伝える信号はその場で読めるものに寄せる」と明示している。それなのにトラッカーの在処が書かれていないため、CLAUDE.md だけを読む読み手は番号体系を再構築できない。軸3（記述と実態のズレ）に該当する欠落だと考える。

実際の失敗経路は「PR 作成で `gh` が動いていたので `gh issue create` にそのまま流れた」というもので、確認を怠った私の落ち度が主因ではあるものの、CLAUDE.md 側にも読み手が気付ける材料が無かった。

## 変更（3行・§2 プロジェクトの座標）

```
- **Issue トラッカーの正本は Linear**（`nothink` workspace / **Sprints** チーム＝本文中の `SPR-*` / プロジェクト `suzumina.click`）。
  Issue を起票・参照するときは Linear を使う。**GitHub Issues は #386 までで運用終了**（2026 年前半の遺物）。
  MCP が未接続なら起票せず、内容を提示して人に渡す（`gh issue create` に流れない）
```

3行目は今回の直接的な失敗経路を塞ぐためのもの。`plugin:engineering:linear` が未認証のセッションでは Linear に書けないので、そのとき GitHub Issues へ迂回しないことを明記した。

## 確認した事実

- Linear: `nothink` workspace / チーム **Sprints**（SPR 接頭辞）/ プロジェクト **suzumina.click**。本日も SPR-271・273・274 が Done、SPR-276〜278 が Backlog 追加と現役
- GitHub Issues: #368〜#386（2026 年前半のパフォーマンス改善・better-auth 移行）で停止。それ以降は今回の #868 / #869 のみ

`pnpm lint:docs` EXIT=0（リンク194件・転記チェック通過）。ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)