### PR TITLE
feat(dev): ローカル開発ログインを追加（Discord OAuth を通さず認証必須ページを確認可能に）

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -23,6 +23,13 @@
 			"autoPort": false
 		},
 		{
+			"name": "web-local-auth",
+			"runtimeExecutable": "pnpm",
+			"runtimeArgs": ["--filter", "@suzumina.click/web", "dev:local:auth"],
+			"port": 3000,
+			"autoPort": false
+		},
+		{
 			"name": "web-prod",
 			"runtimeExecutable": "pnpm",
 			"runtimeArgs": ["--filter", "@suzumina.click/web", "start", "--port", "3001"],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,7 @@ PR は「やり直しが効くか」で自己マージ可否を分ける。AI �
 ### 開発コマンド
 ```bash
 pnpm dev:local                          # 推奨: Firestore Emulator 起動 + シード投入 + web dev（ADC 不要・本番に触れない）
+pnpm dev:local:auth                     # 上記 + ローカル開発ログイン有効（認証必須ページの確認時のみ）
 pnpm --filter @suzumina.click/web dev   # 本番 Firestore 直結（ADC 必須。データ確認や本番調査時のみ）
 pnpm verify                             # lint + typecheck + test（CI と同一判定）
 pnpm build                              # ビルド
@@ -166,7 +167,8 @@ pnpm build                              # ビルド
   コマンドは使わない＝§1 の禁止を順守）を起動し、シード投入後に web dev を立ち上げる。
   `@google-cloud/firestore` は `FIRESTORE_EMULATOR_HOST` を見て自動接続する（ダミー認証＝**ADC 不要**）。
   データは**ハイブリッド方式**：`apps/functions/src/tools/firestore-local/fixtures/*.json`（公開系のみ・コミット対象）を
-  `pnpm seed` で投入し、鮮度更新は `pnpm seed:dump`（ADC 1 回で本番から再取得）。ユーザー機微系は dump 対象外。
+  `pnpm seed` で投入し、鮮度更新は `pnpm seed:dump`（ADC 1 回で本番から再取得）。ユーザー機微系は dump 対象外
+  （例外は `users.json` の開発用ユーザー 1 件で、これは本番由来ではなく**手書きの合成データ**＝下記ログイン用）。
   個別操作: `pnpm emulator`（Emulator のみ） / `pnpm seed`（投入のみ） / `pnpm seed:dump`（本番→fixtures 更新）。
   安全弁: 本番 (`NODE_ENV=production`) で `FIRESTORE_EMULATOR_HOST` が設定されていたら接続を拒否する（両 `firestore.ts`）。
 - **`pnpm --filter @suzumina.click/web dev`（ADC 直結 / 本番 Firestore）**：ADC 必須。本番に直接読み書きする。
@@ -177,8 +179,21 @@ pnpm build                              # ビルド
   1. **本番データ起因バグの調査**（TZ パース・merge の sticky フィールド等、実データが無いと再現しない類）
   2. **新規クエリのインデックス検証**（Emulator は複合インデックスを強制しないため、ローカルで通っても本番で
      `FAILED_PRECONDITION` になる。新しい `where + orderBy` 追加時は ADC 直結か本番で要確認）
-  3. **ユーザー系・サブコレクションを含む網羅確認**（Emulator には users/favorites/evaluations や
-     `works/{id}/priceHistory` を投入しない。ログインは可だが role は既定 `member`、価格チャートは空）
+  3. **ユーザー系・サブコレクションを含む網羅確認**（Emulator の `users` は開発用ユーザー 1 件のみで、
+     favorites/evaluations や `works/{id}/priceHistory` は投入しない＝お気に入り・評価は空、価格チャートも空）
+
+**ローカル開発ログイン（`pnpm dev:local:auth`）**
+`/live`・`/buttons/create`・`/favorites`・`/settings`・`/users/me` など `ProtectedRoute` / `getCurrentUser()` で
+守られたページをブラウザ確認するときだけ使う。起動後 `http://localhost:3000/api/dev/signin` を開くと
+開発用ユーザーでログイン済みになる（`?callbackUrl=/buttons/create` で戻り先指定可。ログアウトは通常のヘッダーから）。
+
+- **認証コードには分岐を入れていない**。発行されるのは better-auth の**実セッション**で、
+  `getCurrentUser()` / `ProtectedRoute` / クライアントの `useSession()` はすべて Discord ログインと同じ経路を通る
+- **本番では構造的に無効**。`NODE_ENV !== "production"`（例外なし）＋ `DEV_AUTH_BYPASS=1` の明示 opt-in ＋
+  `FIRESTORE_EMULATOR_HOST` 設定済（＝ ADC 直結では有効化できない）の 3 条件 AND。
+  1 つでも欠ければ `/api/dev/signin` は 404。正本は [guard.ts](apps/web/src/lib/dev-auth/guard.ts)
+- 開発用ユーザーの doc ID は `guard.ts` の `DEV_AUTH_DISCORD_ID` と `fixtures/users.json` で**一致させる**
+  （ずれると「ログインしたのに未認証」になる。テストで突き合わせ済み）
 
 **いつ Emulator を立ち上げるか（毎セッションの判断・能動ルール）**
 原則は **lazy start**：セッション開始時に先回りで起動しない。**ブラウザ preview での確認が必要だと判断した直前**にだけ

--- a/apps/functions/src/tools/firestore-local/dump.ts
+++ b/apps/functions/src/tools/firestore-local/dump.ts
@@ -17,6 +17,8 @@ import { Firestore } from "@google-cloud/firestore";
 import { type CollectionFixture, encodeValue } from "./serialize";
 
 // 公開（サイト上で既に閲覧可能）なカタログ系のみ。ユーザー紐付けコレクションは除外。
+// fixtures/users.json はここに含めない＝本番 dump 由来ではなく**手書きの合成データ**（ローカル開発ログイン用）。
+// dump はこの一覧のファイルだけを書き出すため、seed:dump で上書き・削除されることはない。
 const PUBLIC_COLLECTIONS = ["works", "circles", "videos", "audioButtons", "creators", "top10"];
 
 // 公開コレクション内でも伏せるフィールド（Discord ID 等の生の識別子）。

--- a/apps/functions/src/tools/firestore-local/fixtures/users.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/users.json
@@ -1,0 +1,29 @@
+{
+  "collection": "users",
+  "docs": [
+    {
+      "id": "000000000000000001",
+      "data": {
+        "discordId": "000000000000000001",
+        "username": "dev-user",
+        "globalName": "ローカル開発ユーザー",
+        "avatar": null,
+        "guildMembership": {
+          "guildId": "959095494456537158",
+          "userId": "000000000000000001",
+          "isMember": true
+        },
+        "displayName": "ローカル開発ユーザー",
+        "isActive": true,
+        "flags": {
+          "isFamilyMember": true
+        },
+        "createdAt": "2026-01-01T00:00:00.000Z",
+        "updatedAt": "2026-01-01T00:00:00.000Z",
+        "lastLoginAt": "2026-01-01T00:00:00.000Z",
+        "isPublicProfile": true,
+        "showStatistics": true
+      }
+    }
+  ]
+}

--- a/apps/functions/src/tools/firestore-local/seed.ts
+++ b/apps/functions/src/tools/firestore-local/seed.ts
@@ -5,6 +5,10 @@
  *
  * 接続先は必ず Emulator。安全のため FIRESTORE_EMULATOR_HOST を強制設定し、
  * 本番 Firestore へ書き込む経路を塞ぐ。
+ *
+ * fixtures の大半は seed:dump が本番から取得したものだが、`users.json` だけは**手書きの合成データ**で、
+ * ローカル開発ログイン（`pnpm dev:local:auth` → /api/dev/signin）が使う開発用ユーザー 1 件を持つ。
+ * doc ID は `apps/web/src/lib/dev-auth/guard.ts` の DEV_AUTH_DISCORD_ID と一致させること。
  */
 
 import { readdir, readFile } from "node:fs/promises";

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,6 +16,12 @@ GOOGLE_CLOUD_PROJECT=suzumina-click
 # 通常は `pnpm dev:local` が自動設定するため手動指定は不要。本番では絶対に設定しない。
 # FIRESTORE_EMULATOR_HOST=127.0.0.1:8080
 
+# ── ローカル開発ログイン（任意 / ローカル専用）──
+# Discord OAuth を通さずにログイン済み状態を作る /api/dev/signin を有効化する。
+# NODE_ENV=production では無条件に無効・FIRESTORE_EMULATOR_HOST 未設定でも無効（3 段ゲート）。
+# 通常は `pnpm dev:local:auth` が自動設定するため手動指定は不要。本番では絶対に設定しない。
+# DEV_AUTH_BYPASS=1
+
 # ── サイト / アクセス制御（任意）──
 # robots.txt / sitemap.xml の canonical URL。未設定なら https://suzumina.click
 # NEXT_PUBLIC_APP_URL=https://suzumina.click

--- a/apps/web/biome.json
+++ b/apps/web/biome.json
@@ -30,7 +30,12 @@
 			}
 		},
 		{
-			"includes": ["src/lib/auth/**", "src/lib/better-auth/**", "src/app/api/auth/**"],
+			"includes": [
+				"src/lib/auth/**",
+				"src/lib/better-auth/**",
+				"src/app/api/auth/**",
+				"src/app/api/dev/**"
+			],
 			"linter": {
 				"rules": {
 					"style": {
@@ -52,10 +57,14 @@
 							"better-auth/client/plugins": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
 							"better-auth/plugins": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
 							"better-auth/next-js": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
-							"better-auth/adapters": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
-							"@/lib/better-auth/auth": "better-auth 実装の直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。",
-							"@/lib/better-auth/firestore-adapter": "better-auth 実装の直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。"
-						}
+							"better-auth/adapters": "認証プロバイダの直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。"
+						},
+						"patterns": [
+							{
+								"group": ["@/lib/better-auth/*"],
+								"message": "better-auth 実装の直接 import は禁止。@/lib/auth/* 経由で使うこと（SPR-168 抽象境界）。個別列挙ではなくディレクトリ全体を対象にする＝新しいファイルを足したときに自動で境界の内側に入る。"
+							}
+						]
 					}
 				}
 			}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "next dev",
 		"dev:local": "FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 next dev",
+		"dev:local:auth": "DEV_AUTH_BYPASS=1 FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 next dev",
 		"build": "next build",
 		"start": "next start",
 		"lint": "biome check src/ e2e/ *.ts *.mjs --files-ignore-unknown=true",

--- a/apps/web/src/app/api/dev/signin/route.ts
+++ b/apps/web/src/app/api/dev/signin/route.ts
@@ -1,0 +1,30 @@
+/**
+ * ローカル開発ログイン（dev 専用 / Discord OAuth を通さずに better-auth の実セッションを発行する）。
+ *
+ *   http://localhost:3000/api/dev/signin
+ *   http://localhost:3000/api/dev/signin?callbackUrl=/buttons/create
+ *
+ * `pnpm dev:local:auth` で起動したときだけ生きる。有効化条件は `lib/dev-auth/guard.ts` の 3 段ゲートで、
+ * 1 つでも欠ければ 404（＝存在しないルートとして振る舞う）。本番では無条件に 404 になる。
+ *
+ * サインアウトは通常どおりヘッダーのログアウト（better-auth の `/api/auth/sign-out`）で行える
+ * ＝発行しているのが本物のセッションのため、専用の解除経路は要らない。
+ */
+import { type NextRequest, NextResponse } from "next/server";
+import { sanitizeRelativePath } from "@/lib/auth/auth-redirect";
+import { issueDevSessionCookie } from "@/lib/better-auth/dev-session";
+import { isDevAuthEnabled } from "@/lib/dev-auth/guard";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+	if (!isDevAuthEnabled()) {
+		return new NextResponse(null, { status: 404 });
+	}
+
+	// callbackUrl は URL 経由で外から来るため、通常のログインと同じサニタイズを通す。
+	const callbackUrl = sanitizeRelativePath(request.nextUrl.searchParams.get("callbackUrl"));
+	const cookie = await issueDevSessionCookie();
+
+	const response = NextResponse.redirect(new URL(callbackUrl, request.nextUrl.origin));
+	response.cookies.set(cookie.name, cookie.value, cookie.options);
+	return response;
+}

--- a/apps/web/src/lib/better-auth/__tests__/dev-session.test.ts
+++ b/apps/web/src/lib/better-auth/__tests__/dev-session.test.ts
@@ -1,0 +1,61 @@
+/**
+ * ローカル開発ログインのセッション発行が、ゲート無効時に**自分で**拒否することの回帰ガード。
+ *
+ * 呼び出し側（`/api/dev/signin`）のゲートとは独立に、実セッションを発行する関数自体が
+ * 最後の砦を持つ設計（PR #891 レビュー指摘）。この throw を消しても呼び出し側が正しい限り
+ * 挙動が変わらず静かに退行するため、ここで固定する。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// better-auth 実体（インスタンス生成 / Firestore 接続）は発行経路の検証に不要なので遮断する。
+vi.mock("../auth", () => ({ auth: { $context: Promise.resolve({}) } }));
+vi.mock("../firestore-adapter", () => ({
+	firestoreOps: () => ({ findOne: vi.fn(), create: vi.fn() }),
+}));
+
+const ENV_KEYS = ["NODE_ENV", "DEV_AUTH_BYPASS", "FIRESTORE_EMULATOR_HOST"] as const;
+const mutableEnv = process.env as Record<string, string | undefined>;
+
+describe("issueDevSessionCookie", () => {
+	const original: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of ENV_KEYS) {
+			original[key] = mutableEnv[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			if (original[key] === undefined) {
+				delete mutableEnv[key];
+			} else {
+				mutableEnv[key] = original[key];
+			}
+		}
+	});
+
+	it("ゲートが無効なら Firestore に触れる前に throw する", async () => {
+		mutableEnv.NODE_ENV = "development";
+		delete mutableEnv.DEV_AUTH_BYPASS;
+		mutableEnv.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
+
+		const { issueDevSessionCookie } = await import("../dev-session");
+
+		await expect(issueDevSessionCookie()).rejects.toThrow(
+			"ローカル開発ログインが無効な環境では呼び出せません",
+		);
+	});
+
+	it("本番では opt-in と Emulator が揃っていても throw する", async () => {
+		mutableEnv.NODE_ENV = "production";
+		mutableEnv.DEV_AUTH_BYPASS = "1";
+		mutableEnv.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
+
+		const { issueDevSessionCookie } = await import("../dev-session");
+
+		await expect(issueDevSessionCookie()).rejects.toThrow(
+			"ローカル開発ログインが無効な環境では呼び出せません",
+		);
+	});
+});

--- a/apps/web/src/lib/better-auth/dev-session.ts
+++ b/apps/web/src/lib/better-auth/dev-session.ts
@@ -1,0 +1,109 @@
+/**
+ * ローカル開発ログインのセッション発行（dev 専用 / 有効化条件は `@/lib/dev-auth/guard`）。
+ *
+ * better-auth の**本物のセッション**を作る。トークン生成・有効期限・行の形は
+ * `internalAdapter.createSession()` に任せ、cookie 名と属性も `authCookies` から読むため、
+ * Discord ログインで発行されるセッションと同一の形になる（＝この層に仕様の写しを持たない）。
+ * 結果として `getCurrentUser()` / `ProtectedRoute` / クライアントの `useSession()` には分岐が要らない。
+ *
+ * dev 専用でありながらこのディレクトリに置くのは、better-auth 実装（auth / firestore-adapter）に
+ * 触れるコードの置き場が SPR-168 の抽象境界でここに限られているため（guild-sync 等と同じ扱い）。
+ * 環境ゲートは provider 非依存なので `lib/dev-auth/guard.ts` 側に分けてある。
+ *
+ * 呼び出し前に `isDevAuthEnabled()` が真であることは呼び出し側（`/api/dev/signin`）が保証する。
+ */
+import { makeSignature } from "better-auth/crypto";
+import {
+	DEV_AUTH_BA_USER_ID,
+	DEV_AUTH_DISCORD_ID,
+	DEV_AUTH_EMAIL,
+	DEV_AUTH_NAME,
+} from "@/lib/dev-auth/guard";
+import { warn } from "@/lib/logger";
+import { auth } from "./auth";
+import { firestoreOps } from "./firestore-adapter";
+
+/** Next の `cookies.set()` にそのまま渡せる形（属性の実値は better-auth 由来）。 */
+export interface DevSessionCookie {
+	name: string;
+	value: string;
+	options: {
+		path?: string;
+		domain?: string;
+		maxAge?: number;
+		httpOnly?: boolean;
+		secure?: boolean;
+		sameSite?: "lax" | "strict" | "none";
+	};
+}
+
+// better-auth 標準モデル(user 等)へのアクセスはアダプタ境界(firestoreOps)を共有する（guild-sync と同方針）。
+const ops = firestoreOps();
+
+/**
+ * better-auth の user 行（`ba_user`）を固定 ID で冪等に用意する。
+ *
+ * `discordId` は additionalField（`input:false`）で、本番では account.create フックが充填する。
+ * dev では Discord 連携が無いためここで直接書く。これが無いと enrich-session が
+ * `users/{discordId}` を引けず appUser が null になり、ログインしていない状態と区別がつかなくなる。
+ */
+async function ensureDevAuthUser(): Promise<void> {
+	const existing = await ops.findOne({
+		model: "user",
+		where: [{ field: "id", value: DEV_AUTH_BA_USER_ID, operator: "eq", connector: "AND" }],
+	});
+	if (existing) {
+		return;
+	}
+	const now = new Date();
+	await ops.create({
+		model: "user",
+		data: {
+			id: DEV_AUTH_BA_USER_ID,
+			name: DEV_AUTH_NAME,
+			email: DEV_AUTH_EMAIL,
+			emailVerified: true,
+			discordId: DEV_AUTH_DISCORD_ID,
+			createdAt: now,
+			updatedAt: now,
+		},
+	});
+}
+
+/**
+ * 開発用ユーザーの better-auth セッションを作成し、ブラウザへ載せる cookie を返す。
+ * `account` 行は作らない（＝ account.create フックを踏まない）。dev ではアクセストークンが無く
+ * guild 同期は best-effort で素通りするため、セッション成立には user 行だけで足りる。
+ */
+export async function issueDevSessionCookie(): Promise<DevSessionCookie> {
+	await ensureDevAuthUser();
+
+	const ctx = await auth.$context;
+	const session = await ctx.internalAdapter.createSession(DEV_AUTH_BA_USER_ID);
+	const { name, attributes } = ctx.authCookies.sessionToken;
+
+	if (attributes.secure) {
+		// secure cookie は http://localhost へ送信されず「押しても何も起きない」無言の失敗になる。
+		warn("dev-auth: セッション cookie に secure が付くためローカルではログインが成立しません", {
+			hint: "BETTER_AUTH_URL を http://localhost:3000 にしてください",
+		});
+	}
+
+	// better-call が読む形式 `<token>.<HMAC-SHA256 の base64>`。URL エンコードは Next の
+	// cookies.set() 側が行う（better-call の signCookieValue と同じく 1 回）ため、ここでは掛けない。
+	const signature = await makeSignature(session.token, ctx.secret);
+
+	return {
+		name,
+		value: `${session.token}.${signature}`,
+		options: {
+			path: attributes.path,
+			domain: attributes.domain,
+			maxAge: attributes.maxAge,
+			httpOnly: attributes.httpOnly,
+			secure: attributes.secure,
+			// better-auth 側は "Lax" 等の大文字始まりも取りうるが Next の型は小文字のみ。
+			sameSite: attributes.sameSite?.toLowerCase() as DevSessionCookie["options"]["sameSite"],
+		},
+	};
+}

--- a/apps/web/src/lib/better-auth/dev-session.ts
+++ b/apps/web/src/lib/better-auth/dev-session.ts
@@ -10,7 +10,8 @@
  * 触れるコードの置き場が SPR-168 の抽象境界でここに限られているため（guild-sync 等と同じ扱い）。
  * 環境ゲートは provider 非依存なので `lib/dev-auth/guard.ts` 側に分けてある。
  *
- * 呼び出し前に `isDevAuthEnabled()` が真であることは呼び出し側（`/api/dev/signin`）が保証する。
+ * 呼び出し側（`/api/dev/signin`）もゲートするが、この関数自身も入口で `isDevAuthEnabled()` を検証する。
+ * 実セッションを発行する以上、呼び出し側の規律だけに依存させない（呼び出し元が増えたときの取りこぼし防止）。
  */
 import { makeSignature } from "better-auth/crypto";
 import {
@@ -18,6 +19,7 @@ import {
 	DEV_AUTH_DISCORD_ID,
 	DEV_AUTH_EMAIL,
 	DEV_AUTH_NAME,
+	isDevAuthEnabled,
 } from "@/lib/dev-auth/guard";
 import { warn } from "@/lib/logger";
 import { auth } from "./auth";
@@ -74,8 +76,15 @@ async function ensureDevAuthUser(): Promise<void> {
  * 開発用ユーザーの better-auth セッションを作成し、ブラウザへ載せる cookie を返す。
  * `account` 行は作らない（＝ account.create フックを踏まない）。dev ではアクセストークンが無く
  * guild 同期は best-effort で素通りするため、セッション成立には user 行だけで足りる。
+ *
+ * @throws ローカル開発ログインが無効な環境（本番を含む）で呼ばれた場合
  */
 export async function issueDevSessionCookie(): Promise<DevSessionCookie> {
+	// 呼び出し側のゲートと二重になるが、認証バイパスを発行する関数自体が最後の砦を持つ。
+	if (!isDevAuthEnabled()) {
+		throw new Error("dev-auth: ローカル開発ログインが無効な環境では呼び出せません");
+	}
+
 	await ensureDevAuthUser();
 
 	const ctx = await auth.$context;

--- a/apps/web/src/lib/dev-auth/__tests__/guard.test.ts
+++ b/apps/web/src/lib/dev-auth/__tests__/guard.test.ts
@@ -1,0 +1,113 @@
+/**
+ * ローカル開発ログインの有効化ゲート。
+ *
+ * ここは「本番で絶対に有効にならない」ことの回帰ガードなので、3 条件の AND を網羅する
+ * （どれか 1 つが欠けただけで無効になること・本番は opt-in 済みでも無効になることを固定する）。
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEV_AUTH_DISCORD_ID, isDevAuthEnabled } from "../guard";
+
+const ENV_KEYS = ["NODE_ENV", "DEV_AUTH_BYPASS", "FIRESTORE_EMULATOR_HOST"] as const;
+type EnvKey = (typeof ENV_KEYS)[number];
+
+// NODE_ENV は型上 readonly 相当のためテストからの差し替えは可変ビューを介す。
+const mutableEnv = process.env as Record<string, string | undefined>;
+
+describe("isDevAuthEnabled", () => {
+	const original: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of ENV_KEYS) {
+			original[key] = mutableEnv[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of ENV_KEYS) {
+			if (original[key] === undefined) {
+				delete mutableEnv[key];
+			} else {
+				mutableEnv[key] = original[key];
+			}
+		}
+	});
+
+	function setEnv(env: Partial<Record<EnvKey, string | undefined>>): void {
+		for (const key of ENV_KEYS) {
+			const value = env[key];
+			if (value === undefined) {
+				delete mutableEnv[key];
+			} else {
+				mutableEnv[key] = value;
+			}
+		}
+	}
+
+	it("3 条件が揃えば有効", () => {
+		setEnv({
+			NODE_ENV: "development",
+			DEV_AUTH_BYPASS: "1",
+			FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080",
+		});
+
+		expect(isDevAuthEnabled()).toBe(true);
+	});
+
+	it("本番では opt-in と Emulator が揃っていても無効（例外を設けない）", () => {
+		setEnv({
+			NODE_ENV: "production",
+			DEV_AUTH_BYPASS: "1",
+			FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080",
+		});
+
+		expect(isDevAuthEnabled()).toBe(false);
+	});
+
+	it("opt-in フラグが無ければ無効（dev:local の既定）", () => {
+		setEnv({
+			NODE_ENV: "development",
+			DEV_AUTH_BYPASS: undefined,
+			FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080",
+		});
+
+		expect(isDevAuthEnabled()).toBe(false);
+	});
+
+	it("opt-in フラグが '1' 以外なら無効", () => {
+		setEnv({
+			NODE_ENV: "development",
+			DEV_AUTH_BYPASS: "true",
+			FIRESTORE_EMULATOR_HOST: "127.0.0.1:8080",
+		});
+
+		expect(isDevAuthEnabled()).toBe(false);
+	});
+
+	it("Emulator に繋がっていなければ無効（ADC 直結 dev では有効化できない）", () => {
+		setEnv({
+			NODE_ENV: "development",
+			DEV_AUTH_BYPASS: "1",
+			FIRESTORE_EMULATOR_HOST: undefined,
+		});
+
+		expect(isDevAuthEnabled()).toBe(false);
+	});
+});
+
+describe("DEV_AUTH_DISCORD_ID", () => {
+	// ID がずれると enrich-session が users/{discordId} を引けず「ログインしたのに未認証」になる。
+	// 静かに壊れる類なのでフィクスチャ側と突き合わせて固定する。
+	it("fixtures/users.json の doc ID と一致する", () => {
+		const fixturePath = join(
+			__dirname,
+			"../../../../../functions/src/tools/firestore-local/fixtures/users.json",
+		);
+		const fixture = JSON.parse(readFileSync(fixturePath, "utf-8")) as {
+			docs: Array<{ id: string }>;
+		};
+
+		expect(fixture.docs.map((doc) => doc.id)).toContain(DEV_AUTH_DISCORD_ID);
+	});
+});

--- a/apps/web/src/lib/dev-auth/guard.ts
+++ b/apps/web/src/lib/dev-auth/guard.ts
@@ -1,0 +1,44 @@
+/**
+ * ローカル開発ログイン（Discord OAuth を通さずに better-auth の**実セッション**を発行する）の有効化ゲート。
+ *
+ * 認証の正本（better-auth / `getCurrentUser()` / `ProtectedRoute`）には分岐を一切入れていない。
+ * `/api/dev/signin` が発行するのは better-auth 自身が作った本物のセッションで、以降の解決経路は
+ * Discord ログインと完全に同一。この仕組みの有無で認証コードの振る舞いが変わることはない。
+ *
+ * **本番では構造的に無効**。次の 3 条件がすべて揃わない限り有効にならず、1 つでも欠ければ
+ * ルートは 404 を返す（＝存在しないものとして振る舞う）。
+ *
+ * 1. `NODE_ENV !== "production"` — 本番ビルドでは無条件。opt-in フラグでも覆せず、
+ *    `lib/firestore.ts` の `PLAYWRIGHT_EMULATOR` のような例外も**意図的に設けていない**
+ * 2. `DEV_AUTH_BYPASS === "1"` — 明示 opt-in。`pnpm dev:local:auth` でのみ付き、`pnpm dev:local` では付かない
+ * 3. `FIRESTORE_EMULATOR_HOST` が設定済 — Firestore が Emulator であることの要求。
+ *    偽ユーザーの Server Action 書き込みが本番 Firestore に届く経路を塞ぐため、
+ *    ADC 直結（`pnpm dev`）では 2 を付けても有効にならない
+ */
+
+/**
+ * 開発用ユーザーの Discord ID（アプリ `users` コレクションの doc ID）。
+ * 正本は `apps/functions/src/tools/firestore-local/fixtures/users.json` の doc ID で、**両者を一致させること**。
+ * 実在しない形式（先頭 0 埋めの Snowflake）にして本物の Discord ID と衝突しないようにしてある。
+ */
+export const DEV_AUTH_DISCORD_ID = "000000000000000001";
+
+/** better-auth 側 user（`ba_user`）の doc ID。固定値にして再ログインでも同じ行を使い回す（冪等）。 */
+export const DEV_AUTH_BA_USER_ID = "dev-auth-user";
+
+export const DEV_AUTH_NAME = "ローカル開発ユーザー";
+export const DEV_AUTH_EMAIL = "dev-auth@localhost.invalid";
+
+/**
+ * ローカル開発ログインが有効か。上記 3 条件の AND。
+ * 呼び出し側（`/api/dev/signin`）は false なら 404 を返す。
+ */
+export function isDevAuthEnabled(): boolean {
+	if (process.env.NODE_ENV === "production") {
+		return false;
+	}
+	if (process.env.DEV_AUTH_BYPASS !== "1") {
+		return false;
+	}
+	return !!process.env.FIRESTORE_EMULATOR_HOST;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
 				"src/lib/better-auth/enrich-session.ts",
 				"src/lib/better-auth/on-first-signup.ts",
 				"src/app/api/auth/**",
+				// ローカル開発ログイン（dev 専用・本番では 404）。better-auth の実セッション発行 glue と
+				// ルートハンドラで、判断ロジックは dev-auth/guard.ts 側に寄せてある（そちらはテスト対象）。
+				"src/lib/better-auth/dev-session.ts",
+				"src/app/api/dev/**",
 				// 認証プロバイダ切替の glue（動的 import / better-auth client / hooks 分岐で単体テスト困難）(SPR-157)
 				"src/lib/auth/server.ts",
 				"src/lib/auth/client.ts",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"build": "pnpm -r build",
 		"emulator": "bash scripts/firestore-emulator.sh",
 		"dev:local": "bash scripts/dev-local.sh",
+		"dev:local:auth": "DEV_AUTH_BYPASS=1 bash scripts/dev-local.sh",
 		"dev:clean": "rimraf apps/web/.next && bash scripts/dev-local.sh",
 		"seed": "pnpm --filter @suzumina.click/functions seed:load",
 		"seed:dump": "pnpm --filter @suzumina.click/functions seed:dump",

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -6,6 +6,9 @@
 #   3) web を Emulator 接続で dev 起動
 #
 # ADC は不要。本番 Firestore には一切触れない。
+#
+# DEV_AUTH_BYPASS=1 付き（= `pnpm dev:local:auth`）で起動すると、Discord OAuth を通さずに
+# ログイン済み状態を作れる /api/dev/signin が有効になる（詳細は apps/web/src/lib/dev-auth/guard.ts）。
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -21,5 +24,11 @@ emulator_ensure "${ROOT}"
 echo "[dev:local] フィクスチャを投入します"
 pnpm --filter @suzumina.click/functions seed:load
 
-echo "[dev:local] web を Emulator 接続で起動します (http://localhost:3000)"
-pnpm --filter @suzumina.click/web dev:local
+if [[ "${DEV_AUTH_BYPASS:-}" == "1" ]]; then
+	echo "[dev:local] web を Emulator 接続で起動します (http://localhost:3000)"
+	echo "[dev:local] ローカル開発ログイン有効: http://localhost:3000/api/dev/signin でログイン済みになります"
+	pnpm --filter @suzumina.click/web dev:local:auth
+else
+	echo "[dev:local] web を Emulator 接続で起動します (http://localhost:3000)"
+	pnpm --filter @suzumina.click/web dev:local
+fi


### PR DESCRIPTION
## 背景

`/live`・`/buttons/create`・`/favorites`・`/settings`・`/users/me` は `ProtectedRoute` / `getCurrentUser()` で認証必須。ローカルには認証バイパスが一切無く、ブラウザで表示確認するには毎回 Discord OAuth を通す必要があり、実質的に確認できなかった。

## やったこと

```bash
pnpm dev:local:auth
```

起動後 `http://localhost:3000/api/dev/signin`（`?callbackUrl=/buttons/create` で戻り先指定可）を開くとログイン済みになる。ログアウトは通常のヘッダーから。

**既存の認証コードは無変更**（`getCurrentUser()` / `ProtectedRoute` / `lib/auth/*` / `auth.ts` すべて）。発行するのは better-auth の**実セッション**（`internalAdapter.createSession()` + `authCookies` 由来の署名 cookie）なので、サーバーの `getCurrentUser()` もクライアントの `useSession()` も Discord ログインと同じ経路を通る。

| ファイル | 役割 |
|---|---|
| `lib/dev-auth/guard.ts` | 3 段ゲート + 開発ユーザー定数（テスト対象） |
| `lib/better-auth/dev-session.ts` | better-auth の実セッション発行 glue |
| `app/api/dev/signin/route.ts` | dev 専用ルート（ゲート不成立なら 404） |
| `fixtures/users.json` | 合成の開発用ユーザー 1 件 |

## 本番での無効化（3 条件 AND / 1 つでも欠ければ 404）

1. `NODE_ENV !== "production"` — **例外なし**。`firestore.ts` の `PLAYWRIGHT_EMULATOR` 相当の抜け道は意図的に設けていない
2. `DEV_AUTH_BYPASS=1` の明示 opt-in — `pnpm dev:local` には付かない
3. `FIRESTORE_EMULATOR_HOST` 設定済 — 偽ユーザーの Server Action 書き込みが本番 Firestore に届く経路を塞ぐ。**ADC 直結 dev ではフラグを付けても有効にならない**

## 検証（Emulator + ブラウザ実機）

- `/api/dev/signin` → `better-auth.session_token=<token>.<HMAC署名>; HttpOnly; SameSite=lax`（`secure` 無し）を発行
- `/api/auth/get-session` が `appUser` を返す ＝ クライアント側 `useSession()` も同経路（ヘッダーに「ローカル開発ユーザー」表示を確認）
- `/settings`・`/users/me`・`/buttons/create`・`/favorites`・`/live` が描画。未ログイン時のみ `auth/signin` へリダイレクト
- `/users/me` はファミリーバッジまで fixture から解決、`/buttons/create` もレート制限が通り作成画面が出る
- **`pnpm dev:local`（フラグ無し）では `/api/dev/signin` が 404**
- `pnpm verify` 通過（exit 0）

## 判断で報告すべき点

1. **`dev-session.ts` を `lib/better-auth/` に置いた。** 当初 `lib/dev-auth/` に置いたが、SPR-168 の biome ルール（`@/lib/better-auth/auth` 等の直接 import は `src/lib/{auth,better-auth}/**` のみ許可）に抵触。例外を追加して境界に穴を開けるより provider glue を provider のディレクトリに置く方を選んだ。環境ゲートは provider 非依存なので `lib/dev-auth/guard.ts` に分離。
2. **一度発行したセッションはフラグを外しても失効しない**（実セッションのため）。ただし Emulator はメモリ常駐で `ba_session` ごと消えるため実質 Emulator の寿命が上限。本番では session 行が存在せず secret も異なるので cookie が漏れても通らない。
3. **e2e スモーク（本番ビルド × Emulator）では認証必須ページを踏めない。** 「本番では無条件無効」を優先し `PLAYWRIGHT_EMULATOR` 相当の例外を作らなかった帰結。必要なら別途相談。
4. CLAUDE.md §2 の「Emulator には users を投入しない」「role は既定 `member`」という記述が今回の変更で古くなる／既に事実と違ったため、当該段落を実態に合わせて修正した。

## レビュー方針

CLAUDE.md のセルフマージ・ポリシー上、**認証・認可の変更は One-Way Door** のため AI レビュー任せにせず自分でレビューしてからマージすること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)