### PR TITLE
feat(web): 作成画面に探索レーンと作成済み/下書きマークを追加 (SPR-289)

### DIFF
--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -9,6 +9,7 @@ import { AlertCircle, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getMyButtonDrafts } from "@/actions/button-drafts";
+import { getAudioButtonsList } from "@/app/buttons/actions";
 import { getVideoById } from "@/app/videos/actions";
 import { AudioButtonCreator } from "@/components/audio/audio-button-creator";
 import ProtectedRoute from "@/components/system/protected-route";
@@ -166,18 +167,25 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	// フォールバック: 取得失敗時は10分
 	const videoDuration = videoDurationSeconds > 0 ? videoDurationSeconds : 600;
 
-	// 下書き起点のときだけ同一動画の下書きキューを渡す（連続仕上げ・SPR-266）。
-	// getMyButtonDrafts は未ログイン時に success:false を返すだけなので ProtectedRoute の外で呼んでも安全
-	let videoDrafts: AudioButtonDraft[] | undefined;
-	if (resolvedSearchParams.draft_id) {
-		// 既定 limit=100 だと下書き多数のユーザーでキューが黙って欠けるため、保持上限の500で全件取る
-		const draftsResult = await getMyButtonDrafts(500);
-		if (draftsResult.success) {
-			videoDrafts = draftsResult.data
+	// 探索レーンの目印用に、この動画の作成済みボタンと自分の下書きを取得する（SPR-289）。
+	// getMyButtonDrafts は未ログイン時に success:false を返すだけなので ProtectedRoute の外で呼んでも安全。
+	// 下書きは既定 limit=100 だと多数保持ユーザーで黙って欠けるため、保持上限の500で全件取る
+	const [buttonsResult, draftsResult] = await Promise.all([
+		getAudioButtonsList({ videoId, onlyPublic: true, limit: 1000 }),
+		getMyButtonDrafts(500),
+	]);
+	const madeMarks = buttonsResult.success
+		? buttonsResult.data.audioButtons.map((button) => button.startTime)
+		: [];
+	const myVideoDrafts: AudioButtonDraft[] = draftsResult.success
+		? draftsResult.data
 				.filter((draft) => draft.videoId === videoId)
-				.sort((a, b) => a.suggestedStartTime - b.suggestedStartTime);
-		}
-	}
+				.sort((a, b) => a.suggestedStartTime - b.suggestedStartTime)
+		: [];
+	const draftMarks = myVideoDrafts.map((draft) => draft.suggestedStartTime);
+	// 連続仕上げキュー（SPR-266）に使うのは下書き起点で開いたときだけ。
+	// 常に渡すと通常作成でも成功時にキューへ進んでしまい遷移挙動が変わる（一般化は SPR-290）
+	const videoDrafts = resolvedSearchParams.draft_id ? myVideoDrafts : undefined;
 
 	const callbackQuery = new URLSearchParams(
 		Object.entries({
@@ -202,6 +210,8 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 				initialStartTime={startTime}
 				draftId={resolvedSearchParams.draft_id}
 				videoDrafts={videoDrafts}
+				madeMarks={madeMarks}
+				draftMarks={draftMarks}
 			/>
 		</ProtectedRoute>
 	);

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -130,6 +130,24 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 		});
 	});
 
+	describe("Explore Lane Marks (SPR-289)", () => {
+		it("マークとサマリーカードが表示される", () => {
+			render(<AudioButtonCreator {...defaultProps} madeMarks={[5, 20]} draftMarks={[40]} />);
+
+			expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(2);
+			expect(screen.getAllByTestId("explore-draft-mark")).toHaveLength(1);
+			expect(screen.getByText("この動画からの作成")).toBeInTheDocument();
+			expect(screen.getByText(/作成済み 2個 ・ 下書き 1個/)).toBeInTheDocument();
+		});
+
+		it("マーク未指定（未ログイン相当）でも探索レーンは表示される", () => {
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			expect(screen.getByTestId("clip-explore-lane")).toBeInTheDocument();
+			expect(screen.getByText(/作成済み 0個/)).toBeInTheDocument();
+		});
+	});
+
 	describe("useTimeAdjustment Hook Integration", () => {
 		it("時間調整フックが正常に動作する", async () => {
 			const user = userEvent.setup();

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -557,6 +557,35 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 
 			expect(screen.queryByText("仕上げキュー")).not.toBeInTheDocument();
 		});
+
+		it("作成成功で消化した下書きのマークが探索レーンから消える（SPR-289 レビュー対応）", async () => {
+			const user = userEvent.setup();
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					initialStartTime={30}
+					draftId="draft-1"
+					videoDrafts={[makeDraft("draft-1", 30), makeDraft("draft-2", 120)]}
+					draftMarks={[30, 120]}
+					madeMarks={[500]}
+				/>,
+			);
+
+			expect(screen.getAllByTestId("explore-draft-mark")).toHaveLength(2);
+			expect(screen.getByText(/作成済み 1個 ・ 下書き 2個/)).toBeInTheDocument();
+
+			await createWithTitle(user, "1個目のボタン");
+
+			await waitFor(() => {
+				expect(mockDeleteButtonDraft).toHaveBeenCalledWith("draft-1");
+			});
+			// 消化した draft-1（30秒）のマークが消え、作成済みマークが増える
+			await waitFor(() => {
+				expect(screen.getAllByTestId("explore-draft-mark")).toHaveLength(1);
+			});
+			expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(2);
+			expect(screen.getByText(/作成済み 2個 ・ 下書き 1個/)).toBeInTheDocument();
+		});
 	});
 
 	describe("Accessibility", () => {

--- a/apps/web/src/components/audio/__tests__/clip-explore-lane.test.tsx
+++ b/apps/web/src/components/audio/__tests__/clip-explore-lane.test.tsx
@@ -1,0 +1,102 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClipExploreLane } from "../clip-explore-lane";
+
+/** レーン幅 800px / 動画 13335 秒（3:42:15）で検証。clientX → 時刻は x / 800 * 13335 秒 */
+describe("ClipExploreLane", () => {
+	const defaultProps = {
+		videoDuration: 13335,
+		windowStart: 1920,
+		windowEnd: 1950,
+		madeMarks: [412, 1934, 5210],
+		draftMarks: [4520, 8130],
+		onJump: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+			left: 0,
+			top: 0,
+			right: 800,
+			bottom: 64,
+			width: 800,
+			height: 64,
+			x: 0,
+			y: 0,
+			toJSON: () => ({}),
+		} as DOMRect);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("レーン・窓インジケータ・両端の時刻が描画される", () => {
+		render(<ClipExploreLane {...defaultProps} />);
+
+		expect(screen.getByTestId("clip-explore-lane")).toBeInTheDocument();
+		expect(screen.getByTestId("explore-window")).toBeInTheDocument();
+		expect(screen.getByText("0:00")).toBeInTheDocument();
+		expect(screen.getByText("3:42:15")).toBeInTheDocument();
+	});
+
+	it("時間目盛りが1時間刻みで描画される（3.7時間動画）", () => {
+		render(<ClipExploreLane {...defaultProps} />);
+
+		expect(screen.getByText("1:00:00")).toBeInTheDocument();
+		expect(screen.getByText("2:00:00")).toBeInTheDocument();
+		expect(screen.getByText("3:00:00")).toBeInTheDocument();
+		expect(screen.queryByText("4:00:00")).not.toBeInTheDocument();
+	});
+
+	it("短い動画では10分刻みになる", () => {
+		render(<ClipExploreLane {...defaultProps} videoDuration={3600} />);
+
+		expect(screen.getByText("10:00")).toBeInTheDocument();
+		expect(screen.getByText("30:00")).toBeInTheDocument();
+	});
+
+	it("作成済み・下書きマークが描画される", () => {
+		render(<ClipExploreLane {...defaultProps} />);
+
+		expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(3);
+		expect(screen.getAllByTestId("explore-draft-mark")).toHaveLength(2);
+	});
+
+	it("同一時刻のマークは重複排除される", () => {
+		render(<ClipExploreLane {...defaultProps} madeMarks={[100, 100, 200]} />);
+
+		expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(2);
+	});
+
+	it("マーク未指定でも描画できる（未ログイン・編集画面）", () => {
+		render(
+			<ClipExploreLane
+				videoDuration={13335}
+				windowStart={0}
+				windowEnd={30}
+				onJump={defaultProps.onJump}
+			/>,
+		);
+
+		expect(screen.getByTestId("clip-explore-lane")).toBeInTheDocument();
+		expect(screen.queryAllByTestId("explore-made-mark")).toHaveLength(0);
+	});
+
+	it("クリックでその位置の時刻が onJump に渡る", () => {
+		render(<ClipExploreLane {...defaultProps} />);
+
+		// 400px = 動画のちょうど中央 = 6667.5 秒
+		fireEvent.click(screen.getByTestId("clip-explore-lane"), { clientX: 400 });
+		expect(defaultProps.onJump).toHaveBeenCalledWith(6667.5);
+	});
+
+	it("disabled 時はクリックしても onJump が呼ばれない", () => {
+		render(<ClipExploreLane {...defaultProps} disabled />);
+
+		fireEvent.click(screen.getByTestId("clip-explore-lane"), { clientX: 400 });
+		expect(defaultProps.onJump).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/components/audio/__tests__/time-control-panel.test.tsx
+++ b/apps/web/src/components/audio/__tests__/time-control-panel.test.tsx
@@ -305,6 +305,47 @@ describe("TimeControlPanel", () => {
 		});
 	});
 
+	describe("Explore Lane (SPR-289)", () => {
+		it("探索レーンと凡例が表示される", () => {
+			render(<TimeControlPanel {...defaultProps} madeMarks={[10, 50]} draftMarks={[100]} />);
+
+			expect(screen.getByText("動画全体から探す")).toBeInTheDocument();
+			expect(screen.getByTestId("clip-explore-lane")).toBeInTheDocument();
+			expect(screen.getByText("作成済み 2")).toBeInTheDocument();
+			expect(screen.getByText("下書き 1")).toBeInTheDocument();
+		});
+
+		it("下書きが無いときは下書き凡例を出さない", () => {
+			render(<TimeControlPanel {...defaultProps} madeMarks={[10]} />);
+
+			expect(screen.getByText("作成済み 1")).toBeInTheDocument();
+			expect(screen.queryByText(/下書き/)).not.toBeInTheDocument();
+		});
+
+		it("探索レーンのクリックでクリップが長さを保ったまま移動する", () => {
+			const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+				left: 0,
+				top: 0,
+				right: 800,
+				bottom: 64,
+				width: 800,
+				height: 64,
+				x: 0,
+				y: 0,
+				toJSON: () => ({}),
+			} as DOMRect);
+
+			render(<TimeControlPanel {...defaultProps} startTime={10} endTime={20} />);
+
+			// 400px = 動画(300秒)の中央 150 秒 → 長さ10秒のまま 150-160 へ
+			fireEvent.click(screen.getByTestId("clip-explore-lane"), { clientX: 400 });
+			expect(defaultProps.onSetStartTime).toHaveBeenCalledWith(150);
+			expect(defaultProps.onSetEndTime).toHaveBeenCalledWith(160);
+
+			rectSpy.mockRestore();
+		});
+	});
+
 	describe("I/O Set Buttons", () => {
 		it("開始・終了時間に設定ボタンでコールバックが呼ばれる", async () => {
 			const user = userEvent.setup();

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -30,6 +30,10 @@ interface AudioButtonCreatorProps {
 	 * 作成成功後に遷移せず次の下書きへ進む連続仕上げに使う（SPR-266 第2段）
 	 */
 	videoDrafts?: AudioButtonDraft[];
+	/** この動画の作成済みボタンの開始時刻（探索レーンの目印・SPR-289） */
+	madeMarks?: number[];
+	/** 自分の下書きの開始時刻（探索レーンの目印・SPR-289）。キューとは独立に常時渡る */
+	draftMarks?: number[];
 }
 
 /**
@@ -47,6 +51,8 @@ export function AudioButtonCreator({
 	initialStartTime = 0,
 	draftId,
 	videoDrafts,
+	madeMarks: initialMadeMarks,
+	draftMarks,
 }: AudioButtonCreatorProps) {
 	const router = useRouter();
 	const user = useSession();
@@ -78,6 +84,9 @@ export function AudioButtonCreator({
 		(videoDrafts ?? []).filter((draft) => draft.id !== draftId),
 	);
 	const [lastCreated, setLastCreated] = useState<{ id: string; buttonText: string } | null>(null);
+
+	// 探索レーンの作成済みマーク。作成成功時にその場で追記する（再取得はしない・SPR-289）
+	const [madeMarks, setMadeMarks] = useState<number[]>(() => initialMadeMarks ?? []);
 
 	// 次の下書きへフォームとプレイヤーを進める（遷移なし＝プレイヤー維持が連続仕上げの本体）
 	const { setStartTime, setEndTime } = timeAdjustment;
@@ -145,6 +154,8 @@ export function AudioButtonCreator({
 					videoId,
 					fromDraft: Boolean(activeDraftId),
 				});
+				// 探索レーンへ即時反映（連続作成時に同じ箇所の二重作成を防ぐ）
+				setMadeMarks((prev) => [...prev, input.startTime]);
 				// 下書きから開いた場合は消化（削除）する。ベストエフォート＝失敗してもボタン作成は
 				// 成立しているため遷移を止めない（残った下書きは /live から手動削除できる）。
 				if (activeDraftId) {
@@ -246,6 +257,8 @@ export function AudioButtonCreator({
 									{...timeHandlers}
 									onSeek={youtubeManager.seekTo}
 									audition={audition}
+									madeMarks={madeMarks}
+									draftMarks={draftMarks}
 									isCreating={isCreating}
 								/>
 							</div>
@@ -326,6 +339,15 @@ export function AudioButtonCreator({
 								onTagsChange={setTags}
 								disabled={isCreating}
 							/>
+
+							{/* この動画からの作成サマリー（SPR-289）。本日の作成数の統合はヘッダー簡素化（SPR-290）で行う */}
+							<div className="rounded-lg border bg-minase-100 p-3 text-minase-900">
+								<div className="mb-1 text-xs font-semibold">この動画からの作成</div>
+								<div className="text-xs">
+									作成済み {madeMarks.length}個
+									{(draftMarks?.length ?? 0) > 0 && ` ・ 下書き ${draftMarks?.length}個`}
+								</div>
+							</div>
 						</div>
 
 						<div className="col-span-full flex flex-col gap-4 mt-6 pt-6 border-t">

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -36,6 +36,13 @@ interface AudioButtonCreatorProps {
 	draftMarks?: number[];
 }
 
+/** 同値が複数あっても1件分だけ取り除く（下書きマークは同時刻が並存しうる） */
+function removeOneOccurrence(list: number[], value: number): number[] {
+	const index = list.indexOf(value);
+	if (index === -1) return list;
+	return [...list.slice(0, index), ...list.slice(index + 1)];
+}
+
 /**
  * 音声ボタン作成フォーム。
  * フォーム値（タイトル/説明/タグ/開始・終了時刻）は useState で保持する。
@@ -85,8 +92,10 @@ export function AudioButtonCreator({
 	);
 	const [lastCreated, setLastCreated] = useState<{ id: string; buttonText: string } | null>(null);
 
-	// 探索レーンの作成済みマーク。作成成功時にその場で追記する（再取得はしない・SPR-289）
+	// 探索レーンのマーク。作成成功時にその場で加減する（再取得はしない・SPR-289）。
+	// 下書きマークも state 化しないと、連続仕上げ（遷移なし）で消化した下書きが残って見える
 	const [madeMarks, setMadeMarks] = useState<number[]>(() => initialMadeMarks ?? []);
+	const [draftMarkList, setDraftMarkList] = useState<number[]>(() => draftMarks ?? []);
 
 	// 次の下書きへフォームとプレイヤーを進める（遷移なし＝プレイヤー維持が連続仕上げの本体）
 	const { setStartTime, setEndTime } = timeAdjustment;
@@ -118,6 +127,17 @@ export function AudioButtonCreator({
 			seekTo,
 		],
 	);
+
+	// 下書きの消化: 削除（ベストエフォート）＋探索レーンのマーク除去。
+	// 削除 API の成否に関わらずボタン作成は成立している＝「未処理」表示のまま残すほうが誤誘導になる
+	const consumeActiveDraft = useCallback(async () => {
+		if (!activeDraftId) return;
+		await deleteButtonDraft(activeDraftId).catch(() => undefined);
+		const consumed = videoDrafts?.find((draft) => draft.id === activeDraftId);
+		if (consumed) {
+			setDraftMarkList((prev) => removeOneOccurrence(prev, consumed.suggestedStartTime));
+		}
+	}, [activeDraftId, videoDrafts]);
 
 	// スキップ: 現在の下書きは消化せず（/live から再度仕上げられる）次へ進む
 	const handleSkip = useCallback(() => {
@@ -156,11 +176,8 @@ export function AudioButtonCreator({
 				});
 				// 探索レーンへ即時反映（連続作成時に同じ箇所の二重作成を防ぐ）
 				setMadeMarks((prev) => [...prev, input.startTime]);
-				// 下書きから開いた場合は消化（削除）する。ベストエフォート＝失敗してもボタン作成は
-				// 成立しているため遷移を止めない（残った下書きは /live から手動削除できる）。
-				if (activeDraftId) {
-					await deleteButtonDraft(activeDraftId).catch(() => undefined);
-				}
+				// 下書きから開いた場合は消化する（残った下書きは /live から手動削除できる）
+				await consumeActiveDraft();
 				// 連続仕上げ: 同一動画の下書きが残っていれば遷移せず次へ（プレイヤー維持・SPR-266）
 				const [next, ...rest] = remainingDrafts;
 				if (next) {
@@ -200,6 +217,7 @@ export function AudioButtonCreator({
 		activeDraftId,
 		remainingDrafts,
 		advanceToDraft,
+		consumeActiveDraft,
 	]);
 
 	// 時間調整用のハンドラーは共通フックから取得
@@ -258,7 +276,7 @@ export function AudioButtonCreator({
 									onSeek={youtubeManager.seekTo}
 									audition={audition}
 									madeMarks={madeMarks}
-									draftMarks={draftMarks}
+									draftMarks={draftMarkList}
 									isCreating={isCreating}
 								/>
 							</div>
@@ -345,7 +363,7 @@ export function AudioButtonCreator({
 								<div className="mb-1 text-xs font-semibold">この動画からの作成</div>
 								<div className="text-xs">
 									作成済み {madeMarks.length}個
-									{(draftMarks?.length ?? 0) > 0 && ` ・ 下書き ${draftMarks?.length}個`}
+									{draftMarkList.length > 0 && ` ・ 下書き ${draftMarkList.length}個`}
 								</div>
 							</div>
 						</div>

--- a/apps/web/src/components/audio/clip-explore-lane.tsx
+++ b/apps/web/src/components/audio/clip-explore-lane.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { formatSeconds } from "@/utils/format-seconds";
+
+const roundTenth = (value: number) => Math.round(value * 10) / 10;
+
+/** 目盛り間隔の候補（秒）。ラベルが8本以下に収まる最小の間隔を選ぶ */
+const TICK_STEP_CANDIDATES = [600, 1800, 3600, 7200, 14400];
+const MAX_TICKS = 8;
+
+function pickTickStep(videoDuration: number): number {
+	for (const step of TICK_STEP_CANDIDATES) {
+		if (videoDuration / step <= MAX_TICKS) return step;
+	}
+	return TICK_STEP_CANDIDATES[TICK_STEP_CANDIDATES.length - 1] ?? 14400;
+}
+
+interface ClipExploreLaneProps {
+	videoDuration: number;
+	/** トリムレーンが拡大表示している範囲（窓インジケータの描画用） */
+	windowStart: number;
+	windowEnd: number;
+	/** この動画の作成済みボタンの開始時刻 */
+	madeMarks?: number[];
+	/** 自分の下書きの開始時刻 */
+	draftMarks?: number[];
+	disabled?: boolean;
+	/** クリックでその位置へジャンプ（クリップ移動＋トリムレーン追従は親が行う） */
+	onJump: (time: number) => void;
+}
+
+/**
+ * 動画全体の探索レーン(SPR-289)。
+ * 1px ≈ 十数秒の粗いスケールで「どこを切るか」の当たりをつける段。細部はトリムレーン
+ * （clip-trim-lane）が受け持つ二段スケールの上段。作成済み・下書きの目印で重複作成も防ぐ。
+ */
+export function ClipExploreLane({
+	videoDuration,
+	windowStart,
+	windowEnd,
+	madeMarks = [],
+	draftMarks = [],
+	disabled = false,
+	onJump,
+}: ClipExploreLaneProps) {
+	const positionPercent = (time: number) => (videoDuration > 0 ? (time / videoDuration) * 100 : 0);
+
+	const tickStep = pickTickStep(videoDuration);
+	const ticks: number[] = [];
+	for (let t = tickStep; t < videoDuration; t += tickStep) {
+		ticks.push(t);
+	}
+
+	const windowLeft = Math.max(positionPercent(windowStart), 0);
+	const windowRight = Math.min(positionPercent(windowEnd), 100);
+	const windowCenter = positionPercent((windowStart + windowEnd) / 2);
+
+	// 同一時刻のマークは重なって見分けがつかないため重複排除（key の一意性も兼ねる）
+	const uniqueDraftMarks = [...new Set(draftMarks)];
+	const uniqueMadeMarks = [...new Set(madeMarks)];
+
+	const onLaneClick = (event: React.MouseEvent<HTMLDivElement>) => {
+		if (disabled) return;
+		const rect = event.currentTarget.getBoundingClientRect();
+		if (rect.width <= 0) return;
+		const ratio = (event.clientX - rect.left) / rect.width;
+		onJump(roundTenth(Math.max(0, Math.min(ratio * videoDuration, videoDuration))));
+	};
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: ジャンプはキーボードでは ←→ シークと I/O が同機能を提供する
+		// biome-ignore lint/a11y/noStaticElementInteractions: 目印と窓インジケータを内包する帯のため button にできない。クリックは補助操作
+		<div
+			data-testid="clip-explore-lane"
+			onClick={onLaneClick}
+			className={`relative h-14 overflow-hidden rounded-md bg-muted select-none sm:h-16 ${disabled ? "" : "cursor-pointer"}`}
+		>
+			{ticks.map((t) => (
+				<div key={`tick-${t}`}>
+					<div
+						className="absolute inset-y-0 w-px bg-border"
+						style={{ left: `${positionPercent(t)}%` }}
+					/>
+					<div
+						className="absolute bottom-0.5 hidden translate-x-1 font-mono text-[11px] leading-none text-muted-foreground sm:block"
+						style={{ left: `${positionPercent(t)}%` }}
+					>
+						{formatSeconds(t)}
+					</div>
+				</div>
+			))}
+
+			{/* 下書きマーク（上段） */}
+			{uniqueDraftMarks.map((t) => (
+				<div
+					key={`draft-${t}`}
+					data-testid="explore-draft-mark"
+					className="absolute top-1.5 h-2.5 w-[3px] rounded-full bg-heart"
+					style={{ left: `${positionPercent(t)}%` }}
+				/>
+			))}
+			{/* 作成済みマーク（中段） */}
+			{uniqueMadeMarks.map((t) => (
+				<div
+					key={`made-${t}`}
+					data-testid="explore-made-mark"
+					className="absolute top-5 h-2.5 w-[3px] rounded-full bg-suzuka-600"
+					style={{ left: `${positionPercent(t)}%` }}
+				/>
+			))}
+
+			{/* トリムレーンが拡大中の範囲 */}
+			<div
+				data-testid="explore-window"
+				className="pointer-events-none absolute inset-y-0 rounded-sm border-2 border-foreground bg-foreground/15"
+				style={{
+					left: `${windowLeft}%`,
+					width: `${Math.max(windowRight - windowLeft, 0.4)}%`,
+				}}
+			/>
+			<div
+				className="pointer-events-none absolute top-0 -translate-x-1/2 text-[10px] leading-none text-foreground"
+				style={{ left: `${windowCenter}%` }}
+			>
+				▼
+			</div>
+
+			<div className="pointer-events-none absolute bottom-0.5 left-2 font-mono text-[11px] leading-none text-muted-foreground">
+				0:00
+			</div>
+			<div className="pointer-events-none absolute right-2 bottom-0.5 font-mono text-[11px] leading-none text-muted-foreground">
+				{formatSeconds(videoDuration)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/audio/time-control-panel.tsx
+++ b/apps/web/src/components/audio/time-control-panel.tsx
@@ -9,6 +9,7 @@ import { Input } from "@suzumina.click/ui/components/ui/input";
 import { Clock, MousePointer, Play, Square } from "lucide-react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { matchShortcutKey } from "@/lib/keyboard-shortcut";
+import { ClipExploreLane } from "./clip-explore-lane";
 import { ClipTrimLane } from "./clip-trim-lane";
 
 /** ズーム段階（レーンの片幅・秒） */
@@ -130,6 +131,10 @@ interface TimeControlPanelProps {
 	// 試聴
 	audition: AuditionControls;
 
+	// 探索レーンの目印（SPR-289）。省略時はレーンだけ表示する（編集画面など）
+	madeMarks?: number[];
+	draftMarks?: number[];
+
 	// UI状態
 	isCreating: boolean;
 }
@@ -221,6 +226,8 @@ export function TimeControlPanel({
 	onSetEndTime,
 	onSeek,
 	audition,
+	madeMarks = [],
+	draftMarks = [],
 	isCreating,
 }: TimeControlPanelProps) {
 	const prerollId = useId();
@@ -273,6 +280,19 @@ export function TimeControlPanel({
 		[onSetStartTime, onSetEndTime],
 	);
 
+	// 探索レーンのジャンプ: クリップを長さを保ったままその位置へ動かし、トリムレーンも追従させる。
+	// プレイヤーのシークは editor 側の境界追従（調整のたび自動シーク）に任せる
+	const handleExploreJump = useCallback(
+		(time: number) => {
+			const length = Math.max(roundTenth(endTime - startTime), 1);
+			const nextStart = roundTenth(Math.max(0, Math.min(time, videoDuration - length)));
+			onSetStartTime(nextStart);
+			onSetEndTime(roundTenth(nextStart + length));
+			setViewCenter(clampCenter(nextStart + length / 2, halfWindow));
+		},
+		[startTime, endTime, videoDuration, onSetStartTime, onSetEndTime, clampCenter, halfWindow],
+	);
+
 	return (
 		<div className="space-y-3">
 			{/* 再生位置と I/O 設定 */}
@@ -313,6 +333,36 @@ export function TimeControlPanel({
 							O
 						</kbd>
 					</Button>
+				</div>
+			</div>
+
+			{/* 動画全体の探索レーン（SPR-289） */}
+			<div className="space-y-1.5">
+				<div className="flex items-baseline justify-between gap-2">
+					<span className="text-sm font-medium sm:text-base">動画全体から探す</span>
+					<span className="text-xs text-muted-foreground">クリックでその位置へ</span>
+				</div>
+				<ClipExploreLane
+					videoDuration={videoDuration}
+					windowStart={viewCenter - halfWindow}
+					windowEnd={viewCenter + halfWindow}
+					madeMarks={madeMarks}
+					draftMarks={draftMarks}
+					disabled={isCreating}
+					onJump={handleExploreJump}
+				/>
+				<div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+					{draftMarks.length > 0 && (
+						<span className="flex items-center gap-1 whitespace-nowrap">
+							<span className="inline-block h-2.5 w-1 rounded-full bg-heart" />
+							下書き {draftMarks.length}
+						</span>
+					)}
+					<span className="flex items-center gap-1 whitespace-nowrap">
+						<span className="inline-block h-2.5 w-1 rounded-full bg-suzuka-600" />
+						作成済み {madeMarks.length}
+					</span>
+					<span className="ml-auto whitespace-nowrap">▼ の枠内が下の拡大表示の範囲</span>
 				</div>
 			</div>
 


### PR DESCRIPTION
## 概要

音声ボタン作成画面刷新の第2段（[SPR-289](https://linear.app/nothink/issue/SPR-289/)）。二段スケールの上段＝**動画全体の探索レーン**をトリムレーン（#878 / SPR-288）の上に載せ、**作成済みボタン・自分の下書きの位置**をレーン上に目印表示する。

## 変更内容

### 探索レーン（新規 `clip-explore-lane.tsx`）
- 動画全体（0〜duration）の帯。時間目盛りは本数が8以下に収まる最小刻み（10分/30分/1時間/2時間/4時間）を自動選択
- **クリックでその位置へジャンプ**: クリップを長さを保ったまま移動し、トリムレーンの表示窓も追従。プレイヤーのシークは SPR-288 の境界追従に乗る
- トリムレーンが拡大中の範囲を**窓インジケータ（▼＋枠）**で表示
- モバイルはレーン高さを落とし目盛りラベルを省略（`sm:` ブレークポイント）

### マーク表示
- **作成済み**（suzuka-600）と**下書き**（`bg-heart`・semantic トークン）を色分けした目印＋凡例。重複作成の回避と下書き消化の導線
- 同一時刻のマークは重複排除（key の一意性兼用）
- **作成成功時は即時反映**（連続作成時に同じ箇所の二重作成を防ぐ）

### データ配線（`page.tsx`）
- `getAudioButtonsList({ videoId, onlyPublic: true })` と `getMyButtonDrafts(500)` を並列取得。**いずれも本番稼働中クエリの流用＝新規 Firestore インデックス不要**
- 下書きは draft_id の有無に関わらずマーク用に取得。ただし**連続仕上げキュー（SPR-266）への受け渡しは従来どおり draft_id 起点のみ**（常に渡すと通常作成の遷移挙動が変わるため。一般化は SPR-290）
- 未ログイン時は下書きマークなしで成立（getMyButtonDrafts が success:false を返すだけ）

### サマリーカード
- 右カラムに「この動画からの作成: 作成済み N個 ・ 下書き N個」（minase トーン）を追加
- 本日の作成数（x/110）の統合はヘッダー簡素化とセットのため **SPR-290 で実施**

## 検証

- `pnpm verify` 通過（探索レーンのユニットテスト8件・パネル/creator テスト追加込み）
- Firestore Emulator + 実プレイヤーで実機確認: マーク・凡例・窓インジケータの表示、レーン60%位置クリック → クリップが 1:50:35.8–1:50:45.8 へ長さ維持のまま移動・トリムレーン再中心化・プレイヤー追従シーク

## 区分

Two-Way Door（UI＋既存クエリ流用のみ。サーバ/スキーマ/インデックス変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)