### PR TITLE
feat(transcription): 全編プリコンピュート＋セリフ検索＋探索レーンのヒットマーク (SPR-293)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -252,7 +252,29 @@ jobs:
             --ingress-settings internal-only \
             --quiet &
           deploy_pids["checkDataIntegrity"]=$!
-          
+
+          # transcribeVideoBacklog（SPR-293）
+          # 1実行 = 最大12チャンク×約30秒の直列 Gemini 呼び出し。CPU はほぼ待ちだが
+          # timeout は上限の 540s を取り、処理側の 420s デッドラインで安全に切り上げる。
+          # GEMINI_API_KEY は --set-secrets で明示宣言する（暗黙の secret 持ち越しに依存しない）
+          gcloud functions deploy transcribeVideoBacklog \
+            --gen2 \
+            --source ${{ env.DEPLOYMENT_SOURCE }} \
+            --runtime nodejs24 \
+            --entry-point transcribeVideoBacklog \
+            --trigger-topic transcribe-video-backlog-trigger \
+            --region asia-northeast1 \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --set-env-vars NODE_ENV=production,FUNCTION_SIGNATURE_TYPE=cloudevent,FUNCTION_TARGET=transcribeVideoBacklog \
+            --set-secrets GEMINI_API_KEY=GEMINI_API_KEY:latest \
+            --memory 512Mi \
+            --timeout 540s \
+            --max-instances 1 \
+            --service-account transcribe-video-backlog-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
+            --ingress-settings internal-only \
+            --quiet &
+          deploy_pids["transcribeVideoBacklog"]=$!
+
           # 全デプロイの完了を待つ
           failed=false
           for func_name in "${!deploy_pids[@]}"; do

--- a/apps/functions/src/endpoints/index.ts
+++ b/apps/functions/src/endpoints/index.ts
@@ -15,6 +15,7 @@ import type { MessagePublishedData } from "../shared/pubsub-utils";
 // 各モジュールから関数をインポート（統合アーキテクチャ）
 import { checkDataIntegrity } from "./data-integrity/check-data-integrity";
 import { fetchDLsiteUnifiedData } from "./dlsite/fetch-dlsite-unified-data";
+import { transcribeVideoBacklog } from "./transcription/transcribe-video-backlog";
 import { fetchYouTubeVideos } from "./youtube/fetch-youtube-videos";
 
 /**
@@ -50,6 +51,7 @@ initializeApplication();
 functions.cloudEvent<MessagePublishedData>("fetchYouTubeVideos", fetchYouTubeVideos);
 functions.cloudEvent<MessagePublishedData>("fetchDLsiteUnifiedData", fetchDLsiteUnifiedData);
 functions.cloudEvent<unknown>("checkDataIntegrity", checkDataIntegrity);
+functions.cloudEvent<unknown>("transcribeVideoBacklog", transcribeVideoBacklog);
 
 /**
  * プロセス終了処理

--- a/apps/functions/src/endpoints/transcription/transcribe-video-backlog.ts
+++ b/apps/functions/src/endpoints/transcription/transcribe-video-backlog.ts
@@ -1,0 +1,33 @@
+/**
+ * 発話文字起こしバックログのエンドポイント（薄いハンドラ・SPR-293）。
+ * CloudEvent の受領 → バックログ処理 → 結果ログのみを担う。
+ * 本処理は services/transcription/transcribe-backlog.ts。
+ */
+
+import type { CloudEvent } from "@google-cloud/functions-framework";
+import { runTranscribeBacklog } from "../../services/transcription/transcribe-backlog";
+import * as logger from "../../shared/logger";
+
+/**
+ * Cloud Functions エントリーポイント（Cloud Scheduler → Pub/Sub トリガ）。
+ * チェックポイントはチャンク doc の存在＝多重起動・再実行とも安全（max-instances 1 前提）。
+ */
+export async function transcribeVideoBacklog(event: CloudEvent<unknown>): Promise<void> {
+	logger.info("文字起こしバックログ処理を開始", { eventType: event.type });
+
+	try {
+		const result = await runTranscribeBacklog();
+
+		// message はメトリクス契約（英語キー）: backlog 完走の監視は backlogRemaining=false を数える
+		logger.info("transcribe_backlog_run", {
+			scannedVideos: result.scannedVideos,
+			processedChunks: result.processedChunks,
+			failedChunks: result.failedChunks,
+			backlogRemaining: result.backlogRemaining,
+			elapsedMs: result.elapsedMs,
+		});
+	} catch (error) {
+		logger.error("文字起こしバックログ処理エラー", { error });
+		throw error;
+	}
+}

--- a/apps/functions/src/services/transcription/__tests__/transcribe-backlog.test.ts
+++ b/apps/functions/src/services/transcription/__tests__/transcribe-backlog.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGenerate = vi.fn();
+vi.mock("../gemini-client", () => ({
+	generateTranscriptionContent: (input: unknown) => mockGenerate(input),
+}));
+
+vi.mock("../../../shared/logger", () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
+// Firestore モック: videos 一覧・transcriptChunks の listDocuments / set
+const mockVideosGet = vi.fn();
+const mockListDocuments = vi.fn();
+const mockSet = vi.fn(async (_doc: Record<string, unknown>) => undefined);
+
+vi.mock("../../../infrastructure/database/firestore", () => ({
+	default: {
+		collection: () => ({
+			select: () => ({ get: mockVideosGet }),
+			doc: () => ({
+				collection: () => ({
+					listDocuments: mockListDocuments,
+					doc: () => ({ set: mockSet }),
+				}),
+			}),
+		}),
+	},
+}));
+
+const { runTranscribeBacklog } = await import("../transcribe-backlog");
+
+const GEMINI_TEXT = JSON.stringify({
+	utterances: [{ start: 1.0, end: 2.5, text: "こんにちは" }],
+});
+
+/** 動画 doc モック（PT 表記の duration・archived/embeddable 切替可能） */
+function videoDoc(
+	id: string,
+	{
+		duration = "PT15M",
+		archived = true,
+		embeddable = true,
+		publishedAt = "2026-07-01T00:00:00Z",
+	} = {},
+) {
+	return {
+		id,
+		data: () => ({
+			duration,
+			liveStreamingDetails: archived ? { actualEndTime: "2026-07-01T02:00:00Z" } : undefined,
+			status: { embeddable },
+			publishedAt,
+		}),
+	};
+}
+
+describe("runTranscribeBacklog (SPR-293)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.TRANSCRIBE_CHUNKS_PER_RUN;
+		mockGenerate.mockResolvedValue({ success: true, text: GEMINI_TEXT, totalTokens: 60000 });
+		mockListDocuments.mockResolvedValue([]);
+	});
+
+	it("未生成チャンクを生成して保存する（15分動画=チャンク2枚）", async () => {
+		mockVideosGet.mockResolvedValue({ docs: [videoDoc("video-00001")] });
+
+		const result = await runTranscribeBacklog();
+
+		expect(result.processedChunks).toBe(2);
+		expect(result.failedChunks).toBe(0);
+		expect(result.backlogRemaining).toBe(false);
+		expect(mockSet).toHaveBeenCalledTimes(2);
+		const written = mockSet.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(written.chunkIndex).toBe(0);
+		// Firestore は Date を Timestamp として保存する（新規コレクションの日時規約）
+		expect(written.createdAt).toBeInstanceOf(Date);
+	});
+
+	it("生成済みチャンクはスキップする（チェックポイント=doc 存在）", async () => {
+		mockVideosGet.mockResolvedValue({ docs: [videoDoc("video-00001")] });
+		mockListDocuments.mockResolvedValue([{ id: "0" }]);
+
+		const result = await runTranscribeBacklog();
+
+		expect(result.processedChunks).toBe(1);
+		const call = mockGenerate.mock.calls[0]?.[0] as { startOffsetSeconds: number };
+		expect(call.startOffsetSeconds).toBe(600);
+	});
+
+	it("チャンク予算で打ち切り backlogRemaining=true を返す", async () => {
+		process.env.TRANSCRIBE_CHUNKS_PER_RUN = "1";
+		mockVideosGet.mockResolvedValue({ docs: [videoDoc("video-00001")] });
+
+		const result = await runTranscribeBacklog();
+
+		expect(result.processedChunks).toBe(1);
+		expect(result.backlogRemaining).toBe(true);
+	});
+
+	it("新しい動画から先に処理する", async () => {
+		process.env.TRANSCRIBE_CHUNKS_PER_RUN = "1";
+		mockVideosGet.mockResolvedValue({
+			docs: [
+				videoDoc("older-video-1", { publishedAt: "2026-01-01T00:00:00Z" }),
+				videoDoc("newer-video-1", { publishedAt: "2026-07-01T00:00:00Z" }),
+			],
+		});
+
+		await runTranscribeBacklog();
+
+		const call = mockGenerate.mock.calls[0]?.[0] as { videoId: string };
+		expect(call.videoId).toBe("newer-video-1");
+	});
+
+	it("生成失敗は保存せず次の動画へ進む（次回リトライ）", async () => {
+		mockVideosGet.mockResolvedValue({
+			docs: [
+				videoDoc("video-00001", { publishedAt: "2026-07-01T00:00:00Z" }),
+				videoDoc("video-00002", { publishedAt: "2026-06-01T00:00:00Z" }),
+			],
+		});
+		mockGenerate
+			.mockResolvedValueOnce({ success: false, error: "HTTP 403" })
+			.mockResolvedValue({ success: true, text: GEMINI_TEXT });
+
+		const result = await runTranscribeBacklog();
+
+		// 1本目は初回失敗で打ち切り→2本目の2チャンクを処理
+		expect(result.failedChunks).toBe(1);
+		expect(result.processedChunks).toBe(2);
+		const videoIds = mockGenerate.mock.calls.map((c) => (c[0] as { videoId: string }).videoId);
+		expect(videoIds).toEqual(["video-00001", "video-00002", "video-00002"]);
+	});
+
+	it("配信アーカイブ以外・埋め込み不可・duration 不明はスキップする", async () => {
+		mockVideosGet.mockResolvedValue({
+			docs: [
+				videoDoc("normal-video-1", { archived: false }),
+				videoDoc("no-embed-vide1", { embeddable: false }),
+				videoDoc("no-duration-1", { duration: "" }),
+			],
+		});
+
+		const result = await runTranscribeBacklog();
+
+		expect(result.processedChunks).toBe(0);
+		expect(result.scannedVideos).toBe(0);
+		expect(mockGenerate).not.toHaveBeenCalled();
+	});
+
+	it("解釈不能な応答は保存せず失敗として数える", async () => {
+		mockVideosGet.mockResolvedValue({ docs: [videoDoc("video-00001")] });
+		mockGenerate.mockResolvedValue({ success: true, text: "not json" });
+
+		const result = await runTranscribeBacklog();
+
+		expect(result.failedChunks).toBe(1);
+		expect(mockSet).not.toHaveBeenCalled();
+	});
+});

--- a/apps/functions/src/services/transcription/gemini-client.ts
+++ b/apps/functions/src/services/transcription/gemini-client.ts
@@ -1,0 +1,105 @@
+/**
+ * Gemini API クライアント（functions 用・SPR-293）。
+ * YouTube URL + 区間クリップの generateContent に限定した素 fetch ラッパー。
+ * apps/web/src/lib/gemini/client.ts と同型（ロガーのみ functions 側）。SDK は追加しない。
+ * 生成パラメータの根拠は SPR-291 スパイク実測（思考上限なしは JSON 切断・レイテンシ数倍）。
+ */
+
+import * as logger from "../../shared/logger";
+
+const BASE_URL = "https://generativelanguage.googleapis.com/v1beta";
+const DEFAULT_MODEL = "gemini-3-flash-preview";
+/** 文字起こしは10分窓＝約30秒かかる（SPR-291 実測） */
+const REQUEST_TIMEOUT_MS = 120_000;
+const MAX_OUTPUT_TOKENS = 16_384;
+const THINKING_BUDGET = 1_024;
+
+export type TranscribeClipResult =
+	| { success: true; text: string; totalTokens?: number }
+	| { success: false; error: string };
+
+/**
+ * YouTube 動画の指定区間へのテキスト生成（文字起こし用固定パラメータ）。
+ * 失敗は success:false で返す（バッチ側で継続判断。throw しない）。
+ */
+export async function generateTranscriptionContent(input: {
+	videoId: string;
+	startOffsetSeconds: number;
+	endOffsetSeconds: number;
+	prompt: string;
+}): Promise<TranscribeClipResult> {
+	const apiKey = process.env.GEMINI_API_KEY;
+	if (!apiKey) {
+		logger.error("環境変数に GEMINI_API_KEY が設定されていません");
+		return { success: false, error: "GEMINI_API_KEY missing" };
+	}
+	const model = process.env.GEMINI_MODEL || DEFAULT_MODEL;
+
+	const body = {
+		contents: [
+			{
+				parts: [
+					{
+						file_data: {
+							file_uri: `https://www.youtube.com/watch?v=${input.videoId}`,
+						},
+						video_metadata: {
+							start_offset: `${input.startOffsetSeconds}s`,
+							end_offset: `${input.endOffsetSeconds}s`,
+						},
+					},
+					{ text: input.prompt },
+				],
+			},
+		],
+		generationConfig: {
+			response_mime_type: "application/json",
+			temperature: 0.1,
+			maxOutputTokens: MAX_OUTPUT_TOKENS,
+			thinkingConfig: { thinkingBudget: THINKING_BUDGET },
+		},
+	};
+
+	try {
+		const startedAt = Date.now();
+		const response = await fetch(`${BASE_URL}/models/${model}:generateContent`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"x-goog-api-key": apiKey,
+			},
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+		const elapsedMs = Date.now() - startedAt;
+
+		if (!response.ok) {
+			// 残高枯渇(429)・モデル廃止(404)は運用で気づく必要があるためエラーログに残す
+			const detail = (await response.text()).slice(0, 500);
+			logger.error("Gemini API がエラーを返却", {
+				model,
+				status: response.status,
+				elapsedMs,
+				detail,
+			});
+			return { success: false, error: `HTTP ${response.status}` };
+		}
+
+		const json = (await response.json()) as {
+			candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+			usageMetadata?: { totalTokenCount?: number };
+		};
+		const text = json.candidates?.[0]?.content?.parts?.map((part) => part.text ?? "").join("");
+		if (!text) {
+			logger.error("Gemini API 応答に候補テキストがありません", { model, elapsedMs });
+			return { success: false, error: "empty response" };
+		}
+		return { success: true, text, totalTokens: json.usageMetadata?.totalTokenCount };
+	} catch (error) {
+		logger.error("Gemini API 呼び出しでエラーが発生", {
+			model,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { success: false, error: "request failed" };
+	}
+}

--- a/apps/functions/src/services/transcription/transcribe-backlog.ts
+++ b/apps/functions/src/services/transcription/transcribe-backlog.ts
@@ -1,0 +1,185 @@
+/**
+ * 配信アーカイブの発話文字起こしバックログ処理（SPR-293）。
+ * チャンク（10分）単位で未生成分を新しい動画から順に埋める。
+ * チェックポイントは transcriptChunks の doc 存在そのもの＝再実行は常に安全（冪等）。
+ * 1回の実行はチャンク数と経過時間の両方で打ち切り、コストと関数タイムアウトを制御する。
+ */
+
+import {
+	buildTranscriptionPrompt,
+	chunkRange,
+	maxChunkIndex,
+	parseDurationToSeconds,
+	parseTranscriptionResponse,
+	type TranscriptUtterance,
+} from "@suzumina.click/shared-types";
+import firestore from "../../infrastructure/database/firestore";
+import * as logger from "../../shared/logger";
+import { generateTranscriptionContent } from "./gemini-client";
+
+/** 1実行あたりの生成チャンク上限（1チャンク≈30秒・入力55kトークン。SPR-291 実測） */
+const DEFAULT_CHUNKS_PER_RUN = 12;
+/** タイムアウト（540s）前に安全に切り上げる経過時間の上限 */
+const RUN_DEADLINE_MS = 420_000;
+
+interface ArchiveVideo {
+	videoId: string;
+	durationSeconds: number;
+}
+
+export interface TranscribeBacklogResult {
+	scannedVideos: number;
+	processedChunks: number;
+	failedChunks: number;
+	backlogRemaining: boolean;
+	elapsedMs: number;
+}
+
+function chunksPerRun(): number {
+	const raw = Number.parseInt(process.env.TRANSCRIBE_CHUNKS_PER_RUN ?? "", 10);
+	return Number.isInteger(raw) && raw > 0 ? raw : DEFAULT_CHUNKS_PER_RUN;
+}
+
+/**
+ * 文字起こし対象のアーカイブ一覧（新しい順）。
+ * 全件取得 + in-memory フィルタは本リポジトリの標準パターン（複合インデックスを増やさない）
+ */
+async function listArchiveVideos(): Promise<ArchiveVideo[]> {
+	const snapshot = await firestore
+		.collection("videos")
+		.select("duration", "liveStreamingDetails", "status", "publishedAt")
+		.get();
+
+	const archives: Array<ArchiveVideo & { publishedAt: string }> = [];
+	for (const doc of snapshot.docs) {
+		const data = doc.data() as {
+			duration?: string;
+			liveStreamingDetails?: { actualEndTime?: unknown };
+			status?: { embeddable?: boolean };
+			publishedAt?: string;
+		};
+		// 音声ボタン作成対象（配信アーカイブ・埋め込み可）だけを文字起こしする
+		if (!data.liveStreamingDetails?.actualEndTime || data.status?.embeddable === false) {
+			continue;
+		}
+		const durationSeconds = parseDurationToSeconds(data.duration);
+		if (durationSeconds <= 0) {
+			continue;
+		}
+		archives.push({ videoId: doc.id, durationSeconds, publishedAt: data.publishedAt ?? "" });
+	}
+	archives.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+	return archives.map(({ videoId, durationSeconds }) => ({ videoId, durationSeconds }));
+}
+
+/** 未生成チャンク番号（昇順）。doc ID 一覧のみ取得（listDocuments）で内容は読まない */
+async function listMissingChunkIndexes(video: ArchiveVideo): Promise<number[]> {
+	const refs = await firestore
+		.collection("videos")
+		.doc(video.videoId)
+		.collection("transcriptChunks")
+		.listDocuments();
+	const existing = new Set(refs.map((ref) => Number.parseInt(ref.id, 10)));
+	const missing: number[] = [];
+	for (let index = 0; index <= maxChunkIndex(video.durationSeconds); index++) {
+		if (!existing.has(index)) {
+			missing.push(index);
+		}
+	}
+	return missing;
+}
+
+/** 1チャンク生成して保存。失敗は false（書き込まない＝次回リトライ） */
+async function generateChunk(video: ArchiveVideo, chunkIndex: number): Promise<boolean> {
+	const { chunkStart, chunkEnd, requestStart, requestEnd } = chunkRange(
+		chunkIndex,
+		video.durationSeconds,
+	);
+	const generated = await generateTranscriptionContent({
+		videoId: video.videoId,
+		startOffsetSeconds: requestStart,
+		endOffsetSeconds: requestEnd,
+		prompt: buildTranscriptionPrompt(),
+	});
+	if (!generated.success) {
+		return false;
+	}
+	const utterances: TranscriptUtterance[] | null = parseTranscriptionResponse(
+		generated.text,
+		chunkStart,
+		chunkEnd,
+	);
+	if (utterances === null) {
+		logger.warn("文字起こし応答を解釈できませんでした", {
+			videoId: video.videoId,
+			chunkIndex,
+			raw: generated.text.slice(0, 200),
+		});
+		return false;
+	}
+	await firestore
+		.collection("videos")
+		.doc(video.videoId)
+		.collection("transcriptChunks")
+		.doc(String(chunkIndex))
+		.set({
+			chunkIndex,
+			chunkStart,
+			chunkEnd,
+			utterances,
+			model: process.env.GEMINI_MODEL || "gemini-3-flash-preview",
+			createdAt: new Date(),
+		});
+	logger.info("文字起こしチャンクを生成", {
+		videoId: video.videoId,
+		chunkIndex,
+		utteranceCount: utterances.length,
+		totalTokens: generated.totalTokens,
+	});
+	return true;
+}
+
+/**
+ * バックログを1実行分だけ進める。
+ * 予算（チャンク数・経過時間）に達したら途中で切り上げる。次回実行が続きから埋める
+ */
+export async function runTranscribeBacklog(): Promise<TranscribeBacklogResult> {
+	const startedAt = Date.now();
+	const budget = chunksPerRun();
+	let processedChunks = 0;
+	let failedChunks = 0;
+	let scannedVideos = 0;
+	let backlogRemaining = false;
+
+	const archives = await listArchiveVideos();
+	for (const video of archives) {
+		if (processedChunks >= budget || Date.now() - startedAt > RUN_DEADLINE_MS) {
+			backlogRemaining = true;
+			break;
+		}
+		scannedVideos++;
+		const missing = await listMissingChunkIndexes(video);
+		for (const chunkIndex of missing) {
+			if (processedChunks >= budget || Date.now() - startedAt > RUN_DEADLINE_MS) {
+				backlogRemaining = true;
+				break;
+			}
+			const ok = await generateChunk(video, chunkIndex);
+			if (ok) {
+				processedChunks++;
+			} else {
+				failedChunks++;
+				// 同一動画で連続失敗する場合（削除済み・地域制限等）に予算を溶かさないよう次の動画へ
+				break;
+			}
+		}
+	}
+
+	return {
+		scannedVideos,
+		processedChunks,
+		failedChunks,
+		backlogRemaining,
+		elapsedMs: Date.now() - startedAt,
+	};
+}

--- a/apps/web/src/actions/__tests__/video-transcription.test.ts
+++ b/apps/web/src/actions/__tests__/video-transcription.test.ts
@@ -11,7 +11,9 @@ vi.mock("@/lib/logger", () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })
 const mockGetFirestore = vi.fn();
 vi.mock("@/lib/firestore", () => ({ getFirestore: mockGetFirestore }));
 
-const { getVideoTranscriptChunk } = await import("../video-transcription");
+const { getCachedTranscriptChunks, getVideoTranscriptChunk } = await import(
+	"../video-transcription"
+);
 
 const VALID_INPUT = { videoId: "97UnRtIlMc0", chunkIndex: 1 };
 
@@ -26,10 +28,12 @@ function setupFirestore({
 	cachedChunk = null,
 	videoDuration = "PT2H23M59S",
 	videoExists = true,
+	allChunks = [],
 }: {
 	cachedChunk?: Record<string, unknown> | null;
 	videoDuration?: string;
 	videoExists?: boolean;
+	allChunks?: Array<Record<string, unknown>>;
 } = {}) {
 	const mockSet = vi.fn(async (_doc: Record<string, unknown>) => undefined);
 	const chunkDoc = {
@@ -39,12 +43,18 @@ function setupFirestore({
 		})),
 		set: mockSet,
 	};
+	const chunkCollectionRef = {
+		doc: vi.fn(() => chunkDoc),
+		get: vi.fn(async () => ({
+			docs: allChunks.map((chunk) => ({ data: () => chunk })),
+		})),
+	};
 	const videoDocRef = {
 		get: vi.fn(async () => ({
 			exists: videoExists,
 			data: () => ({ duration: videoDuration }),
 		})),
-		collection: vi.fn(() => ({ doc: vi.fn(() => chunkDoc) })),
+		collection: vi.fn(() => chunkCollectionRef),
 	};
 	mockGetFirestore.mockReturnValue({
 		collection: vi.fn(() => ({ doc: vi.fn(() => videoDocRef) })),
@@ -155,5 +165,54 @@ describe("getVideoTranscriptChunk (SPR-292)", () => {
 		mockGenerateClipContent.mockResolvedValue({ success: true, text: "not json" });
 		expect((await getVideoTranscriptChunk(VALID_INPUT)).success).toBe(false);
 		expect(mockSet).not.toHaveBeenCalled();
+	});
+});
+
+describe("getCachedTranscriptChunks (SPR-293)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: true });
+	});
+
+	it("キャッシュ済みチャンクを chunkIndex 昇順で返す（生成はしない）", async () => {
+		setupFirestore({
+			allChunks: [
+				{ chunkIndex: 2, utterances: [{ start: 1201, end: 1203, text: "後半" }] },
+				{ chunkIndex: 0, utterances: [{ start: 1, end: 3, text: "冒頭" }] },
+			],
+		});
+
+		const result = await getCachedTranscriptChunks({ videoId: "97UnRtIlMc0" });
+
+		expect(result).toEqual({
+			success: true,
+			data: {
+				chunks: [
+					{ chunkIndex: 0, utterances: [{ start: 1, end: 3, text: "冒頭" }] },
+					{ chunkIndex: 2, utterances: [{ start: 1201, end: 1203, text: "後半" }] },
+				],
+			},
+		});
+		expect(mockGenerateClipContent).not.toHaveBeenCalled();
+	});
+
+	it("未ログイン・無効ユーザー・不正な videoId は弾く", async () => {
+		setupFirestore();
+		mockGetCurrentUser.mockResolvedValue(null);
+		expect((await getCachedTranscriptChunks({ videoId: "97UnRtIlMc0" })).success).toBe(false);
+
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: false });
+		expect((await getCachedTranscriptChunks({ videoId: "97UnRtIlMc0" })).success).toBe(false);
+
+		mockGetCurrentUser.mockResolvedValue({ discordId: "u1", isActive: true });
+		expect((await getCachedTranscriptChunks({ videoId: "bad id!" })).success).toBe(false);
+	});
+
+	it("キャッシュが空でも成功として空配列を返す", async () => {
+		setupFirestore({ allChunks: [] });
+
+		const result = await getCachedTranscriptChunks({ videoId: "97UnRtIlMc0" });
+
+		expect(result).toEqual({ success: true, data: { chunks: [] } });
 	});
 });

--- a/apps/web/src/actions/video-transcription.ts
+++ b/apps/web/src/actions/video-transcription.ts
@@ -1,16 +1,16 @@
 "use server";
 
-import { parseDurationToSeconds } from "@suzumina.click/shared-types";
-import { getCurrentUser } from "@/lib/auth/server";
-import { getFirestore } from "@/lib/firestore";
-import { generateClipContent } from "@/lib/gemini/client";
 import {
 	buildTranscriptionPrompt,
 	chunkRange,
 	maxChunkIndex,
+	parseDurationToSeconds,
 	parseTranscriptionResponse,
 	type TranscriptUtterance,
-} from "@/lib/gemini/transcription-core";
+} from "@suzumina.click/shared-types";
+import { getCurrentUser } from "@/lib/auth/server";
+import { getFirestore } from "@/lib/firestore";
+import { generateClipContent } from "@/lib/gemini/client";
 import * as logger from "@/lib/logger";
 
 const VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
@@ -33,6 +33,47 @@ interface TranscriptChunkDocument {
 export interface GetTranscriptChunkInput {
 	videoId: string;
 	chunkIndex: number;
+}
+
+export type GetCachedTranscriptChunksResult =
+	| {
+			success: true;
+			data: { chunks: Array<{ chunkIndex: number; utterances: TranscriptUtterance[] }> };
+	  }
+	| { success: false; error: string };
+
+/**
+ * キャッシュ済みの全チャンクを返す（SPR-293 セリフ検索用）。
+ * **生成はしない**（読み取りのみ）。バックログ処理（transcribeVideoBacklog）が
+ * 埋めた分だけが返る＝カバレッジはクライアント側で表示する
+ */
+export async function getCachedTranscriptChunks(input: {
+	videoId: string;
+}): Promise<GetCachedTranscriptChunksResult> {
+	try {
+		const user = await getCurrentUser();
+		if (!user?.discordId || !user.isActive) {
+			return { success: false, error: "ログインが必要です" };
+		}
+		if (!VIDEO_ID_PATTERN.test(input.videoId)) {
+			return { success: false, error: "動画IDが不正です" };
+		}
+
+		const snapshot = await chunkCollection(input.videoId).get();
+		const chunks = snapshot.docs
+			.map((doc) => {
+				const data = doc.data() as TranscriptChunkDocument;
+				return { chunkIndex: data.chunkIndex, utterances: data.utterances ?? [] };
+			})
+			.sort((a, b) => a.chunkIndex - b.chunkIndex);
+		return { success: true, data: { chunks } };
+	} catch (error) {
+		logger.error("キャッシュ済み文字起こしの取得でエラーが発生", {
+			videoId: input.videoId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return { success: false, error: "文字起こしの取得に失敗しました" };
+	}
 }
 
 export type GetTranscriptChunkResult =

--- a/apps/web/src/components/audio/__tests__/clip-explore-lane.test.tsx
+++ b/apps/web/src/components/audio/__tests__/clip-explore-lane.test.tsx
@@ -71,6 +71,12 @@ describe("ClipExploreLane", () => {
 		expect(screen.getAllByTestId("explore-made-mark")).toHaveLength(2);
 	});
 
+	it("セリフ検索ヒットマークが描画される（重複排除つき・SPR-293）", () => {
+		render(<ClipExploreLane {...defaultProps} searchHitMarks={[300, 300, 4993.6]} />);
+
+		expect(screen.getAllByTestId("explore-search-hit")).toHaveLength(2);
+	});
+
 	it("マーク未指定でも描画できる（未ログイン・編集画面）", () => {
 		render(
 			<ClipExploreLane

--- a/apps/web/src/components/audio/__tests__/utterance-list-panel.test.tsx
+++ b/apps/web/src/components/audio/__tests__/utterance-list-panel.test.tsx
@@ -17,6 +17,9 @@ describe("UtteranceListPanel", () => {
 		isLoadedAt: vi.fn(() => true),
 		onLoadAt: vi.fn(),
 		onSelect: vi.fn(),
+		onLoadAllCached: vi.fn(),
+		hasLoadedAllCached: false,
+		onSearchHitsChange: vi.fn(),
 	};
 
 	beforeEach(() => {
@@ -75,5 +78,53 @@ describe("UtteranceListPanel", () => {
 			expect(row).toBeDisabled();
 		}
 		expect(screen.getByRole("button", { name: /再生位置の周辺の発話を読み込む/ })).toBeDisabled();
+	});
+
+	describe("セリフ検索 (SPR-293)", () => {
+		it("検索でかな正規化の部分一致に絞り込み、ヒット位置を通知する", () => {
+			render(<UtteranceListPanel {...defaultProps} hasLoadedAllCached />);
+
+			const input = screen.getByPlaceholderText(/セリフで探す/);
+			// カタカナ入力でもひらがな発話にヒットする
+			fireEvent.change(input, { target: { value: "コンニチハ" } });
+
+			expect(screen.getAllByTestId("utterance-row")).toHaveLength(1);
+			expect(screen.getByText("こんにちは")).toBeInTheDocument();
+			expect(screen.getByText(/1件ヒット/)).toBeInTheDocument();
+			expect(defaultProps.onSearchHitsChange).toHaveBeenLastCalledWith([601.5]);
+		});
+
+		it("検索を消すと全件表示に戻りヒット通知は空になる", () => {
+			render(<UtteranceListPanel {...defaultProps} hasLoadedAllCached />);
+
+			const input = screen.getByPlaceholderText(/セリフで探す/);
+			fireEvent.change(input, { target: { value: "こんにちは" } });
+			fireEvent.change(input, { target: { value: "" } });
+
+			expect(screen.getAllByTestId("utterance-row")).toHaveLength(2);
+			expect(defaultProps.onSearchHitsChange).toHaveBeenLastCalledWith([]);
+		});
+
+		it("初回の検索入力でキャッシュ済み全チャンクの読み込みが走る", () => {
+			render(<UtteranceListPanel {...defaultProps} />);
+
+			fireEvent.change(screen.getByPlaceholderText(/セリフで探す/), {
+				target: { value: "あはは" },
+			});
+
+			expect(defaultProps.onLoadAllCached).toHaveBeenCalled();
+			expect(screen.getByText(/全編読み込み中/)).toBeInTheDocument();
+		});
+
+		it("読み込み済みなら再読み込みしない", () => {
+			render(<UtteranceListPanel {...defaultProps} hasLoadedAllCached />);
+
+			fireEvent.change(screen.getByPlaceholderText(/セリフで探す/), {
+				target: { value: "あはは" },
+			});
+
+			expect(defaultProps.onLoadAllCached).not.toHaveBeenCalled();
+			expect(screen.getByText("ヒットなし")).toBeInTheDocument();
+		});
 	});
 });

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AudioButtonDraft, CreateAudioButtonInput } from "@suzumina.click/shared-types";
+import { snapRangeForUtterance, type TranscriptUtterance } from "@suzumina.click/shared-types";
 import { YouTubePlayer } from "@suzumina.click/ui/components/custom/youtube-player";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { ExternalLink, SkipForward } from "lucide-react";
@@ -12,7 +13,6 @@ import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
 import { useVideoTranscript } from "@/hooks/use-video-transcript";
 import { trackCreateError, trackCreateStart, trackCreateSuccess } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
-import { snapRangeForUtterance, type TranscriptUtterance } from "@/lib/gemini/transcription-core";
 import { formatSeconds } from "@/utils/format-seconds";
 import { BasicInfoPanel } from "./basic-info-panel";
 import { CreateButtonLimit } from "./create-button-limit";
@@ -104,6 +104,8 @@ export function AudioButtonCreator({
 
 	// 発話文字起こし（SPR-292）。オンデマンド読み込み＝開いただけでは Gemini を呼ばない
 	const transcript = useVideoTranscript(videoId, youtubeManager.videoDuration || videoDuration);
+	// セリフ検索のヒット位置（SPR-293）。リストパネルが検索するたび探索レーンへ反映する
+	const [searchHits, setSearchHits] = useState<number[]>([]);
 
 	// 次の下書きへフォームとプレイヤーを進める（遷移なし＝プレイヤー維持が連続仕上げの本体）
 	const { setStartTime, setEndTime } = timeAdjustment;
@@ -342,6 +344,7 @@ export function AudioButtonCreator({
 									draftMarks={draftMarkList}
 									utterances={transcript.utterances}
 									onUtteranceClick={handleUtteranceSelect}
+									searchHitMarks={searchHits}
 									isCreating={isCreating}
 								/>
 							</div>
@@ -408,6 +411,9 @@ export function AudioButtonCreator({
 								disabled={isCreating}
 								onLoadAt={transcript.loadChunkAt}
 								onSelect={handleUtteranceSelect}
+								onLoadAllCached={transcript.loadAllCached}
+								hasLoadedAllCached={transcript.hasLoadedAllCached}
+								onSearchHitsChange={setSearchHits}
 							/>
 
 							<BasicInfoPanel

--- a/apps/web/src/components/audio/clip-explore-lane.tsx
+++ b/apps/web/src/components/audio/clip-explore-lane.tsx
@@ -24,6 +24,8 @@ interface ClipExploreLaneProps {
 	madeMarks?: number[];
 	/** 自分の下書きの開始時刻 */
 	draftMarks?: number[];
+	/** セリフ検索のヒット開始時刻（SPR-293）。全編から一発で引くための縦線 */
+	searchHitMarks?: number[];
 	disabled?: boolean;
 	/** クリックでその位置へジャンプ（クリップ移動＋トリムレーン追従は親が行う） */
 	onJump: (time: number) => void;
@@ -40,6 +42,7 @@ export function ClipExploreLane({
 	windowEnd,
 	madeMarks = [],
 	draftMarks = [],
+	searchHitMarks = [],
 	disabled = false,
 	onJump,
 }: ClipExploreLaneProps) {
@@ -58,6 +61,7 @@ export function ClipExploreLane({
 	// 同一時刻のマークは重なって見分けがつかないため重複排除（key の一意性も兼ねる）
 	const uniqueDraftMarks = [...new Set(draftMarks)];
 	const uniqueMadeMarks = [...new Set(madeMarks)];
+	const uniqueSearchHitMarks = [...new Set(searchHitMarks)];
 
 	const onLaneClick = (event: React.MouseEvent<HTMLDivElement>) => {
 		if (disabled) return;
@@ -88,6 +92,16 @@ export function ClipExploreLane({
 						{formatSeconds(t)}
 					</div>
 				</div>
+			))}
+
+			{/* セリフ検索ヒット（縦通し・SPR-293）: 「あの一言」を全編から一発で引く */}
+			{uniqueSearchHitMarks.map((t) => (
+				<div
+					key={`hit-${t}`}
+					data-testid="explore-search-hit"
+					className="pointer-events-none absolute top-1 h-8 w-0.5 bg-heart"
+					style={{ left: `${positionPercent(t)}%` }}
+				/>
 			))}
 
 			{/* 下書きマーク（上段） */}

--- a/apps/web/src/components/audio/clip-trim-lane.tsx
+++ b/apps/web/src/components/audio/clip-trim-lane.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import type { TranscriptUtterance } from "@suzumina.click/shared-types";
 import { formatTimestamp } from "@suzumina.click/shared-types";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { TranscriptUtterance } from "@/lib/gemini/transcription-core";
 import { formatSeconds } from "@/utils/format-seconds";
 
 /** 切り抜き長の制約（バリデーションの正本は use-audio-button-validation。ドラッグ時の先行クランプ用） */

--- a/apps/web/src/components/audio/time-control-panel.tsx
+++ b/apps/web/src/components/audio/time-control-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { TranscriptUtterance } from "@suzumina.click/shared-types";
 import { formatTimestamp } from "@suzumina.click/shared-types";
 import { TimeDisplay } from "@suzumina.click/ui/components/custom/time-display";
 import { ValidationMessages } from "@suzumina.click/ui/components/custom/validation-message";
@@ -8,7 +9,6 @@ import { Checkbox } from "@suzumina.click/ui/components/ui/checkbox";
 import { Input } from "@suzumina.click/ui/components/ui/input";
 import { Clock, MousePointer, Play, Square } from "lucide-react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
-import type { TranscriptUtterance } from "@/lib/gemini/transcription-core";
 import { matchShortcutKey } from "@/lib/keyboard-shortcut";
 import { ClipExploreLane } from "./clip-explore-lane";
 import { ClipTrimLane } from "./clip-trim-lane";
@@ -139,6 +139,8 @@ interface TimeControlPanelProps {
 	// 発話行（SPR-292）。省略時は従来レイアウト（編集画面など）
 	utterances?: TranscriptUtterance[];
 	onUtteranceClick?: (utterance: TranscriptUtterance, extend: boolean) => void;
+	// セリフ検索ヒットの探索レーン表示（SPR-293）
+	searchHitMarks?: number[];
 
 	// UI状態
 	isCreating: boolean;
@@ -235,6 +237,7 @@ export function TimeControlPanel({
 	draftMarks = [],
 	utterances,
 	onUtteranceClick,
+	searchHitMarks,
 	isCreating,
 }: TimeControlPanelProps) {
 	const prerollId = useId();
@@ -355,6 +358,7 @@ export function TimeControlPanel({
 					windowEnd={viewCenter + halfWindow}
 					madeMarks={madeMarks}
 					draftMarks={draftMarks}
+					searchHitMarks={searchHitMarks}
 					disabled={isCreating}
 					onJump={handleExploreJump}
 				/>

--- a/apps/web/src/components/audio/utterance-list-panel.tsx
+++ b/apps/web/src/components/audio/utterance-list-panel.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import {
+	normalizeForTranscriptSearch,
+	type TranscriptUtterance,
+} from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
-import { Captions, Loader2 } from "lucide-react";
-import type { TranscriptUtterance } from "@/lib/gemini/transcription-core";
+import { Input } from "@suzumina.click/ui/components/ui/input";
+import { Captions, Loader2, Search } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { formatSeconds } from "@/utils/format-seconds";
 
 const roundTenth = (value: number) => Math.round(value * 10) / 10;
@@ -20,12 +25,18 @@ interface UtteranceListPanelProps {
 	onLoadAt: (timeSeconds: number) => void;
 	/** 行クリック（extend=Shift クリック: 現在区間を発話まで広げる） */
 	onSelect: (utterance: TranscriptUtterance, extend: boolean) => void;
+	/** セリフ検索（SPR-293）: 初回の検索入力でキャッシュ済み全チャンクを読み込む */
+	onLoadAllCached: () => void;
+	hasLoadedAllCached: boolean;
+	/** 検索ヒットの開始秒（探索レーンの縦線マーク用）。検索が空なら [] */
+	onSearchHitsChange: (hitStartTimes: number[]) => void;
 }
 
 /**
- * 読み込み済み範囲の発話リスト（SPR-292）。
+ * 発話リストとセリフ検索（SPR-292/293）。
  * 「探す＝聴く」を「読む」に変える段。クリックで発話に区間スナップ＋タイトルプリフィル。
- * 全編検索は Stage 2（SPR-293）。
+ * 検索はキャッシュ済み文字起こし（バックログ処理が随時埋める）に対する
+ * かな正規化の部分一致。カバレッジが部分的な間はその旨を表示する。
  */
 export function UtteranceListPanel({
 	utterances,
@@ -37,7 +48,35 @@ export function UtteranceListPanel({
 	disabled = false,
 	onLoadAt,
 	onSelect,
+	onLoadAllCached,
+	hasLoadedAllCached,
+	onSearchHitsChange,
 }: UtteranceListPanelProps) {
+	const [query, setQuery] = useState("");
+	const normalizedQuery = normalizeForTranscriptSearch(query);
+	const isSearching = normalizedQuery.length > 0;
+
+	// 検索意図が見えた時点でキャッシュ済み全チャンクを読み込む（生成なし＝軽い）
+	useEffect(() => {
+		if (isSearching && !hasLoadedAllCached) {
+			onLoadAllCached();
+		}
+	}, [isSearching, hasLoadedAllCached, onLoadAllCached]);
+
+	const visibleUtterances = useMemo(() => {
+		if (!isSearching) {
+			return utterances;
+		}
+		return utterances.filter((utterance) =>
+			normalizeForTranscriptSearch(utterance.text).includes(normalizedQuery),
+		);
+	}, [utterances, isSearching, normalizedQuery]);
+
+	// 探索レーンの縦線マーク（検索中のみ）
+	useEffect(() => {
+		onSearchHitsChange(isSearching ? visibleUtterances.map((u) => u.start) : []);
+	}, [isSearching, visibleUtterances, onSearchHitsChange]);
+
 	const rangeLabel =
 		loadedRanges.length > 0
 			? loadedRanges
@@ -57,11 +96,32 @@ export function UtteranceListPanel({
 				で隣の発話まで広げます
 			</p>
 
+			<div className="relative mb-3">
+				<Search className="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+				<Input
+					type="text"
+					value={query}
+					onChange={(event) => setQuery(event.target.value)}
+					placeholder="セリフで探す（例: あはは）"
+					disabled={disabled}
+					className="min-h-[44px] pl-9 text-sm"
+				/>
+			</div>
+
 			{error && <p className="mb-2 text-sm text-destructive">{error}</p>}
 
-			{utterances.length > 0 && (
+			{isSearching && (
+				<p className="mb-2 text-xs text-muted-foreground">
+					{visibleUtterances.length > 0
+						? `${visibleUtterances.length}件ヒット（探索レーンに位置を表示中）`
+						: "ヒットなし"}
+					{!hasLoadedAllCached && "・全編読み込み中…"}
+				</p>
+			)}
+
+			{visibleUtterances.length > 0 && (
 				<div className="mb-3 flex max-h-72 flex-col gap-1 overflow-y-auto">
-					{utterances.map((utterance) => (
+					{visibleUtterances.map((utterance) => (
 						<button
 							key={`row-${utterance.start}`}
 							type="button"
@@ -88,6 +148,7 @@ export function UtteranceListPanel({
 					文字起こしを生成しています（初回は30秒ほどかかります）
 				</div>
 			) : (
+				!isSearching &&
 				!currentLoaded && (
 					<Button
 						variant="outline"
@@ -101,7 +162,7 @@ export function UtteranceListPanel({
 				)
 			)}
 
-			{rangeLabel && (
+			{rangeLabel && !isSearching && (
 				<p className="mt-2 text-xs text-muted-foreground">読み込み済み: {rangeLabel}</p>
 			)}
 		</div>

--- a/apps/web/src/hooks/use-video-transcript.ts
+++ b/apps/web/src/hooks/use-video-transcript.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
-import { getVideoTranscriptChunk } from "@/actions/video-transcription";
 import {
 	CHUNK_SECONDS,
 	chunkIndexForTime,
 	type TranscriptUtterance,
-} from "@/lib/gemini/transcription-core";
+} from "@suzumina.click/shared-types";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { getCachedTranscriptChunks, getVideoTranscriptChunk } from "@/actions/video-transcription";
 
 export interface VideoTranscriptState {
 	/** 読み込み済み発話（チャンク横断・start 昇順） */
@@ -19,6 +19,10 @@ export interface VideoTranscriptState {
 	loadChunkAt: (timeSeconds: number) => void;
 	/** 指定秒が読み込み済みか */
 	isLoadedAt: (timeSeconds: number) => boolean;
+	/** キャッシュ済み全チャンクを読み込む（生成なし・セリフ検索用・SPR-293） */
+	loadAllCached: () => void;
+	/** loadAllCached 実行済みか（検索の初回トリガ判定用） */
+	hasLoadedAllCached: boolean;
 }
 
 /**
@@ -69,6 +73,37 @@ export function useVideoTranscript(
 		[videoId, videoDurationSeconds, chunks],
 	);
 
+	// キャッシュ済み全チャンクの一括読み込み（生成なし＝doc 読み取りのみで高速）
+	const [hasLoadedAllCached, setHasLoadedAllCached] = useState(false);
+	const loadAllCachedInFlightRef = useRef(false);
+	const loadAllCached = useCallback(() => {
+		if (hasLoadedAllCached || loadAllCachedInFlightRef.current) {
+			return;
+		}
+		loadAllCachedInFlightRef.current = true;
+		void getCachedTranscriptChunks({ videoId })
+			.then((result) => {
+				if (result.success) {
+					setChunks((prev) => {
+						const next = new Map(prev);
+						for (const chunk of result.data.chunks) {
+							next.set(chunk.chunkIndex, chunk.utterances);
+						}
+						return next;
+					});
+					setHasLoadedAllCached(true);
+				} else {
+					setError(result.error);
+				}
+			})
+			.catch(() => {
+				setError("文字起こしの取得に失敗しました");
+			})
+			.finally(() => {
+				loadAllCachedInFlightRef.current = false;
+			});
+	}, [videoId, hasLoadedAllCached]);
+
 	const utterances = useMemo(() => {
 		const merged: TranscriptUtterance[] = [];
 		for (const list of chunks.values()) {
@@ -98,5 +133,14 @@ export function useVideoTranscript(
 		[chunks, videoDurationSeconds],
 	);
 
-	return { utterances, loadedRanges, isLoading, error, loadChunkAt, isLoadedAt };
+	return {
+		utterances,
+		loadedRanges,
+		isLoading,
+		error,
+		loadChunkAt,
+		isLoadedAt,
+		loadAllCached,
+		hasLoadedAllCached,
+	};
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -163,3 +163,5 @@ export * from "./utilities/price-history";
 export * from "./utilities/user/display-name";
 // DLsite ID validators (extracted from entities/circle-creator)
 export * from "./utilities/validators/dlsite-ids";
+// 発話文字起こし（SPR-292/293）: web と functions が共有するチャンク割り・パース・スナップ
+export * from "./utilities/video-transcription";

--- a/packages/shared-types/src/utilities/__tests__/video-transcription.test.ts
+++ b/packages/shared-types/src/utilities/__tests__/video-transcription.test.ts
@@ -5,9 +5,10 @@ import {
 	chunkIndexForTime,
 	chunkRange,
 	maxChunkIndex,
+	normalizeForTranscriptSearch,
 	parseTranscriptionResponse,
 	snapRangeForUtterance,
-} from "../transcription-core";
+} from "../video-transcription";
 
 describe("chunkIndexForTime / maxChunkIndex", () => {
 	it("10分単位でチャンク番号を返す", () => {
@@ -138,5 +139,26 @@ describe("snapRangeForUtterance", () => {
 			startTime: 0,
 			endTime: 3600,
 		});
+	});
+});
+
+describe("normalizeForTranscriptSearch", () => {
+	it("カタカナをひらがなへ寄せる（表記ゆれ吸収）", () => {
+		expect(normalizeForTranscriptSearch("コンニチハ")).toBe(
+			normalizeForTranscriptSearch("こんにちは"),
+		);
+	});
+
+	it("空白・句読点・感嘆・長音・♪ を除去する", () => {
+		expect(normalizeForTranscriptSearch("え、ほんと！？ 〜すごい…♪ー")).toBe("えほんとすごい");
+	});
+
+	it("英字は小文字へ寄せる", () => {
+		expect(normalizeForTranscriptSearch("OK です")).toBe("okです");
+	});
+
+	it("正規化後に部分一致で使える（実利用の形）", () => {
+		const utterance = normalizeForTranscriptSearch("えっ、ベェ〜！");
+		expect(utterance.includes(normalizeForTranscriptSearch("べぇ"))).toBe(true);
 	});
 });

--- a/packages/shared-types/src/utilities/video-transcription.ts
+++ b/packages/shared-types/src/utilities/video-transcription.ts
@@ -1,7 +1,8 @@
 /**
- * 動画の発話単位文字起こし（SPR-292）の純粋ロジック。
- * Gemini API 呼び出し本体は client.ts。ここはチャンク計算・プロンプト・応答検証のみ（テスト対象）。
- * 設計パラメータ（10分チャンク・オーバーラップ・思考上限）の根拠は SPR-291 スパイク実測。
+ * 動画の発話単位文字起こし（SPR-292/293）の純粋ロジック。
+ * web（オンデマンド取得）と functions（バッチ生成）が同じチャンク割り・プロンプト・
+ * 応答検証を使うため shared-types に置く（正本の一元化）。Gemini API 呼び出し本体は
+ * 各アプリ側のクライアント。設計パラメータの根拠は SPR-291 スパイク実測。
  */
 
 /** 発話1件（時刻は動画先頭からの絶対秒） */
@@ -130,6 +131,18 @@ export function parseTranscriptionResponse(
 	}
 	utterances.sort((a, b) => a.start - b.start);
 	return utterances;
+}
+
+/**
+ * セリフ検索用の正規化（SPR-293）。
+ * 叫び・感嘆の音写は揺れる（例: ベェ→たー、SPR-291 実測）ため完全一致は狙わず、
+ * カタカナ→ひらがな・空白/記号除去・小文字化の部分一致で再現率を上げる
+ */
+export function normalizeForTranscriptSearch(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/[ァ-ヶ]/g, (char) => String.fromCharCode(char.charCodeAt(0) - 0x60))
+		.replace(/[\s、。・！!？?〜~ー…♪]/g, "");
 }
 
 /** 発話スナップの区間（パディング込み・動画長でクランプ） */

--- a/terraform/function_transcribe_video_backlog.tf
+++ b/terraform/function_transcribe_video_backlog.tf
@@ -1,0 +1,105 @@
+# ==============================================================================
+# 発話文字起こしバックログ機能（SPR-293）
+# ==============================================================================
+# 概要: 配信アーカイブの発話文字起こし（videos/{id}/transcriptChunks）を
+# チャンク（10分）単位で定期的に埋める。作成画面の「セリフで探す」の供給源。
+# - チェックポイントはチャンク doc の存在（冪等・再実行安全）
+# - 1実行の生成量は TRANSCRIBE_CHUNKS_PER_RUN（既定12）と経過時間で打ち切り
+#   → 2時間毎 × 12チャンク ≒ 1日あたり動画24時間分のペース（コスト制御）
+# - 関数 spec（runtime / memory / timeout / secret）の正本は GitHub Actions
+#   （deploy-functions.yml）。ADR-009 原則2: terraform はインフラのみを持つ。
+# ==============================================================================
+
+locals {
+  transcribe_video_backlog_function_name = "transcribeVideoBacklog"
+}
+
+# 文字起こしバックログ用のPub/Subトピック
+resource "google_pubsub_topic" "transcribe_video_backlog_trigger" {
+  project = var.gcp_project_id
+  name    = "transcribe-video-backlog-trigger"
+
+  labels = {
+    environment = var.environment
+    function    = "transcribe-video-backlog"
+    managed-by  = "terraform"
+  }
+
+  depends_on = [google_project_service.pubsub]
+}
+
+# 文字起こしバックログ用のCloud Scheduler（2時間毎）
+# :17 は毎時 :00/:03 に走る既存ジョブ（YouTube/DLsite）との同時起動を避けるオフセット
+resource "google_cloud_scheduler_job" "transcribe_video_backlog_bi_hourly" {
+  project = var.gcp_project_id
+  region  = var.region
+  name    = "transcribe-video-backlog-bi-hourly"
+
+  description = "発話文字起こしバックログ処理（2時間毎）"
+  schedule    = "17 */2 * * *"
+  time_zone   = "Asia/Tokyo"
+  paused      = false
+
+  pubsub_target {
+    topic_name = google_pubsub_topic.transcribe_video_backlog_trigger.id
+    data = base64encode(jsonencode({
+      type        = "transcribe_video_backlog"
+      description = "発話文字起こしバックログの定期処理"
+    }))
+  }
+
+  depends_on = [
+    google_pubsub_topic.transcribe_video_backlog_trigger,
+  ]
+}
+
+# ------------------------------------------------------------------------------
+# transcribeVideoBacklog関数用のサービスアカウントとIAM権限設定
+# ------------------------------------------------------------------------------
+
+resource "google_service_account" "transcribe_video_backlog_sa" {
+  project      = var.gcp_project_id
+  account_id   = "transcribe-video-backlog-sa"
+  display_name = "発話文字起こしバックログ関数用サービスアカウント"
+}
+
+# Firestore 読み書き（videos の走査と transcriptChunks の保存）
+resource "google_project_iam_member" "transcribe_video_backlog_firestore_user" {
+  project = var.gcp_project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.transcribe_video_backlog_sa.email}"
+
+  depends_on = [google_service_account.transcribe_video_backlog_sa]
+}
+
+# GEMINI_API_KEY シークレットへのアクセス権限
+# （関数への環境変数マウントは deploy-functions.yml の --set-secrets が正本）
+resource "google_secret_manager_secret_iam_member" "transcribe_video_backlog_gemini_key_accessor" {
+  project   = var.gcp_project_id
+  secret_id = google_secret_manager_secret.secrets["GEMINI_API_KEY"].secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.transcribe_video_backlog_sa.email}"
+
+  depends_on = [
+    google_secret_manager_secret.secrets,
+    google_service_account.transcribe_video_backlog_sa,
+  ]
+}
+
+# ログ書き込み
+resource "google_project_iam_member" "transcribe_video_backlog_log_writer" {
+  project = var.gcp_project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.transcribe_video_backlog_sa.email}"
+
+  depends_on = [google_service_account.transcribe_video_backlog_sa]
+}
+
+# Gen2（Cloud Run 基盤）関数の実行
+resource "google_project_iam_member" "transcribe_video_backlog_run_invoker" {
+  project = var.gcp_project_id
+  role    = "roles/run.invoker"
+  member  = "serviceAccount:${google_service_account.transcribe_video_backlog_sa.email}"
+
+  depends_on = [google_service_account.transcribe_video_backlog_sa]
+}


### PR DESCRIPTION
## ⚠️ One-Way Door — セルフレビュー必須

新規 Cloud Function（継続コスト発生）＋ Terraform/GCP インフラ＋ `.github/workflows` 変更を含むため、CLAUDE.md のポリシー上 **AI レビューのみでのマージ不可**です。

## 概要（SPR-293）

SPR-292 のオンデマンド文字起こしを土台に、アーカイブ全編の文字起こしをバックグラウンドで事前計算し、作成画面に「セリフで探す」検索と探索レーンのヒットマークを追加します。「あの一言」を全編から一発で引けるようにする段です。

## 構成

### 1. shared-types へのコア移設
`apps/web/src/lib/gemini/transcription-core.ts` → `packages/shared-types/src/utilities/video-transcription.ts`（git mv・web と functions で共有）。検索用の `normalizeForTranscriptSearch`（カタカナ→ひらがな・空白/句読点/長音等の除去・小文字化）を追加。

### 2. functions: transcribeVideoBacklog（新規）
- Pub/Sub トリガ。**アーカイブの新しい順**に未生成チャンク（`videos/{videoId}/transcriptChunks/{chunkIndex}` の doc 不在）を検出し、1 run 最大 **12 チャンク**（env `TRANSCRIBE_CHUNKS_PER_RUN`）生成
- checkpoint はチャンク doc の存在＝**冪等・再開可能**。チャンク失敗時は同一動画を打ち切り次の動画へ（予算保護）
- run 終了時に `transcribe_backlog_run` を構造化ログ（processedChunks / failedChunks / backlogRemaining 等＝監視契約なので英語キー）
- 生成パラメータは SPR-291 実測の正（thinkingBudget 1024 / maxOutputTokens 16384 / temperature 0.1）

### 3. terraform + deploy workflow
- `function_transcribe_video_backlog.tf`: topic / scheduler（**2時間毎 :17 JST** — 既存 :00/:03 ジョブとの衝突回避）/ 専用 SA（datastore.user + GEMINI_API_KEY accessor + logWriter + invoker）
- ADR-009 準拠: terraform はインフラのみ、関数 spec の正本は `deploy-functions.yml`（512Mi / 540s / max-instances 1）
- **GEMINI_API_KEY は明示 `--set-secrets`** で渡す（YOUTUBE_API_KEY が workflow 宣言なしで届いている既存 drift には乗らない）

### 4. web: セリフ検索＋ヒットマーク
- `getCachedTranscriptChunks`（読み取り専用アクション。**生成はしない**＝バックログが埋めた分だけ返る）
- 検索ボックス初回入力でキャッシュ済み全チャンクを一括読み込み → かな正規化の部分一致で絞り込み
- ヒット開始時刻を探索レーンに縦線（`bg-heart`）で表示 → クリックで従来どおりジャンプ

## コスト・ペース設計

12 chunks/run × 12 runs/日 = **1日あたり動画約24時間分**。全アーカイブ（数百本）は数週間で完走し、以後は新着分のみが対象（新しい順スキャンなので新着は自然に最優先＝新規 hook 不要）。Gemini は paid tier（public 動画は無制限）、~55k tokens/chunk。max-instances 1 + 単一 run 内直列で暴走上限は構造的に 12 chunks/2h。

## 検証

- `pnpm verify` 全パス（shared-types 418 / functions 7 新規テスト含む / web カバレッジ閾値クリア）
- `terraform fmt -check` パス
- Emulator + Playwright でブラウザ検証: transcriptChunks 3 docs をシード → 「べぇ」検索で カタカナ「ベェ」2件ヒット（かな正規化）・探索レーンのマーク位置が 130.2s / 4993.6s と一致・行クリックでスナップ（1:23:13.5〜1:23:14.8）＋タイトルプリフィル・検索クリアで全件復帰とマーク消滅を確認
- バックログ関数はユニットテストで検証（Cloud Function ランタイムはローカル再現不可のため、初回 deploy 後に `transcribe_backlog_run` ログで実動確認する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)