### PR TITLE
fix(functions): googleapis umbrella import を撤去しメモリ診断ログを追加 (SPR-277)

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -37,8 +37,8 @@
 	"dependencies": {
 		"@google-cloud/firestore": "^8.6.0",
 		"@google-cloud/functions-framework": "^5.0.5",
-		"@suzumina.click/shared-types": "workspace:*",
-		"googleapis": "^173.0.0"
+		"@googleapis/youtube": "^33.0.0",
+		"@suzumina.click/shared-types": "workspace:*"
 	},
 	"devDependencies": {
 		"@suzumina.click/typescript-config": "workspace:*",

--- a/apps/functions/scripts/build.mjs
+++ b/apps/functions/scripts/build.mjs
@@ -22,7 +22,7 @@ const buildOptions = {
 	minify: !watch,
 	conditions: ["import", "node"],
 	mainFields: ["module", "main"],
-	external: ["googleapis", "@google-cloud/firestore", "@google-cloud/functions-framework"],
+	external: ["@googleapis/youtube", "@google-cloud/firestore", "@google-cloud/functions-framework"],
 	logLevel: "info",
 	legalComments: "none",
 };

--- a/apps/functions/src/endpoints/index.ts
+++ b/apps/functions/src/endpoints/index.ts
@@ -10,6 +10,7 @@
 import * as functions from "@google-cloud/functions-framework";
 // 適切なロギング
 import * as logger from "../shared/logger";
+import { logRuntimeMemoryLimits } from "../shared/memory-diagnostics";
 import type { MessagePublishedData } from "../shared/pubsub-utils";
 // 各モジュールから関数をインポート（統合アーキテクチャ）
 import { checkDataIntegrity } from "./data-integrity/check-data-integrity";
@@ -29,6 +30,10 @@ export function initializeApplication(): boolean {
 
 		// 基本的な初期化処理
 		// 注意: 個別モジュール固有の初期化は各モジュールで行う
+
+		// SPR-277: この時点で全モジュールの読み込みが済んでいる＝cold start のベースラインと
+		// V8 に見えている上限が確定している。3関数とも同じバンドルなのでここで一括して出す。
+		logRuntimeMemoryLimits();
 
 		// 初期化完了
 		initialized = true;

--- a/apps/functions/src/endpoints/youtube/__tests__/fetch-youtube-videos.test.ts
+++ b/apps/functions/src/endpoints/youtube/__tests__/fetch-youtube-videos.test.ts
@@ -5,7 +5,7 @@
  * dlsite/fetch-dlsite-unified-data.test.tsと同様のパターンでエンドポイントの分岐を検証する。
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../infrastructure/database/firestore", () => {

--- a/apps/functions/src/endpoints/youtube/fetch-youtube-videos.ts
+++ b/apps/functions/src/endpoints/youtube/fetch-youtube-videos.ts
@@ -7,6 +7,7 @@
 
 import type { CloudEvent } from "@google-cloud/functions-framework";
 import * as logger from "../../shared/logger";
+import { logRunMemoryUsage } from "../../shared/memory-diagnostics";
 import { decodePubsubMode, type MessagePublishedData } from "../../shared/pubsub-utils";
 import { updateMetadata } from "./fetch-metadata";
 import { type FetchMode, fetchYouTubeVideosLogic } from "./run-video-fetch";
@@ -22,6 +23,9 @@ export const fetchYouTubeVideos = async (
 ): Promise<void> => {
 	logger.info("fetchYouTubeVideos 関数を開始しました (GCFv2 CloudEvent Handler)");
 
+	// SPR-277: メモリ使用量ログ（finally）でモード別に集計するため try の外で保持する
+	let fetchMode: FetchMode = "normal";
+
 	try {
 		// CloudEvent（Pub/Sub）の場合
 		logger.info("Pub/Subトリガーからの実行を検出しました");
@@ -33,7 +37,7 @@ export const fetchYouTubeVideos = async (
 
 		// SPR-230/SPR-263: ペイロードのmodeを確認し、実行モードを判定する
 		const decodedMode = decodePubsubMode(event.data);
-		const fetchMode: FetchMode =
+		fetchMode =
 			decodedMode === "weekly_full_sweep" || decodedMode === "fast_recheck"
 				? decodedMode
 				: "normal";
@@ -69,5 +73,9 @@ export const fetchYouTubeVideos = async (
 		} catch (updateError) {
 			logger.error("エラー状態の記録に失敗しました:", updateError);
 		}
+	} finally {
+		// SPR-277: run 完了時のメモリ使用量を必ず記録する。ウォームインスタンスでしか
+		// 観測できないため、成功した run だけに絞ると蓄積の主因を取り逃がす
+		logRunMemoryUsage(fetchMode);
 	}
 };

--- a/apps/functions/src/endpoints/youtube/playlist-mapping.ts
+++ b/apps/functions/src/endpoints/youtube/playlist-mapping.ts
@@ -5,7 +5,7 @@
  * プレイリストタグ付与を担う。通常 run と fast_recheck の両方から使われる。
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { getJSTDate } from "../../services/price-history";
 import { fetchChannelPlaylists, fetchPlaylistItems } from "../../services/youtube/youtube-api";
 import {

--- a/apps/functions/src/endpoints/youtube/run-video-fetch.ts
+++ b/apps/functions/src/endpoints/youtube/run-video-fetch.ts
@@ -7,7 +7,7 @@
  * `fetchYouTubeVideosLogic` が呼ばれる。
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { Timestamp } from "../../infrastructure/database/firestore";
 import { getJSTDate } from "../../services/price-history";
 import { RECENT_WINDOW_DAYS } from "../../services/youtube/video-tiering";

--- a/apps/functions/src/endpoints/youtube/video-discovery.ts
+++ b/apps/functions/src/endpoints/youtube/video-discovery.ts
@@ -5,7 +5,7 @@
  * 取りこぼし検知（週次フルスイープ）、fast_recheck 向けの軽量新着発見を担う。
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import {
 	fetchUploadsPlaylistId,
 	fetchUploadsPlaylistPage,

--- a/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/video-mapper.test.ts
@@ -1,4 +1,4 @@
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { describe, expect, it, vi } from "vitest";
 import { mapYouTubeToVideoPlainObject, VideoMapper } from "../video-mapper";
 

--- a/apps/functions/src/services/mappers/video-mapper.ts
+++ b/apps/functions/src/services/mappers/video-mapper.ts
@@ -5,10 +5,9 @@
  * This is a simplified version that works with plain objects instead of entities.
  */
 
+import type { youtube_v3 } from "@googleapis/youtube";
 import type { VideoPlainObject } from "@suzumina.click/shared-types";
 import { parseDurationToSeconds } from "@suzumina.click/shared-types";
-
-import type { youtube_v3 } from "googleapis";
 import * as logger from "../../shared/logger";
 
 /**

--- a/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-api-quota.test.ts
@@ -1,4 +1,4 @@
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // quota monitor をモックして quota 充足/不足の両分岐を検証する

--- a/apps/functions/src/services/youtube/__tests__/youtube-api.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-api.test.ts
@@ -1,4 +1,4 @@
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as youtubeApi from "../youtube-api";
 
@@ -7,7 +7,7 @@ interface VideoListResponse {
 	data: youtube_v3.Schema$VideoListResponse;
 }
 
-// googleapisのモック
+// @googleapis/youtubeのモック
 const mockYoutubeVideosList = vi.fn();
 const mockYoutubeClient = {
 	videos: {
@@ -15,10 +15,8 @@ const mockYoutubeClient = {
 	},
 };
 
-vi.mock("googleapis", () => ({
-	google: {
-		youtube: vi.fn().mockImplementation(() => mockYoutubeClient),
-	},
+vi.mock("@googleapis/youtube", () => ({
+	youtube: vi.fn().mockImplementation(() => mockYoutubeClient),
 }));
 
 // logger関数のモック

--- a/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
+++ b/apps/functions/src/services/youtube/__tests__/youtube-firestore.test.ts
@@ -2,7 +2,7 @@
  * YouTube Firestore Service Tests
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SUZUKA_MINASE_CHANNEL_ID } from "../../../shared/common";
 

--- a/apps/functions/src/services/youtube/youtube-api.ts
+++ b/apps/functions/src/services/youtube/youtube-api.ts
@@ -1,5 +1,9 @@
-import type { youtube_v3 } from "googleapis";
-import { google } from "googleapis";
+// SPR-277: umbrella の `googleapis` ではなく分割パッケージを使う（戻すと本番が壊れる）。
+// `googleapis` の index は全 Google API を eager に require する自動生成ファイルで、
+// これ1行で cold start の rss が +115MB（実測 215MB → 100MB）増える。
+// 256Mi 時代の fetchYouTubeVideos は起動直後で使用率 0.86 に張り付き OOM した。
+// 型（youtube_v3）も同じパッケージから取る＝`googleapis` への依存自体を残さない。
+import { youtube as createYouTubeClient, type youtube_v3 } from "@googleapis/youtube";
 import { getYouTubeConfig } from "../../infrastructure/management/config-manager";
 import {
 	canExecuteOperation,
@@ -35,7 +39,7 @@ export function initializeYouTubeClient(): [
 	}
 
 	// YouTubeクライアント初期化
-	const youtube = google.youtube({
+	const youtube = createYouTubeClient({
 		version: "v3",
 		auth: apiKey,
 	});

--- a/apps/functions/src/services/youtube/youtube-firestore.ts
+++ b/apps/functions/src/services/youtube/youtube-firestore.ts
@@ -5,8 +5,8 @@
  * 新規データには_v2Migrationフラグを自動付与
  */
 
+import type { youtube_v3 } from "@googleapis/youtube";
 import { videoToFirestore } from "@suzumina.click/shared-types";
-import type { youtube_v3 } from "googleapis";
 import firestore, { Timestamp } from "../../infrastructure/database/firestore";
 import { chunkArray } from "../../shared/array-utils";
 import { SUZUKA_MINASE_CHANNEL_ID } from "../../shared/common";

--- a/apps/functions/src/shared/__tests__/memory-diagnostics.test.ts
+++ b/apps/functions/src/shared/__tests__/memory-diagnostics.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../logger", () => ({
+	debug: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+}));
+
+const { logRunMemoryUsage, logRuntimeMemoryLimits, resetRunCountForTest } = await import(
+	"../memory-diagnostics"
+);
+const logger = await import("../logger");
+
+describe("memory-diagnostics", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		resetRunCountForTest();
+		process.env.FUNCTION_TARGET = "fetchYouTubeVideos";
+	});
+
+	describe("logRuntimeMemoryLimits", () => {
+		it("V8のヒープ上限と容器の制約を数値（MB）で出力する", () => {
+			logRuntimeMemoryLimits();
+
+			expect(logger.info).toHaveBeenCalledWith(
+				"Node.js runtime memory limits",
+				expect.objectContaining({
+					metric_type: "runtime_memory_limits",
+					function_target: "fetchYouTubeVideos",
+				}),
+			);
+
+			const payload = vi.mocked(logger.info).mock.calls[0]?.[1] as Record<string, unknown>;
+			// log-basedメトリクスで数値比較する契約のため、文字列化して出さない
+			expect(typeof payload.heap_size_limit_mb).toBe("number");
+			expect(payload.heap_size_limit_mb).toBeGreaterThan(0);
+			expect(typeof payload.constrained_memory_mb).toBe("number");
+			expect(typeof payload.available_memory_mb).toBe("number");
+		});
+
+		it("FUNCTION_TARGET未設定でも落ちずにunknownを出す", () => {
+			delete process.env.FUNCTION_TARGET;
+
+			logRuntimeMemoryLimits();
+
+			expect(logger.info).toHaveBeenCalledWith(
+				"Node.js runtime memory limits",
+				expect.objectContaining({ function_target: "unknown" }),
+			);
+		});
+	});
+
+	describe("logRunMemoryUsage", () => {
+		it("run毎のメモリ使用量とモードを出力する", () => {
+			logRunMemoryUsage("fast_recheck");
+
+			const payload = vi.mocked(logger.info).mock.calls[0]?.[1] as Record<string, unknown>;
+			expect(vi.mocked(logger.info).mock.calls[0]?.[0]).toBe("Run memory usage");
+			expect(payload.metric_type).toBe("run_memory_usage");
+			expect(payload.mode).toBe("fast_recheck");
+			expect(typeof payload.rss_mb).toBe("number");
+			expect(payload.rss_mb).toBeGreaterThan(0);
+			expect(typeof payload.heap_used_mb).toBe("number");
+			expect(typeof payload.heap_total_mb).toBe("number");
+			expect(typeof payload.external_mb).toBe("number");
+			expect(typeof payload.array_buffers_mb).toBe("number");
+			expect(typeof payload.uptime_sec).toBe("number");
+		});
+
+		it("run_indexがインスタンス内で単調増加する（増加をrun回数で回帰するための軸）", () => {
+			logRunMemoryUsage("normal");
+			logRunMemoryUsage("normal");
+			logRunMemoryUsage("weekly_full_sweep");
+
+			const runIndexes = vi
+				.mocked(logger.info)
+				.mock.calls.map((call) => (call[1] as Record<string, unknown>).run_index);
+
+			expect(runIndexes).toEqual([1, 2, 3]);
+		});
+	});
+});

--- a/apps/functions/src/shared/memory-diagnostics.ts
+++ b/apps/functions/src/shared/memory-diagnostics.ts
@@ -1,0 +1,86 @@
+/**
+ * メモリ診断ログ（SPR-277）
+ *
+ * 目的は2つで、どちらも「本番のウォームインスタンスでしか観測できない」ものを可視化する。
+ *
+ *   1. **V8 が容器サイズを見ているか**（cold start 時に1回）。`--max-old-space-size` 未指定のとき
+ *      V8 は cgroup 上限ではなくホストの物理メモリからヒープ上限を決めることがある。その場合
+ *      「使用量が容器上限に迫っても V8 は余裕があると判断して full GC を急がない」ため、RSS が
+ *      単調に伸びてコンテナ側に殺される。`heap_size_limit_mb` が容器サイズ（512Mi）を大きく
+ *      超えていればこれが起きている＝`NODE_OPTIONS=--max-old-space-size` の設定が是正手段になる。
+ *   2. **増加が run 回数に比例するか、経過時間に比例するか**（run ごと）。`run_index` は
+ *      このインスタンスで何回目の run かを表すため、`rss_mb` を run_index で回帰すれば
+ *      「run あたり何 MB 増えるか」が直接出る。`uptime_sec` と併せて見ることで、
+ *      run 起因（処理が残す何か）と時間起因（アイドル中も伸びる何か）を切り分けられる。
+ *
+ * ここは**診断専用**でアラートは持たない（使用率のアラートは SPR-235 の
+ * `YouTube Function Memory Pressure` が Cloud Run のメトリクスから既に見ている）。
+ *
+ * 数値キーを英語にしているのは §1 の「監視の契約になるキーは英語」に従うため。
+ * log-based メトリクス化するときにそのままフィルタ・数値比較の対象にできる。
+ */
+
+import { getHeapStatistics } from "node:v8";
+import * as logger from "./logger";
+
+const BYTES_PER_MB = 1024 * 1024;
+
+/** このインスタンスが処理した run の回数（プロセス生存中のみ単調増加する有界なカウンタ） */
+let runCount = 0;
+
+function toMb(bytes: number): number {
+	return Math.round((bytes / BYTES_PER_MB) * 10) / 10;
+}
+
+/**
+ * V8 / プロセスに見えているメモリ上限を1回だけログに出す（cold start 診断）
+ *
+ * `constrained_memory_mb` が 0 のときは cgroup 上限を検出できていない＝V8 はホストの
+ * 物理メモリを基準にヒープを設計している。この値と `heap_size_limit_mb` の組み合わせが
+ * 「GC 圧が掛からないまま RSS が伸びる」仮説の判定材料になる。
+ */
+export function logRuntimeMemoryLimits(): void {
+	const constrainedMemory = process.constrainedMemory?.() ?? 0;
+
+	logger.info("Node.js runtime memory limits", {
+		metric_type: "runtime_memory_limits",
+		heap_size_limit_mb: toMb(getHeapStatistics().heap_size_limit),
+		constrained_memory_mb: toMb(constrainedMemory),
+		available_memory_mb: toMb(process.availableMemory?.() ?? 0),
+		function_target: process.env.FUNCTION_TARGET ?? "unknown",
+	});
+}
+
+/**
+ * run 完了時のメモリ使用量をログに出す
+ *
+ * 成功・失敗どちらの経路でも必ず出す（失敗した run だけが何かを残している可能性を
+ * 潰せなくなるため）。呼び出し側は finally から呼ぶ。
+ *
+ * @param mode run の実行モード（normal / fast_recheck / weekly_full_sweep など）。
+ *   モードごとに処理量が違うため、混ぜたまま回帰すると傾きがぼやける
+ */
+export function logRunMemoryUsage(mode: string): void {
+	runCount += 1;
+	const usage = process.memoryUsage();
+
+	logger.info("Run memory usage", {
+		metric_type: "run_memory_usage",
+		mode,
+		run_index: runCount,
+		uptime_sec: Math.round(process.uptime()),
+		rss_mb: toMb(usage.rss),
+		heap_used_mb: toMb(usage.heapUsed),
+		heap_total_mb: toMb(usage.heapTotal),
+		external_mb: toMb(usage.external),
+		array_buffers_mb: toMb(usage.arrayBuffers),
+		function_target: process.env.FUNCTION_TARGET ?? "unknown",
+	});
+}
+
+/**
+ * テスト用に run カウンタをリセットする（本番コードでは使用しない）
+ */
+export function resetRunCountForTest(): void {
+	runCount = 0;
+}

--- a/apps/functions/src/tools/backfill-missing-videos.ts
+++ b/apps/functions/src/tools/backfill-missing-videos.ts
@@ -10,7 +10,7 @@
  * 「uploadsPlaylistのみに存在する件数」と一致する固定リスト。
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import {
 	fetchChannelPlaylists,
 	fetchPlaylistItems,

--- a/apps/functions/src/tools/backfill-video-status.ts
+++ b/apps/functions/src/tools/backfill-video-status.ts
@@ -15,7 +15,7 @@
  * 保有）。ここで正しく再計算せず放置すると新しいバグを生む。
  */
 
-import type { youtube_v3 } from "googleapis";
+import type { youtube_v3 } from "@googleapis/youtube";
 import firestore from "../infrastructure/database/firestore";
 import {
 	fetchChannelPlaylists,

--- a/apps/functions/vitest.config.ts
+++ b/apps/functions/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
 		exclude: ["node_modules/**", "lib/**"],
 		server: {
 			deps: {
-				external: ["googleapis"],
+				external: ["@googleapis/youtube"],
 				inline: ["cheerio", "css-select", "css-what", "cheerio-select", "domutils", "boolbase"],
 			},
 		},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,12 +65,12 @@ importers:
       '@google-cloud/functions-framework':
         specifier: ^5.0.5
         version: 5.0.5(supports-color@10.2.2)
+      '@googleapis/youtube':
+        specifier: ^33.0.0
+        version: 33.0.0(supports-color@10.2.2)
       '@suzumina.click/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
-      googleapis:
-        specifier: ^173.0.0
-        version: 173.0.0(supports-color@10.2.2)
     devDependencies:
       '@suzumina.click/typescript-config':
         specifier: workspace:*
@@ -833,6 +833,10 @@ packages:
     resolution: {integrity: sha512-/w+OB1MxJux1uO9KRud4CRPLouaB7bZcy0v6STfFVh7yqafZ1L5coWIpseoKPLUgyNfawyoEfE2mEBDRZNGL2w==}
     engines: {node: '>=10.0.0'}
     hasBin: true
+
+  '@googleapis/youtube@33.0.0':
+    resolution: {integrity: sha512-PW3SdoZ8ULzW0We0lgplyZHjuXJtOdRvU5RL6ErNUlcTeSqjoHtk1pWdHKTwk3brPuIiqUB26K7fX84VroDqRg==}
+    engines: {node: '>=12.0.0'}
 
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
@@ -3088,10 +3092,6 @@ packages:
     resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
     engines: {node: '>=18.0.0'}
 
-  googleapis@173.0.0:
-    resolution: {integrity: sha512-xEJJYLZ4qeenVyfzispNfRjCe9bsv7CzBv5zYFLvScOze9snJ8S9W6hjQ729CWPQt5mvn/JrcRaCHzQiukt0ng==}
-    engines: {node: '>=18'}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -5092,6 +5092,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@googleapis/youtube@33.0.0(supports-color@10.2.2)':
+    dependencies:
+      googleapis-common: 8.0.1(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
@@ -7043,13 +7049,6 @@ snapshots:
       google-auth-library: 10.6.1(supports-color@10.2.2)
       qs: 6.15.2
       url-template: 2.0.8
-    transitivePeerDependencies:
-      - supports-color
-
-  googleapis@173.0.0(supports-color@10.2.2):
-    dependencies:
-      google-auth-library: 10.6.1(supports-color@10.2.2)
-      googleapis-common: 8.0.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
# fix(functions): googleapis umbrella import を撤去しメモリ診断ログを追加 (SPR-277)

## 要件

[SPR-277](https://linear.app/nothink/issue/SPR-277) の調査結果と、その第一の是正。

### 調査でわかったこと

`fetchYouTubeVideos` が 256Mi 時代に OOM した主因は、**run をまたいで蓄積するデータ構造ではなく cold start のベースライン**だった。`import { google } from "googleapis"` は全 Google API を eager に `require` する自動生成 index を読み込むため、**モジュールを読んだだけで上限の 84% を消費**していた。

疑っていた蓄積源はいずれも否定された:

| 候補 | 判定 | 根拠 |
| --- | --- | --- |
| `YouTubeQuotaMonitor` シングルトン | 有界 | カウンタ + 固定キーの `operationCount` |
| playlist→video マッピング | 非保持 | `Map` は run ローカル。実体は Firestore キャッシュ |
| run 毎の `google.youtube()` 生成 | リークではない | 600 回生成 + GC で **+0.2KB/client**（完全回収） |
| タイマー / リスナー / global | 皆無 | `setInterval` / `process.on` / `globalThis` の使用ゼロ |

### 変更1: `googleapis` → `@googleapis/youtube`

公式分割パッケージに置換し、`googleapis` への依存自体を除去した（型の `youtube_v3` も同パッケージから取る）。

デプロイ成果物 `lib/index.js` を実際に require した実測:

| | 変更前 | 変更後 | 差分 |
| --- | --- | --- | --- |
| cold start rss | 215.1 MB | **100.3 MB** | **-114.8 MB (-53%)** |
| heapUsed | 82.9 MB | 23.3 MB | -72% |
| heapTotal | 206.0 MB | 53.1 MB | -74% |
| node_modules 実サイズ | 202 MB | **1.7 MB** | -99% |

512Mi 換算でベースラインの utilization が約 0.42 → 0.20 に下がる。3関数は同一バンドルなので `fetchDLsiteUnifiedData` / `checkDataIntegrity` にも同じだけ効く。

デプロイは `apps/functions/package.json` をコピーして `pnpm install --prod` する構成のため、ワークフローの変更は不要。

### 変更2: メモリ診断ログ（SPR-277 step 2）

ウォームインスタンスでしか観測できないものを本番で切り分けるための計器。アラートは持たない（使用率のアラートは SPR-235 の `YouTube Function Memory Pressure` が既に見ている）。

- **cold start に1回** … `heap_size_limit_mb` / `constrained_memory_mb` / `available_memory_mb`。`--max-old-space-size` 未指定のとき V8 は cgroup 上限ではなくホストの物理メモリからヒープ上限を決めることがあり、その場合「容器上限に迫っても V8 は余裕があると判断して full GC を急がない」ため RSS が単調に伸びる。容器サイズを大きく超える値が出れば `NODE_OPTIONS` の設定が是正手段になる
- **run 完了ごと** … `rss_mb` / `heap_used_mb` / `run_index` / `uptime_sec` / `mode`。`run_index` で回帰すれば「run あたり何 MB 増えるか」が直接出る。`uptime_sec` と併せて run 起因か時間起因かを切り分けられる。成功・失敗どちらの経路でも出す（`finally`）

数値キーを英語にしているのは CLAUDE.md §1 の「監視の契約になるキーは英語」に従うため（log-based メトリクス化時にそのままフィルタ・数値比較の対象にできる）。

## テスト項目

- [x] `pnpm verify` exit 0（functions 494 passed / 1 skipped、lint・typecheck・カバレッジ閾値すべて通過）
- [x] **本物の YouTube API への疎通確認**: 読み取り専用の `channels.list`（1 unit・Firestore 非接触）で `uploadsPlaylistId = UUhiMMOhl6FpzjoRqvZ5rcaA` を取得成功。型が通っただけでなく API キー認証の実行経路が動くことを確認
- [x] ビルド後の `lib/index.js` の `require` が external 3つ（`@google-cloud/firestore` / `@google-cloud/functions-framework` / `@googleapis/youtube`）のみであることを確認
- [x] cold start ログの実出力を確認（ローカルでは `heap_size_limit_mb: 4288` / `constrained_memory_mb: 0`）
- [x] `pnpm install --frozen-lockfile` が通ることを確認
- [ ] **デプロイ後の本番観測**: 新インスタンスの `runtime_memory_limits` でベースライン低下と `heap_size_limit_mb` の実値を確認し、`run_memory_usage` の `run_index` vs `rss_mb` で傾きが残るかを追う

## 補足

Firestore スキーマ・認可・Terraform・CI いずれにも触れないため Two-Way Door（revert 1回で戻せる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
