### PR TITLE
feat(og): ブランドフォント縮退を観測可能にする

### DIFF
--- a/apps/web/src/lib/__tests__/og-response.test.tsx
+++ b/apps/web/src/lib/__tests__/og-response.test.tsx
@@ -12,7 +12,9 @@ vi.mock("next/og", () => ({
 	},
 }));
 vi.mock("@/lib/og-font", () => ({ loadMPlusRoundedSubset: vi.fn() }));
+vi.mock("@/lib/logger", () => ({ warn: vi.fn() }));
 
+import { warn } from "@/lib/logger";
 import { loadMPlusRoundedSubset } from "@/lib/og-font";
 import { buildOgImageResponse } from "../og-response";
 
@@ -21,6 +23,7 @@ const size = { width: 1200, height: 630 };
 describe("buildOgImageResponse", () => {
 	beforeEach(() => {
 		vi.mocked(loadMPlusRoundedSubset).mockReset();
+		vi.mocked(warn).mockReset();
 	});
 
 	it("bold 取得成功時は renderFull を使い、bold フォントのみ付与する（regularText 省略時）", async () => {
@@ -94,5 +97,69 @@ describe("buildOgImageResponse", () => {
 		expect(response.options.fonts).toBeUndefined();
 		// bold が失敗した時点で regular は取得しに行かない（無駄な外部fetchを避ける）
 		expect(loadMPlusRoundedSubset).toHaveBeenCalledTimes(1);
+	});
+
+	// 縮退を無言で握りつぶすと縮退率が測れず、Google Fonts への runtime 依存を
+	// 続けるか同梱に倒すかを判断できない。message / alert は監視の契約なので値ごと固定する
+	describe("縮退の観測ログ", () => {
+		it("bold 失敗時は degradation=ascii_fallback で WARN を出す", async () => {
+			const err = new Error("bold font error");
+			vi.mocked(loadMPlusRoundedSubset).mockRejectedValueOnce(err);
+
+			await buildOgImageResponse({
+				size,
+				boldText: "title",
+				regularText: "subtitle",
+				renderFallback: () => <div>fallback</div>,
+				renderFull: () => <div>full</div>,
+			});
+
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn).toHaveBeenCalledWith("OG image brand font unavailable", {
+				alert: "og_font_fallback",
+				font_weight: 700,
+				degradation: "ascii_fallback",
+				error: err,
+			});
+		});
+
+		it("regular 失敗時は degradation=bold_only で WARN を出す", async () => {
+			const err = new Error("regular font error");
+			vi.mocked(loadMPlusRoundedSubset)
+				.mockResolvedValueOnce(new ArrayBuffer(8))
+				.mockRejectedValueOnce(err);
+
+			await buildOgImageResponse({
+				size,
+				boldText: "title",
+				regularText: "subtitle",
+				renderFallback: () => <div>fallback</div>,
+				renderFull: () => <div>full</div>,
+			});
+
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn).toHaveBeenCalledWith("OG image brand font unavailable", {
+				alert: "og_font_fallback",
+				font_weight: 400,
+				degradation: "bold_only",
+				error: err,
+			});
+		});
+
+		it("両方成功した通常時はログを出さない（正常系をノイズにしない）", async () => {
+			vi.mocked(loadMPlusRoundedSubset)
+				.mockResolvedValueOnce(new ArrayBuffer(8))
+				.mockResolvedValueOnce(new ArrayBuffer(4));
+
+			await buildOgImageResponse({
+				size,
+				boldText: "title",
+				regularText: "subtitle",
+				renderFallback: () => <div>fallback</div>,
+				renderFull: () => <div>full</div>,
+			});
+
+			expect(warn).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/apps/web/src/lib/og-response.ts
+++ b/apps/web/src/lib/og-response.ts
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { warn } from "@/lib/logger";
 import { loadMPlusRoundedSubset } from "@/lib/og-font";
 
 /**
@@ -31,6 +32,36 @@ interface BuildOgImageResponseParams {
 	renderFull: () => React.ReactElement;
 }
 
+/**
+ * ブランドフォント取得の失敗を観測可能にしたうえで null に畳む。
+ *
+ * ここを無言で握りつぶすと「OG 画像がどのくらいの頻度で縮退しているか」が測れず、
+ * Google Fonts への runtime 依存を続けるか、フルフォント同梱（実測 6.59MB）に倒すかの
+ * 判断材料が永久に得られない。`error` には HTTP ステータス / シグネチャ不正 / タイムアウトの
+ * どれで落ちたかが入るため、原因別の切り分けもログだけで済む。
+ *
+ * `message` と `alert` は log-based メトリクスのフィルタ対象になる契約なので英語で固定する
+ * （CLAUDE.md §1）。options を必ず渡すのは、引数なし呼び出しだと jsonPayload に残らず
+ * textPayload へ昇格してしまい構造化フィールドで絞り込めなくなるため
+ */
+async function loadFontOrLogFallback(
+	weight: 400 | 700,
+	text: string,
+	degradation: "ascii_fallback" | "bold_only",
+): Promise<ArrayBuffer | null> {
+	try {
+		return await loadMPlusRoundedSubset(weight, text);
+	} catch (err) {
+		warn("OG image brand font unavailable", {
+			alert: "og_font_fallback",
+			font_weight: weight,
+			degradation,
+			error: err,
+		});
+		return null;
+	}
+}
+
 export async function buildOgImageResponse({
 	size,
 	boldText,
@@ -38,14 +69,15 @@ export async function buildOgImageResponse({
 	renderFallback,
 	renderFull,
 }: BuildOgImageResponseParams): Promise<InstanceType<typeof ImageResponse>> {
-	const fontBold = await loadMPlusRoundedSubset(700, boldText).catch(() => null);
+	// bold の失敗は全面 ASCII 縮退、regular の失敗は bold のみでの描画と影響範囲が違うため区別する
+	const fontBold = await loadFontOrLogFallback(700, boldText, "ascii_fallback");
 
 	if (!fontBold) {
 		return new ImageResponse(renderFallback(), { ...size });
 	}
 
 	const fontRegular = regularText
-		? await loadMPlusRoundedSubset(400, regularText).catch(() => null)
+		? await loadFontOrLogFallback(400, regularText, "bold_only")
 		: null;
 
 	return new ImageResponse(renderFull(), {


### PR DESCRIPTION
## 背景

#895 で OG 画像フォント取得の失敗を潰したが、**縮退そのものは無言のまま**だった。
`og-response.ts` の `.catch(() => null)` はエラーを捨てるため、
「OG 画像が実際どのくらいの頻度でブランドフォントを失っているか」が観測できない。

これは CLAUDE.md §1 の「`FAILED_PRECONDITION` を catch で握りつぶさない（最低ログ）」と同型の問題。

観測できないと、次の設計判断ができない:

| 方式 | フォントサイズ（実測） |
|---|---|
| runtime サブセット取得（現行） | 2,936B / 4,936B（weight 400 / 700） |
| フルフォント同梱 | **3.22MB + 3.37MB = 6.59MB** |

OG 画像には任意の作品タイトルが入るためビルド時サブセットが使えず、同梱を選ぶなら CJK フル 6.59MB が前提になる。
**6.59MB を払う価値があるかは、実際の縮退率が分からないと決められない。** この PR はその分母を作る。

## 変更内容

縮退時に WARN を 1 件出す。

```
message: "OG image brand font unavailable"
alert: "og_font_fallback"
font_weight: 700 | 400
degradation: "ascii_fallback" | "bold_only"
error: { message, name, stack }
```

- `message` / `alert` は log-based メトリクスのフィルタ契約になるため**英語で固定**（CLAUDE.md §1）
- bold 失敗（全面 ASCII 縮退）と regular 失敗（bold のみで描画）を `degradation` で区別。影響範囲が違うため
- `error` に HTTP ステータス / シグネチャ不正 / タイムアウトのどれで落ちたかが入るので、**原因別の切り分けがログだけで済む**
- 正常時は出さない（正常系をノイズにしない）

`options` を必ず渡しているのは、引数なし呼び出しだと jsonPayload に残らず textPayload へ昇格し、
構造化フィールドで絞り込めなくなるため。

## 検証

取得先を到達不能ホストへ差し替えて**実際に縮退を発生させ**、dev サーバのログと描画結果を確認した。

```
[WARNING] OG image brand font unavailable {
  alert: 'og_font_fallback',
  font_weight: 700,
  degradation: 'ascii_fallback',
  error: { message: 'fetch failed', name: 'TypeError', stack: ... }
}
```

- 画像は **200 のまま**描画され、ASCII 縮退版になる（73,298B / ブランドフォント版は 82,384B）
- 配色・レイアウトは維持され、テキストのみ英語のシステムフォントに落ちる
- `pnpm verify` **EXIT=0**（og-response 7 件パス、うち観測ログ 3 件を新規追加）

## 使い方（マージ後）

```
jsonPayload.alert="og_font_fallback"
```

で件数を見て、`degradation` で影響度、`error.message` で原因を切り分けられる。
縮退率が無視できない水準なら、6.59MB を払ってフォント同梱に倒す判断ができる。

## Door 判定

**Two-Way Door**（ログ追加のみ・挙動不変・戻せる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
