### PR TITLE
feat(tooling): BigQuery export リンクを宣言して drift 検出の対象にする (SPR-283)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,11 @@ LLM に毎回全部読ませて再構築させない。能動的に効かせた�
   登録済みは `customEvent:<param>` で Data API からクエリ可能。live↔JSON の突合は `pnpm check:ga4-drift`
   （GA4 認証が要るため verify には入れない＝`check:index-drift` と同じ扱い。`--apply` で未登録の登録と
   description の同期まで行う。displayName/scope の差は人が判断・SPR-279）。
-  **プロパティ設定（Googleシグナル / データ保持）の正本は `ga4-property-settings.json`** で、同じスクリプトが
-  突合する。ただし**設定は `--apply` で直さない**（保持期間の短縮はデータ削除で不可逆・Googleシグナルは
-  privacy ページの公開記述「無効に設定しています」と対で判断する＝SPR-285）。
+  **プロパティ設定（Googleシグナル / データ保持 / BigQuery リンク）の正本は `ga4-property-settings.json`** で、
+  同じスクリプトが突合する。ただし**設定は `--apply` で直さない**（保持期間の短縮はデータ削除で不可逆・
+  Googleシグナルは privacy ページの公開記述「無効に設定しています」と対で判断する＝SPR-285）。
+  BigQuery export は日次のみ有効（ストリーミングは課金対象なので既定オフ）。**リンクの作成・変更は
+  GA4 管理画面のみ**＝`ga4-reader@` は GCP プロジェクトの IAM ロールを持たないため API では 403（SPR-283）。
   週次の非ブロッキング CI（`ga4-dimension-drift.yml`）も同じスクリプトを検出のみで走らせる。
   GCP 側の identity は terraform（`analytics_ga4.tf`）だが、**GA4 プロパティのアクセス権は
   terraform では付与できず GA4 管理画面のみ**（CI は閲覧者の `ga4-ci-reader@`・ローカルの `--apply` は編集者の `ga4-reader@`）

--- a/apps/web/src/lib/analytics/ga4-property-settings.json
+++ b/apps/web/src/lib/analytics/ga4-property-settings.json
@@ -6,5 +6,14 @@
 		"eventDataRetention": "FOURTEEN_MONTHS",
 		"userDataRetention": "FOURTEEN_MONTHS",
 		"resetUserDataOnNewActivity": true
-	}
+	},
+	"bigQueryLinks": [
+		{
+			"datasetLocation": "asia-northeast1",
+			"dailyExportEnabled": true,
+			"streamingExportEnabled": false,
+			"includeAdvertisingId": false,
+			"exportStreams": ["properties/496464197/dataStreams/11473068450"]
+		}
+	]
 }

--- a/scripts/check-ga4-drift.mjs
+++ b/scripts/check-ga4-drift.mjs
@@ -4,7 +4,11 @@
 // live GA4 と宣言の drift を検出する（SPR-279 / SPR-285）。check-firestore-index-drift.mjs と同型。
 // 宣言の正本は 2 ファイル（どちらも apps/web/src/lib/analytics/ 配下・Admin API の payload と同一形）:
 //   ga4-custom-dimensions.json  カスタムディメンション
-//   ga4-property-settings.json  プロパティ設定（Googleシグナル / データ保持）
+//   ga4-property-settings.json  プロパティ設定（Googleシグナル / データ保持 / BigQuery リンク）
+//
+// bigQueryLinks は宣言から `project` を意図的に外している（プロジェクト番号は CI 側で
+// secrets.GCP_PROJECT_NUMBER として扱っているため、リポジトリに置かない）。
+// エクスポートが有効かどうかは dailyExportEnabled / datasetLocation / exportStreams で判定できる。
 //
 // 責務の分担:
 //   pnpm lint:ga4        コード（gtag へ渡すパラメータ）↔ 宣言。認証不要なので verify に載る
@@ -53,10 +57,16 @@ const TARGET_SA = process.env.GA4_READER_SA ?? "ga4-reader@suzumina-click.iam.gs
 const READ_SCOPE = "https://www.googleapis.com/auth/analytics.readonly";
 const EDIT_SCOPE = "https://www.googleapis.com/auth/analytics.edit";
 const API_BASE = "https://analyticsadmin.googleapis.com";
-// プロパティ設定のリソースごとの API バージョン。googleSignalsSettings は v1beta に無い
+// プロパティ設定のリソースごとの API バージョン。googleSignalsSettings / bigQueryLinks は v1beta に無い
 const SETTINGS_API_VERSION = {
 	googleSignalsSettings: "v1alpha",
 	dataRetentionSettings: "v1beta",
+	bigQueryLinks: "v1alpha",
+};
+// リスト応答のリソースと、その配列が入るレスポンスキー
+// （URL は bigQueryLinks だがレスポンスキーは bigqueryLinks で q の大小が違う）
+const SETTINGS_LIST_FIELD = {
+	bigQueryLinks: "bigqueryLinks",
 };
 // 宣言に書いている項目だけ比較する（live の disallowAdsPersonalization 等は宣言側に無いため対象外）
 const COMPARED_FIELDS = ["displayName", "scope", "description"];
@@ -155,8 +165,40 @@ for (const resource of Object.keys(settingsManifest)) {
 }
 
 /**
- * プロパティ設定（Googleシグナル / データ保持）を宣言と突き合わせる。
- * 宣言に書いたフィールドだけ比較する（live の name 等は対象外）。--apply では直さない。
+ * 宣言値と live 値が一致するか。
+ * **false の boolean は live のレスポンスから省略される**ため、undefined を false として扱う
+ * （素朴に String() 比較すると "false" ≠ "undefined" で誤検知する）。
+ */
+function valuesEqual(declared, live) {
+	if (typeof declared === "boolean") return Boolean(live) === declared;
+	if (Array.isArray(declared)) return JSON.stringify(declared) === JSON.stringify(live ?? []);
+	return String(declared) === String(live);
+}
+
+/** 単一リソース（googleSignalsSettings / dataRetentionSettings）の突合 */
+function diffObject(label, declared, live) {
+	return Object.keys(declared)
+		.filter((f) => !valuesEqual(declared[f], live?.[f]))
+		.map((f) => ({
+			field: `${label}.${f}`,
+			declared: declared[f],
+			// boolean は live 側が省略されうる。比較と同じ正規化を表示にも適用する
+			// （そのままだと "live=undefined" と出て、undefined=false という比較規則とズレて読める）
+			live: typeof declared[f] === "boolean" ? Boolean(live?.[f]) : live?.[f],
+		}));
+}
+
+/** リストリソース（bigQueryLinks）の突合。「宣言した数だけ、宣言した設定で存在する」を見る */
+function diffList(resource, declaredList, liveList) {
+	if (declaredList.length !== liveList.length) {
+		return [{ field: `${resource}.length`, declared: declaredList.length, live: liveList.length }];
+	}
+	return declaredList.flatMap((d, i) => diffObject(`${resource}[${i}]`, d, liveList[i]));
+}
+
+/**
+ * プロパティ設定（Googleシグナル / データ保持 / BigQuery リンク）を宣言と突き合わせる。
+ * 宣言に書いたフィールドだけ比較する（live の name / createTime 等は対象外）。--apply では直さない。
  */
 async function checkSettings(token) {
 	const results = [];
@@ -168,10 +210,12 @@ async function checkSettings(token) {
 		} catch (e) {
 			return abort(`${resource} を取得できませんでした: ${e.message}`);
 		}
-		const diffs = Object.keys(declared)
-			.filter((f) => String(declared[f]) !== String(live[f]))
-			.map((f) => ({ field: `${resource}.${f}`, declared: declared[f], live: live[f] }));
-		results.push(...diffs);
+		const listField = SETTINGS_LIST_FIELD[resource];
+		results.push(
+			...(listField
+				? diffList(resource, declared, live[listField] ?? [])
+				: diffObject(resource, declared, live)),
+		);
 	}
 	return results;
 }
@@ -251,8 +295,15 @@ const settingDiffs = await checkSettings(readToken);
 
 console.log(`GA4 drift check (${PROPERTY})`);
 console.log(`  カスタムディメンション: live ${drift.live.length} / 宣言 ${manifest.length}`);
+// リスト（bigQueryLinks）は要素内のフィールドまで数える。配列を1件と数えると実数とズレる
+const declaredFieldCount = Object.values(settingsManifest).reduce(
+	(n, v) =>
+		n +
+		(Array.isArray(v) ? v.reduce((m, o) => m + Object.keys(o).length, 0) : Object.keys(v).length),
+	0,
+);
 console.log(
-	`  プロパティ設定: ${Object.keys(settingsManifest).join(" / ")}（宣言フィールド ${Object.values(settingsManifest).reduce((n, o) => n + Object.keys(o).length, 0)} 件）\n`,
+	`  プロパティ設定: ${Object.keys(settingsManifest).join(" / ")}（宣言フィールド ${declaredFieldCount} 件）\n`,
 );
 
 if (apply && (drift.missing.length || drift.syncable.length)) {

--- a/scripts/check-ga4-drift.mjs
+++ b/scripts/check-ga4-drift.mjs
@@ -175,6 +175,17 @@ function valuesEqual(declared, live) {
 	return String(declared) === String(live);
 }
 
+/**
+ * 表示用に live 値を正規化する。**比較（valuesEqual）と同じ規則を使う**のが要点で、
+ * 揃えないと「live=undefined」と出るのに undefined=false として一致判定される、という
+ * 読み手が混乱する組み合わせが生まれる。
+ */
+function normalizeForDisplay(declared, live) {
+	if (typeof declared === "boolean") return Boolean(live);
+	if (Array.isArray(declared)) return live ?? [];
+	return live;
+}
+
 /** 単一リソース（googleSignalsSettings / dataRetentionSettings）の突合 */
 function diffObject(label, declared, live) {
 	return Object.keys(declared)
@@ -182,18 +193,27 @@ function diffObject(label, declared, live) {
 		.map((f) => ({
 			field: `${label}.${f}`,
 			declared: declared[f],
-			// boolean は live 側が省略されうる。比較と同じ正規化を表示にも適用する
-			// （そのままだと "live=undefined" と出て、undefined=false という比較規則とズレて読める）
-			live: typeof declared[f] === "boolean" ? Boolean(live?.[f]) : live?.[f],
+			live: normalizeForDisplay(declared[f], live?.[f]),
 		}));
 }
 
-/** リストリソース（bigQueryLinks）の突合。「宣言した数だけ、宣言した設定で存在する」を見る */
+/**
+ * リストリソース（bigQueryLinks）の突合。「宣言した数だけ、宣言した設定で存在する」を見る。
+ * **live の返却順に依存しない**（API は順序を保証しないため、宣言ごとに全フィールド一致する
+ * live 要素を探して消費する）。一致しなかった宣言は残った live 要素と並べて差分を出す。
+ */
 function diffList(resource, declaredList, liveList) {
 	if (declaredList.length !== liveList.length) {
 		return [{ field: `${resource}.length`, declared: declaredList.length, live: liveList.length }];
 	}
-	return declaredList.flatMap((d, i) => diffObject(`${resource}[${i}]`, d, liveList[i]));
+	const remaining = [...liveList];
+	const unmatched = [];
+	for (const declared of declaredList) {
+		const hit = remaining.findIndex((l) => diffObject("", declared, l).length === 0);
+		if (hit >= 0) remaining.splice(hit, 1);
+		else unmatched.push(declared);
+	}
+	return unmatched.flatMap((d, i) => diffObject(`${resource}[${i}]`, d, remaining[i]));
 }
 
 /**


### PR DESCRIPTION
[SPR-283](https://linear.app/nothink/issue/SPR-283/ga4-の-bigquery-export-が未設定custom-dimension-で拾えない生パラメータが消える)。

## 経緯

GA4 の BigQuery export を有効化しました（**2026-07-25T12:13Z**・日次のみ・`asia-northeast1`）。

API から作ろうとして **403** になりました。`ga4-reader@` は **GCP プロジェクトの IAM ロールを1つも持っていない**（実測: 該当バインディング0件）ためです。BigQuery リンクの作成は GA4 側の編集者権限だけでなくリンク先プロジェクトの権限も要求します。一度きりの操作に terraform 変更（One-Way Door）は割に合わないので **GA4 管理画面で実施**し、API で結果を検証しました。

```
name: properties/496464197/bigQueryLinks/mUnZDGEvTFKlJ8BEkrrRlA
dailyExportEnabled: true / datasetLocation: asia-northeast1 / exportStreams: [ウェブストリーム1本]
（streamingExportEnabled・includeAdvertisingId・excludedEvents はレスポンス省略＝false/なし）
```

**export も遡及しません。** リンクが無効化・削除されるとデータ蓄積が静かに止まり、止まった分は永久に取り戻せないので SPR-285 の枠組みに載せます。

## 変更

**宣言に `bigQueryLinks` を追加**（`ga4-property-settings.json`）

`project`（プロジェクト番号）は**意図的に宣言から外しています**。CI では `secrets.GCP_PROJECT_NUMBER` として扱っている値なのでリポジトリに置きません。エクスポートの有効性は `dailyExportEnabled` / `datasetLocation` / `exportStreams` で判定できます。

**リスト応答への対応**（`diffList`）

`bigQueryLinks` は単一リソースの GET ではなくリストなので「宣言した数だけ、宣言した設定で存在する」を見ます。**URL は `bigQueryLinks` なのにレスポンスキーは `bigqueryLinks`（q の大小が違う）** という罠があり、対応表をコードに残しました。

## 潜在バグを1つ修正しました

従来の比較は `String(declared) !== String(live)` で、**宣言 `false` と live のフィールド省略（undefined）を `"false" ≠ "undefined"` として誤検知**していました。

既存の `dataRetentionSettings.resetUserDataOnNewActivity` は `true` 同士だったため露出していませんでしたが、**`streamingExportEnabled: false` を宣言した瞬間に踏む状態**でした（実際に踏みました）。`valuesEqual` で boolean は undefined=false、配列は JSON 比較に正規化しています。差分表示も同じ正規化を適用し、`live"undefined"` ではなく `live"false"` と出します。

あわせて、宣言フィールド数の表示が配列を1件と数えていたのを要素内まで数えるよう直しました（5件 → 9件）。

## 検証（live は変更せず宣言側を一時改変）

| ケース | 結果 |
|---|---|
| 変更なし | ✅ exit 0 |
| `dailyExportEnabled` を false 宣言 | 🟣 exit 1 |
| `streamingExportEnabled` を true 宣言（live は省略） | 🟣 exit 1・表示は `live"false"` |
| `datasetLocation` を us 宣言 | 🟣 exit 1 |
| リンクを2本宣言（live は1本） | 🟣 exit 1（`bigQueryLinks.length`） |
| `exportStreams` を別ストリームに | 🟣 exit 1 |

`pnpm verify` EXIT=0（コミット済み状態で確認）/ biome の複雑度も上限内。

## 正直に書いておきます

1. **テスト手順で同じ罠を2回踏みました。** `git checkout -- <file>` はコミット/stage 済みの版に戻すため、未コミットの宣言追加が消えてケース1以降が空振りしていました。SPR-285 で一度踏んで注意したのに繰り返したので、stage してから再実行しています
2. **`pnpm verify` が EXIT=1 の状態でコミットまで進めました。** `&&` の連鎖で停止しなかったためです。原因は「整形前のファイルで verify → pre-commit フックが整形 → コミット」という順序で、コミット済みの状態では EXIT=0 になることを確認済みですが、手順としては誤りでした

## 残り（SPR-283 の残タスク）

- 翌日以降に `bq ls` で `analytics_496464197` と `events_YYYYMMDD` を確認（初回エクスポート待ち）
- 数週間後にコスト実測（SPR-83 の予算超過傾向を踏まえ、増分がほぼゼロであることの確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)