### PR TITLE
feat(tooling): GA4 カスタムディメンションの live↔宣言 drift 検出を追加 (SPR-279 Step 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ LLM に毎回全部読ませて再構築させない。能動的に効かせた�
   **カスタムディメンションは遡及適用されない**＝登録が遅れた期間のデータは永久に集計不能
   （実測: 登録前の `web_vitals` 113件は `customEvent:metric_name` が全て `(not set)`）。
   Firestore 複合インデックスと同型の負債だが、index は後から足せば効く点で向こうの方が軽い。
-  登録済みは `customEvent:<param>` で Data API からクエリ可能。live↔JSON の突合は未実装（要 GA4 認証）。
+  登録済みは `customEvent:<param>` で Data API からクエリ可能。live↔JSON の突合は `pnpm check:ga4-drift`
+  （GA4 認証が要るため verify には入れない＝`check:index-drift` と同じ扱い。`--apply` で未登録の登録と
+  description の同期まで行う。displayName/scope の差は人が判断・SPR-279）。
   なお計器を足しただけでは測れない: カスタムイベントは consent ゲート内で送るため、同意率がそのまま母数になる
 - **Firestore 時刻フィールド**: 新規コレクション・新規フィールドの日時は Firestore `Timestamp` で保存する。
   既存は string ISO（works / audioButtons / users / contacts）と Timestamp（circles / creators / evaluations / ba_*）が

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"lint:tokens": "node scripts/lint-css-tokens.mjs",
 		"lint:ga4": "node scripts/lint-ga4-params.mjs",
 		"check:index-drift": "node scripts/check-firestore-index-drift.mjs",
+		"check:ga4-drift": "node scripts/check-ga4-dimension-drift.mjs",
 		"format": "pnpm -r format",
 		"check": "pnpm -r check",
 		"secretlint": "secretlint \"**/*\"",

--- a/scripts/check-ga4-dimension-drift.mjs
+++ b/scripts/check-ga4-dimension-drift.mjs
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+// scripts/check-ga4-dimension-drift.mjs
+//
+// live GA4 のカスタムディメンションと宣言（apps/web/src/lib/analytics/ga4-custom-dimensions.json）の
+// drift を検出する（SPR-279）。check-firestore-index-drift.mjs と同型の位置づけ。
+//
+// 責務の分担:
+//   pnpm lint:ga4        コード（gtag へ渡すパラメータ）↔ 宣言。認証不要なので verify に載る
+//   pnpm check:ga4-drift 宣言 ↔ live GA4。GA4 認証が要るので verify には載せない（本スクリプト）
+//
+// 検出する drift:
+//   🔴 管理外: live にあり宣言に無い（GA4 管理画面で直接作られた or 宣言からの削除漏れ）
+//   🟠 未登録: 宣言にあり live に無い。**カスタムディメンションは遡及適用されない**ため、
+//              発見が遅れた期間のデータは永久に集計不能になる（index の apply 漏れより重い）
+//   ⚪ 属性差: parameterName は一致するが displayName / scope / description が異なる
+//
+// 使い方:
+//   node scripts/check-ga4-dimension-drift.mjs           # 検出のみ（読み取り専用）
+//   node scripts/check-ga4-dimension-drift.mjs --apply   # 未登録分を GA4 に登録（追加のみ）
+//   （ローカルは ADC → ga4-reader@ を impersonate。gcloud が PATH に必要。npm 依存なし）
+// 終了コード: 0=drift なし / 1=drift あり / 2=実行エラー
+//
+// 注意:
+//   - GA4 のカスタムディメンションは API で削除できずアーカイブのみ。--apply は追加専用で、
+//     「管理外」の掃除は人が GA4 管理画面で判断する（CLAUDE.md 軸1: 判断をツール任せにしない）
+//   - 属性差も --apply では直さない（scope は変更不可・displayName/description の PATCH は
+//     レポート上の表示名が変わるため人が判断すべき）
+//   - ADC に直接 analytics スコープを付けるのは Google 側にブロックされるため、
+//     必ず ga4-reader@ の impersonate 経由でトークンを取る
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST = join(repoRoot, "apps/web/src/lib/analytics/ga4-custom-dimensions.json");
+const PROPERTY = `properties/${process.env.GA4_PROPERTY_ID ?? "496464197"}`;
+const TARGET_SA = process.env.GA4_READER_SA ?? "ga4-reader@suzumina-click.iam.gserviceaccount.com";
+const READ_SCOPE = "https://www.googleapis.com/auth/analytics.readonly";
+const EDIT_SCOPE = "https://www.googleapis.com/auth/analytics.edit";
+const API = "https://analyticsadmin.googleapis.com/v1beta";
+// 宣言に書いている項目だけ比較する（live の disallowAdsPersonalization 等は宣言側に無いため対象外）
+const COMPARED_FIELDS = ["displayName", "scope", "description"];
+
+function abort(message) {
+	console.error(`✗ ${message}`);
+	process.exit(2);
+}
+
+/** ADC から ga4-reader@ を impersonate してアクセストークンを取る（トークンは一切出力しない） */
+function accessToken(scope) {
+	try {
+		return execFileSync(
+			"gcloud",
+			[
+				"auth",
+				"print-access-token",
+				`--impersonate-service-account=${TARGET_SA}`,
+				`--scopes=${scope}`,
+			],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		).trim();
+	} catch (e) {
+		const detail = String(e.stderr || e.message)
+			.trim()
+			.split("\n")
+			.at(-1);
+		return abort(
+			`アクセストークンを取得できませんでした（ADC 未設定 or ${TARGET_SA} の impersonate 権限なし）: ${detail}`,
+		);
+	}
+}
+
+async function callApi(path, token, init = {}) {
+	const res = await fetch(`${API}/${path}`, {
+		...init,
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+			...init.headers,
+		},
+	});
+	const body = await res.json().catch(() => ({}));
+	if (!res.ok) throw new Error(`HTTP ${res.status} ${body.error?.message ?? "(詳細不明)"}`);
+	return body;
+}
+
+async function fetchLive(token) {
+	const all = [];
+	let pageToken;
+	do {
+		const query = new URLSearchParams({ pageSize: "200" });
+		if (pageToken) query.set("pageToken", pageToken);
+		const page = await callApi(`${PROPERTY}/customDimensions?${query}`, token);
+		all.push(...(page.customDimensions ?? []));
+		pageToken = page.nextPageToken;
+	} while (pageToken);
+	return all;
+}
+
+/** 宣言と live で比較対象フィールドの差分を返す（差が無ければ空配列） */
+function fieldDiffs(declared, live) {
+	return COMPARED_FIELDS.filter((f) => (declared[f] ?? "") !== (live[f] ?? "")).map((f) => ({
+		field: f,
+		declared: declared[f] ?? "",
+		live: live[f] ?? "",
+	}));
+}
+
+function formatDiff(d) {
+	return `${d.field}: 宣言"${d.declared}" ≠ live"${d.live}"`;
+}
+
+let manifest;
+try {
+	manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
+} catch (e) {
+	abort(`宣言ファイルを読めませんでした（${MANIFEST}）: ${e.message}`);
+}
+
+const apply = process.argv.includes("--apply");
+const readToken = accessToken(READ_SCOPE);
+
+let live;
+try {
+	live = await fetchLive(readToken);
+} catch (e) {
+	abort(`live のカスタムディメンションを取得できませんでした: ${e.message}`);
+}
+
+const liveByParam = new Map(live.map((d) => [d.parameterName, d]));
+const declaredByParam = new Map(manifest.map((d) => [d.parameterName, d]));
+
+const unmanaged = live.filter((d) => !declaredByParam.has(d.parameterName));
+const missing = manifest.filter((d) => !liveByParam.has(d.parameterName));
+const changed = manifest
+	.filter((d) => liveByParam.has(d.parameterName))
+	.map((d) => ({
+		declared: d,
+		live: liveByParam.get(d.parameterName),
+		diffs: fieldDiffs(d, liveByParam.get(d.parameterName)),
+	}))
+	.filter((x) => x.diffs.length > 0);
+
+// description だけの差は --apply で live へ同期する（内部向けの説明文＝レポートの見え方に影響しない）。
+// displayName / scope はレポートの表示や再作成に関わるので人が判断する（軸1: ツール任せにしない）
+const syncable = changed.filter((x) => x.diffs.every((d) => d.field === "description"));
+const needsHuman = changed.filter((x) => x.diffs.some((d) => d.field !== "description"));
+
+console.log(`GA4 custom dimension drift check (${PROPERTY})`);
+console.log(`  live: ${live.length} / 宣言(ga4-custom-dimensions.json): ${manifest.length}\n`);
+
+if (apply && (missing.length || syncable.length)) {
+	const editToken = accessToken(EDIT_SCOPE);
+	let failed = 0;
+
+	if (missing.length) {
+		console.log(`⚙ --apply: 未登録 ${missing.length} 件を登録`);
+		for (const d of missing) {
+			try {
+				await callApi(`${PROPERTY}/customDimensions`, editToken, {
+					method: "POST",
+					body: JSON.stringify(d),
+				});
+				console.log(`   ✅ ${d.parameterName}`);
+			} catch (e) {
+				failed++;
+				console.log(`   ✗ ${d.parameterName}: ${e.message}`);
+			}
+		}
+		console.log("   → 遡及適用されないため、値が付くのはこれ以降のイベントのみ\n");
+	}
+
+	if (syncable.length) {
+		console.log(`⚙ --apply: description の差 ${syncable.length} 件を live へ同期`);
+		for (const { declared, live: liveDim } of syncable) {
+			try {
+				// live のリソース名（properties/*/customDimensions/*）に対して description だけ PATCH
+				const resource = liveDim.name.replace(/^properties\/[^/]+\//, "");
+				await callApi(`${PROPERTY}/${resource}?updateMask=description`, editToken, {
+					method: "PATCH",
+					body: JSON.stringify({ description: declared.description ?? "" }),
+				});
+				console.log(`   ✅ ${declared.parameterName}`);
+			} catch (e) {
+				failed++;
+				console.log(`   ✗ ${declared.parameterName}: ${e.message}`);
+			}
+		}
+		console.log("");
+	}
+
+	if (failed) {
+		console.log(
+			`   → ${failed} 件が失敗。編集者権限（${TARGET_SA}）と displayName の制約（コロン不可）を確認\n`,
+		);
+	}
+	if (needsHuman.length === 0 && unmanaged.length === 0) process.exit(failed ? 1 : 0);
+}
+
+if (unmanaged.length === 0 && missing.length === 0 && changed.length === 0) {
+	console.log("✅ drift なし（live と宣言が一致）");
+	process.exit(0);
+}
+
+if (unmanaged.length) {
+	console.log(`🔴 管理外（live にあり宣言に無い）: ${unmanaged.length}`);
+	for (const d of unmanaged) console.log(`   - ${d.parameterName} (${d.displayName} / ${d.scope})`);
+	console.log(
+		"   → 使うなら ga4-custom-dimensions.json に追加、不要なら GA4 管理画面でアーカイブ（API では削除できない）\n",
+	);
+}
+if (missing.length) {
+	console.log(`🟠 未登録（宣言にあり live に無い）: ${missing.length}`);
+	for (const d of missing) console.log(`   - ${d.parameterName} (${d.displayName})`);
+	console.log(
+		"   → `pnpm check:ga4-drift --apply` で登録。遡及適用されないので、放置した期間のデータは永久に集計不能\n",
+	);
+}
+if (syncable.length) {
+	console.log(`⚪ description の差（--apply で同期可）: ${syncable.length}`);
+	for (const { declared, diffs } of syncable) {
+		console.log(`   - ${declared.parameterName}`);
+		for (const diff of diffs) console.log(`       ${formatDiff(diff)}`);
+	}
+	console.log("   → `pnpm check:ga4-drift --apply` で宣言の内容を live へ反映\n");
+}
+if (needsHuman.length) {
+	console.log(`⚠ displayName / scope の差（人が判断）: ${needsHuman.length}`);
+	for (const { declared, diffs } of needsHuman) {
+		console.log(`   - ${declared.parameterName}`);
+		for (const diff of diffs) console.log(`       ${formatDiff(diff)}`);
+	}
+	console.log(
+		"   → displayName は GA4 レポートの表示名なので影響を確認して手で直す。scope は変更不可＝作り直しが必要\n",
+	);
+}
+process.exit(1);

--- a/scripts/check-ga4-dimension-drift.mjs
+++ b/scripts/check-ga4-dimension-drift.mjs
@@ -12,19 +12,23 @@
 //   🔴 管理外: live にあり宣言に無い（GA4 管理画面で直接作られた or 宣言からの削除漏れ）
 //   🟠 未登録: 宣言にあり live に無い。**カスタムディメンションは遡及適用されない**ため、
 //              発見が遅れた期間のデータは永久に集計不能になる（index の apply 漏れより重い）
-//   ⚪ 属性差: parameterName は一致するが displayName / scope / description が異なる
+//   ⚪ description 差: --apply で live へ同期できる（内部向けの説明文）
+//   ⚠ displayName / scope 差: 人が判断する（表示名はレポートに出る・scope は変更不可）
 //
 // 使い方:
 //   node scripts/check-ga4-dimension-drift.mjs           # 検出のみ（読み取り専用）
-//   node scripts/check-ga4-dimension-drift.mjs --apply   # 未登録分を GA4 に登録（追加のみ）
+//   node scripts/check-ga4-dimension-drift.mjs --apply   # 未登録の登録 + description の同期
 //   （ローカルは ADC → ga4-reader@ を impersonate。gcloud が PATH に必要。npm 依存なし）
 // 終了コード: 0=drift なし / 1=drift あり / 2=実行エラー
 //
 // 注意:
-//   - GA4 のカスタムディメンションは API で削除できずアーカイブのみ。--apply は追加専用で、
-//     「管理外」の掃除は人が GA4 管理画面で判断する（CLAUDE.md 軸1: 判断をツール任せにしない）
-//   - 属性差も --apply では直さない（scope は変更不可・displayName/description の PATCH は
-//     レポート上の表示名が変わるため人が判断すべき）
+//   - GA4 のカスタムディメンションは API で削除できずアーカイブのみ。--apply は追加と
+//     description 同期だけで、「管理外」の掃除は人が GA4 管理画面で判断する
+//     （CLAUDE.md 軸1: 判断をツール任せにしない）
+//   - displayName / scope の差も --apply では直さない（表示名は GA4 レポートに出る・
+//     scope は変更不可で作り直しが必要）
+//   - **報告は必ず apply 後の live を再取得して行う**。apply 前の集計で報告すると、
+//     登録した直後のものを「未登録」と矛盾表示してしまう（drift 検出という名前の約束に反する）
 //   - ADC に直接 analytics スコープを付けるのは Google 側にブロックされるため、
 //     必ず ga4-reader@ の impersonate 経由でトークンを取る
 
@@ -119,41 +123,39 @@ try {
 	abort(`宣言ファイルを読めませんでした（${MANIFEST}）: ${e.message}`);
 }
 
-const apply = process.argv.includes("--apply");
-const readToken = accessToken(READ_SCOPE);
-
-let live;
-try {
-	live = await fetchLive(readToken);
-} catch (e) {
-	abort(`live のカスタムディメンションを取得できませんでした: ${e.message}`);
-}
-
-const liveByParam = new Map(live.map((d) => [d.parameterName, d]));
 const declaredByParam = new Map(manifest.map((d) => [d.parameterName, d]));
 
-const unmanaged = live.filter((d) => !declaredByParam.has(d.parameterName));
-const missing = manifest.filter((d) => !liveByParam.has(d.parameterName));
-const changed = manifest
-	.filter((d) => liveByParam.has(d.parameterName))
-	.map((d) => ({
-		declared: d,
-		live: liveByParam.get(d.parameterName),
-		diffs: fieldDiffs(d, liveByParam.get(d.parameterName)),
-	}))
-	.filter((x) => x.diffs.length > 0);
+/** live を取得して宣言と突き合わせる。--apply の後は必ず呼び直して報告に使う */
+async function computeDrift(token) {
+	let live;
+	try {
+		live = await fetchLive(token);
+	} catch (e) {
+		return abort(`live のカスタムディメンションを取得できませんでした: ${e.message}`);
+	}
+	const liveByParam = new Map(live.map((d) => [d.parameterName, d]));
+	const changed = manifest
+		.filter((d) => liveByParam.has(d.parameterName))
+		.map((d) => ({
+			declared: d,
+			live: liveByParam.get(d.parameterName),
+			diffs: fieldDiffs(d, liveByParam.get(d.parameterName)),
+		}))
+		.filter((x) => x.diffs.length > 0);
+	return {
+		live,
+		unmanaged: live.filter((d) => !declaredByParam.has(d.parameterName)),
+		missing: manifest.filter((d) => !liveByParam.has(d.parameterName)),
+		// description だけの差は --apply で live へ同期する（内部向けの説明文＝レポートの見え方に影響しない）。
+		// displayName / scope はレポートの表示や再作成に関わるので人が判断する（軸1: ツール任せにしない）
+		syncable: changed.filter((x) => x.diffs.every((d) => d.field === "description")),
+		needsHuman: changed.filter((x) => x.diffs.some((d) => d.field !== "description")),
+	};
+}
 
-// description だけの差は --apply で live へ同期する（内部向けの説明文＝レポートの見え方に影響しない）。
-// displayName / scope はレポートの表示や再作成に関わるので人が判断する（軸1: ツール任せにしない）
-const syncable = changed.filter((x) => x.diffs.every((d) => d.field === "description"));
-const needsHuman = changed.filter((x) => x.diffs.some((d) => d.field !== "description"));
-
-console.log(`GA4 custom dimension drift check (${PROPERTY})`);
-console.log(`  live: ${live.length} / 宣言(ga4-custom-dimensions.json): ${manifest.length}\n`);
-
-if (apply && (missing.length || syncable.length)) {
+/** 未登録の登録と description の同期。失敗しても中断せず、結果は呼び出し側の再取得で確認する */
+async function applyDrift({ missing, syncable }) {
 	const editToken = accessToken(EDIT_SCOPE);
-	let failed = 0;
 
 	if (missing.length) {
 		console.log(`⚙ --apply: 未登録 ${missing.length} 件を登録`);
@@ -165,7 +167,6 @@ if (apply && (missing.length || syncable.length)) {
 				});
 				console.log(`   ✅ ${d.parameterName}`);
 			} catch (e) {
-				failed++;
 				console.log(`   ✗ ${d.parameterName}: ${e.message}`);
 			}
 		}
@@ -184,22 +185,33 @@ if (apply && (missing.length || syncable.length)) {
 				});
 				console.log(`   ✅ ${declared.parameterName}`);
 			} catch (e) {
-				failed++;
 				console.log(`   ✗ ${declared.parameterName}: ${e.message}`);
 			}
 		}
 		console.log("");
 	}
-
-	if (failed) {
-		console.log(
-			`   → ${failed} 件が失敗。編集者権限（${TARGET_SA}）と displayName の制約（コロン不可）を確認\n`,
-		);
-	}
-	if (needsHuman.length === 0 && unmanaged.length === 0) process.exit(failed ? 1 : 0);
 }
 
-if (unmanaged.length === 0 && missing.length === 0 && changed.length === 0) {
+const apply = process.argv.includes("--apply");
+const readToken = accessToken(READ_SCOPE);
+let drift = await computeDrift(readToken);
+
+console.log(`GA4 custom dimension drift check (${PROPERTY})`);
+console.log(
+	`  live: ${drift.live.length} / 宣言(ga4-custom-dimensions.json): ${manifest.length}\n`,
+);
+
+if (apply && (drift.missing.length || drift.syncable.length)) {
+	await applyDrift(drift);
+	// apply 前の集計で報告すると、登録した直後のものを「未登録」と矛盾表示するため必ず再取得する。
+	// 失敗した分は再取得後も drift として残るので、終了コードもここから導かれる
+	drift = await computeDrift(readToken);
+	console.log(`⚙ apply 後に再取得: live ${drift.live.length} 件\n`);
+}
+
+const { unmanaged, missing, syncable, needsHuman } = drift;
+
+if (!unmanaged.length && !missing.length && !syncable.length && !needsHuman.length) {
 	console.log("✅ drift なし（live と宣言が一致）");
 	process.exit(0);
 }


### PR DESCRIPTION
[SPR-279](https://linear.app/nothink/issue/SPR-279/ga4-カスタムディメンションの-live宣言-drift-検出phase-2) の **Step 1**（ローカル実行のみ）。

## 背景

PR #866 の Phase 1 は「**コード↔宣言**」を `pnpm lint:ga4`（認証不要・`verify` に載る）で塞いだが、「**宣言↔live GA4**」は未検出だった。`check-firestore-index-drift.mjs`（SPR-213）と同型の仕組みを GA4 に当てる。

責務の分担:

| コマンド | 突合 | 認証 | verify |
|---|---|---|---|
| `pnpm lint:ga4` | コード（gtag へ渡すパラメータ）↔ 宣言 | 不要 | 載る |
| `pnpm check:ga4-drift` | 宣言 ↔ live GA4 | 要 | 載せない |

## 初回実行で実際に drift を検出した

最初に走らせた時点で本物の乖離が出ました。#866 で宣言ファイルを書いたときに、登録時に使った description と食い違わせていました。

- `video_id`: 宣言に `user_tag_*` を追記していたが live は未反映
- `tag_count`: 宣言から「（#863 の意図）」を削っていたが live に残存

**宣言を書いた瞬間から乖離していた**わけで、このツールが必要だった証拠がそのまま出た形です。`--apply` で live へ同期し、再検査で drift ゼロを確認しました。

## 設計上の判断を1つ変えました

Issue の当初案では `--apply` を「未登録の登録」だけにする想定で、属性差は報告のみにしていました。しかし上記の通り実運用でいきなり description 差が出て、**それを直す経路が無いとノイズが恒久的に残る**——つまり「無視される lint」になります。そこで境界を引き直しました。

| 差分 | `--apply` | 理由 |
|---|---|---|
| 🟠 未登録 | 登録する | 遡及適用されないので早いほど良い |
| ⚪ description のみ | live へ同期 | 内部向けの説明文でレポートの見え方に影響しない |
| ⚠ displayName | **人が判断** | GA4 レポートの表示名が変わる |
| ⚠ scope | **人が判断** | 変更不可＝作り直しが必要 |
| 🔴 管理外 | **触らない** | API では削除できずアーカイブのみ。掃除は人が GA4 管理画面で判断（軸1） |

## 認証

`gcloud auth print-access-token --impersonate-service-account=ga4-reader@... --scopes=...analytics.readonly` で取得します。既存の drift スクリプトと同様 **npm 依存ゼロ**（`google-auth-library` はこのリポジトリで未宣言の推移的依存なので、committed script では使えません）。ADC へ直接 analytics スコープを付けるのは Google 側にブロックされるため impersonate が必須です。トークンは一切出力しません。

`--apply` のときだけ `analytics.edit` スコープを別途取得します（既定は読み取り専用）。

## 検証

live を変更せず、宣言側を一時的に壊して4経路を確認しました。

| ケース | 結果 |
|---|---|
| 宣言に未登録パラメータを追加 | 🟠 未登録: 1 / exit 1 |
| 宣言から1件削除 | 🔴 管理外: 1 / exit 1 |
| displayName を変更 | ⚠ 人が判断: 1 / exit 1 |
| 変更なし | ✅ drift なし / exit 0 |

`--apply` の実動作（description 同期 → 再検査で exit 0）も上記の通り確認済み。`pnpm verify` EXIT=0。

## Step 2（この PR の範囲外・SPR-279 に残す）

非ブロッキング CI 化は **WIF に `ga4-reader@` を追加する terraform 変更**が必要です（`terraform-plan-sa` では GA4 を読めない＝GA4 のアクセス権は GCP IAM ではなくプロパティ側のユーザー管理）。Terraform/GCP は One-Way Door なので分離しました。`ga4-reader@` 自体の terraform 管理化（`terraform import` 必要）も同じタイミングで扱う想定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)