### PR TITLE
fix(ci): drift 検出の失敗が「緑」に埋もれないようにする (SPR-282)

### DIFF
--- a/.github/workflows/firestore-index-drift.yml
+++ b/.github/workflows/firestore-index-drift.yml
@@ -1,7 +1,8 @@
 name: Firestore Index Drift
 
 # live Firestore 複合インデックスと terraform 定義（firestore_indexes*.tf）の drift を検出する（SPR-213）。
-# 方針: 非ブロッキング（continue-on-error）。手動棚卸しを自動ガード化し、管理外/未適用 index を早期可視化する。
+# 方針: drift あり(exit 1)は非ブロッキングで warning・検査が動かない(exit 2)は run を赤にする（SPR-282）。
+# 手動棚卸しを自動ガード化し、管理外/未適用 index を早期可視化する。
 # 削除/追加の判断はツール任せにせず人=LLM が行う（CLAUDE.md 軸1）。実体は scripts/check-firestore-index-drift.mjs。
 
 on:
@@ -52,7 +53,34 @@ jobs:
         with:
           node-version: '24.18.0'
 
-      # 非ブロッキング: drift があっても PR を落とさない。結果はこのステップのログで確認する。
+      # continue-on-error は使わない（ステップの conclusion まで success に塗られ、
+      # 「緑だが壊れている」を作るため＝SPR-282）。代わりに exit code を出力して次の
+      # ステップで意味づけする。結果は Summary に出るのでログを開かなくても読める。
       - name: Check index drift
-        continue-on-error: true
-        run: node scripts/check-firestore-index-drift.mjs
+        id: drift
+        run: |
+          set +e
+          node scripts/check-firestore-index-drift.mjs 2>&1 | tee /tmp/drift.txt
+          code=${PIPESTATUS[0]}
+          {
+            echo "### Firestore Index Drift (exit ${code})"
+            echo '```'
+            cat /tmp/drift.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # exit 1（drift あり）は非ブロッキングで warning に留める＝削除/追加の判断は人が行う（軸1・SPR-213）。
+      # exit 2（gcloud で live を取得できない等）は run を赤にする。必須チェックではないのでマージは
+      # 止まらないが、緑に埋もれると検出が停止したことに気づけない（SPR-282）。
+      - name: Report drift result
+        env:
+          DRIFT_EXIT: ${{ steps.drift.outputs.exit_code }}
+        run: |
+          case "$DRIFT_EXIT" in
+            0) echo "::notice::Firestore index drift なし（live と terraform 定義が一致）" ;;
+            1) echo "::warning::Firestore index drift を検出しました。Summary を確認してください" ;;
+            *) echo "::error::index drift 検査が実行できませんでした（exit ${DRIFT_EXIT}）。検出が停止しています"
+               exit 1 ;;
+          esac

--- a/.github/workflows/firestore-index-drift.yml
+++ b/.github/workflows/firestore-index-drift.yml
@@ -56,7 +56,7 @@ jobs:
       # continue-on-error は使わない（ステップの conclusion まで success に塗られ、
       # 「緑だが壊れている」を作るため＝SPR-282）。代わりに exit code を出力して次の
       # ステップで意味づけする。結果は Summary に出るのでログを開かなくても読める。
-      - name: Check index drift
+      - name: Run index drift check (capture exit code)
         id: drift
         run: |
           set +e

--- a/.github/workflows/ga4-dimension-drift.yml
+++ b/.github/workflows/ga4-dimension-drift.yml
@@ -5,8 +5,9 @@ name: GA4 Drift
 # firestore-index-drift.yml と同型。
 # ファイル名が ga4-dimension-drift.yml のままなのは実行履歴の継続のため（GitHub は
 # ワークフローをファイルパスで同一視する）。表示名と実体は「GA4 Drift」で揃えている。
-# 方針: 非ブロッキング（continue-on-error）。登録/アーカイブの判断はツール任せにせず人が行う
-# （CLAUDE.md 軸1）。そのため CI では --apply を使わず、検出のみ実行する。
+# 方針: drift あり(exit 1)は非ブロッキングで warning・検査が動かない(exit 2)は run を赤にする（SPR-282）。
+# 登録/アーカイブの判断はツール任せにせず人が行う（CLAUDE.md 軸1）。
+# そのため CI では --apply を使わず、検出のみ実行する。
 # 認証: WIF で terraform-plan-sa を assume し、スクリプトが GA4 閲覧者の ga4-ci-reader を
 # impersonate する。GA4 編集者の ga4-reader は CI からは使わない（実体は terraform/analytics_ga4.tf）。
 
@@ -60,8 +61,35 @@ jobs:
         with:
           node-version: '24.18.0'
 
-      # 非ブロッキング: drift があっても PR を落とさない。結果はこのステップのログで確認する。
       # スクリプトは npm 依存ゼロなので install 不要。
-      - name: Check GA4 dimension drift
-        continue-on-error: true
-        run: node scripts/check-ga4-drift.mjs
+      # continue-on-error は使わない（ステップの conclusion まで success に塗られ、
+      # 「緑だが壊れている」を作るため＝SPR-282）。代わりに exit code を出力して次の
+      # ステップで意味づけする。結果は Summary に出るのでログを開かなくても読める。
+      - name: Check GA4 drift
+        id: drift
+        run: |
+          set +e
+          node scripts/check-ga4-drift.mjs 2>&1 | tee /tmp/drift.txt
+          code=${PIPESTATUS[0]}
+          {
+            echo "### GA4 Drift (exit ${code})"
+            echo '```'
+            cat /tmp/drift.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # exit 1（drift あり）は非ブロッキングで warning に留める＝対応の判断は人が行う（軸1）。
+      # exit 2（検査そのものが動かない）は run を赤にする。必須チェックではないのでマージは
+      # 止まらないが、緑に埋もれると検出が停止したことに気づけない（SPR-282 の本体）。
+      - name: Report drift result
+        env:
+          DRIFT_EXIT: ${{ steps.drift.outputs.exit_code }}
+        run: |
+          case "$DRIFT_EXIT" in
+            0) echo "::notice::GA4 drift なし（live と宣言が一致）" ;;
+            1) echo "::warning::GA4 drift を検出しました。Summary を確認してください" ;;
+            *) echo "::error::GA4 drift 検査が実行できませんでした（exit ${DRIFT_EXIT}）。検出が停止しています"
+               exit 1 ;;
+          esac

--- a/.github/workflows/ga4-dimension-drift.yml
+++ b/.github/workflows/ga4-dimension-drift.yml
@@ -65,7 +65,7 @@ jobs:
       # continue-on-error は使わない（ステップの conclusion まで success に塗られ、
       # 「緑だが壊れている」を作るため＝SPR-282）。代わりに exit code を出力して次の
       # ステップで意味づけする。結果は Summary に出るのでログを開かなくても読める。
-      - name: Check GA4 drift
+      - name: Run GA4 drift check (capture exit code)
         id: drift
         run: |
           set +e


### PR DESCRIPTION
[SPR-282](https://linear.app/nothink/issue/SPR-282/非ブロッキング-drift-ci-が緑だが壊れているを隠すindex-drift-ga4-dimension-drift)。対象は `firestore-index-drift.yml` / `ga4-dimension-drift.yml` の2本です。

> [!IMPORTANT]
> **One-Way Door**（`.github/workflows/`）です。ご自身のレビューをお願いします。

## 問題

PR #872 の初回実行は、スクリプトが **exit 2**（SA 未作成で impersonate 失敗）だったのに **run は緑・全ステップ conclusion=success** でした。`continue-on-error: true` はステップの conclusion まで success に塗り替えるため、失敗がログを開かないと見えません。

週次 cron で回るので、**誰も見ないまま「緑だが検出は停止している」状態が続きます**。SPR-234 の「発火しないメトリクス」と同じ失敗クラスです。

しかも #873 で Google シグナルの監視を入れた直後なので、この穴が残ると「プライバシーポリシーの記述が嘘になっても緑」という状態になりえました。

## 変更：exit code に意味を持たせる

`continue-on-error` を廃止し、Check ステップは**自身は常に exit 0** で終わって exit code を `$GITHUB_OUTPUT` に出します。スクリプト出力は `tee` で `$GITHUB_STEP_SUMMARY` にも書くので、**ログを開かずに Summary で読めます**。

続く Report ステップが意味づけします。

| exit | 意味 | run | annotation |
|---|---|---|---|
| 0 | drift なし | 緑 | `::notice::` |
| 1 | **drift あり** | **緑**（非ブロッキング維持） | `::warning::` |
| 2+ | **検査が動いていない** | **赤** | `::error::` |

exit 1 を緑のままにしたのは、drift への対応（登録するか・アーカイブするか）は人が判断するという既存方針（軸1 / SPR-213）を変えないためです。一方 exit 2 は「仕組みが機能していない」なので赤にします。**main の必須チェックは Secret Scan のみなので、赤でもマージは止まりません。**

exit code は `${{ }}` でシェルに埋め込まず `env` 経由で渡しています（インジェクション面を作らない）。

## 検証：3経路すべて実 CI で確認しました

ローカルでスタブ（exit 0/1/2）を使い `bash -e` 下での exit code 捕捉・Summary 書き込み・分岐を確認したうえで、**ブランチに一時コミットを積んで実際に CI を走らせました**（検証後に force-push で削除済み）。

| 経路 | 再現方法 | run conclusion | annotation |
|---|---|---|---|
| exit 0 | そのまま | `success` | `[notice] GA4 drift なし（live と宣言が一致）` |
| exit 1 | 宣言側に drift を作る | **`success`** | `[warning] GA4 drift を検出しました。Summary を確認してください` |
| exit 2 | 存在しない SA を指定 | **`failure`** | `[error] GA4 drift 検査が実行できませんでした（exit 2）。検出が停止しています` |

exit 1 のとき Summary に `🟣 プロパティ設定の差（人が判断・--apply の対象外）: 1` が出ることも確認しました。**exit 2 の run が赤になる**ことが、この PR の本体です（#872 の初回と同じ状況が今は赤で出ます）。

## 補足：ローカル検証で1回間違えました

最初のスタブ検証で Summary への書き込みが 0 件になり、実装のバグかと思いました。原因は**テストハーネス側のクォート誤り**で、YAML では `echo '```'`（シングルクォート）なのにハーネスで `echo "```"` と書き、バックティックがコマンド置換として解釈されていました。実装は正しく、ハーネスを YAML と同一にして 3経路すべて通っています。

`pnpm verify` EXIT=0。

## 残る限界

`::warning::` / `::error::` は run ページと PR の Checks に出ますが、**週次 cron の run は誰かが見に行かないと気づけません**（メール通知は失敗時のみ・GitHub の既定設定に依存）。exit 2 を赤にしたことで通知が飛ぶ余地は生まれましたが、確実な通知が要るなら Cloud Monitoring 側のアラート（SPR-234/235 系）に寄せる話になります。今回はそこまで踏み込んでいません。