### PR TITLE
feat(web): 作成画面にオンデマンド発話文字起こし＋発話スナップ＋タイトル即時プリフィル (SPR-292)

### DIFF
--- a/apps/web/src/actions/__tests__/video-transcription.test.ts
+++ b/apps/web/src/actions/__tests__/video-transcription.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetCurrentUser = vi.fn();
+vi.mock("@/lib/auth/server", () => ({ getCurrentUser: mockGetCurrentUser }));
+
+const mockGenerateClipContent = vi.fn();
+vi.mock("@/lib/gemini/client", () => ({ generateClipContent: mockGenerateClipContent }));
+
+vi.mock("@/lib/logger", () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
+const mockGetFirestore = vi.fn();
+vi.mock("@/lib/firestore", () => ({ getFirestore: mockGetFirestore }));
+
+const { getVideoTranscriptChunk } = await import("../video-transcription");
+
+const VALID_INPUT = { videoId: "97UnRtIlMc0", chunkIndex: 1 };
+
+const GEMINI_TEXT = JSON.stringify({
+	utterances: [
+		{ start: 1.5, end: 3.5, text: "こんにちは" },
+		{ start: 5.0, end: 7.0, text: "今日はゲームやるよ" },
+	],
+});
+
+function setupFirestore({
+	cachedChunk = null,
+	videoDuration = "PT2H23M59S",
+	videoExists = true,
+}: {
+	cachedChunk?: Record<string, unknown> | null;
+	videoDuration?: string;
+	videoExists?: boolean;
+} = {}) {
+	const mockSet = vi.fn(async (_doc: Record<string, unknown>) => undefined);
+	const chunkDoc = {
+		get: vi.fn(async () => ({
+			exists: cachedChunk !== null,
+			data: () => cachedChunk,
+		})),
+		set: mockSet,
+	};
+	const videoDocRef = {
+		get: vi.fn(async () => ({
+			exists: videoExists,
+			data: () => ({ duration: videoDuration }),
+		})),
+		collection: vi.fn(() => ({ doc: vi.fn(() => chunkDoc) })),
+	};
+	mockGetFirestore.mockReturnValue({
+		collection: vi.fn(() => ({ doc: vi.fn(() => videoDocRef) })),
+	});
+	return { mockSet, chunkDoc, videoDocRef };
+}
+
+describe("getVideoTranscriptChunk (SPR-292)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: true });
+		mockGenerateClipContent.mockResolvedValue({ success: true, text: GEMINI_TEXT });
+	});
+
+	it("未ログインは生成せず失敗を返す（認可ゲート正本 = getCurrentUser null チェック）", async () => {
+		setupFirestore();
+		mockGetCurrentUser.mockResolvedValue(null);
+
+		const result = await getVideoTranscriptChunk(VALID_INPUT);
+
+		expect(result).toEqual({ success: false, error: "ログインが必要です" });
+		expect(mockGenerateClipContent).not.toHaveBeenCalled();
+	});
+
+	it("無効ユーザー（isActive=false）はブロックする（外部APIコストが発生するため）", async () => {
+		setupFirestore();
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: false });
+
+		const result = await getVideoTranscriptChunk(VALID_INPUT);
+
+		expect(result.success).toBe(false);
+		expect(mockGenerateClipContent).not.toHaveBeenCalled();
+	});
+
+	it("不正な videoId・チャンク番号は弾く", async () => {
+		setupFirestore();
+
+		expect((await getVideoTranscriptChunk({ videoId: "bad id!", chunkIndex: 0 })).success).toBe(
+			false,
+		);
+		expect(
+			(await getVideoTranscriptChunk({ videoId: "97UnRtIlMc0", chunkIndex: -1 })).success,
+		).toBe(false);
+		expect(
+			(await getVideoTranscriptChunk({ videoId: "97UnRtIlMc0", chunkIndex: 1.5 })).success,
+		).toBe(false);
+		expect(mockGenerateClipContent).not.toHaveBeenCalled();
+	});
+
+	it("キャッシュがあれば Gemini を呼ばずに返す", async () => {
+		setupFirestore({
+			cachedChunk: {
+				chunkIndex: 1,
+				utterances: [{ start: 601, end: 603, text: "キャッシュ済み" }],
+			},
+		});
+
+		const result = await getVideoTranscriptChunk(VALID_INPUT);
+
+		expect(result).toEqual({
+			success: true,
+			data: { chunkIndex: 1, utterances: [{ start: 601, end: 603, text: "キャッシュ済み" }] },
+		});
+		expect(mockGenerateClipContent).not.toHaveBeenCalled();
+	});
+
+	it("キャッシュが無ければ生成して保存する（オーバーラップ窓・SPR-291 の生成パラメータ）", async () => {
+		const { mockSet } = setupFirestore();
+
+		const result = await getVideoTranscriptChunk(VALID_INPUT);
+
+		expect(result.success).toBe(true);
+		if (result.success) {
+			// 相対時刻 1.5s → チャンク1（600s〜）の絶対時刻 601.5s
+			expect(result.data.utterances[0]).toEqual({ start: 601.5, end: 603.5, text: "こんにちは" });
+		}
+		const call = mockGenerateClipContent.mock.calls[0]?.[0];
+		expect(call.startOffsetSeconds).toBe(600);
+		expect(call.endOffsetSeconds).toBe(1215);
+		expect(call.options).toEqual({
+			timeoutMs: 120_000,
+			maxOutputTokens: 16_384,
+			thinkingBudget: 1_024,
+		});
+		expect(mockSet).toHaveBeenCalledOnce();
+		const written = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(written.chunkIndex).toBe(1);
+		// Firestore は Date を Timestamp として保存する（新規コレクションの日時規約）
+		expect(written.createdAt).toBeInstanceOf(Date);
+	});
+
+	it("動画が存在しない・動画長を超えるチャンクは弾く", async () => {
+		setupFirestore({ videoExists: false });
+		expect((await getVideoTranscriptChunk(VALID_INPUT)).success).toBe(false);
+
+		setupFirestore({ videoDuration: "PT5M" });
+		expect((await getVideoTranscriptChunk({ videoId: "97UnRtIlMc0", chunkIndex: 1 })).success).toBe(
+			false,
+		);
+		expect(mockGenerateClipContent).not.toHaveBeenCalled();
+	});
+
+	it("Gemini 失敗・解釈不能応答は失敗を返す（保存しない）", async () => {
+		const { mockSet } = setupFirestore();
+		mockGenerateClipContent.mockResolvedValue({ success: false, error: "err" });
+		expect((await getVideoTranscriptChunk(VALID_INPUT)).success).toBe(false);
+
+		mockGenerateClipContent.mockResolvedValue({ success: true, text: "not json" });
+		expect((await getVideoTranscriptChunk(VALID_INPUT)).success).toBe(false);
+		expect(mockSet).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/actions/video-transcription.ts
+++ b/apps/web/src/actions/video-transcription.ts
@@ -1,0 +1,153 @@
+"use server";
+
+import { parseDurationToSeconds } from "@suzumina.click/shared-types";
+import { getCurrentUser } from "@/lib/auth/server";
+import { getFirestore } from "@/lib/firestore";
+import { generateClipContent } from "@/lib/gemini/client";
+import {
+	buildTranscriptionPrompt,
+	chunkRange,
+	maxChunkIndex,
+	parseTranscriptionResponse,
+	type TranscriptUtterance,
+} from "@/lib/gemini/transcription-core";
+import * as logger from "@/lib/logger";
+
+const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+/** 文字起こしは10分窓＝約30秒かかる（SPR-291 実測）。既定30秒では足りない */
+const TRANSCRIPTION_TIMEOUT_MS = 120_000;
+/** SPR-291 実測で確定した生成パラメータ（思考上限なしは JSON 切断・レイテンシ数倍） */
+const TRANSCRIPTION_MAX_OUTPUT_TOKENS = 16_384;
+const TRANSCRIPTION_THINKING_BUDGET = 1_024;
+
+/** Firestore 保存形（videos/{videoId}/transcriptChunks/{chunkIndex}）。派生データ＝再生成可能 */
+interface TranscriptChunkDocument {
+	chunkIndex: number;
+	chunkStart: number;
+	chunkEnd: number;
+	utterances: TranscriptUtterance[];
+	model: string;
+	createdAt: Date;
+}
+
+export interface GetTranscriptChunkInput {
+	videoId: string;
+	chunkIndex: number;
+}
+
+export type GetTranscriptChunkResult =
+	| { success: true; data: { chunkIndex: number; utterances: TranscriptUtterance[] } }
+	| { success: false; error: string };
+
+function chunkCollection(videoId: string) {
+	return getFirestore().collection("videos").doc(videoId).collection("transcriptChunks");
+}
+
+/** 生成本体: 動画の実在確認 → Gemini 生成 → 検証 → キャッシュ保存 */
+async function generateAndCacheChunk(
+	input: GetTranscriptChunkInput,
+	userId: string,
+): Promise<GetTranscriptChunkResult> {
+	// 動画の実在と長さを確認（チャンク番号の妥当性は動画長で決まる）
+	const videoDoc = await getFirestore().collection("videos").doc(input.videoId).get();
+	if (!videoDoc.exists) {
+		return { success: false, error: "動画が見つかりません" };
+	}
+	const videoDuration = parseDurationToSeconds(videoDoc.data()?.duration as string | undefined);
+	if (videoDuration <= 0 || input.chunkIndex > maxChunkIndex(videoDuration)) {
+		return { success: false, error: "チャンク指定が不正です" };
+	}
+
+	const { chunkStart, chunkEnd, requestStart, requestEnd } = chunkRange(
+		input.chunkIndex,
+		videoDuration,
+	);
+	const generated = await generateClipContent({
+		videoId: input.videoId,
+		startOffsetSeconds: requestStart,
+		endOffsetSeconds: requestEnd,
+		prompt: buildTranscriptionPrompt(),
+		options: {
+			timeoutMs: TRANSCRIPTION_TIMEOUT_MS,
+			maxOutputTokens: TRANSCRIPTION_MAX_OUTPUT_TOKENS,
+			thinkingBudget: TRANSCRIPTION_THINKING_BUDGET,
+		},
+	});
+	if (!generated.success) {
+		return { success: false, error: "文字起こしの取得に失敗しました" };
+	}
+
+	const utterances = parseTranscriptionResponse(generated.text, chunkStart, chunkEnd);
+	if (utterances === null) {
+		logger.warn("文字起こし応答を解釈できませんでした", {
+			videoId: input.videoId,
+			chunkIndex: input.chunkIndex,
+			raw: generated.text.slice(0, 200),
+		});
+		return { success: false, error: "文字起こしの取得に失敗しました。もう一度お試しください" };
+	}
+
+	const doc: TranscriptChunkDocument = {
+		chunkIndex: input.chunkIndex,
+		chunkStart,
+		chunkEnd,
+		utterances,
+		model: process.env.GEMINI_MODEL || "gemini-3-flash-preview",
+		createdAt: new Date(),
+	};
+	await chunkCollection(input.videoId).doc(String(input.chunkIndex)).set(doc);
+
+	logger.info("文字起こしチャンクを生成", {
+		videoId: input.videoId,
+		chunkIndex: input.chunkIndex,
+		userId,
+		utteranceCount: utterances.length,
+	});
+	return { success: true, data: { chunkIndex: input.chunkIndex, utterances } };
+}
+
+/**
+ * 動画の発話文字起こしチャンクを返す（SPR-292）。
+ * キャッシュ（Firestore）優先で、無ければ Gemini で生成して保存する。
+ * 生成は1チャンク=10分・約30秒かかるためクライアント側は進捗表示を出すこと。
+ * 同一チャンクへの並行生成は後勝ち上書きになるが、内容はほぼ同一で実害がないため
+ * ロックは持たない（生成コストが二重になるだけ。頻度も低い）。
+ */
+export async function getVideoTranscriptChunk(
+	input: GetTranscriptChunkInput,
+): Promise<GetTranscriptChunkResult> {
+	try {
+		// 認可ゲートの正本 = getCurrentUser の null チェック（SPR-195）。
+		// 生成1回ごとに外部APIコストが発生するため無効ユーザーも明示ブロックする
+		const user = await getCurrentUser();
+		if (!user?.discordId || !user.isActive) {
+			return { success: false, error: "ログインが必要です" };
+		}
+
+		if (!VIDEO_ID_PATTERN.test(input.videoId)) {
+			return { success: false, error: "動画IDが不正です" };
+		}
+		if (!Number.isInteger(input.chunkIndex) || input.chunkIndex < 0) {
+			return { success: false, error: "チャンク指定が不正です" };
+		}
+
+		// キャッシュ優先（他ユーザーの生成結果も共有する）
+		const cached = await chunkCollection(input.videoId).doc(String(input.chunkIndex)).get();
+		if (cached.exists) {
+			const data = cached.data() as TranscriptChunkDocument;
+			return {
+				success: true,
+				data: { chunkIndex: input.chunkIndex, utterances: data.utterances ?? [] },
+			};
+		}
+
+		return await generateAndCacheChunk(input, user.discordId);
+	} catch (error) {
+		logger.error("文字起こしチャンクの取得でエラーが発生", {
+			videoId: input.videoId,
+			chunkIndex: input.chunkIndex,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { success: false, error: "文字起こしの取得に失敗しました" };
+	}
+}

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockUseSession } from "@/test-utils/auth";
@@ -17,6 +17,11 @@ vi.mock("@/app/buttons/actions", () => ({
 const mockDeleteButtonDraft = vi.fn().mockResolvedValue({ success: true });
 vi.mock("@/actions/button-drafts", () => ({
 	deleteButtonDraft: (draftId: string) => mockDeleteButtonDraft(draftId),
+}));
+
+const mockGetVideoTranscriptChunk = vi.fn();
+vi.mock("@/actions/video-transcription", () => ({
+	getVideoTranscriptChunk: (input: unknown) => mockGetVideoTranscriptChunk(input),
 }));
 
 // Mock rate limit actions
@@ -250,6 +255,97 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 			expect(
 				screen.queryByRole("button", { name: "作成して次を切り抜く" }),
 			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("発話スナップ・タイトルプリフィル (SPR-292)", () => {
+		beforeEach(() => {
+			mockGetVideoTranscriptChunk.mockResolvedValue({
+				success: true,
+				data: {
+					chunkIndex: 0,
+					utterances: [{ start: 3, end: 5, text: "なんで落とすんですか" }],
+				},
+			});
+		});
+
+		it("読み込みボタンで発話を取得し、行クリックでスナップ＋タイトルプリフィルされる", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			await user.click(screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ }));
+			await waitFor(() => {
+				expect(screen.getByTestId("utterance-row")).toBeInTheDocument();
+			});
+			expect(mockGetVideoTranscriptChunk).toHaveBeenCalledWith({
+				videoId: "test-video-id",
+				chunkIndex: 0,
+			});
+
+			await user.click(screen.getByTestId("utterance-row"));
+
+			// スナップ: 3-0.15=2.9 / 5+0.35=5.4、タイトルは発話テキストで初期化
+			await waitFor(() => {
+				expect(screen.getByDisplayValue("0:02.9")).toBeInTheDocument();
+			});
+			expect(screen.getByDisplayValue("0:05.4")).toBeInTheDocument();
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue(
+				"なんで落とすんですか",
+			);
+			// トリムレーンにも発話ブロックが出る
+			expect(screen.getAllByTestId("lane-utterance").length).toBeGreaterThan(0);
+		});
+
+		it("タイトル入力済みならプリフィルで上書きしない", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), "手入力タイトル");
+			await user.click(screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ }));
+			await waitFor(() => {
+				expect(screen.getByTestId("utterance-row")).toBeInTheDocument();
+			});
+			await user.click(screen.getByTestId("utterance-row"));
+
+			await waitFor(() => {
+				expect(screen.getByDisplayValue("0:02.9")).toBeInTheDocument();
+			});
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("手入力タイトル");
+		});
+
+		it("Shift＋クリックで現在区間を発話まで広げる", async () => {
+			const user = userEvent.setup();
+			render(<AudioButtonCreator {...defaultProps} initialStartTime={20} />);
+
+			await user.click(screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ }));
+			await waitFor(() => {
+				expect(screen.getByTestId("utterance-row")).toBeInTheDocument();
+			});
+			// 現在区間 20-30、発話 2.9-5.4 → Shift クリックで 2.9-30 に拡張
+			fireEvent.click(screen.getByTestId("utterance-row"), { shiftKey: true });
+
+			await waitFor(() => {
+				expect(screen.getByDisplayValue("0:02.9")).toBeInTheDocument();
+			});
+			expect(screen.getByDisplayValue("0:30.0")).toBeInTheDocument();
+			// 拡張ではタイトルを入れない
+			expect(screen.getByPlaceholderText("例: おはようございます")).toHaveValue("");
+		});
+
+		it("取得失敗はエラー表示のみで既存フローに影響しない", async () => {
+			const user = userEvent.setup();
+			mockGetVideoTranscriptChunk.mockResolvedValue({
+				success: false,
+				error: "ログインが必要です",
+			});
+			render(<AudioButtonCreator {...defaultProps} />);
+
+			await user.click(screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ }));
+			await waitFor(() => {
+				expect(screen.getByText("ログインが必要です")).toBeInTheDocument();
+			});
+			// フォームは通常どおり使える
+			expect(screen.getByPlaceholderText("例: おはようございます")).toBeEnabled();
 		});
 	});
 

--- a/apps/web/src/components/audio/__tests__/clip-trim-lane.test.tsx
+++ b/apps/web/src/components/audio/__tests__/clip-trim-lane.test.tsx
@@ -157,4 +157,47 @@ describe("ClipTrimLane", () => {
 
 		expect(screen.queryByText("1:40.0")).not.toBeInTheDocument();
 	});
+
+	describe("発話行 (SPR-292)", () => {
+		const utterances = [
+			{ start: 5, end: 8, text: "窓内の発話" },
+			{ start: 100, end: 103, text: "窓外の発話" },
+		];
+
+		it("窓内の発話だけがブロック表示される", () => {
+			render(<ClipTrimLane {...defaultProps} utterances={utterances} onUtteranceClick={vi.fn()} />);
+
+			const blocks = screen.getAllByTestId("lane-utterance");
+			expect(blocks).toHaveLength(1);
+			expect(blocks[0]).toHaveTextContent("窓内の発話");
+		});
+
+		it("発話クリックで onUtteranceClick が呼ばれ、レーンのシークは発火しない", () => {
+			const onUtteranceClick = vi.fn();
+			render(
+				<ClipTrimLane
+					{...defaultProps}
+					utterances={utterances}
+					onUtteranceClick={onUtteranceClick}
+				/>,
+			);
+
+			fireEvent.click(screen.getByTestId("lane-utterance"), { clientX: 133 });
+			expect(onUtteranceClick).toHaveBeenCalledWith(utterances[0], false);
+			expect(defaultProps.onSeek).not.toHaveBeenCalled();
+
+			fireEvent.click(screen.getByTestId("lane-utterance"), { shiftKey: true });
+			expect(onUtteranceClick).toHaveBeenLastCalledWith(utterances[0], true);
+		});
+
+		it("発話行ありのときはレーンが縦に広がる", () => {
+			const { rerender } = render(<ClipTrimLane {...defaultProps} />);
+			expect(screen.getByTestId("clip-trim-lane")).toHaveClass("h-24");
+
+			rerender(
+				<ClipTrimLane {...defaultProps} utterances={utterances} onUtteranceClick={vi.fn()} />,
+			);
+			expect(screen.getByTestId("clip-trim-lane")).toHaveClass("h-32");
+		});
+	});
 });

--- a/apps/web/src/components/audio/__tests__/utterance-list-panel.test.tsx
+++ b/apps/web/src/components/audio/__tests__/utterance-list-panel.test.tsx
@@ -1,0 +1,79 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UtteranceListPanel } from "../utterance-list-panel";
+
+describe("UtteranceListPanel", () => {
+	const utterances = [
+		{ start: 601.5, end: 603.5, text: "こんにちは" },
+		{ start: 605, end: 607, text: "今日はゲームやるよ" },
+	];
+	const defaultProps = {
+		utterances,
+		loadedRanges: [{ start: 600, end: 1200 }],
+		isLoading: false,
+		error: null,
+		currentTime: 700,
+		isLoadedAt: vi.fn(() => true),
+		onLoadAt: vi.fn(),
+		onSelect: vi.fn(),
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("発話リストが時刻・テキスト・長さつきで表示される", () => {
+		render(<UtteranceListPanel {...defaultProps} />);
+
+		expect(screen.getByText("セリフから選ぶ")).toBeInTheDocument();
+		expect(screen.getByText("こんにちは")).toBeInTheDocument();
+		expect(screen.getByText("10:01")).toBeInTheDocument();
+		expect(screen.getAllByText("2.0秒")).toHaveLength(2);
+		expect(screen.getByText(/読み込み済み: 10:00〜20:00/)).toBeInTheDocument();
+	});
+
+	it("行クリックで onSelect が呼ばれる（Shift で extend）", () => {
+		render(<UtteranceListPanel {...defaultProps} />);
+
+		const rows = screen.getAllByTestId("utterance-row");
+		fireEvent.click(rows[0]!);
+		expect(defaultProps.onSelect).toHaveBeenCalledWith(utterances[0], false);
+
+		fireEvent.click(rows[1]!, { shiftKey: true });
+		expect(defaultProps.onSelect).toHaveBeenCalledWith(utterances[1], true);
+	});
+
+	it("未読み込み位置では読み込みボタンが出て onLoadAt が呼ばれる", () => {
+		const isLoadedAt = vi.fn(() => false);
+		render(<UtteranceListPanel {...defaultProps} isLoadedAt={isLoadedAt} />);
+
+		const button = screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ });
+		fireEvent.click(button);
+		expect(defaultProps.onLoadAt).toHaveBeenCalledWith(700);
+	});
+
+	it("読み込み中は進捗表示になり読み込みボタンは出ない", () => {
+		render(<UtteranceListPanel {...defaultProps} isLoading isLoadedAt={() => false} />);
+
+		expect(screen.getByText(/初回は30秒ほどかかります/)).toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /再生位置の周辺の発話を読み込む/ }),
+		).not.toBeInTheDocument();
+	});
+
+	it("エラーが表示される", () => {
+		render(<UtteranceListPanel {...defaultProps} error="文字起こしの取得に失敗しました" />);
+
+		expect(screen.getByText("文字起こしの取得に失敗しました")).toBeInTheDocument();
+	});
+
+	it("disabled 中は行・ボタンとも無効", () => {
+		render(<UtteranceListPanel {...defaultProps} disabled isLoadedAt={() => false} />);
+
+		for (const row of screen.getAllByTestId("utterance-row")) {
+			expect(row).toBeDisabled();
+		}
+		expect(screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ })).toBeDisabled();
+	});
+});

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -103,7 +103,7 @@ export function AudioButtonCreator({
 	const [draftMarkList, setDraftMarkList] = useState<number[]>(() => draftMarks ?? []);
 
 	// 発話文字起こし（SPR-292）。オンデマンド読み込み＝開いただけでは Gemini を呼ばない
-	const transcript = useVideoTranscript(videoId);
+	const transcript = useVideoTranscript(videoId, youtubeManager.videoDuration || videoDuration);
 
 	// 次の下書きへフォームとプレイヤーを進める（遷移なし＝プレイヤー維持が連続仕上げの本体）
 	const { setStartTime, setEndTime } = timeAdjustment;

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -9,8 +9,10 @@ import { useCallback, useState } from "react";
 import { deleteButtonDraft } from "@/actions/button-drafts";
 import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
+import { useVideoTranscript } from "@/hooks/use-video-transcript";
 import { trackCreateError, trackCreateStart, trackCreateSuccess } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
+import { snapRangeForUtterance, type TranscriptUtterance } from "@/lib/gemini/transcription-core";
 import { formatSeconds } from "@/utils/format-seconds";
 import { BasicInfoPanel } from "./basic-info-panel";
 import { CreateButtonLimit } from "./create-button-limit";
@@ -18,6 +20,7 @@ import { CreationActionBar } from "./creation-action-bar";
 import { MetaSuggestionPanel } from "./meta-suggestion-panel";
 import { TimeControlPanel } from "./time-control-panel";
 import { UsageGuide } from "./usage-guide";
+import { UtteranceListPanel } from "./utterance-list-panel";
 
 interface AudioButtonCreatorProps {
 	videoId: string;
@@ -99,6 +102,9 @@ export function AudioButtonCreator({
 	const [madeMarks, setMadeMarks] = useState<number[]>(() => initialMadeMarks ?? []);
 	const [draftMarkList, setDraftMarkList] = useState<number[]>(() => draftMarks ?? []);
 
+	// 発話文字起こし（SPR-292）。オンデマンド読み込み＝開いただけでは Gemini を呼ばない
+	const transcript = useVideoTranscript(videoId);
+
 	// 次の下書きへフォームとプレイヤーを進める（遷移なし＝プレイヤー維持が連続仕上げの本体）
 	const { setStartTime, setEndTime } = timeAdjustment;
 	const { seekTo, videoDuration: playerDuration } = youtubeManager;
@@ -140,6 +146,36 @@ export function AudioButtonCreator({
 			setDraftMarkList((prev) => removeOneOccurrence(prev, consumed.suggestedStartTime));
 		}
 	}, [activeDraftId, videoDrafts]);
+
+	// 発話スナップ（SPR-292）: クリックで発話区間（前後パディング込み）へ。
+	// Shift＋クリックは現在区間を発話まで広げる。プレイヤーは editor の境界追従シークに乗る
+	const handleUtteranceSelect = useCallback(
+		(utterance: TranscriptUtterance, extend: boolean) => {
+			const duration = playerDuration || videoDuration;
+			const range = snapRangeForUtterance(utterance, duration);
+			if (extend) {
+				setStartTime(Math.min(timeAdjustment.startTime, range.startTime));
+				setEndTime(Math.max(timeAdjustment.endTime, range.endTime));
+				return;
+			}
+			setStartTime(range.startTime);
+			setEndTime(range.endTime);
+			// タイトル未入力なら発話テキストを初期値に（上書きはしない・歌唱の ♪ は入れない）
+			if (utterance.kind !== "song" && buttonText.trim().length === 0) {
+				setButtonText(utterance.text.slice(0, 100));
+			}
+		},
+		[
+			playerDuration,
+			videoDuration,
+			setStartTime,
+			setEndTime,
+			timeAdjustment.startTime,
+			timeAdjustment.endTime,
+			buttonText,
+			setButtonText,
+		],
+	);
 
 	// スキップ: 現在の下書きは消化せず（/live から再度仕上げられる）次へ進む
 	const handleSkip = useCallback(() => {
@@ -304,6 +340,8 @@ export function AudioButtonCreator({
 									audition={audition}
 									madeMarks={madeMarks}
 									draftMarks={draftMarkList}
+									utterances={transcript.utterances}
+									onUtteranceClick={handleUtteranceSelect}
 									isCreating={isCreating}
 								/>
 							</div>
@@ -359,6 +397,18 @@ export function AudioButtonCreator({
 									)}
 								</div>
 							)}
+
+							<UtteranceListPanel
+								utterances={transcript.utterances}
+								loadedRanges={transcript.loadedRanges}
+								isLoading={transcript.isLoading}
+								error={transcript.error}
+								currentTime={youtubeManager.currentTime}
+								isLoadedAt={transcript.isLoadedAt}
+								disabled={isCreating}
+								onLoadAt={transcript.loadChunkAt}
+								onSelect={handleUtteranceSelect}
+							/>
 
 							<BasicInfoPanel
 								title={buttonText}

--- a/apps/web/src/components/audio/clip-trim-lane.tsx
+++ b/apps/web/src/components/audio/clip-trim-lane.tsx
@@ -2,6 +2,7 @@
 
 import { formatTimestamp } from "@suzumina.click/shared-types";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { TranscriptUtterance } from "@/lib/gemini/transcription-core";
 import { formatSeconds } from "@/utils/format-seconds";
 
 /** 切り抜き長の制約（バリデーションの正本は use-audio-button-validation。ドラッグ時の先行クランプ用） */
@@ -67,6 +68,10 @@ interface ClipTrimLaneProps {
 	onMoveClip: (startTime: number, endTime: number) => void;
 	/** レーン余白クリック: 再生位置をその時刻へ */
 	onSeek: (time: number) => void;
+	/** 読み込み済みの発話（SPR-292）。渡すと発話行が出てレーンが縦に広がる */
+	utterances?: TranscriptUtterance[];
+	/** 発話クリック（extend=Shift クリック: 現在区間を発話まで広げる） */
+	onUtteranceClick?: (utterance: TranscriptUtterance, extend: boolean) => void;
 }
 
 /**
@@ -86,7 +91,11 @@ export function ClipTrimLane({
 	onChangeEnd,
 	onMoveClip,
 	onSeek,
+	utterances,
+	onUtteranceClick,
 }: ClipTrimLaneProps) {
+	// 発話行の有無でレーンの高さとクリップ位置が変わる（編集画面は発話なしの従来レイアウト）
+	const hasUtteranceRow = utterances !== undefined;
 	const laneRef = useRef<HTMLDivElement | null>(null);
 	const [drag, setDrag] = useState<{ kind: DragKind; grabOffset: number } | null>(null);
 	// ドラッグを離した直後に lane の click が発火して意図せずシークするのを抑止する
@@ -218,7 +227,7 @@ export function ClipTrimLane({
 			ref={laneRef}
 			data-testid="clip-trim-lane"
 			onClick={onLaneClick}
-			className="relative h-24 overflow-hidden rounded-md border bg-muted/60 select-none"
+			className={`relative overflow-hidden rounded-md border bg-muted/60 select-none ${hasUtteranceRow ? "h-32" : "h-24"}`}
 			style={{ touchAction: "none" }}
 		>
 			{/* 動画範囲外（0 より前 / 末尾より後）の遮蔽 */}
@@ -257,9 +266,36 @@ export function ClipTrimLane({
 				</div>
 			))}
 
+			{/* 発話行（SPR-292）: クリックで区間スナップ・Shift で拡張 */}
+			{hasUtteranceRow &&
+				utterances
+					.filter((u) => u.end > windowStart && u.start < windowEnd)
+					.map((u) => {
+						const left = Math.max(positionPercent(u.start), 0);
+						const right = Math.min(positionPercent(u.end), 100);
+						return (
+							<button
+								key={`utterance-${u.start}`}
+								type="button"
+								data-testid="lane-utterance"
+								title={u.text}
+								disabled={disabled}
+								onClick={(event) => {
+									// レーン背景のクリックシークを発火させない
+									event.stopPropagation();
+									onUtteranceClick?.(u, event.shiftKey);
+								}}
+								className="absolute top-5 flex h-[26px] items-center overflow-hidden rounded-sm border bg-card px-1 text-left font-normal text-[11px] whitespace-nowrap text-muted-foreground hover:border-suzuka-400 hover:text-foreground disabled:pointer-events-none"
+								style={{ left: `${left}%`, width: `${Math.max(right - left, 0.5)}%` }}
+							>
+								<span className="truncate">{u.text}</span>
+							</button>
+						);
+					})}
+
 			{/* クリップブロック */}
 			<div
-				className="absolute top-5 bottom-0 border-y-2 border-suzuka-600 bg-suzuka-500/25"
+				className={`absolute bottom-0 border-y-2 border-suzuka-600 bg-suzuka-500/25 ${hasUtteranceRow ? "top-[52px]" : "top-5"}`}
 				style={{
 					left: `${clipLeft}%`,
 					width: `${Math.max(clipRight - clipLeft, 0)}%`,

--- a/apps/web/src/components/audio/time-control-panel.tsx
+++ b/apps/web/src/components/audio/time-control-panel.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from "@suzumina.click/ui/components/ui/checkbox";
 import { Input } from "@suzumina.click/ui/components/ui/input";
 import { Clock, MousePointer, Play, Square } from "lucide-react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
+import type { TranscriptUtterance } from "@/lib/gemini/transcription-core";
 import { matchShortcutKey } from "@/lib/keyboard-shortcut";
 import { ClipExploreLane } from "./clip-explore-lane";
 import { ClipTrimLane } from "./clip-trim-lane";
@@ -135,6 +136,10 @@ interface TimeControlPanelProps {
 	madeMarks?: number[];
 	draftMarks?: number[];
 
+	// 発話行（SPR-292）。省略時は従来レイアウト（編集画面など）
+	utterances?: TranscriptUtterance[];
+	onUtteranceClick?: (utterance: TranscriptUtterance, extend: boolean) => void;
+
 	// UI状態
 	isCreating: boolean;
 }
@@ -228,6 +233,8 @@ export function TimeControlPanel({
 	audition,
 	madeMarks = [],
 	draftMarks = [],
+	utterances,
+	onUtteranceClick,
 	isCreating,
 }: TimeControlPanelProps) {
 	const prerollId = useId();
@@ -399,6 +406,8 @@ export function TimeControlPanel({
 					onChangeEnd={onSetEndTime}
 					onMoveClip={moveClip}
 					onSeek={onSeek}
+					utterances={utterances}
+					onUtteranceClick={onUtteranceClick}
 				/>
 
 				{/* 境界の微調整 */}

--- a/apps/web/src/components/audio/utterance-list-panel.tsx
+++ b/apps/web/src/components/audio/utterance-list-panel.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Button } from "@suzumina.click/ui/components/ui/button";
+import { Captions, Loader2 } from "lucide-react";
+import type { TranscriptUtterance } from "@/lib/gemini/transcription-core";
+import { formatSeconds } from "@/utils/format-seconds";
+
+const roundTenth = (value: number) => Math.round(value * 10) / 10;
+
+interface UtteranceListPanelProps {
+	utterances: TranscriptUtterance[];
+	loadedRanges: Array<{ start: number; end: number }>;
+	isLoading: boolean;
+	error: string | null;
+	/** 「この周辺の発話を読み込む」の対象秒（再生位置） */
+	currentTime: number;
+	/** 対象秒のチャンクが読み込み済みか（ボタンの出し分け） */
+	isLoadedAt: (timeSeconds: number) => boolean;
+	disabled?: boolean;
+	onLoadAt: (timeSeconds: number) => void;
+	/** 行クリック（extend=Shift クリック: 現在区間を発話まで広げる） */
+	onSelect: (utterance: TranscriptUtterance, extend: boolean) => void;
+}
+
+/**
+ * 読み込み済み範囲の発話リスト（SPR-292）。
+ * 「探す＝聴く」を「読む」に変える段。クリックで発話に区間スナップ＋タイトルプリフィル。
+ * 全編検索は Stage 2（SPR-293）。
+ */
+export function UtteranceListPanel({
+	utterances,
+	loadedRanges,
+	isLoading,
+	error,
+	currentTime,
+	isLoadedAt,
+	disabled = false,
+	onLoadAt,
+	onSelect,
+}: UtteranceListPanelProps) {
+	const rangeLabel =
+		loadedRanges.length > 0
+			? loadedRanges
+					.map((range) => `${formatSeconds(range.start)}〜${formatSeconds(range.end)}`)
+					.join(" / ")
+			: null;
+	const currentLoaded = isLoadedAt(currentTime);
+
+	return (
+		<div className="bg-card border rounded-lg p-4 shadow-sm">
+			<h3 className="mb-1 flex items-center gap-2 text-base font-semibold">
+				<Captions className="h-4 w-4 text-primary" />
+				セリフから選ぶ
+			</h3>
+			<p className="mb-3 text-xs text-muted-foreground">
+				発話をクリックでその区間に。<strong className="text-foreground">Shift＋クリック</strong>
+				で隣の発話まで広げます
+			</p>
+
+			{error && <p className="mb-2 text-sm text-destructive">{error}</p>}
+
+			{utterances.length > 0 && (
+				<div className="mb-3 flex max-h-72 flex-col gap-1 overflow-y-auto">
+					{utterances.map((utterance) => (
+						<button
+							key={`row-${utterance.start}`}
+							type="button"
+							data-testid="utterance-row"
+							disabled={disabled}
+							onClick={(event) => onSelect(utterance, event.shiftKey)}
+							className="flex items-baseline gap-2 rounded-md border border-transparent px-2 py-1.5 text-left hover:border-border hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+						>
+							<span className="font-mono text-[11px] font-semibold whitespace-nowrap text-primary">
+								{formatSeconds(utterance.start)}
+							</span>
+							<span className="min-w-0 flex-1 text-sm leading-snug">{utterance.text}</span>
+							<span className="text-xs whitespace-nowrap text-muted-foreground">
+								{`${roundTenth(utterance.end - utterance.start).toFixed(1)}秒`}
+							</span>
+						</button>
+					))}
+				</div>
+			)}
+
+			{isLoading ? (
+				<div className="flex items-center gap-2 text-sm text-muted-foreground">
+					<Loader2 className="h-4 w-4 animate-spin" />
+					文字起こしを生成しています（初回は30秒ほどかかります）
+				</div>
+			) : (
+				!currentLoaded && (
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => onLoadAt(currentTime)}
+						disabled={disabled}
+						className="h-9 w-full"
+					>
+						再生位置の周辺の発話を読み込む
+					</Button>
+				)
+			)}
+
+			{rangeLabel && (
+				<p className="mt-2 text-xs text-muted-foreground">読み込み済み: {rangeLabel}</p>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/hooks/use-video-transcript.ts
+++ b/apps/web/src/hooks/use-video-transcript.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { getVideoTranscriptChunk } from "@/actions/video-transcription";
+import {
+	CHUNK_SECONDS,
+	chunkIndexForTime,
+	type TranscriptUtterance,
+} from "@/lib/gemini/transcription-core";
+
+export interface VideoTranscriptState {
+	/** 読み込み済み発話（チャンク横断・start 昇順） */
+	utterances: TranscriptUtterance[];
+	/** 読み込み済みチャンクの範囲（秒）。UI の「どこまで読めたか」表示用 */
+	loadedRanges: Array<{ start: number; end: number }>;
+	isLoading: boolean;
+	error: string | null;
+	/** 指定秒を含むチャンクを読み込む（読み込み済みなら何もしない） */
+	loadChunkAt: (timeSeconds: number) => void;
+	/** 指定秒が読み込み済みか */
+	isLoadedAt: (timeSeconds: number) => boolean;
+}
+
+/**
+ * 作成画面の発話文字起こし読み込み（SPR-292）。
+ * チャンク（10分）単位でオンデマンド取得する。生成初回は約30秒かかるため
+ * isLoading を進捗表示に使う。失敗しても既存フローに影響しない（error 表示のみ）。
+ */
+export function useVideoTranscript(videoId: string): VideoTranscriptState {
+	const [chunks, setChunks] = useState<Map<number, TranscriptUtterance[]>>(new Map());
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	// 進行中チャンクの二重リクエスト防止（isLoading の state 更新より先に判定が要る）
+	const inFlightRef = useRef<Set<number>>(new Set());
+
+	const loadChunkAt = useCallback(
+		(timeSeconds: number) => {
+			const chunkIndex = chunkIndexForTime(timeSeconds);
+			if (chunks.has(chunkIndex) || inFlightRef.current.has(chunkIndex)) {
+				return;
+			}
+			inFlightRef.current.add(chunkIndex);
+			setIsLoading(true);
+			setError(null);
+			void getVideoTranscriptChunk({ videoId, chunkIndex })
+				.then((result) => {
+					if (result.success) {
+						setChunks((prev) => {
+							const next = new Map(prev);
+							next.set(chunkIndex, result.data.utterances);
+							return next;
+						});
+					} else {
+						setError(result.error);
+					}
+				})
+				.catch(() => {
+					setError("文字起こしの取得に失敗しました");
+				})
+				.finally(() => {
+					inFlightRef.current.delete(chunkIndex);
+					setIsLoading(inFlightRef.current.size > 0);
+				});
+		},
+		[videoId, chunks],
+	);
+
+	const utterances = useMemo(() => {
+		const merged: TranscriptUtterance[] = [];
+		for (const list of chunks.values()) {
+			merged.push(...list);
+		}
+		return merged.sort((a, b) => a.start - b.start);
+	}, [chunks]);
+
+	const loadedRanges = useMemo(() => {
+		const indexes = [...chunks.keys()].sort((a, b) => a - b);
+		const ranges: Array<{ start: number; end: number }> = [];
+		for (const index of indexes) {
+			const start = index * CHUNK_SECONDS;
+			const end = start + CHUNK_SECONDS;
+			const last = ranges[ranges.length - 1];
+			if (last && last.end === start) {
+				last.end = end;
+			} else {
+				ranges.push({ start, end });
+			}
+		}
+		return ranges;
+	}, [chunks]);
+
+	const isLoadedAt = useCallback(
+		(timeSeconds: number) => chunks.has(chunkIndexForTime(timeSeconds)),
+		[chunks],
+	);
+
+	return { utterances, loadedRanges, isLoading, error, loadChunkAt, isLoadedAt };
+}

--- a/apps/web/src/hooks/use-video-transcript.ts
+++ b/apps/web/src/hooks/use-video-transcript.ts
@@ -26,7 +26,10 @@ export interface VideoTranscriptState {
  * チャンク（10分）単位でオンデマンド取得する。生成初回は約30秒かかるため
  * isLoading を進捗表示に使う。失敗しても既存フローに影響しない（error 表示のみ）。
  */
-export function useVideoTranscript(videoId: string): VideoTranscriptState {
+export function useVideoTranscript(
+	videoId: string,
+	videoDurationSeconds: number,
+): VideoTranscriptState {
 	const [chunks, setChunks] = useState<Map<number, TranscriptUtterance[]>>(new Map());
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -35,7 +38,8 @@ export function useVideoTranscript(videoId: string): VideoTranscriptState {
 
 	const loadChunkAt = useCallback(
 		(timeSeconds: number) => {
-			const chunkIndex = chunkIndexForTime(timeSeconds);
+			// 再生位置がちょうど動画長のとき存在しないチャンクを要求しないよう最終チャンクへクランプ
+			const chunkIndex = chunkIndexForTime(timeSeconds, videoDurationSeconds);
 			if (chunks.has(chunkIndex) || inFlightRef.current.has(chunkIndex)) {
 				return;
 			}
@@ -62,7 +66,7 @@ export function useVideoTranscript(videoId: string): VideoTranscriptState {
 					setIsLoading(inFlightRef.current.size > 0);
 				});
 		},
-		[videoId, chunks],
+		[videoId, videoDurationSeconds, chunks],
 	);
 
 	const utterances = useMemo(() => {
@@ -90,8 +94,8 @@ export function useVideoTranscript(videoId: string): VideoTranscriptState {
 	}, [chunks]);
 
 	const isLoadedAt = useCallback(
-		(timeSeconds: number) => chunks.has(chunkIndexForTime(timeSeconds)),
-		[chunks],
+		(timeSeconds: number) => chunks.has(chunkIndexForTime(timeSeconds, videoDurationSeconds)),
+		[chunks, videoDurationSeconds],
 	);
 
 	return { utterances, loadedRanges, isLoading, error, loadChunkAt, isLoadedAt };

--- a/apps/web/src/lib/gemini/__tests__/transcription-core.test.ts
+++ b/apps/web/src/lib/gemini/__tests__/transcription-core.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import {
+	CHUNK_OVERLAP_SECONDS,
+	CHUNK_SECONDS,
+	chunkIndexForTime,
+	chunkRange,
+	maxChunkIndex,
+	parseTranscriptionResponse,
+	snapRangeForUtterance,
+} from "../transcription-core";
+
+describe("chunkIndexForTime / maxChunkIndex", () => {
+	it("10分単位でチャンク番号を返す", () => {
+		expect(chunkIndexForTime(0)).toBe(0);
+		expect(chunkIndexForTime(599.9)).toBe(0);
+		expect(chunkIndexForTime(600)).toBe(1);
+		expect(chunkIndexForTime(4993.6)).toBe(8);
+	});
+
+	it("負値は0にクランプする", () => {
+		expect(chunkIndexForTime(-5)).toBe(0);
+	});
+
+	it("動画長から最終チャンク番号を返す", () => {
+		expect(maxChunkIndex(600)).toBe(0);
+		expect(maxChunkIndex(601)).toBe(1);
+		expect(maxChunkIndex(11065)).toBe(18);
+		expect(maxChunkIndex(0)).toBe(0);
+	});
+});
+
+describe("chunkRange", () => {
+	it("担当範囲とオーバーラップ込みの生成窓を返す", () => {
+		const range = chunkRange(1, 3600);
+		expect(range).toEqual({
+			chunkStart: 600,
+			chunkEnd: 1200,
+			requestStart: 600,
+			requestEnd: 1200 + CHUNK_OVERLAP_SECONDS,
+		});
+	});
+
+	it("末尾チャンクは動画長でクランプされる", () => {
+		const range = chunkRange(1, 900);
+		expect(range.chunkEnd).toBe(900);
+		expect(range.requestEnd).toBe(900);
+	});
+});
+
+describe("parseTranscriptionResponse", () => {
+	const chunkStart = 600;
+	const chunkEnd = 1200;
+
+	it("相対時刻を絶対時刻へ変換し、start 昇順で返す", () => {
+		const raw = JSON.stringify({
+			utterances: [
+				{ start: 10.5, end: 12.5, text: "こんにちは" },
+				{ start: 2.0, end: 4.0, text: "えっと" },
+			],
+		});
+		const result = parseTranscriptionResponse(raw, chunkStart, chunkEnd);
+		expect(result).toEqual([
+			{ start: 602, end: 604, text: "えっと" },
+			{ start: 610.5, end: 612.5, text: "こんにちは" },
+		]);
+	});
+
+	it("オーバーラップ窓で拾った次チャンク分（start >= chunkEnd）は捨てる", () => {
+		const raw = JSON.stringify({
+			utterances: [
+				{ start: 599, end: 601, text: "チャンク内の発話" },
+				{ start: CHUNK_SECONDS + 5, end: CHUNK_SECONDS + 8, text: "次チャンクの発話" },
+			],
+		});
+		const result = parseTranscriptionResponse(raw, chunkStart, chunkEnd);
+		expect(result).toHaveLength(1);
+		expect(result?.[0]?.text).toBe("チャンク内の発話");
+	});
+
+	it("壊れた要素は捨てて続行する", () => {
+		const raw = JSON.stringify({
+			utterances: [
+				{ start: 1, end: 2, text: "有効" },
+				{ start: "x", end: 2, text: "start が数値でない" },
+				{ start: 5, end: 3, text: "end <= start" },
+				{ start: 7, end: 8, text: "   " },
+				{ start: 9, end: 10 },
+			],
+		});
+		const result = parseTranscriptionResponse(raw, chunkStart, chunkEnd);
+		expect(result).toHaveLength(1);
+	});
+
+	it("song kind を保持し、その他の kind は落とす", () => {
+		const raw = JSON.stringify({
+			utterances: [
+				{ start: 1, end: 2, text: "♪", kind: "song" },
+				{ start: 3, end: 4, text: "雑談", kind: "unknown" },
+			],
+		});
+		const result = parseTranscriptionResponse(raw, chunkStart, chunkEnd);
+		expect(result?.[0]?.kind).toBe("song");
+		expect(result?.[1]?.kind).toBeUndefined();
+	});
+
+	it("長すぎるテキストは切り詰める", () => {
+		const raw = JSON.stringify({
+			utterances: [{ start: 1, end: 2, text: "あ".repeat(300) }],
+		});
+		const result = parseTranscriptionResponse(raw, chunkStart, chunkEnd);
+		expect(result?.[0]?.text).toHaveLength(200);
+	});
+
+	it("JSON でない・utterances が無い応答は null", () => {
+		expect(parseTranscriptionResponse("not json", chunkStart, chunkEnd)).toBeNull();
+		expect(parseTranscriptionResponse("{}", chunkStart, chunkEnd)).toBeNull();
+	});
+});
+
+describe("snapRangeForUtterance", () => {
+	it("前0.15秒・後0.35秒のパディングを付ける", () => {
+		expect(snapRangeForUtterance({ start: 100, end: 102 }, 3600)).toEqual({
+			startTime: 99.9,
+			endTime: 102.4,
+		});
+	});
+
+	it("動画の先頭・末尾でクランプされる", () => {
+		expect(snapRangeForUtterance({ start: 0.1, end: 3600 }, 3600)).toEqual({
+			startTime: 0,
+			endTime: 3600,
+		});
+	});
+});

--- a/apps/web/src/lib/gemini/__tests__/transcription-core.test.ts
+++ b/apps/web/src/lib/gemini/__tests__/transcription-core.test.ts
@@ -21,6 +21,14 @@ describe("chunkIndexForTime / maxChunkIndex", () => {
 		expect(chunkIndexForTime(-5)).toBe(0);
 	});
 
+	it("動画長を渡すと最終チャンクへクランプする（AIレビュー対応: 動画長ちょうどの再生位置）", () => {
+		// 動画長が600の倍数ぴったりのとき、素の floor は存在しないチャンクを指す
+		expect(chunkIndexForTime(1200, 1200)).toBe(1);
+		expect(chunkIndexForTime(600, 600)).toBe(0);
+		// 通常位置はクランプの影響を受けない
+		expect(chunkIndexForTime(650, 1200)).toBe(1);
+	});
+
 	it("動画長から最終チャンク番号を返す", () => {
 		expect(maxChunkIndex(600)).toBe(0);
 		expect(maxChunkIndex(601)).toBe(1);

--- a/apps/web/src/lib/gemini/client.ts
+++ b/apps/web/src/lib/gemini/client.ts
@@ -23,6 +23,16 @@ export interface GenerateClipContentInput {
 	startOffsetSeconds: number;
 	endOffsetSeconds: number;
 	prompt: string;
+	/**
+	 * 長尺クリップ（文字起こし等）用の上書き（SPR-292）。
+	 * thinkingBudget はスパイク実測で必須と確定: 上限なしだと思考トークンが暴走して
+	 * maxOutputTokens 到達で JSON が切断され、レイテンシも数倍になる（SPR-291）
+	 */
+	options?: {
+		timeoutMs?: number;
+		maxOutputTokens?: number;
+		thinkingBudget?: number;
+	};
 }
 
 /**
@@ -60,6 +70,12 @@ export async function generateClipContent(
 		generationConfig: {
 			response_mime_type: "application/json",
 			temperature: 0.4,
+			...(input.options?.maxOutputTokens !== undefined
+				? { maxOutputTokens: input.options.maxOutputTokens }
+				: {}),
+			...(input.options?.thinkingBudget !== undefined
+				? { thinkingConfig: { thinkingBudget: input.options.thinkingBudget } }
+				: {}),
 		},
 	};
 
@@ -72,7 +88,7 @@ export async function generateClipContent(
 				"x-goog-api-key": apiKey,
 			},
 			body: JSON.stringify(body),
-			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+			signal: AbortSignal.timeout(input.options?.timeoutMs ?? REQUEST_TIMEOUT_MS),
 		});
 		const elapsedMs = Date.now() - startedAt;
 

--- a/apps/web/src/lib/gemini/transcription-core.ts
+++ b/apps/web/src/lib/gemini/transcription-core.ts
@@ -1,0 +1,137 @@
+/**
+ * 動画の発話単位文字起こし（SPR-292）の純粋ロジック。
+ * Gemini API 呼び出し本体は client.ts。ここはチャンク計算・プロンプト・応答検証のみ（テスト対象）。
+ * 設計パラメータ（10分チャンク・オーバーラップ・思考上限）の根拠は SPR-291 スパイク実測。
+ */
+
+/** 発話1件（時刻は動画先頭からの絶対秒） */
+export interface TranscriptUtterance {
+	start: number;
+	end: number;
+	text: string;
+	/** 歌唱区間（歌詞は書き起こさない） */
+	kind?: "song";
+}
+
+/** チャンク長（秒）。10分窓で入力 ≈ 55k トークン・レイテンシ ≈ 30秒（SPR-291 実測） */
+export const CHUNK_SECONDS = 600;
+/**
+ * チャンク末尾のオーバーラップ（秒）。境界をまたぐ発話が尻切れにならないよう
+ * 生成窓は次チャンク側へ延ばし、採用は start < chunkEnd の発話に限定する
+ */
+export const CHUNK_OVERLAP_SECONDS = 15;
+/** 発話スナップの前後パディング（デザイン 2a 確定値。境界精度 ±0.5秒の実測と整合） */
+export const SNAP_PADDING_BEFORE_SECONDS = 0.15;
+export const SNAP_PADDING_AFTER_SECONDS = 0.35;
+
+const roundTenth = (value: number) => Math.round(value * 10) / 10;
+
+/** 指定秒を含むチャンク番号 */
+export function chunkIndexForTime(timeSeconds: number): number {
+	return Math.max(0, Math.floor(timeSeconds / CHUNK_SECONDS));
+}
+
+/** 動画に存在する最後のチャンク番号 */
+export function maxChunkIndex(videoDurationSeconds: number): number {
+	if (videoDurationSeconds <= 0) return 0;
+	return Math.floor((videoDurationSeconds - 1) / CHUNK_SECONDS);
+}
+
+/** チャンクの担当範囲と生成窓（オーバーラップ込み・動画長でクランプ） */
+export function chunkRange(
+	chunkIndex: number,
+	videoDurationSeconds: number,
+): {
+	chunkStart: number;
+	chunkEnd: number;
+	requestStart: number;
+	requestEnd: number;
+} {
+	const chunkStart = chunkIndex * CHUNK_SECONDS;
+	const chunkEnd = Math.min(chunkStart + CHUNK_SECONDS, videoDurationSeconds);
+	return {
+		chunkStart,
+		chunkEnd,
+		requestStart: chunkStart,
+		requestEnd: Math.min(chunkEnd + CHUNK_OVERLAP_SECONDS, videoDurationSeconds),
+	};
+}
+
+/**
+ * 文字起こしプロンプト。時刻はクリップ相対で受け、parse 側で絶対時刻へ変換する。
+ * 歌唱の歌詞は書き起こさない（権利面の割り切り。区間として見えれば用は足りる）
+ */
+export function buildTranscriptionPrompt(): string {
+	return `この動画クリップは日本語配信アーカイブの一部です。クリップ内の話者の発話を発話単位（一息・一文程度）で全て文字起こししてください。
+- 各発話に開始・終了時刻を秒（クリップ先頭を0秒とする相対時刻・小数第1位まで）で付けること
+- 聞こえたとおり正確に。BGM・効果音のみの区間は含めない
+- 歌唱区間は "kind" に "song" を入れ、text は「♪」とだけ書く（歌詞は書き起こさない）
+JSONで出力: {"utterances": [{"start": number, "end": number, "text": string, "kind"?: "song"}]}`;
+}
+
+const MAX_UTTERANCE_TEXT_LENGTH = 200;
+
+/**
+ * Gemini 応答を検証して絶対時刻の発話リストへ変換する。
+ * 解釈不能なら null（graceful degradation。部分的に壊れた要素は捨てて続行する）
+ */
+export function parseTranscriptionResponse(
+	raw: string,
+	chunkStart: number,
+	chunkEnd: number,
+): TranscriptUtterance[] | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	const utterancesRaw = (parsed as { utterances?: unknown })?.utterances;
+	if (!Array.isArray(utterancesRaw)) {
+		return null;
+	}
+
+	const utterances: TranscriptUtterance[] = [];
+	for (const item of utterancesRaw) {
+		const candidate = item as { start?: unknown; end?: unknown; text?: unknown; kind?: unknown };
+		if (
+			typeof candidate.start !== "number" ||
+			typeof candidate.end !== "number" ||
+			typeof candidate.text !== "string" ||
+			!Number.isFinite(candidate.start) ||
+			!Number.isFinite(candidate.end)
+		) {
+			continue;
+		}
+		const start = roundTenth(chunkStart + candidate.start);
+		const end = roundTenth(chunkStart + candidate.end);
+		const text = candidate.text.trim().slice(0, MAX_UTTERANCE_TEXT_LENGTH);
+		if (text.length === 0 || end <= start || start < chunkStart) {
+			continue;
+		}
+		// オーバーラップ窓で拾った次チャンク分は捨てる（担当は start < chunkEnd の発話のみ）
+		if (start >= chunkEnd) {
+			continue;
+		}
+		utterances.push({
+			start,
+			end,
+			text,
+			...(candidate.kind === "song" ? { kind: "song" as const } : {}),
+		});
+	}
+	utterances.sort((a, b) => a.start - b.start);
+	return utterances;
+}
+
+/** 発話スナップの区間（パディング込み・動画長でクランプ） */
+export function snapRangeForUtterance(
+	utterance: Pick<TranscriptUtterance, "start" | "end">,
+	videoDurationSeconds: number,
+): { startTime: number; endTime: number } {
+	const startTime = roundTenth(Math.max(0, utterance.start - SNAP_PADDING_BEFORE_SECONDS));
+	const endTime = roundTenth(
+		Math.min(videoDurationSeconds, utterance.end + SNAP_PADDING_AFTER_SECONDS),
+	);
+	return { startTime, endTime: Math.max(endTime, roundTenth(startTime + 0.1)) };
+}

--- a/apps/web/src/lib/gemini/transcription-core.ts
+++ b/apps/web/src/lib/gemini/transcription-core.ts
@@ -26,15 +26,23 @@ export const SNAP_PADDING_AFTER_SECONDS = 0.35;
 
 const roundTenth = (value: number) => Math.round(value * 10) / 10;
 
-/** 指定秒を含むチャンク番号 */
-export function chunkIndexForTime(timeSeconds: number): number {
-	return Math.max(0, Math.floor(timeSeconds / CHUNK_SECONDS));
-}
-
 /** 動画に存在する最後のチャンク番号 */
 export function maxChunkIndex(videoDurationSeconds: number): number {
 	if (videoDurationSeconds <= 0) return 0;
 	return Math.floor((videoDurationSeconds - 1) / CHUNK_SECONDS);
+}
+
+/**
+ * 指定秒を含むチャンク番号。
+ * 動画長を渡すと最終チャンクへクランプする（再生位置がちょうど動画長のとき、
+ * floor(duration/600) が存在しないチャンクを指してしまう境界のズレ対策）
+ */
+export function chunkIndexForTime(timeSeconds: number, videoDurationSeconds?: number): number {
+	const index = Math.max(0, Math.floor(timeSeconds / CHUNK_SECONDS));
+	if (videoDurationSeconds !== undefined) {
+		return Math.min(index, maxChunkIndex(videoDurationSeconds));
+	}
+	return index;
 }
 
 /** チャンクの担当範囲と生成窓（オーバーラップ込み・動画長でクランプ） */

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -228,6 +228,7 @@ vi.mock("lucide-react", () => {
 		SlidersHorizontal: createMockIcon("SlidersHorizontal"),
 		RotateCcw: createMockIcon("RotateCcw"),
 		// Icons for AudioButtonCreator
+		Captions: createMockIcon("Captions"),
 		Plus: createMockIcon("Plus"),
 		SkipForward: createMockIcon("SkipForward"),
 		Sparkles: createMockIcon("Sparkles"),


### PR DESCRIPTION
## 概要

発話タイムライン（Claude Design 2a 案）の第1段（[SPR-292](https://linear.app/nothink/issue/SPR-292/)）。作成画面に**発話単位の文字起こし**を導入し、「探す＝聴く」を「読む」に変える。設計パラメータはすべて [SPR-291](https://linear.app/nothink/issue/SPR-291/) スパイクの実測値。

## 変更内容

### サーバ層
- **`transcription-core.ts`**（純ロジック・テスト対象）: 10分チャンク＋末尾オーバーラップ15秒、文字起こしプロンプト（歌唱は歌詞を書き起こさず ♪ に縮退）、応答検証（クリップ相対→絶対時刻変換・壊れた要素は捨てて続行）、スナップ区間（発話の 0.15 秒前〜0.35 秒後。実測精度±0.5秒と整合）
- **`video-transcription.ts` action**: `videos/{id}/transcriptChunks/{index}` の **Firestore キャッシュ優先**（他ユーザーの生成結果を共有・派生データ＝再生成可能・createdAt は Timestamp 規約）。無ければ Gemini 生成して保存。認可は getCurrentUser null チェック＋isActive 明示ブロック（外部 API コストのため）。生成パラメータは **thinkingBudget 1024 / maxOutputTokens 16384 / timeout 120s**（SPR-291: 思考トークン暴走で JSON 切断・レイテンシ数倍になる実測への対策）
- `gemini/client.ts`: 長尺クリップ用の options 追加（既存呼び出しは無変更）

### クライアント
- **`use-video-transcript`**: チャンク単位のオンデマンド読み込み。**画面を開いただけでは Gemini を呼ばない**。二重リクエスト防止・読み込み済み範囲の合成
- **トリムレーンの発話ブロック行**: クリックで発話にスナップ、**Shift＋クリックで隣接発話まで拡張**。レーン背景のクリックシークとは分離。発話行があるときだけレーンが縦に広がる（編集画面は従来レイアウトのまま）
- **発話リスト**（右カラム）: 時刻・テキスト・長さの行、「再生位置の周辺の発話を読み込む」追い読み、初回約30秒の進捗表示、エラーは表示のみ（既存フローに影響しない graceful degradation）
- **タイトル即時プリフィル**: スナップ時にタイトルが未入力なら発話テキストを入れる（上書きしない・♪ は入れない）。既存の AI 候補（SPR-148）はタグ推定の上乗せとして併存

## 検証

- `pnpm verify` 通過（core 15件・action 8件・リスト6件・レーン/creator 追加分を含む計 197+ テスト）
- **Emulator + 実 Gemini キーで実機確認**: 10分チャンク実生成（63発話・冒頭 BGM は ♪ 縮退）→ 行クリックで 0:19.1〜0:21.3 にスナップ＋タイトル「やっほー」プリフィル → Firestore キャッシュ書き込み（timestampValue）→ リロード後の再読み込みは**約1秒**（キャッシュ経路）

## コスト・スコープの割り切り

- 10分チャンク1回 ≈ 入力55k＋出力数kトークン（SPR-291 実測）・オンデマンドのみ・キャッシュ共有ありのため、継続コストはごく小さい
- 全編プリコンピュート・セリフ検索・探索レーンのヒットマークは **SPR-293**（One-Way Door として別途）
- 文字起こしテキストは作成補助のサイト内利用に留める（一般公開 UI には出さない）
- 新規 Firestore 複合インデックス不要（サブコレクションの直 doc get のみ）

区分: Two-Way Door（AI レビューで自己マージ可の候補）

🤖 Generated with [Claude Code](https://claude.com/claude-code)