### PR TITLE
feat(web): 作成画面に固定アクションバーと「作成して次を切り抜く」を追加 (SPR-290)

### DIFF
--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -110,7 +110,7 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			expect(screen.getByRole("heading", { name: /音声ボタンを作成/ })).toBeInTheDocument();
 			expect(screen.getByTestId("youtube-player")).toBeInTheDocument();
 			expect(screen.getByTestId("clip-trim-lane")).toBeInTheDocument();
-			expect(screen.getByText("基本情報")).toBeInTheDocument();
+			expect(screen.getByText(/ボタンタイトル/)).toBeInTheDocument();
 		});
 
 		it("全ての子コンポーネントが存在する", () => {
@@ -121,12 +121,90 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			expect(screen.getByText("開始時間に設定")).toBeInTheDocument();
 			expect(screen.getByText("終了時間に設定")).toBeInTheDocument();
 
-			// Basic Info Panel
+			// Basic Info Panel（説明は既定で折りたたまれている・SPR-290）
 			expect(screen.getByPlaceholderText("例: おはようございます")).toBeInTheDocument();
-			expect(screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）")).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: /説明を追加/ })).toBeInTheDocument();
 
 			// Usage Guide
 			expect(screen.getByText("動画を見ながら範囲を決めてください")).toBeInTheDocument();
+		});
+	});
+
+	describe("固定アクションバー・作成して次を切り抜く (SPR-290)", () => {
+		it("押せない理由がバーに表示され、入力すると消える", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			expect(screen.getByText("タイトルを入力すると作成できます")).toBeInTheDocument();
+
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), "タイトル");
+			const timeInputs = screen.getAllByPlaceholderText("0:00.0");
+			await user.clear(timeInputs[1]!);
+			await user.type(timeInputs[1]!, "0:05.0");
+			await user.tab();
+
+			await waitFor(() => {
+				expect(screen.queryByText("タイトルを入力すると作成できます")).not.toBeInTheDocument();
+			});
+		});
+
+		it("作成して次を切り抜く: 遷移せずタイトルだけリセットして残留する", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} madeMarks={[500]} />);
+
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), "連続作成ボタン");
+			const timeInputs = screen.getAllByPlaceholderText("0:00.0");
+			await user.clear(timeInputs[1]!);
+			await user.type(timeInputs[1]!, "0:05.0");
+			await user.tab();
+
+			const continueButton = screen.getByRole("button", { name: "作成して次を切り抜く" });
+			await waitFor(() => expect(continueButton).toBeEnabled());
+			await user.click(continueButton);
+
+			// 遷移せず残留し、タイトルはリセット・時刻は維持
+			await waitFor(() => {
+				expect(screen.getByText(/「連続作成ボタン」を作成しました/)).toBeInTheDocument();
+			});
+			expect(mockPush).not.toHaveBeenCalled();
+			expect(window.location.href).not.toContain("/buttons/new-audio-button-id");
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
+			expect(screen.getByDisplayValue("0:05.0")).toBeInTheDocument();
+			// 作成済みマークが即時反映される（500 と 0 の2箇所）
+			expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(2);
+		});
+
+		it("下書きキュー進行中は「作成して次を切り抜く」を出さない（作成自体が次へ進む）", () => {
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					draftId="draft-1"
+					videoDrafts={[
+						{
+							id: "draft-1",
+							videoId: "test-video-id",
+							videoTitle: "テスト動画タイトル",
+							playerTime: 45,
+							markedAt: "2026-07-15T12:00:00.000Z",
+							createdAt: "2026-07-15T12:00:00.000Z",
+							suggestedStartTime: 30,
+						},
+						{
+							id: "draft-2",
+							videoId: "test-video-id",
+							videoTitle: "テスト動画タイトル",
+							playerTime: 135,
+							markedAt: "2026-07-15T12:00:00.000Z",
+							createdAt: "2026-07-15T12:00:00.000Z",
+							suggestedStartTime: 120,
+						},
+					]}
+				/>,
+			);
+
+			expect(
+				screen.queryByRole("button", { name: "作成して次を切り抜く" }),
+			).not.toBeInTheDocument();
 		});
 	});
 

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -174,6 +174,51 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(2);
 		});
 
+		it("下書き起点の最後の1件を continue で仕上げたら activeDraftId がクリアされる（AIレビュー対応）", async () => {
+			const user = userEvent.setup();
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					initialStartTime={30}
+					draftId="draft-1"
+					videoDrafts={[
+						{
+							id: "draft-1",
+							videoId: "test-video-id",
+							videoTitle: "テスト動画タイトル",
+							playerTime: 45,
+							markedAt: "2026-07-15T12:00:00.000Z",
+							createdAt: "2026-07-15T12:00:00.000Z",
+							suggestedStartTime: 30,
+						},
+					]}
+					draftMarks={[30]}
+				/>,
+			);
+
+			// 1回目: 下書きを continue で仕上げる → 消化される
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), "下書きから作成");
+			const continueButton = screen.getByRole("button", { name: "作成して次を切り抜く" });
+			await waitFor(() => expect(continueButton).toBeEnabled());
+			await user.click(continueButton);
+
+			await waitFor(() => {
+				expect(mockDeleteButtonDraft).toHaveBeenCalledTimes(1);
+			});
+			await waitFor(() => {
+				expect(screen.queryAllByTestId("explore-draft-mark")).toHaveLength(0);
+			});
+
+			// 2回目: 同じ画面で続けて作成 → もう下書き由来ではない＝再削除されない
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), "続けて作成");
+			await user.click(screen.getByRole("button", { name: "作成して次を切り抜く" }));
+
+			await waitFor(() => {
+				expect(screen.getByText(/「続けて作成」を作成しました/)).toBeInTheDocument();
+			});
+			expect(mockDeleteButtonDraft).toHaveBeenCalledTimes(1);
+		});
+
 		it("下書きキュー進行中は「作成して次を切り抜く」を出さない（作成自体が次へ進む）", () => {
 			render(
 				<AudioButtonCreator
@@ -252,16 +297,17 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 
 			render(<AudioButtonCreator {...defaultProps} />);
 
-			// Wait for player to be ready
+			// プレイヤー ready（モックは 10ms 遅延で onReady）を待ってからクリックする。
+			// ready 前にクリックすると youtubePlayerRef が null で currentTime(0) にフォールバックし
+			// 恒久的に失敗する（ready 後は 100ms ポーリングが getCurrentTime を呼ぶ＝ready の観測点）
 			await waitFor(() => {
-				expect(screen.getByRole("button", { name: /開始時間に設定/ })).toBeInTheDocument();
+				expect(mockYouTubePlayer.getCurrentTime).toHaveBeenCalled();
 			});
 
 			const setStartTimeButton = screen.getByRole("button", { name: /開始時間に設定/ });
 			await user.click(setStartTimeButton);
 
 			await waitFor(() => {
-				expect(mockYouTubePlayer.getCurrentTime).toHaveBeenCalled();
 				expect(screen.getByDisplayValue("0:10.5")).toBeInTheDocument();
 			});
 		});

--- a/apps/web/src/components/audio/__tests__/basic-info-panel.test.tsx
+++ b/apps/web/src/components/audio/__tests__/basic-info-panel.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BasicInfoPanel } from "../basic-info-panel";
@@ -29,6 +29,11 @@ vi.mock("../audio-button-tag-editor", () => ({
 	),
 }));
 
+/** 折りたたまれた説明入力を開く（SPR-290: 既定は畳まれている） */
+function openDescription() {
+	fireEvent.click(screen.getByRole("button", { name: /説明を追加/ }));
+}
+
 describe("BasicInfoPanel", () => {
 	const defaultProps = {
 		title: "",
@@ -48,10 +53,11 @@ describe("BasicInfoPanel", () => {
 		it("コンポーネントが正常にレンダリングされる", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
 
-			expect(screen.getByText("基本情報")).toBeInTheDocument();
 			expect(screen.getByLabelText(/ボタンタイトル/)).toBeInTheDocument();
-			expect(screen.getByLabelText(/説明（任意）/)).toBeInTheDocument();
 			expect(screen.getByTestId("tag-editor")).toBeInTheDocument();
+			// 説明は既定で折りたたまれている（SPR-290）
+			expect(screen.getByRole("button", { name: /説明を追加/ })).toBeInTheDocument();
+			expect(screen.queryByLabelText(/説明（任意）/)).not.toBeInTheDocument();
 		});
 
 		it("必須マークが正しく表示される", () => {
@@ -64,6 +70,7 @@ describe("BasicInfoPanel", () => {
 
 		it("入力フィールドが適切な属性を持つ", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const titleInput = screen.getByPlaceholderText("例: おはようございます");
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
@@ -126,6 +133,7 @@ describe("BasicInfoPanel", () => {
 			const props = { ...defaultProps, onDescriptionChange };
 
 			render(<BasicInfoPanel {...props} />);
+			openDescription();
 
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
 			await user.type(descriptionInput, "テスト説明文");
@@ -156,15 +164,33 @@ describe("BasicInfoPanel", () => {
 		});
 
 		it("説明文入力が無効化状態を反映する", () => {
-			const props = { ...defaultProps, disabled: true };
+			// 初期値があると開いた状態で始まる（編集画面相当）
+			const props = { ...defaultProps, description: "既存", disabled: true };
 			render(<BasicInfoPanel {...props} />);
 
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
 			expect(descriptionInput).toBeDisabled();
 		});
 
+		it("説明は既定で折りたたまれ、ボタンで開ける", () => {
+			render(<BasicInfoPanel {...defaultProps} />);
+
+			expect(
+				screen.queryByPlaceholderText("音声ボタンの詳細説明を入力（任意）"),
+			).not.toBeInTheDocument();
+			openDescription();
+			expect(screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）")).toBeInTheDocument();
+		});
+
+		it("disabled 中は説明を開くボタンも無効", () => {
+			render(<BasicInfoPanel {...defaultProps} disabled />);
+
+			expect(screen.getByRole("button", { name: /説明を追加/ })).toBeDisabled();
+		});
+
 		it("テキストエリアのリサイズが無効化されている", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
 			expect(descriptionInput).toHaveClass("resize-none");
@@ -212,6 +238,7 @@ describe("BasicInfoPanel", () => {
 
 		it("説明文の最大文字数制限が適用される", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
 			expect(descriptionInput).toHaveAttribute("maxLength", "500");
@@ -237,6 +264,7 @@ describe("BasicInfoPanel", () => {
 	describe("Accessibility", () => {
 		it("ラベルとフィールドが適切に関連付けられている", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const titleInput = screen.getByLabelText(/ボタンタイトル/);
 			const descriptionInput = screen.getByLabelText(/説明（任意）/);
@@ -247,6 +275,7 @@ describe("BasicInfoPanel", () => {
 
 		it("適切なフォームラベルが設定されている", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			expect(screen.getByText("ボタンタイトル")).toBeInTheDocument();
 			expect(screen.getByText("説明（任意）")).toBeInTheDocument();
@@ -254,6 +283,7 @@ describe("BasicInfoPanel", () => {
 
 		it("適切なIDが設定されている", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const titleInput = screen.getByPlaceholderText("例: おはようございます");
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
@@ -266,6 +296,7 @@ describe("BasicInfoPanel", () => {
 	describe("Responsive Design", () => {
 		it("レスポンシブテキストクラスが適用されている", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const titleInput = screen.getByPlaceholderText("例: おはようございます");
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");
@@ -276,6 +307,7 @@ describe("BasicInfoPanel", () => {
 
 		it("レスポンシブラベルクラスが適用されている", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			const titleLabel = screen.getByText("ボタンタイトル").closest("label");
 			const descriptionLabel = screen.getByText("説明（任意）").closest("label");
@@ -298,6 +330,7 @@ describe("BasicInfoPanel", () => {
 	describe("Edge Cases", () => {
 		it("空文字での文字数カウンターが正しく動作する", () => {
 			render(<BasicInfoPanel {...defaultProps} />);
+			openDescription();
 
 			expect(screen.getByText("0/100")).toBeInTheDocument();
 			expect(screen.getByText("0/500")).toBeInTheDocument();
@@ -385,6 +418,7 @@ describe("BasicInfoPanel", () => {
 			const props = { ...defaultProps, onTitleChange, onDescriptionChange };
 
 			render(<BasicInfoPanel {...props} />);
+			openDescription();
 
 			const titleInput = screen.getByPlaceholderText("例: おはようございます");
 			const descriptionInput = screen.getByPlaceholderText("音声ボタンの詳細説明を入力（任意）");

--- a/apps/web/src/components/audio/__tests__/creation-action-bar.test.tsx
+++ b/apps/web/src/components/audio/__tests__/creation-action-bar.test.tsx
@@ -1,0 +1,83 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CreationActionBar } from "../creation-action-bar";
+
+describe("CreationActionBar", () => {
+	const defaultProps = {
+		startTime: 65.5,
+		endTime: 75.5,
+		disabledReason: null,
+		isCreating: false,
+		showContinue: true,
+		onCancel: vi.fn(),
+		onCreate: vi.fn(),
+		onCreateAndContinue: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("開始・終了・長さが表示される", () => {
+		render(<CreationActionBar {...defaultProps} />);
+
+		expect(screen.getByText("1:05.5")).toBeInTheDocument();
+		expect(screen.getByText("1:15.5")).toBeInTheDocument();
+		expect(screen.getByText("10.0秒")).toBeInTheDocument();
+	});
+
+	it("無効な範囲では長さが — になる", () => {
+		render(<CreationActionBar {...defaultProps} startTime={10} endTime={5} />);
+
+		expect(screen.getByText("—")).toBeInTheDocument();
+	});
+
+	it("押せない理由があると表示され、作成系ボタンが無効になる", () => {
+		render(
+			<CreationActionBar {...defaultProps} disabledReason="タイトルを入力すると作成できます" />,
+		);
+
+		expect(screen.getByText("タイトルを入力すると作成できます")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /音声ボタンを作成/ })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "作成して次を切り抜く" })).toBeDisabled();
+		// キャンセルは押せる
+		expect(screen.getByRole("button", { name: "キャンセル" })).toBeEnabled();
+	});
+
+	it("理由が無ければ表示されず、作成ボタンが有効", () => {
+		render(<CreationActionBar {...defaultProps} />);
+
+		expect(screen.queryByText(/作成できます/)).not.toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /音声ボタンを作成/ })).toBeEnabled();
+	});
+
+	it("showContinue=false では「作成して次を切り抜く」を出さない", () => {
+		render(<CreationActionBar {...defaultProps} showContinue={false} />);
+
+		expect(screen.queryByRole("button", { name: "作成して次を切り抜く" })).not.toBeInTheDocument();
+	});
+
+	it("作成中は全ボタンが無効になり「作成中...」表示になる", () => {
+		render(<CreationActionBar {...defaultProps} isCreating />);
+
+		expect(screen.getByRole("button", { name: /作成中/ })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "キャンセル" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "作成して次を切り抜く" })).toBeDisabled();
+	});
+
+	it("各ボタンでコールバックが呼ばれる", async () => {
+		const user = userEvent.setup();
+		render(<CreationActionBar {...defaultProps} />);
+
+		await user.click(screen.getByRole("button", { name: "キャンセル" }));
+		expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+
+		await user.click(screen.getByRole("button", { name: "作成して次を切り抜く" }));
+		expect(defaultProps.onCreateAndContinue).toHaveBeenCalledTimes(1);
+
+		await user.click(screen.getByRole("button", { name: /音声ボタンを作成/ }));
+		expect(defaultProps.onCreate).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -47,8 +47,9 @@ function removeOneOccurrence(list: number[], value: number): number[] {
 /**
  * 音声ボタン作成フォーム。
  * フォーム値（タイトル/説明/タグ/開始・終了時刻）は useState で保持する。
- * 作成成功・キャンセルはいずれも create セグメント外（詳細ページ / 戻り先）へ遷移するため
- * この instance は unmount され、次に作成画面へ来たときは必ずまっさらに mount される。
+ * 「作成」・キャンセルは create セグメント外（詳細ページ / 戻り先）へ遷移して instance が
+ * unmount される。一方「作成して次を切り抜く」と下書きキュー進行（SPR-266/290）は遷移せず
+ * 残留するため、フォーム値のリセットは finishAfterCreate / advanceToDraft が明示的に行う。
  * 同一セグメントを別動画で再訪したときの値残留は page 側の `key`（videoId+startTime）で
  * remount して防ぐ（apps/web/src/app/buttons/create/page.tsx）。
  */
@@ -165,7 +166,10 @@ export function AudioButtonCreator({
 			}
 			if (continueAfter) {
 				// 遷移せず同じ画面で次の切り抜きへ。時刻とプレイヤーは維持し、テキストだけ空にする
-				// （次の切り抜き位置は探索レーンやシークで選ぶ想定）
+				// （次の切り抜き位置は探索レーンやシークで選ぶ想定）。
+				// 下書き起点で来ていた場合もここで下書きは消化済み＝以降の作成は下書き由来ではない。
+				// クリアしないと fromDraft の誤記録と消化済み下書きの再削除・マーク誤除去が起きる
+				setActiveDraftId(undefined);
 				setLastCreated({ id: createdId, buttonText: createdText });
 				setButtonText("");
 				setDescription("");

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -3,7 +3,7 @@
 import type { AudioButtonDraft, CreateAudioButtonInput } from "@suzumina.click/shared-types";
 import { YouTubePlayer } from "@suzumina.click/ui/components/custom/youtube-player";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { ExternalLink, Loader2, Plus, SkipForward } from "lucide-react";
+import { ExternalLink, SkipForward } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { deleteButtonDraft } from "@/actions/button-drafts";
@@ -14,6 +14,7 @@ import { useSession } from "@/lib/auth/client";
 import { formatSeconds } from "@/utils/format-seconds";
 import { BasicInfoPanel } from "./basic-info-panel";
 import { CreateButtonLimit } from "./create-button-limit";
+import { CreationActionBar } from "./creation-action-bar";
 import { MetaSuggestionPanel } from "./meta-suggestion-panel";
 import { TimeControlPanel } from "./time-control-panel";
 import { UsageGuide } from "./usage-guide";
@@ -147,96 +148,118 @@ export function AudioButtonCreator({
 		advanceToDraft(next);
 	}, [remainingDrafts, advanceToDraft]);
 
-	// 作成処理
-	const handleCreate = useCallback(async () => {
-		if (!isValid) return;
-
-		setIsCreating(true);
-		setError("");
-		trackCreateStart(videoId, Boolean(activeDraftId));
-
-		try {
-			const input: CreateAudioButtonInput = {
-				videoId: videoId,
-				videoTitle: videoTitle,
-				buttonText: buttonText.trim(),
-				tags,
-				startTime: timeAdjustment.startTime,
-				endTime: timeAdjustment.endTime,
-				isPublic: true,
-			};
-
-			const result = await createAudioButton(input);
-
-			if (result.success) {
-				trackCreateSuccess({
-					audioButtonId: result.data.id,
-					videoId,
-					fromDraft: Boolean(activeDraftId),
-				});
-				// 探索レーンへ即時反映（連続作成時に同じ箇所の二重作成を防ぐ）
-				setMadeMarks((prev) => [...prev, input.startTime]);
-				// 下書きから開いた場合は消化する（残った下書きは /live から手動削除できる）
-				await consumeActiveDraft();
-				// 連続仕上げ: 同一動画の下書きが残っていれば遷移せず次へ（プレイヤー維持・SPR-266）
-				const [next, ...rest] = remainingDrafts;
-				if (next) {
-					setLastCreated({ id: result.data.id, buttonText: buttonText.trim() });
-					setRemainingDrafts(rest);
-					advanceToDraft(next);
-					setIsCreating(false);
-					return;
-				}
-				// 詳細ページへフルロード遷移（SPR-252）。router.push だと /buttons ツリー内の soft nav が
-				// @modal にインターセプトされ、作成フォームの上にクイックビューが重なってしまう
-				// （フォーム instance も破棄されず「作成中…」が固着する）。フルロードなら
-				// フル詳細ページ表示と instance 破棄の両方が保証される。
-				// 遷移完了まで「作成中…」を維持し、フォームを空白化しない（ちらつき防止）。
-				window.location.href = `/buttons/${result.data.id}`;
+	// 作成成功後の行き先を1箇所に集約:
+	// 1) 下書きキューが残っていれば次へ（SPR-266） 2) 「作成して次を切り抜く」なら残留（SPR-290）
+	// 3) それ以外は詳細ページへフルロード遷移（SPR-252。router.push だと /buttons ツリー内の
+	//    soft nav が @modal にインターセプトされフォームの上にクイックビューが重なる。
+	//    遷移完了まで「作成中…」を維持し、フォームを空白化しない＝ちらつき防止）
+	const finishAfterCreate = useCallback(
+		(createdId: string, createdText: string, continueAfter: boolean) => {
+			const [next, ...rest] = remainingDrafts;
+			if (next) {
+				setLastCreated({ id: createdId, buttonText: createdText });
+				setRemainingDrafts(rest);
+				advanceToDraft(next);
+				setIsCreating(false);
 				return;
 			}
+			if (continueAfter) {
+				// 遷移せず同じ画面で次の切り抜きへ。時刻とプレイヤーは維持し、テキストだけ空にする
+				// （次の切り抜き位置は探索レーンやシークで選ぶ想定）
+				setLastCreated({ id: createdId, buttonText: createdText });
+				setButtonText("");
+				setDescription("");
+				setTags([]);
+				setIsCreating(false);
+				return;
+			}
+			window.location.href = `/buttons/${createdId}`;
+		},
+		[remainingDrafts, advanceToDraft, setIsCreating, setButtonText, setDescription, setTags],
+	);
 
-			trackCreateError(videoId, result.error || "unknown");
-			setError(result.error || "作成に失敗しました");
-			setIsCreating(false);
-		} catch (_error) {
-			trackCreateError(videoId, "unexpected");
-			setError("予期しないエラーが発生しました");
-			setIsCreating(false);
-		}
-	}, [
-		isValid,
-		videoId,
-		buttonText,
-		tags,
-		timeAdjustment.startTime,
-		timeAdjustment.endTime,
-		setIsCreating,
-		setError,
-		videoTitle,
-		activeDraftId,
-		remainingDrafts,
-		advanceToDraft,
-		consumeActiveDraft,
-	]);
+	// 作成処理。continueAfter=true は「作成して次を切り抜く」（SPR-290）
+	const handleCreate = useCallback(
+		async (continueAfter: boolean) => {
+			if (!isValid) return;
 
-	// 時間調整用のハンドラーは共通フックから取得
+			setIsCreating(true);
+			setError("");
+			trackCreateStart(videoId, Boolean(activeDraftId));
+
+			try {
+				const input: CreateAudioButtonInput = {
+					videoId: videoId,
+					videoTitle: videoTitle,
+					buttonText: buttonText.trim(),
+					tags,
+					startTime: timeAdjustment.startTime,
+					endTime: timeAdjustment.endTime,
+					isPublic: true,
+				};
+
+				const result = await createAudioButton(input);
+
+				if (result.success) {
+					trackCreateSuccess({
+						audioButtonId: result.data.id,
+						videoId,
+						fromDraft: Boolean(activeDraftId),
+					});
+					// 探索レーンへ即時反映（連続作成時に同じ箇所の二重作成を防ぐ）
+					setMadeMarks((prev) => [...prev, input.startTime]);
+					// 下書きから開いた場合は消化する（残った下書きは /live から手動削除できる）
+					await consumeActiveDraft();
+					finishAfterCreate(result.data.id, input.buttonText, continueAfter);
+					return;
+				}
+
+				trackCreateError(videoId, result.error || "unknown");
+				setError(result.error || "作成に失敗しました");
+				setIsCreating(false);
+			} catch (_error) {
+				trackCreateError(videoId, "unexpected");
+				setError("予期しないエラーが発生しました");
+				setIsCreating(false);
+			}
+		},
+		[
+			isValid,
+			videoId,
+			buttonText,
+			tags,
+			timeAdjustment.startTime,
+			timeAdjustment.endTime,
+			setIsCreating,
+			setError,
+			videoTitle,
+			activeDraftId,
+			consumeActiveDraft,
+			finishAfterCreate,
+		],
+	);
+
+	// 作成できない理由（固定バーに併記する。disabled ボタンは tooltip が出ないため文言で示す）
+	const disabledReason =
+		validation.errors.title === "タイトルを入力してください"
+			? "タイトルを入力すると作成できます"
+			: (validation.errors.title ??
+				validation.errors.timeRange ??
+				validation.errors.duration ??
+				validation.errors.tags ??
+				validation.errors.description ??
+				null);
 
 	return (
-		<div className="min-h-screen bg-background">
+		<div className="min-h-screen bg-background flex flex-col">
 			<div className="container mx-auto px-4 py-6">
-				<div className="mb-6">
-					<div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
-						<div>
-							<h1 className="text-2xl font-bold mb-2">音声ボタンを作成</h1>
-							<p className="text-muted-foreground text-sm">動画: {videoTitle}</p>
-						</div>
-						{user?.discordId && (
-							<div className="sm:min-w-[280px]">
-								<CreateButtonLimit userId={user.discordId} />
-							</div>
-						)}
-					</div>
+				{/* ヘッダーは1行に簡素化（SPR-290）。作成数はサマリーカード側（右カラム）へ */}
+				<div className="mb-4 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+					<h1 className="text-xl sm:text-2xl font-bold">音声ボタンを作成</h1>
+					<p className="min-w-0 flex-1 truncate text-sm text-muted-foreground">{videoTitle}</p>
+					<span className="text-xs text-muted-foreground whitespace-nowrap">
+						{formatSeconds(youtubeManager.videoDuration || videoDuration)}
+					</span>
 				</div>
 
 				{error && (
@@ -333,21 +356,6 @@ export function AudioButtonCreator({
 								</div>
 							)}
 
-							<MetaSuggestionPanel
-								videoId={videoId}
-								startTime={timeAdjustment.startTime}
-								endTime={timeAdjustment.endTime}
-								disabled={isCreating}
-								currentTags={tags}
-								onSelectTitle={setButtonText}
-								onAddTag={(tag) => {
-									// バリデーション上限（10個）内でのみ追加。重複はパネル側で disabled 済み
-									if (!tags.includes(tag) && tags.length < 10) {
-										setTags([...tags, tag]);
-									}
-								}}
-							/>
-
 							<BasicInfoPanel
 								title={buttonText}
 								description={description}
@@ -356,9 +364,26 @@ export function AudioButtonCreator({
 								onDescriptionChange={setDescription}
 								onTagsChange={setTags}
 								disabled={isCreating}
+								metaSuggestion={
+									<MetaSuggestionPanel
+										videoId={videoId}
+										startTime={timeAdjustment.startTime}
+										endTime={timeAdjustment.endTime}
+										disabled={isCreating}
+										currentTags={tags}
+										onSelectTitle={setButtonText}
+										onAddTag={(tag) => {
+											// バリデーション上限（10個）内でのみ追加。重複はパネル側で disabled 済み
+											if (!tags.includes(tag) && tags.length < 10) {
+												setTags([...tags, tag]);
+											}
+										}}
+									/>
+								}
 							/>
 
-							{/* この動画からの作成サマリー（SPR-289）。本日の作成数の統合はヘッダー簡素化（SPR-290）で行う */}
+							{/* ヘッダーから移した作成上限と、この動画からのサマリー（SPR-289/290） */}
+							{user?.discordId && <CreateButtonLimit userId={user.discordId} />}
 							<div className="rounded-lg border bg-minase-100 p-3 text-minase-900">
 								<div className="mb-1 text-xs font-semibold">この動画からの作成</div>
 								<div className="text-xs">
@@ -367,42 +392,21 @@ export function AudioButtonCreator({
 								</div>
 							</div>
 						</div>
-
-						<div className="col-span-full flex flex-col gap-4 mt-6 pt-6 border-t">
-							<div className="flex flex-col sm:flex-row gap-3 w-full lg:justify-end">
-								<Button
-									variant="outline"
-									onClick={() => {
-										router.back();
-									}}
-									disabled={isCreating}
-									className="w-full sm:w-auto min-h-[44px] order-2 sm:order-1"
-								>
-									キャンセル
-								</Button>
-								<Button
-									onClick={handleCreate}
-									disabled={!isValid || isCreating}
-									className="w-full sm:w-auto min-h-[44px] h-11 sm:h-12 px-6 sm:px-8 order-1 sm:order-2"
-									size="lg"
-								>
-									{isCreating ? (
-										<>
-											<Loader2 className="h-4 w-4 mr-2 animate-spin" />
-											作成中...
-										</>
-									) : (
-										<>
-											<Plus className="h-4 w-4 mr-2" />
-											音声ボタンを作成
-										</>
-									)}
-								</Button>
-							</div>
-						</div>
 					</div>
 				</div>
 			</div>
+
+			{/* 固定アクションバー（SPR-290）。ラッパーで包むと sticky の可動域が潰れるため直下に置く */}
+			<CreationActionBar
+				startTime={timeAdjustment.startTime}
+				endTime={timeAdjustment.endTime}
+				disabledReason={disabledReason}
+				isCreating={isCreating}
+				showContinue={remainingDrafts.length === 0}
+				onCancel={() => router.back()}
+				onCreate={() => handleCreate(false)}
+				onCreateAndContinue={() => handleCreate(true)}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/components/audio/basic-info-panel.tsx
+++ b/apps/web/src/components/audio/basic-info-panel.tsx
@@ -2,7 +2,8 @@
 
 import { Input } from "@suzumina.click/ui/components/ui/input";
 import { Textarea } from "@suzumina.click/ui/components/ui/textarea";
-import { useId } from "react";
+import { Plus } from "lucide-react";
+import { type ReactNode, useId, useState } from "react";
 import { AudioButtonTagEditor } from "./audio-button-tag-editor";
 
 interface BasicInfoPanelProps {
@@ -13,8 +14,15 @@ interface BasicInfoPanelProps {
 	onDescriptionChange: (description: string) => void;
 	onTagsChange: (tags: string[]) => void;
 	disabled?: boolean;
+	/** タイトル入力の直下に埋め込む AI候補ブロック（作成画面のみ・SPR-290） */
+	metaSuggestion?: ReactNode;
 }
 
+/**
+ * 基本情報の入力群（SPR-290 でカード分割）。
+ * タイトル（+AI候補）・タグ・説明の3カード構成。説明は使用頻度が低いため
+ * 折りたたみで畳んでおき、初期値があるとき（編集画面）は開いた状態で始める。
+ */
 export function BasicInfoPanel({
 	title,
 	description,
@@ -23,53 +31,71 @@ export function BasicInfoPanel({
 	onDescriptionChange,
 	onTagsChange,
 	disabled = false,
+	metaSuggestion,
 }: BasicInfoPanelProps) {
 	const titleId = useId();
 	const descriptionId = useId();
+	// 一度開いたら閉じない（畳み直す動機がなく、閉じると入力済みの値が見えなくなるため）。
+	// 初期値があるとき（編集画面）は開いた状態で始める
+	const [isDescriptionOpen, setIsDescriptionOpen] = useState(() => (description || "").length > 0);
 
 	return (
-		<div className="bg-card border rounded-lg p-4 lg:p-6 shadow-sm">
-			<h3 className="text-lg font-semibold mb-4">基本情報</h3>
-			<div className="space-y-4">
-				{/* タイトル入力 */}
-				<div className="space-y-2">
-					<label htmlFor={titleId} className="text-sm sm:text-base font-medium">
-						ボタンタイトル <span className="text-destructive">*</span>
-					</label>
-					<Input
-						id={titleId}
-						value={title || ""}
-						onChange={(e) => onTitleChange(e.target.value)}
-						placeholder="例: おはようございます"
-						maxLength={100}
-						disabled={disabled}
-						className="text-base min-h-[44px]"
-					/>
-					<p className="text-xs sm:text-sm text-muted-foreground">{(title || "").length}/100</p>
-				</div>
+		<div className="space-y-4">
+			{/* タイトル */}
+			<div className="bg-card border rounded-lg p-4 shadow-sm space-y-2">
+				<label htmlFor={titleId} className="text-sm sm:text-base font-medium">
+					ボタンタイトル <span className="text-destructive">*</span>
+				</label>
+				<Input
+					id={titleId}
+					value={title || ""}
+					onChange={(e) => onTitleChange(e.target.value)}
+					placeholder="例: おはようございます"
+					maxLength={100}
+					disabled={disabled}
+					className="text-base min-h-[44px]"
+				/>
+				<p className="text-xs sm:text-sm text-muted-foreground">{(title || "").length}/100</p>
+				{metaSuggestion}
+			</div>
 
-				{/* 説明文入力 */}
-				<div className="space-y-2">
-					<label htmlFor={descriptionId} className="text-sm sm:text-base font-medium">
-						説明（任意）
-					</label>
-					<Textarea
-						id={descriptionId}
-						value={description || ""}
-						onChange={(e) => onDescriptionChange(e.target.value)}
-						placeholder="音声ボタンの詳細説明を入力（任意）"
-						maxLength={500}
-						disabled={disabled}
-						rows={3}
-						className="text-base resize-none"
-					/>
-					<p className="text-xs sm:text-sm text-muted-foreground">
-						{(description || "").length}/500
-					</p>
-				</div>
-
-				{/* タグ入力 */}
+			{/* タグ */}
+			<div className="bg-card border rounded-lg p-4 shadow-sm">
 				<AudioButtonTagEditor tags={tags || []} onTagsChange={onTagsChange} disabled={disabled} />
+			</div>
+
+			{/* 説明: 折りたたみ（任意項目のため既定は畳む） */}
+			<div className="bg-card border rounded-lg shadow-sm">
+				{isDescriptionOpen ? (
+					<div className="p-4 space-y-2">
+						<label htmlFor={descriptionId} className="text-sm sm:text-base font-medium">
+							説明（任意）
+						</label>
+						<Textarea
+							id={descriptionId}
+							value={description || ""}
+							onChange={(e) => onDescriptionChange(e.target.value)}
+							placeholder="音声ボタンの詳細説明を入力（任意）"
+							maxLength={500}
+							disabled={disabled}
+							rows={3}
+							className="text-base resize-none"
+						/>
+						<p className="text-xs sm:text-sm text-muted-foreground">
+							{(description || "").length}/500
+						</p>
+					</div>
+				) : (
+					<button
+						type="button"
+						onClick={() => setIsDescriptionOpen(true)}
+						disabled={disabled}
+						className="flex min-h-[44px] w-full items-center justify-between px-4 py-3 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+					>
+						説明を追加（任意）
+						<Plus className="h-4 w-4" />
+					</button>
+				)}
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/audio/creation-action-bar.tsx
+++ b/apps/web/src/components/audio/creation-action-bar.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { formatTimestamp } from "@suzumina.click/shared-types";
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { ChevronRight, Loader2, Plus } from "lucide-react";
+
+const roundTenth = (value: number) => Math.round(value * 10) / 10;
+
+interface CreationActionBarProps {
+	startTime: number;
+	endTime: number;
+	/** 作成できない理由（null なら作成可能）。disabled ボタンは tooltip が出ないため文言で併記する */
+	disabledReason: string | null;
+	isCreating: boolean;
+	/**
+	 * 「作成して次を切り抜く」を出すか。下書きキュー進行中（SPR-266）は
+	 * 「作成」自体が次へ進むため出さない
+	 */
+	showContinue: boolean;
+	onCancel: () => void;
+	onCreate: () => void;
+	onCreateAndContinue: () => void;
+}
+
+/**
+ * 作成画面の固定アクションバー（SPR-290）。
+ * 選択範囲と作成ボタンを常時視界に置き、押せないときは理由を隣に出す
+ * （共有 Button の disabled は pointer-events-none で title tooltip が効かない）。
+ */
+export function CreationActionBar({
+	startTime,
+	endTime,
+	disabledReason,
+	isCreating,
+	showContinue,
+	onCancel,
+	onCreate,
+	onCreateAndContinue,
+}: CreationActionBarProps) {
+	const duration = roundTenth(endTime - startTime);
+	const canCreate = disabledReason === null;
+
+	return (
+		// mt-auto: 親（flex-col）の末尾で、短いページでも下端に付ける
+		<div className="sticky bottom-0 z-10 mt-auto border-t bg-card shadow-lg">
+			<div className="container mx-auto flex flex-wrap items-center gap-x-4 gap-y-2 px-4 py-3">
+				<div className="flex items-baseline gap-2">
+					<span className="font-mono text-sm font-semibold text-primary sm:text-base">
+						{formatTimestamp(startTime)}
+					</span>
+					<ChevronRight className="h-3.5 w-3.5 self-center text-muted-foreground" />
+					<span className="font-mono text-sm font-semibold text-primary sm:text-base">
+						{formatTimestamp(endTime)}
+					</span>
+					<span className="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary whitespace-nowrap">
+						{duration > 0 ? `${duration.toFixed(1)}秒` : "—"}
+					</span>
+				</div>
+
+				{!canCreate && <span className="text-sm text-destructive">{disabledReason}</span>}
+
+				<div className="ml-auto flex items-center gap-2 sm:gap-3">
+					<Button variant="ghost" onClick={onCancel} disabled={isCreating} className="min-h-[44px]">
+						キャンセル
+					</Button>
+					{showContinue && (
+						<Button
+							variant="outline"
+							onClick={onCreateAndContinue}
+							disabled={!canCreate || isCreating}
+							className="hidden min-h-[44px] whitespace-nowrap sm:inline-flex"
+						>
+							作成して次を切り抜く
+						</Button>
+					)}
+					<Button
+						onClick={onCreate}
+						disabled={!canCreate || isCreating}
+						size="lg"
+						className="min-h-[44px] px-5 sm:px-8"
+					>
+						{isCreating ? (
+							<>
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								作成中...
+							</>
+						) : (
+							<>
+								<Plus className="mr-2 h-4 w-4" />
+								音声ボタンを作成
+							</>
+						)}
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/audio/meta-suggestion-panel.tsx
+++ b/apps/web/src/components/audio/meta-suggestion-panel.tsx
@@ -19,7 +19,8 @@ interface MetaSuggestionPanelProps {
 }
 
 /**
- * 選択区間から buttonText・タグ候補を生成して提示するパネル（SPR-148 Phase 1）。
+ * 選択区間から buttonText・タグ候補を生成して提示するブロック（SPR-148 Phase 1）。
+ * SPR-290 で独立カードからタイトル入力直下の埋め込みに変更（BasicInfoPanel の metaSuggestion）。
  * 候補はクリックで入力欄へ反映する提案であって自動上書きはしない。
  * 生成失敗時も手入力フローには影響しない（graceful degradation）。
  */
@@ -73,12 +74,12 @@ export function MetaSuggestionPanel({
 	);
 
 	return (
-		<div className="bg-card border rounded-lg p-4 lg:p-6 shadow-sm">
-			<div className="flex items-center justify-between gap-2 mb-2">
-				<h3 className="text-lg font-semibold flex items-center gap-2">
+		<div className="border-t pt-3">
+			<div className="flex items-center justify-between gap-2 mb-1">
+				<span className="text-sm font-medium flex items-center gap-1.5">
 					<Sparkles className="h-4 w-4 text-primary" />
 					AI候補
-				</h3>
+				</span>
 				<Button
 					size="sm"
 					variant="outline"
@@ -98,7 +99,7 @@ export function MetaSuggestionPanel({
 					)}
 				</Button>
 			</div>
-			<p className="text-xs text-muted-foreground mb-3">
+			<p className="text-xs text-muted-foreground mb-2">
 				選択中の区間の発話からタイトル・タグ候補を生成します（10秒ほどかかります）
 			</p>
 


### PR DESCRIPTION
## 概要

音声ボタン作成画面刷新の第3段・最終（[SPR-290](https://linear.app/nothink/issue/SPR-290/)）。#878（トリムレーン）・#879（探索レーン）に続き、**作成導線と右カラム**を整理して3段構成を完成させる。

## 変更内容

### 固定アクションバー（新規 `creation-action-bar.tsx`）
- sticky 下端バーに開始→終了＋長さを常時表示。**押せない理由を文言で併記**（例:「タイトルを入力すると作成できます」。共有 Button の disabled は pointer-events-none で tooltip が出ない既知の罠への対処）。理由は `useAudioButtonValidation` の errors から導出
- キャンセル（ghost）／作成して次を切り抜く（outline・モバイルでは非表示に縮退）／音声ボタンを作成（primary）
- sticky はラッパーで包むと可動域が潰れるため flex-col 直下に配置（`mt-auto` で短いページでも下端）

### 「作成して次を切り抜く」の一般化
- 下書きキューがなくても、作成成功後に**遷移せず残留**してテキストだけリセット（時刻・プレイヤー維持）。次の切り抜き位置は探索レーンやシークで選ぶ想定。作成済みマークは即時反映（#879）
- 作成後の行き先分岐を `finishAfterCreate` に集約: キュー進行（SPR-266）→ 残留（本 PR）→ フルロード遷移（SPR-252 の判断維持）
- **キュー進行中は continue ボタンを出さない**（「作成」自体が次へ進むため二重の導線になる）

### 右カラム整理
- AI候補（SPR-148 MetaSuggestionPanel）を独立カードからタイトル入力直下の埋め込みへ（ボタン文言・挙動・トラッキングは不変）
- タグを独立カード化、説明は「説明を追加（任意）」の折りたたみに（初期値ありのとき＝編集画面は開いた状態で開始。上限500維持）
- ヘッダーを1行に簡素化（タイトル truncate＋動画長）。本日の作成数（CreateButtonLimit）は右カラムのサマリーカード隣へ移動（SPR-289 のカードと同居）

## 検証

- `pnpm verify` 通過（basic-info-panel 折りたたみ・アクションバー・continue フローのテスト追加、全144→150件）
- Emulator + **Playwright 実ブラウザ**で実測: sticky バーが scroll 位置に関わらず下端固定（`pinnedAtTop: true`）・不透明背景・`作成して次を切り抜く` の sm+ 表示・タイトル入力で理由表示が消灯
- 回帰テスト: continue 作成で「遷移せず・タイトルリセット・時刻維持・マーク即時反映」、下書きキュー進行中は continue 非表示

## 区分

Two-Way Door（UI のみ・サーバ/スキーマ/インデックス変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)