### PR TITLE
fix(deps): Security Check の audit floor 不整合を修正

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: '>=4.3.0'
+  js-yaml: '>=5.2.2'
   protobufjs: '>=8.6.6'
-  brace-expansion@^2: '>=2.1.2'
-  brace-expansion@^5: '>=5.0.7'
+  brace-expansion: '>=5.0.8'
   uuid: '>=11.1.1'
   ws: '>=8.21.0'
   postcss: '>=8.5.10'
@@ -2519,9 +2518,9 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3279,8 +3278,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -5945,7 +5944,7 @@ snapshots:
       '@textlint/types': 15.7.1
       chalk: 4.1.2
       debug: 4.4.3(supports-color@10.2.2)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -6473,7 +6472,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7234,7 +7233,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -7739,11 +7738,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -8018,7 +8017,7 @@ snapshots:
   rc-config-loader@4.1.4(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
-      js-yaml: 5.2.1
+      js-yaml: 5.2.2
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,18 +8,19 @@ overrides:
   # qs / esbuild / @grpc/grpc-js）は依存元が追従済みのため撤去した（解決値は不変）。
   # js-yaml: secretlint 系（@textlint/linter-formatter・rc-config-loader）が4.2.0を要求し続けており
   # 自然解決が4.3.0未満に戻ったため override を復活（YAML merge-key連鎖によるCPU二次消費 GHSA-52cp-r559-cp3m）。
-  js-yaml: ">=4.3.0"
+  # >=5.0.0 <=5.2.1: flow collection の解析が指数時間になる別DoS（GHSA-pm4m-ph32-ghv5）。5.2.2 で修正のため floor を引き上げ。
+  js-yaml: ">=5.2.2"
   # protobufjs <= 8.5.0: schema 由来の名前が runtime プロパティを shadow（CVE-2026-54269）/
   # binary decode の unknown fields 保持によるメモリ増幅（CVE-2026-54270）。8.6.0 で修正。
   # <= 8.6.4: Text Format の string map parsing が返り値の prototype を汚染しうる（GHSA-jfj6-75fj-8934）。8.6.5 で修正。
   # <= 8.6.5: .proto option parsing の無限ループによる DoS（GHSA-j3f2-48v5-ccww）。8.6.6 で修正。
   # 直接の依存元（google-gax 等）は ^7.5.3 を要求し、override を外すと 7.6.4 に落ちるため維持。
   protobufjs: ">=8.6.6"
-  # brace-expansion: 非展開 {} グループ連続による指数時間展開 DoS（GHSA-3jxr-9vmj-r5cp）。
-  # 同一advisoryが系統ごとに別々にpatchされている。2.x系（minimatch@9経由）は2.1.2で、
-  # 5.x系（minimatch@10経由）は5.0.7で修正。片方だけ上げるとpnpm auditで検知される（要両対応）。
-  "brace-expansion@^2": ">=2.1.2"
-  "brace-expansion@^5": ">=5.0.7"
+  # brace-expansion: 非展開 {} グループ連続による指数時間展開 DoS（GHSA-3jxr-9vmj-r5cp、2.x/5.x系で別々に
+  # patch）に加え、5.x系のみの別advisory「非制限な展開長によるOOM DoS」（GHSA-mh99-v99m-4gvg、5.0.8で修正）がある。
+  # pnpm の override はセレクタが違っても同一パッケージ名では最後の1件のみが解決全体に効く（実測・複数セレクタ
+  # 併記は無意味）ため、単一ルールで最新パッチ済みの5.x系に寄せる。
+  brace-expansion: ">=5.0.8"
   # uuid: override を外すと transitive が 8.3.2（deprecated）に落ちる。11.x に統一して維持。
   uuid: ">=11.1.1"
   # ws < 8.21.0: 小さな fragment/data chunk によるメモリ枯渇 DoS（GHSA-96hv-2xvq-fx4p）。8.21.0 で修正。


### PR DESCRIPTION
## Summary
- 全PRで `Security Check`（`pnpm audit --audit-level moderate`）が fail していた原因は Dependabot PR固有の問題ではなく、`pnpm-workspace.yaml` の override 自体が実際には効いていない/古いバージョンを指定していたことだった。
- `brace-expansion`: `^2`/`^5` の2セレクタ併記は実測で最後の1件しか解決全体に反映されず（pnpm の挙動）、5.x系の新規advisory（GHSA-mh99-v99m-4gvg、5.0.8で修正）に追従できていなかった。単一ルール `>=5.0.8` に統合。
- `js-yaml`: floor `>=4.3.0` を自然解決の5.2.1が満たしていたが、5.2.1自体が別advisory（GHSA-pm4m-ph32-ghv5）で脆弱だった。floorを `>=5.2.2` に引き上げ。

## Test plan
- [x] `pnpm audit --audit-level moderate` → `No known vulnerabilities found`
- [x] `pnpm verify`（lint/typecheck/test 一括）→ pass
- [ ] マージ後、Dependabot の4件（#880〜#883）の `Security Check` が green になることを確認

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>