### PR TITLE
feat(ci,terraform): GA4 dimension drift の週次検出を追加 (SPR-279 Step 2)

### DIFF
--- a/.github/workflows/ga4-dimension-drift.yml
+++ b/.github/workflows/ga4-dimension-drift.yml
@@ -1,0 +1,63 @@
+name: GA4 Dimension Drift
+
+# live GA4 のカスタムディメンションと宣言（apps/web/src/lib/analytics/ga4-custom-dimensions.json）の
+# drift を検出する（SPR-279 Step 2）。firestore-index-drift.yml と同型。
+# 方針: 非ブロッキング（continue-on-error）。登録/アーカイブの判断はツール任せにせず人が行う
+# （CLAUDE.md 軸1）。そのため CI では --apply を使わず、検出のみ実行する。
+# 認証: WIF で terraform-plan-sa を assume し、スクリプトが GA4 閲覧者の ga4-ci-reader を
+# impersonate する。GA4 編集者の ga4-reader は CI からは使わない（実体は terraform/analytics_ga4.tf）。
+
+on:
+  schedule:
+    - cron: '30 0 * * 1' # 毎週月曜 00:30 UTC（index-drift の 00:00 とずらす）
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/web/src/lib/analytics/ga4-custom-dimensions.json'
+      - 'scripts/check-ga4-dimension-drift.mjs'
+      - '.github/workflows/ga4-dimension-drift.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  drift:
+    name: GA4 dimension drift report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # スクリプトの既定は GA4 編集者の ga4-reader。CI では読み取り専用の SA に差し替える
+      GA4_READER_SA: ga4-ci-reader@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+    steps:
+      - uses: actions/checkout@v7
+
+      # 読み取り専用。terraform plan と同じ SA を入口に流用する（WIF 連携先を増やさない）。
+      # この SA には ga4-ci-reader への serviceAccountTokenCreator のみを付与している。
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'terraform-plan-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.18.0'
+
+      # 非ブロッキング: drift があっても PR を落とさない。結果はこのステップのログで確認する。
+      # スクリプトは npm 依存ゼロなので install 不要。
+      - name: Check GA4 dimension drift
+        continue-on-error: true
+        run: node scripts/check-ga4-dimension-drift.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,9 @@ LLM に毎回全部読ませて再構築させない。能動的に効かせた�
   登録済みは `customEvent:<param>` で Data API からクエリ可能。live↔JSON の突合は `pnpm check:ga4-drift`
   （GA4 認証が要るため verify には入れない＝`check:index-drift` と同じ扱い。`--apply` で未登録の登録と
   description の同期まで行う。displayName/scope の差は人が判断・SPR-279）。
+  週次の非ブロッキング CI（`ga4-dimension-drift.yml`）も同じスクリプトを検出のみで走らせる。
+  GCP 側の identity は terraform（`analytics_ga4.tf`）だが、**GA4 プロパティのアクセス権は
+  terraform では付与できず GA4 管理画面のみ**（CI は閲覧者の `ga4-ci-reader@`・ローカルの `--apply` は編集者の `ga4-reader@`）
   なお計器を足しただけでは測れない: カスタムイベントは consent ゲート内で送るため、同意率がそのまま母数になる
 - **Firestore 時刻フィールド**: 新規コレクション・新規フィールドの日時は Firestore `Timestamp` で保存する。
   既存は string ISO（works / audioButtons / users / contacts）と Timestamp（circles / creators / evaluations / ba_*）が

--- a/terraform/analytics_ga4.tf
+++ b/terraform/analytics_ga4.tf
@@ -1,0 +1,50 @@
+# ------------------------------------------------------------------------------
+# GA4 連携用サービスアカウント（SPR-279）
+# ------------------------------------------------------------------------------
+# GA4 のカスタムディメンションそのものは terraform で管理できない（GA4 は GCP リソースではなく
+# Google Marketing Platform 側で、公式 provider に Analytics Admin API のリソースが無い）。
+# 宣言の正本は apps/web/src/lib/analytics/ga4-custom-dimensions.json で、live への反映と
+# drift 検出は scripts/check-ga4-dimension-drift.mjs が Admin API 経由で行う。
+#
+# つまり terraform が管理するのは **Admin API を叩く GCP 側の identity だけ**。
+# 次の2つは terraform の管轄外なので、変更したらこのコメントも更新すること:
+#   - GA4 プロパティ側のアクセス権（閲覧者/編集者）は GA4 管理画面でしか付与できない
+#   - ローカルで --apply を実行するために個人アカウントへ付与済みの
+#     roles/iam.serviceAccountTokenCreator（ga4_reader 宛）は手動のまま
+
+# SPR-137 の調査時に手動作成された既存 SA を管理下へ取り込む（IaC 管理外だった＝PR #866 のレビュー指摘）。
+import {
+  to = google_service_account.ga4_reader
+  id = "projects/${var.gcp_project_id}/serviceAccounts/ga4-reader@${var.gcp_project_id}.iam.gserviceaccount.com"
+}
+
+# GA4 プロパティでは「編集者」。ローカルから --apply（未登録の登録・description 同期）を実行するのに使う。
+resource "google_service_account" "ga4_reader" {
+  project      = var.gcp_project_id
+  account_id   = "ga4-reader"
+  display_name = "GA4 Admin/Data API SA"
+  description  = "GA4 Data API / Admin API 用の SA。GA4 プロパティでは編集者（権限付与は GA4 管理画面・手動）"
+}
+
+# CI 用は読み取り専用の別 identity にする。ga4_reader は GA4 編集者であり、
+# CI（PR から assume 可）に編集権限まで渡す必要がないため（drift 検出は読みだけで足りる）。
+# GA4 プロパティ側では **閲覧者** として登録する（手動・GA4 管理画面）。
+resource "google_service_account" "ga4_ci_reader" {
+  project      = var.gcp_project_id
+  account_id   = "ga4-ci-reader"
+  display_name = "GA4 drift check (read-only) SA"
+  description  = "CI の GA4 drift 検出用 SA。GA4 プロパティでは閲覧者のみ（権限付与は GA4 管理画面・手動）"
+}
+
+# CI は WIF で terraform-plan-sa を assume し、そこから ga4_ci_reader を impersonate する。
+# 既存の WIF 連携先を増やさないため、index-drift ワークフローと同じ SA を入口に流用している。
+resource "google_service_account_iam_member" "ga4_ci_reader_token_creator" {
+  service_account_id = google_service_account.ga4_ci_reader.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.terraform_plan_sa.email}"
+
+  depends_on = [
+    google_service_account.ga4_ci_reader,
+    google_service_account.terraform_plan_sa,
+  ]
+}


### PR DESCRIPTION
[SPR-279](https://linear.app/nothink/issue/SPR-279/ga4-カスタムディメンションの-live宣言-drift-検出phase-2) の **Step 2**。#871（Step 1・ローカル実行）に CI を足します。

> [!IMPORTANT]
> **One-Way Door です**（`terraform/` と `.github/workflows/` の両方に該当）。CLAUDE.md のセルフマージ・ポリシーに従い、AI レビューだけでなくご自身のレビューをお願いします。マージ後に**手動の GA4 操作が1つ必要**です（下記「マージ後の手順」）。

## 認証設計：CI は読み取り専用の別 SA にしました

`terraform-plan-sa` では GA4 を読めません（GA4 のアクセス権は GCP IAM ではなくプロパティ側のユーザー管理）。そこで GCP 側の identity を terraform に足しますが、**`ga4-reader@` を CI に使い回すのは避けました**。

理由: `ga4-reader@` は 2026-07-25 に GA4 **編集者**へ変更済みで、その WIF 連携先（`terraform-plan-sa`）は**任意ブランチの PR から assume 可能**です。drift 検出は読みだけで足りるので、CI に編集 credential への経路を作る必要がありません。

| identity | GA4 プロパティ権限 | 用途 |
|---|---|---|
| `ga4-reader@`（既存） | 編集者 | ローカルの `--apply`（登録・description 同期） |
| `ga4-ci-reader@`（新規） | **閲覧者** | CI の drift 検出のみ |

CI の経路は `WIF → terraform-plan-sa → impersonate ga4-ci-reader`。**既存の WIF 連携先は増やしていません**（`terraform-plan-sa` に `ga4-ci-reader` 宛の `serviceAccountTokenCreator` を1つ付与するだけ）。スクリプトは `GA4_READER_SA` env の上書きに対応済みなので**変更ゼロ**です。

## 変更

**`terraform/analytics_ga4.tf`（新規）**

- `ga4-ci-reader` SA を新設
- `terraform-plan-sa` → `ga4-ci-reader` の `serviceAccountTokenCreator`
- 手動作成されていた **`ga4-reader` を `import` ブロックで管理下へ取り込み**（#866 のレビュー指摘。`grep -rn "ga4-reader" terraform/` が0件だった件）

> [!NOTE]
> import 後に **表示名・説明の更新差分が出ます**。live は `"GA4 read-only for PM analysis (SPR-137)"` のままで、編集者へ変更した実態と食い違っているためです（description は空）。plan で確認してください。

コメントに「terraform の管轄外」を明示しています——GA4 プロパティのアクセス権、およびローカル `--apply` 用に個人アカウントへ付与済みの `serviceAccountTokenCreator` は手動のままです。

**`.github/workflows/ga4-dimension-drift.yml`（新規）**

週次 cron（月曜 00:30 UTC・index-drift の 00:00 とずらす）+ 該当パスの PR + `workflow_dispatch`。`continue-on-error: true` で非ブロッキング（index-drift と同方針）。**CI では `--apply` を使わず検出のみ**です（登録/アーカイブの判断は人が行う＝軸1）。

## 検証したこと・できていないこと

**できたこと**

- `terraform validate` EXIT=0（`import` ブロックに変数を使う形も通る）
- `terraform fmt -check -recursive` EXIT=0
- `pnpm verify` EXIT=0 / `pnpm check:ga4-drift` は drift なし

**できていないこと（正直に）**

**CI の認証経路（WIF → plan-sa → ga4-ci-reader の impersonate）はローカルから検証できません。** さらに、この PR の CI 実行時点では terraform 未 apply かつ GA4 権限も未付与なので、**このワークフローの初回実行は失敗します**（非ブロッキングなのでマージは妨げません）。スクリプトは `アクセストークンを取得できませんでした（...impersonate 権限なし）` と出て exit 2 になります。

`terraform/**` を触るので **Terraform Plan ワークフローが自動で plan を出します**。そちらが実質のレビュー材料です（ADR-010: plan → 承認 → apply）。

## マージ後の手順

1. main の terraform apply（ADR-010 の承認ゲート）
2. **GA4 管理画面 → プロパティのアクセス管理 → `ga4-ci-reader@suzumina-click.iam.gserviceaccount.com` を「閲覧者」で追加**（terraform では付与できません）
3. Actions から `GA4 Dimension Drift` を `workflow_dispatch` で実行し、`✅ drift なし` を確認

2 を忘れると週次 CI が毎回失敗ログを出し続けます（非ブロッキングなので他への影響はありません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)