### PR TITLE
docs: CLAUDE.md のローカル開発ログイン節から死んだルート名を除く

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ pnpm build                              # ビルド
      favorites/evaluations や `works/{id}/priceHistory` は投入しない＝お気に入り・評価は空、価格チャートも空）
 
 **ローカル開発ログイン（`pnpm dev:local:auth`）**
-`/live`・`/buttons/create`・`/favorites`・`/settings`・`/users/me` など `ProtectedRoute` / `getCurrentUser()` で
+`/watch`・`/drafts`・`/buttons/create`・`/favorites`・`/settings`・`/users/me` など `ProtectedRoute` / `getCurrentUser()` で
 守られたページをブラウザ確認するときだけ使う。起動後 `http://localhost:3000/api/dev/signin` を開くと
 開発用ユーザーでログイン済みになる（`?callbackUrl=/buttons/create` で戻り先指定可。ログアウトは通常のヘッダーから）。
 


### PR DESCRIPTION
#892 で `/live` は `/watch` へ改名され、認証必須ページに `/drafts` が加わりました。#891 が追記したローカル開発ログインの節に `/live` が残っていたため直します。

CLAUDE.md は毎セッション効かせる能動ルールの単一ソースなので、存在しないルート名が残るとステートレスな読み手（LLM）を直接誤らせます（軸1: 版ズレ＝負債）。

1行のドキュメント修正のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)