### PR TITLE
feat(tooling): GA4 プロパティ設定を宣言して drift 検出の対象にする (SPR-285)

### DIFF
--- a/.github/workflows/ga4-dimension-drift.yml
+++ b/.github/workflows/ga4-dimension-drift.yml
@@ -1,7 +1,10 @@
-name: GA4 Dimension Drift
+name: GA4 Drift
 
-# live GA4 のカスタムディメンションと宣言（apps/web/src/lib/analytics/ga4-custom-dimensions.json）の
-# drift を検出する（SPR-279 Step 2）。firestore-index-drift.yml と同型。
+# live GA4 と宣言（apps/web/src/lib/analytics/ga4-custom-dimensions.json および
+# ga4-property-settings.json）の drift を検出する（SPR-279 Step 2 / SPR-285）。
+# firestore-index-drift.yml と同型。
+# ファイル名が ga4-dimension-drift.yml のままなのは実行履歴の継続のため（GitHub は
+# ワークフローをファイルパスで同一視する）。表示名と実体は「GA4 Drift」で揃えている。
 # 方針: 非ブロッキング（continue-on-error）。登録/アーカイブの判断はツール任せにせず人が行う
 # （CLAUDE.md 軸1）。そのため CI では --apply を使わず、検出のみ実行する。
 # 認証: WIF で terraform-plan-sa を assume し、スクリプトが GA4 閲覧者の ga4-ci-reader を
@@ -30,7 +33,7 @@ permissions:
 
 jobs:
   drift:
-    name: GA4 dimension drift report
+    name: GA4 drift report
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/ga4-dimension-drift.yml
+++ b/.github/workflows/ga4-dimension-drift.yml
@@ -15,7 +15,8 @@ on:
       - main
     paths:
       - 'apps/web/src/lib/analytics/ga4-custom-dimensions.json'
-      - 'scripts/check-ga4-dimension-drift.mjs'
+      - 'apps/web/src/lib/analytics/ga4-property-settings.json'
+      - 'scripts/check-ga4-drift.mjs'
       - '.github/workflows/ga4-dimension-drift.yml'
   workflow_dispatch:
 
@@ -60,4 +61,4 @@ jobs:
       # スクリプトは npm 依存ゼロなので install 不要。
       - name: Check GA4 dimension drift
         continue-on-error: true
-        run: node scripts/check-ga4-dimension-drift.mjs
+        run: node scripts/check-ga4-drift.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,9 @@ LLM に毎回全部読ませて再構築させない。能動的に効かせた�
   登録済みは `customEvent:<param>` で Data API からクエリ可能。live↔JSON の突合は `pnpm check:ga4-drift`
   （GA4 認証が要るため verify には入れない＝`check:index-drift` と同じ扱い。`--apply` で未登録の登録と
   description の同期まで行う。displayName/scope の差は人が判断・SPR-279）。
+  **プロパティ設定（Googleシグナル / データ保持）の正本は `ga4-property-settings.json`** で、同じスクリプトが
+  突合する。ただし**設定は `--apply` で直さない**（保持期間の短縮はデータ削除で不可逆・Googleシグナルは
+  privacy ページの公開記述「無効に設定しています」と対で判断する＝SPR-285）。
   週次の非ブロッキング CI（`ga4-dimension-drift.yml`）も同じスクリプトを検出のみで走らせる。
   GCP 側の identity は terraform（`analytics_ga4.tf`）だが、**GA4 プロパティのアクセス権は
   terraform では付与できず GA4 管理画面のみ**（CI は閲覧者の `ga4-ci-reader@`・ローカルの `--apply` は編集者の `ga4-reader@`）

--- a/apps/web/src/lib/analytics/ga4-property-settings.json
+++ b/apps/web/src/lib/analytics/ga4-property-settings.json
@@ -1,0 +1,10 @@
+{
+	"googleSignalsSettings": {
+		"state": "GOOGLE_SIGNALS_DISABLED"
+	},
+	"dataRetentionSettings": {
+		"eventDataRetention": "FOURTEEN_MONTHS",
+		"userDataRetention": "FOURTEEN_MONTHS",
+		"resetUserDataOnNewActivity": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"lint:tokens": "node scripts/lint-css-tokens.mjs",
 		"lint:ga4": "node scripts/lint-ga4-params.mjs",
 		"check:index-drift": "node scripts/check-firestore-index-drift.mjs",
-		"check:ga4-drift": "node scripts/check-ga4-dimension-drift.mjs",
+		"check:ga4-drift": "node scripts/check-ga4-drift.mjs",
 		"format": "pnpm -r format",
 		"check": "pnpm -r check",
 		"secretlint": "secretlint \"**/*\"",

--- a/scripts/check-ga4-drift.mjs
+++ b/scripts/check-ga4-drift.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
-// scripts/check-ga4-dimension-drift.mjs
+// scripts/check-ga4-drift.mjs
 //
-// live GA4 のカスタムディメンションと宣言（apps/web/src/lib/analytics/ga4-custom-dimensions.json）の
-// drift を検出する（SPR-279）。check-firestore-index-drift.mjs と同型の位置づけ。
+// live GA4 と宣言の drift を検出する（SPR-279 / SPR-285）。check-firestore-index-drift.mjs と同型。
+// 宣言の正本は 2 ファイル（どちらも apps/web/src/lib/analytics/ 配下・Admin API の payload と同一形）:
+//   ga4-custom-dimensions.json  カスタムディメンション
+//   ga4-property-settings.json  プロパティ設定（Googleシグナル / データ保持）
 //
 // 責務の分担:
 //   pnpm lint:ga4        コード（gtag へ渡すパラメータ）↔ 宣言。認証不要なので verify に載る
@@ -14,10 +16,11 @@
 //              発見が遅れた期間のデータは永久に集計不能になる（index の apply 漏れより重い）
 //   ⚪ description 差: --apply で live へ同期できる（内部向けの説明文）
 //   ⚠ displayName / scope 差: 人が判断する（表示名はレポートに出る・scope は変更不可）
+//   🟣 プロパティ設定の差: **人が判断する（--apply の対象外）**。理由は下記
 //
 // 使い方:
-//   node scripts/check-ga4-dimension-drift.mjs           # 検出のみ（読み取り専用）
-//   node scripts/check-ga4-dimension-drift.mjs --apply   # 未登録の登録 + description の同期
+//   node scripts/check-ga4-drift.mjs           # 検出のみ（読み取り専用）
+//   node scripts/check-ga4-drift.mjs --apply   # 未登録の登録 + description の同期
 //   （ローカルは ADC → ga4-reader@ を impersonate。gcloud が PATH に必要。npm 依存なし）
 // 終了コード: 0=drift なし / 1=drift あり / 2=実行エラー
 //
@@ -25,6 +28,10 @@
 //   - GA4 のカスタムディメンションは API で削除できずアーカイブのみ。--apply は追加と
 //     description 同期だけで、「管理外」の掃除は人が GA4 管理画面で判断する
 //     （CLAUDE.md 軸1: 判断をツール任せにしない）
+//   - **プロパティ設定は --apply で直さない**（報告のみ）。保持期間の短縮はイベント単位データの
+//     削除で不可逆、Googleシグナルの切替はプライバシー方針に関わる（privacy ページに
+//     「Googleシグナルは無効に設定しています」と公開記述があり、対で判断すべき）。
+//     変更頻度も年数回なので自動修正の利得が小さい（SPR-285）
 //   - displayName / scope の差も --apply では直さない（表示名は GA4 レポートに出る・
 //     scope は変更不可で作り直しが必要）
 //   - **報告は必ず apply 後の live を再取得して行う**。apply 前の集計で報告すると、
@@ -38,12 +45,19 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const MANIFEST = join(repoRoot, "apps/web/src/lib/analytics/ga4-custom-dimensions.json");
+const ANALYTICS_DIR = join(repoRoot, "apps/web/src/lib/analytics");
+const MANIFEST = join(ANALYTICS_DIR, "ga4-custom-dimensions.json");
+const SETTINGS_MANIFEST = join(ANALYTICS_DIR, "ga4-property-settings.json");
 const PROPERTY = `properties/${process.env.GA4_PROPERTY_ID ?? "496464197"}`;
 const TARGET_SA = process.env.GA4_READER_SA ?? "ga4-reader@suzumina-click.iam.gserviceaccount.com";
 const READ_SCOPE = "https://www.googleapis.com/auth/analytics.readonly";
 const EDIT_SCOPE = "https://www.googleapis.com/auth/analytics.edit";
-const API = "https://analyticsadmin.googleapis.com/v1beta";
+const API_BASE = "https://analyticsadmin.googleapis.com";
+// プロパティ設定のリソースごとの API バージョン。googleSignalsSettings は v1beta に無い
+const SETTINGS_API_VERSION = {
+	googleSignalsSettings: "v1alpha",
+	dataRetentionSettings: "v1beta",
+};
 // 宣言に書いている項目だけ比較する（live の disallowAdsPersonalization 等は宣言側に無いため対象外）
 const COMPARED_FIELDS = ["displayName", "scope", "description"];
 
@@ -77,7 +91,7 @@ function accessToken(scope) {
 }
 
 async function callApi(path, token, init = {}) {
-	const res = await fetch(`${API}/${path}`, {
+	const res = await fetch(`${API_BASE}/${path}`, {
 		...init,
 		headers: {
 			Authorization: `Bearer ${token}`,
@@ -96,7 +110,7 @@ async function fetchLive(token) {
 	do {
 		const query = new URLSearchParams({ pageSize: "200" });
 		if (pageToken) query.set("pageToken", pageToken);
-		const page = await callApi(`${PROPERTY}/customDimensions?${query}`, token);
+		const page = await callApi(`v1beta/${PROPERTY}/customDimensions?${query}`, token);
 		all.push(...(page.customDimensions ?? []));
 		pageToken = page.nextPageToken;
 	} while (pageToken);
@@ -124,6 +138,43 @@ try {
 }
 
 const declaredByParam = new Map(manifest.map((d) => [d.parameterName, d]));
+
+let settingsManifest;
+try {
+	settingsManifest = JSON.parse(readFileSync(SETTINGS_MANIFEST, "utf8"));
+} catch (e) {
+	abort(`プロパティ設定の宣言を読めませんでした（${SETTINGS_MANIFEST}）: ${e.message}`);
+}
+// 未知のリソース名を黙って読み飛ばすと「宣言したのに検査されていない」状態になるため落とす
+for (const resource of Object.keys(settingsManifest)) {
+	if (!SETTINGS_API_VERSION[resource]) {
+		abort(
+			`未知のプロパティ設定 "${resource}"（対応は ${Object.keys(SETTINGS_API_VERSION).join(" / ")}）。SETTINGS_API_VERSION に API バージョンを追加すること`,
+		);
+	}
+}
+
+/**
+ * プロパティ設定（Googleシグナル / データ保持）を宣言と突き合わせる。
+ * 宣言に書いたフィールドだけ比較する（live の name 等は対象外）。--apply では直さない。
+ */
+async function checkSettings(token) {
+	const results = [];
+	for (const [resource, declared] of Object.entries(settingsManifest)) {
+		const version = SETTINGS_API_VERSION[resource];
+		let live;
+		try {
+			live = await callApi(`${version}/${PROPERTY}/${resource}`, token);
+		} catch (e) {
+			return abort(`${resource} を取得できませんでした: ${e.message}`);
+		}
+		const diffs = Object.keys(declared)
+			.filter((f) => String(declared[f]) !== String(live[f]))
+			.map((f) => ({ field: `${resource}.${f}`, declared: declared[f], live: live[f] }));
+		results.push(...diffs);
+	}
+	return results;
+}
 
 /** live を取得して宣言と突き合わせる。--apply の後は必ず呼び直して報告に使う */
 async function computeDrift(token) {
@@ -161,7 +212,7 @@ async function applyDrift({ missing, syncable }) {
 		console.log(`⚙ --apply: 未登録 ${missing.length} 件を登録`);
 		for (const d of missing) {
 			try {
-				await callApi(`${PROPERTY}/customDimensions`, editToken, {
+				await callApi(`v1beta/${PROPERTY}/customDimensions`, editToken, {
 					method: "POST",
 					body: JSON.stringify(d),
 				});
@@ -179,7 +230,7 @@ async function applyDrift({ missing, syncable }) {
 			try {
 				// live のリソース名（properties/*/customDimensions/*）に対して description だけ PATCH
 				const resource = liveDim.name.replace(/^properties\/[^/]+\//, "");
-				await callApi(`${PROPERTY}/${resource}?updateMask=description`, editToken, {
+				await callApi(`v1beta/${PROPERTY}/${resource}?updateMask=description`, editToken, {
 					method: "PATCH",
 					body: JSON.stringify({ description: declared.description ?? "" }),
 				});
@@ -196,9 +247,12 @@ const apply = process.argv.includes("--apply");
 const readToken = accessToken(READ_SCOPE);
 let drift = await computeDrift(readToken);
 
-console.log(`GA4 custom dimension drift check (${PROPERTY})`);
+const settingDiffs = await checkSettings(readToken);
+
+console.log(`GA4 drift check (${PROPERTY})`);
+console.log(`  カスタムディメンション: live ${drift.live.length} / 宣言 ${manifest.length}`);
 console.log(
-	`  live: ${drift.live.length} / 宣言(ga4-custom-dimensions.json): ${manifest.length}\n`,
+	`  プロパティ設定: ${Object.keys(settingsManifest).join(" / ")}（宣言フィールド ${Object.values(settingsManifest).reduce((n, o) => n + Object.keys(o).length, 0)} 件）\n`,
 );
 
 if (apply && (drift.missing.length || drift.syncable.length)) {
@@ -211,9 +265,26 @@ if (apply && (drift.missing.length || drift.syncable.length)) {
 
 const { unmanaged, missing, syncable, needsHuman } = drift;
 
-if (!unmanaged.length && !missing.length && !syncable.length && !needsHuman.length) {
+if (
+	!unmanaged.length &&
+	!missing.length &&
+	!syncable.length &&
+	!needsHuman.length &&
+	!settingDiffs.length
+) {
 	console.log("✅ drift なし（live と宣言が一致）");
 	process.exit(0);
+}
+
+if (settingDiffs.length) {
+	console.log(`🟣 プロパティ設定の差（人が判断・--apply の対象外）: ${settingDiffs.length}`);
+	for (const d of settingDiffs) console.log(`   - ${formatDiff(d)}`);
+	console.log(
+		"   → 意図した変更なら宣言（ga4-property-settings.json）を更新。意図しない変更なら GA4 管理画面で戻す。",
+	);
+	console.log(
+		"     Googleシグナルは privacy ページの公開記述と対で判断する。保持期間の短縮はイベント単位データの削除で不可逆\n",
+	);
 }
 
 if (unmanaged.length) {

--- a/terraform/analytics_ga4.tf
+++ b/terraform/analytics_ga4.tf
@@ -4,7 +4,7 @@
 # GA4 のカスタムディメンションそのものは terraform で管理できない（GA4 は GCP リソースではなく
 # Google Marketing Platform 側で、公式 provider に Analytics Admin API のリソースが無い）。
 # 宣言の正本は apps/web/src/lib/analytics/ga4-custom-dimensions.json で、live への反映と
-# drift 検出は scripts/check-ga4-dimension-drift.mjs が Admin API 経由で行う。
+# drift 検出は scripts/check-ga4-drift.mjs が Admin API 経由で行う。
 #
 # つまり terraform が管理するのは **Admin API を叩く GCP 側の identity だけ**。
 # 次の2つは terraform の管轄外なので、変更したらこのコメントも更新すること:


### PR DESCRIPTION
[SPR-285](https://linear.app/nothink/issue/SPR-285/ga4-プロパティ設定googleシグナル-データ保持が宣言されておらず-drift-検出の対象外)。

> [!NOTE]
> `.github/workflows/` を触るため One-Way Door 扱いですが、変更は**paths フィルタへの1行追加とスクリプト名の追従だけ**です（認証・トリガ・権限は変更なし）。

## 問題

2026-07-25 に API で変更した2つの設定は、**意図した状態がどこにも宣言されていません**でした。

| 設定 | 現在値 | 変更前 | drift 検出 |
|---|---|---|---|
| カスタムディメンション | 14件 | 0件 | ✅ SPR-279 |
| `googleSignalsSettings.state` | DISABLED | ENABLED | ❌ **対象外** |
| `dataRetentionSettings.eventDataRetention` | FOURTEEN_MONTHS | TWO_MONTHS | ❌ **対象外** |

`ga4-reader@` は GA4 編集者で、GA4 管理画面からも変更できます。

**実害はプライバシーポリシーとの連動です。** PR #867 で公開ページに次の記述を入れました。

> Googleアカウントに紐づく広告向け機能（Googleシグナル）は無効に設定しています。

再有効化されると、**この公開記述が誰にも気づかれずに虚偽になります**。GA4 の UI は設定変更を通知しません。保持期間側も 14か月 → 2か月に戻すとイベント単位データが削除され、不可逆です。

SPR-234 の「発火しないメトリクス」と同じ構造——仕組みを入れたのに状態が保証されていない、というやつです。

## 変更

- **`apps/web/src/lib/analytics/ga4-property-settings.json`（新規）** を正本に。ディメンションの正本とは**別ファイル**にしました。既存ファイルは「Admin API の payload と同一形」という性質があり、別種の設定を混ぜると崩れます
- 同スクリプトを拡張し `googleSignalsSettings`（**v1alpha**）/ `dataRetentionSettings`（**v1beta**）を突合。リソースごとに API バージョンが違うため `SETTINGS_API_VERSION` で対応付け
- **宣言に未知のリソース名があれば exit 2 で落とす**。黙って読み飛ばすと「宣言したのに検査されていない」状態になるため（fail-closed）
- スクリプトを `check-ga4-drift.mjs` へ改名（npm script 側は既に `check:ga4-drift` で汎用名でした）

## 設計判断：プロパティ設定は `--apply` の対象外（報告のみ）

ディメンションの `--apply` は「未登録の登録」と「description の同期」を行いますが、設定は自動修正しません。

- **保持期間の短縮は不可逆**（イベント単位データが削除される）
- **Googleシグナルの切替はプライバシー方針に関わる**（上記の公開記述と対で判断すべき）
- 変更頻度は年数回で、手で直す負担は小さい

CLAUDE.md 軸1「判断をツール任せにしない」に沿った線引きです。

## 検証

**live の設定は一切変更していません。** 保持期間の変更は不可逆なので、live を実験台にせず宣言側を一時改変して検出を確認しました。

| ケース | 結果 |
|---|---|
| Googleシグナルの宣言を ENABLED に | 🟣 exit 1 |
| 保持期間の宣言を TWO_MONTHS に | 🟣 exit 1 |
| `resetUserDataOnNewActivity` を false に（boolean 比較） | 🟣 exit 1 |
| 未知のリソース名を宣言 | exit 2（`✗ 未知のプロパティ設定 "attributionSettings"`） |
| 変更なし | ✅ exit 0 |

実行時の出力:

```
GA4 drift check (properties/496464197)
  カスタムディメンション: live 14 / 宣言 14
  プロパティ設定: googleSignalsSettings / dataRetentionSettings（宣言フィールド 4 件）

✅ drift なし（live と宣言が一致）
```

`pnpm verify` EXIT=0 / biome の複雑度も上限内。

## 補足

途中で1つ手戻りがありました。検証スクリプトが `git checkout` で宣言ファイルを復元する作りでしたが、**新規ファイルが未コミットのため復元が効かず**テスト編集が累積しました。stage してから再実行し、5ケースすべて確認し直しています。

なお **SPR-282**（非ブロッキング CI が「緑だが壊れている」を隠す）は未対応です。この PR で検出範囲は広がりましたが、CI 上で失敗が見えない問題は別途残っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)