### PR TITLE
fix: OG画像フォント取得の検証追加と高レイテンシアラートの系列統合

### DIFF
--- a/apps/web/src/lib/__tests__/og-font.test.ts
+++ b/apps/web/src/lib/__tests__/og-font.test.ts
@@ -43,6 +43,23 @@ describe("loadMPlusRoundedSubset", () => {
 		expect(fetchMock.mock.calls[1]?.[0]).toBe("https://fonts.gstatic.com/s/mplus.ttf");
 	});
 
+	// fetch ごとに独立したタイムアウトを張ると待ち上限が 2 倍になるため、
+	// 2 fetch が同一の deadline を共有していることを固定する
+	it("css2 とフォントバイナリの fetch が同一の AbortSignal を共有する", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce({ ok: true, status: 200, text: async () => TTF_CSS })
+			.mockResolvedValueOnce({ ok: true, status: 200, arrayBuffer: async () => sfntBinary() });
+		vi.stubGlobal("fetch", fetchMock);
+
+		await loadMPlusRoundedSubset(700, "あ");
+
+		const first = fetchMock.mock.calls[0]?.[1]?.signal;
+		const second = fetchMock.mock.calls[1]?.[1]?.signal;
+		expect(first).toBeInstanceOf(AbortSignal);
+		expect(second).toBe(first);
+	});
+
 	it("css に TTF/OTF の src が無ければ例外を投げる（呼び出し側で縮退させる）", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/apps/web/src/lib/__tests__/og-font.test.ts
+++ b/apps/web/src/lib/__tests__/og-font.test.ts
@@ -5,20 +5,32 @@ vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
 
 import { loadMPlusRoundedSubset } from "../og-font";
 
+const TTF_CSS =
+	"@font-face { src: url(https://fonts.gstatic.com/s/mplus.ttf) format('truetype'); }";
+
+/** 先頭4バイトが sfnt シグネチャ（TrueType outlines）の、フォントとして受理されるバイナリ */
+function sfntBinary(): ArrayBuffer {
+	const buffer = new ArrayBuffer(8);
+	new DataView(buffer).setUint32(0, 0x00010000, false);
+	return buffer;
+}
+
+/** Google Fonts がエラー時に返す HTML。satori はこれを Unsupported OpenType signature で弾く */
+function htmlBinary(): ArrayBuffer {
+	return new TextEncoder().encode("<!DOCTYPE html><html><body>error</body></html>").buffer;
+}
+
 describe("loadMPlusRoundedSubset", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
 	});
 
 	it("css2 の @font-face から TTF URL を抜き出してフォントバイナリを返す", async () => {
-		const fontData = new ArrayBuffer(8);
+		const fontData = sfntBinary();
 		const fetchMock = vi
 			.fn()
-			.mockResolvedValueOnce({
-				text: async () =>
-					"@font-face { src: url(https://fonts.gstatic.com/s/mplus.ttf) format('truetype'); }",
-			})
-			.mockResolvedValueOnce({ arrayBuffer: async () => fontData });
+			.mockResolvedValueOnce({ ok: true, status: 200, text: async () => TTF_CSS })
+			.mockResolvedValueOnce({ ok: true, status: 200, arrayBuffer: async () => fontData });
 		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(loadMPlusRoundedSubset(700, "ああAB")).resolves.toBe(fontData);
@@ -35,6 +47,8 @@ describe("loadMPlusRoundedSubset", () => {
 		vi.stubGlobal(
 			"fetch",
 			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
 				text: async () =>
 					"@font-face { src: url(https://fonts.gstatic.com/s/mplus.woff2) format('woff2'); }",
 			}),
@@ -43,5 +57,74 @@ describe("loadMPlusRoundedSubset", () => {
 		await expect(loadMPlusRoundedSubset(400, "あ")).rejects.toThrow(
 			"OG画像用フォントのサブセット取得に失敗しました",
 		);
+	});
+
+	it("css2 が 2xx 以外なら例外を投げる", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({ ok: false, status: 429, text: async () => "<!DOCTYPE html>" }),
+		);
+
+		await expect(loadMPlusRoundedSubset(700, "あ")).rejects.toThrow("HTTP 429");
+	});
+
+	it("フォントバイナリの取得が 2xx 以外なら例外を投げる", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce({ ok: true, status: 200, text: async () => TTF_CSS })
+				.mockResolvedValueOnce({ ok: false, status: 500, arrayBuffer: async () => htmlBinary() }),
+		);
+
+		await expect(loadMPlusRoundedSubset(700, "あ")).rejects.toThrow("HTTP 500");
+	});
+
+	// 本番 503 の再発防止: 200 で HTML が返るケースは arrayBuffer() が成功してしまうため、
+	// シグネチャ検査が無いと非 null が cacheLife("max") で恒久キャッシュされ satori が描画中に落ちる
+	it("フォント URL が 200 で HTML を返しても、フォントとして返さず例外を投げる", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce({ ok: true, status: 200, text: async () => TTF_CSS })
+				.mockResolvedValueOnce({ ok: true, status: 200, arrayBuffer: async () => htmlBinary() }),
+		);
+
+		await expect(loadMPlusRoundedSubset(700, "あ")).rejects.toThrow(
+			"OG画像用フォントの取得結果がフォントバイナリではありません",
+		);
+	});
+
+	it("空レスポンスもフォントとして受理しない", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce({ ok: true, status: 200, text: async () => TTF_CSS })
+				.mockResolvedValueOnce({
+					ok: true,
+					status: 200,
+					arrayBuffer: async () => new ArrayBuffer(0),
+				}),
+		);
+
+		await expect(loadMPlusRoundedSubset(700, "あ")).rejects.toThrow(
+			"OG画像用フォントの取得結果がフォントバイナリではありません",
+		);
+	});
+
+	it("OTTO（CFF outlines）シグネチャのフォントも受理する", async () => {
+		const otto = new ArrayBuffer(8);
+		new DataView(otto).setUint32(0, 0x4f54544f, false);
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce({ ok: true, status: 200, text: async () => TTF_CSS })
+				.mockResolvedValueOnce({ ok: true, status: 200, arrayBuffer: async () => otto }),
+		);
+
+		await expect(loadMPlusRoundedSubset(400, "あ")).resolves.toBe(otto);
 	});
 });

--- a/apps/web/src/lib/og-font.ts
+++ b/apps/web/src/lib/og-font.ts
@@ -5,8 +5,16 @@ import { cacheLife } from "next/cache";
  * app/opengraph-image.tsx（サイト既定・SPR-171）と app/buttons/[id]/opengraph-image.tsx（SPR-249）で共用する。
  */
 
-/** フォント取得の待ち上限。ハングを P95 レイテンシに乗せず ASCII 縮退版へ早期フォールバックさせる */
-const FONT_FETCH_TIMEOUT_MS = 5000;
+/**
+ * フォント取得の待ち上限。ハングを P95 レイテンシに乗せず ASCII 縮退版へ早期フォールバックさせる。
+ *
+ * これは **loadMPlusRoundedSubset 1 回あたりの合計**（css2 とバイナリの 2 fetch で 1 つの
+ * deadline を共有する）。fetch ごとに独立したタイムアウトを張ると上限が 2 倍になる。
+ * さらに og-response.ts は bold / regular で本関数を 2 回逐次呼ぶため、
+ * OG 画像 1 枚の最悪値は 3s × 2 = 6s。high_latency アラートの閾値 10s の内側に収める意図。
+ * 実測の所要は 102〜262ms（css2 45-188ms + バイナリ 53-74ms）なので 3s でも 10 倍以上の余裕がある
+ */
+const FONT_FETCH_TIMEOUT_MS = 3000;
 
 /**
  * sfnt（TTF/OTF）コンテナの先頭4バイト。satori はこれ以外を
@@ -24,8 +32,12 @@ const SFNT_SIGNATURES = new Set([
  * `res.ok` を見ないと、エラー HTML が `arrayBuffer()` で「成功」してしまい
  * 呼び出し側の縮退フォールバックを素通りする（本番 503 の実績あり）
  */
-async function fetchFontResource(url: string, label: string): Promise<Response> {
-	const res = await fetch(url, { signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS) });
+async function fetchFontResource(
+	url: string,
+	label: string,
+	signal: AbortSignal,
+): Promise<Response> {
+	const res = await fetch(url, { signal });
 	if (!res.ok) {
 		throw new Error(`OG画像用フォントの${label}取得に失敗しました (HTTP ${res.status})`);
 	}
@@ -60,14 +72,17 @@ export async function loadMPlusRoundedSubset(
 ): Promise<ArrayBuffer> {
 	"use cache";
 	cacheLife("max");
+	// 2 fetch で 1 つの deadline を共有する。呼び出し側から signal を渡す設計は採れない
+	// （"use cache" の引数は直列化可能でなければキャッシュキーが壊れる）ため関数内で生成する
+	const deadline = AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS);
 	const uniqueChars = [...new Set(text)].join("");
 	const cssUrl = `https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@${weight}&text=${encodeURIComponent(uniqueChars)}`;
-	const css = await (await fetchFontResource(cssUrl, "css2")).text();
+	const css = await (await fetchFontResource(cssUrl, "css2", deadline)).text();
 	const fontUrl = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)?.[1];
 	if (!fontUrl) {
 		throw new Error("OG画像用フォントのサブセット取得に失敗しました");
 	}
-	const fontData = await (await fetchFontResource(fontUrl, "バイナリ")).arrayBuffer();
+	const fontData = await (await fetchFontResource(fontUrl, "バイナリ", deadline)).arrayBuffer();
 	if (!isSfntBinary(fontData)) {
 		throw new Error("OG画像用フォントの取得結果がフォントバイナリではありません");
 	}

--- a/apps/web/src/lib/og-font.ts
+++ b/apps/web/src/lib/og-font.ts
@@ -5,6 +5,40 @@ import { cacheLife } from "next/cache";
  * app/opengraph-image.tsx（サイト既定・SPR-171）と app/buttons/[id]/opengraph-image.tsx（SPR-249）で共用する。
  */
 
+/** フォント取得の待ち上限。ハングを P95 レイテンシに乗せず ASCII 縮退版へ早期フォールバックさせる */
+const FONT_FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * sfnt（TTF/OTF）コンテナの先頭4バイト。satori はこれ以外を
+ * `Unsupported OpenType signature` で弾くため、描画前にここで検査する
+ */
+const SFNT_SIGNATURES = new Set([
+	0x00010000, // TrueType outlines
+	0x74727565, // 'true'（Apple TrueType）
+	0x74746366, // 'ttcf'（TrueType Collection）
+	0x4f54544f, // 'OTTO'（CFF outlines）
+]);
+
+/**
+ * 2xx 以外を例外にして返す fetch。
+ * `res.ok` を見ないと、エラー HTML が `arrayBuffer()` で「成功」してしまい
+ * 呼び出し側の縮退フォールバックを素通りする（本番 503 の実績あり）
+ */
+async function fetchFontResource(url: string, label: string): Promise<Response> {
+	const res = await fetch(url, { signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS) });
+	if (!res.ok) {
+		throw new Error(`OG画像用フォントの${label}取得に失敗しました (HTTP ${res.status})`);
+	}
+	return res;
+}
+
+function isSfntBinary(buffer: ArrayBuffer): boolean {
+	if (buffer.byteLength < 4) {
+		return false;
+	}
+	return SFNT_SIGNATURES.has(new DataView(buffer).getUint32(0, false));
+}
+
 /**
  * Google Fonts から表示文字だけの M PLUS Rounded 1c（ブランドフォント正）サブセットを取得する。
  * - ブラウザ UA を名乗らない fetch には woff2 でなく TTF が返るため ImageResponse でそのまま使える
@@ -14,6 +48,11 @@ import { cacheLife } from "next/cache";
  *   不変なので `max` プロファイル。これによりリクエスト毎の Google Fonts 2連続 fetch を排除し、
  *   完全静的な app/opengraph-image.tsx はビルド時 prerender（静的化）が可能になる。
  *   取得失敗は throw で抜ける（エラーはキャッシュされず、次アクセスで再試行される）
+ *
+ * 失敗を必ず throw に寄せるのが要点。HTTP ステータスとフォントシグネチャを検査せずに
+ * `arrayBuffer()` の結果をそのまま返すと、エラー HTML が「成功した非 null の戻り値」として
+ * `cacheLife("max")` で恒久キャッシュされ、satori が描画中に落ちて Cloud Run が 503 を返す
+ * （2026-08-01 の高レイテンシアラート発火源。`/works/[workId]/opengraph-image`）
  */
 export async function loadMPlusRoundedSubset(
 	weight: 400 | 700,
@@ -23,10 +62,14 @@ export async function loadMPlusRoundedSubset(
 	cacheLife("max");
 	const uniqueChars = [...new Set(text)].join("");
 	const cssUrl = `https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@${weight}&text=${encodeURIComponent(uniqueChars)}`;
-	const css = await (await fetch(cssUrl)).text();
+	const css = await (await fetchFontResource(cssUrl, "css2")).text();
 	const fontUrl = css.match(/src: url\((.+?)\) format\('(?:opentype|truetype)'\)/)?.[1];
 	if (!fontUrl) {
 		throw new Error("OG画像用フォントのサブセット取得に失敗しました");
 	}
-	return (await fetch(fontUrl)).arrayBuffer();
+	const fontData = await (await fetchFontResource(fontUrl, "バイナリ")).arrayBuffer();
+	if (!isSfntBinary(fontData)) {
+		throw new Error("OG画像用フォントの取得結果がフォントバイナリではありません");
+	}
+	return fontData;
 }

--- a/terraform/monitoring_performance.tf
+++ b/terraform/monitoring_performance.tf
@@ -16,15 +16,31 @@ resource "google_monitoring_alert_policy" "high_latency" {
       comparison      = "COMPARISON_GT"
       threshold_value = 10000 # 10秒（コールドスタート許容）
 
+      # ALIGN_DELTA で distribution のまま整列し、REDUCE_PERCENTILE_95 で全系列を
+      # マージしてから P95 を取る＝サービス全体の実 P95。単一系列に畳むのが要点で、
+      # cross_series_reducer が無いと response_code / revision ラベルごとに別系列となり、
+      # 503 のような疎な系列が数リクエストで発火する（実測: 2026-08-01 は 503 が 48h で
+      # 2 件しか無く、その 2 点だけの P95 = 22,328ms が閾値を超えて発火）。
+      # さらに疎な系列はデータが途切れると評価不能になり、インシデントが 7 日の
+      # auto_close までクローズされず OPEN 固着する（履歴に openTime→closeTime が
+      # ちょうど 7 日の incident が複数ある）。系列を連続化することで duration の
+      # 5 分継続判定が実際に効くようになる（背景は SPR / Run Absent 偽陽性と同型）
       aggregations {
-        alignment_period   = "60s"
-        per_series_aligner = "ALIGN_PERCENTILE_95"
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_PERCENTILE_95"
       }
 
       trigger {
         count = 1
       }
     }
+  }
+
+  # 夜間など無トラフィック帯では統合後の系列にも欠測が出るため、
+  # 既定の 7 日ではなく 30 分で自動クローズし OPEN 固着を構造的に断つ
+  alert_strategy {
+    auto_close = "1800s"
   }
 
   notification_channels = [
@@ -34,10 +50,12 @@ resource "google_monitoring_alert_policy" "high_latency" {
   documentation {
     content   = <<-EOT
     # 高レイテンシ検知アラート（個人開発版・P95）
-    
+
     Next.jsアプリケーションのP95レスポンス時間が10秒を超えました。
     コールドスタートを考慮した閾値に調整済み。
-    
+    全リクエストをマージしたサービス全体のP95が5分間継続で超過した場合のみ発火する
+    （response_code / revision 単位では評価しない）。
+
     ## 対応アクション
     1. Cloud Loggingで遅いクエリを特定
     2. Firestoreインデックスの最適化確認


### PR DESCRIPTION
## 背景

「高レイテンシ検知アラート」が 2026-08-01T01:05Z から OPEN のままだったため調査した。
**結論から言うと負荷起因ではない。** Cloud Run コンテナの負荷は正常だった。

| 項目 | 実測（48h） | 閾値 |
|---|---|---|
| CPU P99 | 5.9〜52.7% | 95% |
| 200 応答の P95 レイテンシ | 1.4〜2.9s で安定 | 10s |
| インスタンス数 | active 最大 2（`maxScale=2`）/ `minScale=0` | — |
| 2xx リクエスト | 38,076（7/30）→ 18,368（7/31） | — |

発火の実体は `response_code="503"` のラベル系列で、48h の 503 は **2 リクエストのみ**
（いずれも `/works/{id}/opengraph-image`）。その 2 点だけの P95 = 22,328ms が閾値を超えていた。

原因は独立した 2 つで、それぞれ別コミットで直す。

## 1. `fix(og)`: 503 を出していた真因

```
⨯ Error: failed to pipe response
  [cause]: Error: Unsupported OpenType signature <!DO
```

`og-font.ts` の 2 段目 fetch が `res.ok` を見ておらず、Google Fonts がエラー HTML を返すと
`arrayBuffer()` が成功して**非 null** が返る。その結果 `og-response.ts` の
`.catch(() => null)` 縮退フォールバックを素通りし、satori が描画中に落ちて Cloud Run が 503 を返していた。

さらに `cacheLife("max")` のため、**壊れた HTML バッファが「成功した戻り値」として恒久キャッシュされうる**
状態だった。ファイル冒頭の「取得失敗は throw で抜けるのでキャッシュされない」という前提が、
この失敗モードだけ成立していない。失敗を必ず throw に寄せる形へ統一した。

- 両方の fetch で `res.ok` を検査
- sfnt シグネチャ（先頭4バイト）を検査 — `res.ok` だけでは 200+HTML のケースが残るため
- 5 秒タイムアウト — 本番で観測した 20.5s のハングを縮退版へ早期フォールバックさせる

## 2. `fix(monitoring)`: 2 件の 503 で発火し 7 日固着していたアラート

`cross_series_reducer` が無いため `response_code` / `revision` ラベルごとに別系列を評価しており、
503 のような**疎な系列**が数リクエストで発火していた。加えて疎な系列はデータが途切れると評価不能になり、
既定 7 日の `auto_close` まで OPEN 固着する。履歴に openTime→closeTime がちょうど 7 日の incident が
複数ある（2026-05-25→06-01、2026-06-03→06-10）＝同じ現象の再発。

- `ALIGN_DELTA` + `REDUCE_PERCENTILE_95` で distribution のままマージしてから P95 を取る
- `alert_strategy.auto_close = 1800s`

### ⚠️ 効きどころの注意（将来の変更者向け）

「reducer でスパイクが吸収されるから直る」**ではない**。実測すると粒度で挙動が違う。

| 粒度 | 統合後の最大 P95 |
|---|---|
| 1h | 3,433 ms（吸収される） |
| **60s（ポリシー実設定）** | **21,918 ms（残る）** |

効くのは**系列が連続化して `duration = 300s` の 5 分継続判定が実際に機能するため**
（10s 超は 24h 中 1 分間のみ）。**`duration` を短縮すると再発する。**

## 検証

- `pnpm verify` **EXIT=0**（og-font 単体 7 件パス・カバレッジ 100%、OG 関連 9 ファイル 50 件パス）
- **実際の Google Fonts 応答**で新ガードを通過確認 — weight 400/700 とも `0x00010000`（TrueType）＝正常系を弾かない
- **dev サーバで実レンダリング** — `/opengraph-image` が 200 PNG（1200×630, 863ms）、日本語がブランドフォントで描画され縮退版でない経路を通過。`/works/[workId]/opengraph-image` も 200 PNG
- `terraform fmt -check` / `terraform validate` パス
- アグリゲーションを **timeSeries API に同じ triple を投げて事前検証**（系列数が 1 に畳まれ数値 P95 が返ることを実測）
- **live ポリシーと変更前 terraform が完全一致**（ドリフト無し）＝ CI の plan 差分は今回の 2 点のみ

ローカルの `terraform plan` は CI が供給する secret 変数 5 件が無く実行できなかった。ダミー値を入れれば
通るが、偽の入力から作った plan を根拠にするのは避けた（plan は ADR-010 どおり CI に委ねる）。

## レビュー観点

CLAUDE.md のポリシー上、**Terraform 変更は One-Way Door** のため AI レビュー任せにせず要自己レビュー。

## 今回スコープ外にしたもの

- **メモリ 2Gi 引き上げ** — 7/31 09:19 に実 OOM（`Memory limit of 1024 MiB exceeded with 1033 MiB used`）が
  1 件あるが、コスト都合で見送り
- **`og-remote-image.ts` の fetch タイムアウト欠如** — `res.ok` は見ているので今回の 503 とは別物だが、
  DLsite 側が遅延すると OG ルートが無制限に待つ。打ち切り閾値（サムネイルを落としてでも止める判断）が
  設計判断になるため独断では入れていない
- **CPU / メモリアラートの reducer** — revision 単位で見たい性質があり、かつメモリアラートは上記の実 OOM を
  正しく捉えていたため触っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
