### PR TITLE
fix(dlsite): AJAX タイムアウト分岐に TimeoutError を追加

### DIFF
--- a/apps/functions/src/services/dlsite/__tests__/dlsite-ajax-fetcher.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/dlsite-ajax-fetcher.test.ts
@@ -191,6 +191,26 @@ describe("DLsite AJAX Fetcher", () => {
 				"DLsite AJAX APIから不正なレスポンス構造が返されました",
 			);
 		});
+
+		// AbortSignal.timeout() が投げるのは "TimeoutError"。"AbortError" だけを見ていた頃は
+		// タイムアウト分岐が到達不能で、汎用エラー扱いに落ちていた（2026-07-30 のページ22打ち切り）。
+		it("タイムアウト（TimeoutError）を専用メッセージで処理する", async () => {
+			mockFetch.mockRejectedValueOnce(
+				new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+			);
+
+			await expect(fetchDLsiteAjaxResult(22)).rejects.toThrow(
+				"DLsite AJAX リクエストがタイムアウトしました: ページ22",
+			);
+		});
+
+		it("AbortController 由来の中断（AbortError）も同じ分岐で処理する", async () => {
+			mockFetch.mockRejectedValueOnce(new DOMException("This operation was aborted", "AbortError"));
+
+			await expect(fetchDLsiteAjaxResult(3)).rejects.toThrow(
+				"DLsite AJAX リクエストがタイムアウトしました: ページ3",
+			);
+		});
 	});
 
 	describe("validateAjaxHtmlContent", () => {

--- a/apps/functions/src/services/dlsite/dlsite-ajax-fetcher.ts
+++ b/apps/functions/src/services/dlsite/dlsite-ajax-fetcher.ts
@@ -120,7 +120,9 @@ async function parseAndValidateJson(response: Response): Promise<DLsiteAjaxRespo
  */
 function handleFetchError(error: unknown, page: number): never {
 	// タイムアウトエラーの特別処理
-	if (error instanceof Error && error.name === "AbortError") {
+	// fetch は AbortSignal.timeout() 由来だと "TimeoutError" を投げる（"AbortError" は
+	// AbortController.abort() 由来）。TimeoutError を見ないとこの分岐は到達不能になる。
+	if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
 		logger.error(`DLsite AJAX リクエストがタイムアウトしました (${config.timeoutMs}ms)`, {
 			page,
 		});


### PR DESCRIPTION
## 背景

Cloud Alerting の `DLsite Function Error Alert` が 2026-07-30 15:08 UTC に発火。調査したところ、発火自体は設計どおり（SPR-271 のとおり per-page エラーを catch-all で拾う意図的な挙動）でデータ欠損も無かったが、その過程でタイムアウト分岐が到達不能になっていることが分かった。

- 原因: 作品ID収集の最終ページ（22ページ目）が 30s タイムアウトし、収集が 2,100/2,131件で打ち切られた
- 影響: 欠落した31件は後続 run が回収済み。2026-07-31 の価格履歴は 2,131件全件に記録されており**データ欠損なし**
- 頻度: 直近1週間で2回のみ（07-24 は DLsite 側 500、07-30 は timeout）。恒常化していない

## 変更内容

`fetch` を `AbortSignal.timeout()` で中断した場合に投げられるのは `TimeoutError` で、`AbortError`（`AbortController.abort()` 由来）のみを見ていた分岐は**一度も通っていなかった**。

そのため実際のタイムアウトは汎用の「リクエスト中にエラーが発生しました」に落ち、タイムアウト値（30000ms）を含む専用メッセージがログに残らず、切り分けが余計に一手増えていた。

- `handleFetchError` の条件に `TimeoutError` を追加（`AbortError` は残す）
- 実ログと同じ `DOMException(..., "TimeoutError")` で専用分岐に入ることを検証するテストを2件追加

## 影響範囲

- **挙動は変えていない**。リトライ追加やタイムアウト値の変更はせず、ページ打ち切り時に部分結果で継続する動作は従来どおり
- **監視への影響なし**。terraform 内にこの2つのメッセージ文言へ依存する metric filter は無く（ヒットは documentation の散文のみ）、両分岐とも `severity=ERROR` のままなので `dlsite_error_count` の計上は不変

## 確認

- `pnpm verify` 通過
- 追加テストのログ出力で `DLsite AJAX リクエストがタイムアウトしました (30000ms)` / `page: 22` が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)