### PR TITLE
feat(metrics): 成功指標を Firestore から算出するレポートを追加 (SPR-298)

### DIFF
--- a/apps/functions/package.json
+++ b/apps/functions/package.json
@@ -24,6 +24,7 @@
 		"tools:reset": "dotenv -e .env -- tsx src/tools/run-tools.ts reset",
 		"tools:backfill-creators": "dotenv -e .env -- tsx src/tools/run-tools.ts backfill-creators",
 		"tools:help": "dotenv -e .env -- tsx src/tools/run-tools.ts help",
+		"metrics": "dotenv -e .env -- tsx src/tools/success-metrics/report.ts",
 		"check:integrity": "dotenv -e .env -- tsx src/tools/core/run-data-integrity-check.ts",
 		"check:price-history": "dotenv -e .env -- tsx src/tools/check-price-history.ts",
 		"debug:price-history": "dotenv -e .env -- tsx src/tools/debug-price-history.ts",

--- a/apps/functions/src/tools/success-metrics/__tests__/aggregate.test.ts
+++ b/apps/functions/src/tools/success-metrics/__tests__/aggregate.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from "vitest";
+import {
+	type ActivityRecord,
+	type ButtonRecord,
+	detectCreationSessions,
+	median,
+	parseTimestamp,
+	summarizeCreationByMonth,
+	summarizeEffort,
+	summarizeEffortByMonth,
+	summarizeMonthlyActiveUsers,
+	summarizePlayback,
+	summarizeUserActivity,
+	toJstDateKey,
+	toJstMonthKey,
+} from "../aggregate";
+
+function button(overrides: Partial<ButtonRecord> & { createdAt: Date }): ButtonRecord {
+	return {
+		id: "b1",
+		creatorId: "u1",
+		creatorName: "creator",
+		playCount: 0,
+		likeCount: 0,
+		favoriteCount: 0,
+		videoId: "v1",
+		...overrides,
+	};
+}
+
+describe("parseTimestamp", () => {
+	it("ISO string を Date にする", () => {
+		expect(parseTimestamp("2026-07-31T11:09:04.384Z")?.toISOString()).toBe(
+			"2026-07-31T11:09:04.384Z",
+		);
+	});
+
+	it("Firestore Timestamp（toDate を持つ）を Date にする", () => {
+		const timestamp = { toDate: () => new Date("2026-07-01T00:00:00.000Z") };
+		expect(parseTimestamp(timestamp)?.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+	});
+
+	it("シリアライズされた Timestamp（_seconds）を Date にする", () => {
+		expect(parseTimestamp({ _seconds: 1753096381, _nanoseconds: 161000000 })?.toISOString()).toBe(
+			new Date(1753096381000).toISOString(),
+		);
+	});
+
+	it("Date をそのまま通す", () => {
+		const date = new Date("2026-01-01T00:00:00.000Z");
+		expect(parseTimestamp(date)).toBe(date);
+	});
+
+	it("解釈できない値は null（黙って現在時刻にしない）", () => {
+		expect(parseTimestamp(undefined)).toBeNull();
+		expect(parseTimestamp(null)).toBeNull();
+		expect(parseTimestamp("not a date")).toBeNull();
+		expect(parseTimestamp(new Date("invalid"))).toBeNull();
+		expect(parseTimestamp({})).toBeNull();
+		expect(parseTimestamp(123)).toBeNull();
+	});
+});
+
+describe("JST キー", () => {
+	it("UTC 15:00 は翌日の JST 日付になる", () => {
+		expect(toJstDateKey(new Date("2026-07-31T15:00:00.000Z"))).toBe("2026-08-01");
+		expect(toJstMonthKey(new Date("2026-07-31T15:00:00.000Z"))).toBe("2026-08");
+	});
+
+	it("UTC 14:59 は同日の JST 日付のまま", () => {
+		expect(toJstDateKey(new Date("2026-07-31T14:59:00.000Z"))).toBe("2026-07-31");
+	});
+});
+
+describe("median", () => {
+	it("奇数個は中央の値", () => {
+		expect(median([3, 1, 2])).toBe(2);
+	});
+
+	it("偶数個は中央2つの平均", () => {
+		expect(median([1, 2, 3, 4])).toBe(2.5);
+	});
+
+	it("空配列は null", () => {
+		expect(median([])).toBeNull();
+	});
+});
+
+describe("detectCreationSessions", () => {
+	it("間隔が閾値未満なら同一セッションにまとめる", () => {
+		const sessions = detectCreationSessions(
+			[
+				button({ id: "a", createdAt: new Date("2026-07-01T10:00:00Z") }),
+				button({ id: "b", createdAt: new Date("2026-07-01T10:05:00Z") }),
+				button({ id: "c", createdAt: new Date("2026-07-01T10:12:00Z") }),
+			],
+			30,
+		);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.buttonCount).toBe(3);
+		expect(sessions[0]?.intervalsSeconds).toEqual([300, 420]);
+	});
+
+	it("間隔が閾値以上なら別セッションに割る", () => {
+		const sessions = detectCreationSessions(
+			[
+				button({ id: "a", createdAt: new Date("2026-07-01T10:00:00Z") }),
+				button({ id: "b", createdAt: new Date("2026-07-01T11:00:00Z") }),
+			],
+			30,
+		);
+		expect(sessions).toHaveLength(2);
+		expect(sessions.every((s) => s.buttonCount === 1)).toBe(true);
+	});
+
+	it("creator が違えば時間が近くても混ざらない", () => {
+		const sessions = detectCreationSessions(
+			[
+				button({ id: "a", creatorId: "u1", createdAt: new Date("2026-07-01T10:00:00Z") }),
+				button({ id: "b", creatorId: "u2", createdAt: new Date("2026-07-01T10:01:00Z") }),
+			],
+			30,
+		);
+		expect(sessions).toHaveLength(2);
+		expect(sessions.map((s) => s.creatorId).sort()).toEqual(["u1", "u2"]);
+	});
+
+	it("入力順が時系列でなくてもセッション化できる", () => {
+		const sessions = detectCreationSessions(
+			[
+				button({ id: "c", createdAt: new Date("2026-07-01T10:12:00Z") }),
+				button({ id: "a", createdAt: new Date("2026-07-01T10:00:00Z") }),
+				button({ id: "b", createdAt: new Date("2026-07-01T10:05:00Z") }),
+			],
+			30,
+		);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.intervalsSeconds).toEqual([300, 420]);
+	});
+
+	it("空入力は空配列", () => {
+		expect(detectCreationSessions([], 30)).toEqual([]);
+	});
+});
+
+describe("summarizeEffort", () => {
+	it("セッションあたり作成数と間隔の中央値を出す", () => {
+		const sessions = detectCreationSessions(
+			[
+				button({ id: "a", createdAt: new Date("2026-07-01T10:00:00Z") }),
+				button({ id: "b", createdAt: new Date("2026-07-01T10:02:00Z") }),
+				button({ id: "c", createdAt: new Date("2026-07-01T10:10:00Z") }),
+				button({ id: "d", createdAt: new Date("2026-07-02T10:00:00Z") }),
+			],
+			30,
+		);
+		const summary = summarizeEffort(sessions);
+		expect(summary.sessions).toBe(2);
+		expect(summary.buttons).toBe(4);
+		expect(summary.buttonsPerSession).toBe(2);
+		expect(summary.medianIntervalSeconds).toBe(300); // 間隔 120秒 と 480秒 の中央値
+	});
+
+	it("単独作成だけなら間隔は null", () => {
+		const sessions = detectCreationSessions(
+			[button({ id: "a", createdAt: new Date("2026-07-01T10:00:00Z") })],
+			30,
+		);
+		expect(summarizeEffort(sessions).medianIntervalSeconds).toBeNull();
+	});
+
+	it("セッションが無ければ 0 で割らない", () => {
+		expect(summarizeEffort([])).toEqual({
+			sessions: 0,
+			buttons: 0,
+			buttonsPerSession: 0,
+			medianIntervalSeconds: null,
+		});
+	});
+});
+
+describe("summarizeEffortByMonth", () => {
+	it("セッション開始月で束ねて月順に返す", () => {
+		const sessions = detectCreationSessions(
+			[
+				button({ id: "a", createdAt: new Date("2026-06-10T01:00:00Z") }),
+				button({ id: "b", createdAt: new Date("2026-07-10T01:00:00Z") }),
+				button({ id: "c", createdAt: new Date("2026-07-10T01:05:00Z") }),
+			],
+			30,
+		);
+		const rows = summarizeEffortByMonth(sessions);
+		expect(rows.map((r) => r.month)).toEqual(["2026-06", "2026-07"]);
+		expect(rows[1]?.buttons).toBe(2);
+	});
+});
+
+describe("summarizeCreationByMonth", () => {
+	it("月ごとの作成数・ユニーク作成者数・作成日数を出す", () => {
+		const rows = summarizeCreationByMonth([
+			button({ id: "a", creatorId: "u1", createdAt: new Date("2026-07-01T01:00:00Z") }),
+			button({ id: "b", creatorId: "u2", createdAt: new Date("2026-07-02T01:00:00Z") }),
+			button({ id: "c", creatorId: "u1", createdAt: new Date("2026-07-03T01:00:00Z") }),
+			button({ id: "d", creatorId: "u1", createdAt: new Date("2026-08-01T01:00:00Z") }),
+		]);
+		expect(rows).toEqual([
+			{ month: "2026-07", buttons: 3, creators: 2, days: 3 },
+			{ month: "2026-08", buttons: 1, creators: 1, days: 1 },
+		]);
+	});
+
+	it("同日に複数作っても作成日数は 1 日（作成数とは独立に数える）", () => {
+		const rows = summarizeCreationByMonth([
+			button({ id: "a", createdAt: new Date("2026-07-01T01:00:00Z") }),
+			button({ id: "b", createdAt: new Date("2026-07-01T09:00:00Z") }),
+		]);
+		expect(rows).toEqual([{ month: "2026-07", buttons: 2, creators: 1, days: 1 }]);
+	});
+});
+
+describe("summarizeUserActivity", () => {
+	const activities: ActivityRecord[] = [
+		{ userId: "u1", at: new Date("2026-07-01T01:00:00Z"), kind: "create" },
+		{ userId: "u1", at: new Date("2026-07-01T02:00:00Z"), kind: "favorite" },
+		{ userId: "u1", at: new Date("2026-08-05T01:00:00Z"), kind: "draft" },
+		{ userId: "u2", at: new Date("2026-07-02T01:00:00Z"), kind: "like" },
+	];
+
+	it("同日の複数行動は活動日 1 日として数える", () => {
+		const [first] = summarizeUserActivity(activities);
+		expect(first?.userId).toBe("u1");
+		expect(first?.activeDays).toBe(2);
+		expect(first?.activeMonths).toBe(2);
+	});
+
+	it("種別ごとの件数と初回・最終を出す", () => {
+		const [first] = summarizeUserActivity(activities);
+		expect(first?.counts).toEqual({
+			create: 1,
+			favorite: 1,
+			like: 0,
+			dislike: 0,
+			draft: 1,
+			evaluation: 0,
+		});
+		expect(first?.firstAt.toISOString()).toBe("2026-07-01T01:00:00.000Z");
+		expect(first?.lastAt.toISOString()).toBe("2026-08-05T01:00:00.000Z");
+	});
+
+	it("活動日数の多い順に並ぶ", () => {
+		expect(summarizeUserActivity(activities).map((u) => u.userId)).toEqual(["u1", "u2"]);
+	});
+});
+
+describe("summarizeMonthlyActiveUsers", () => {
+	it("活動ユーザーと、うち作成した人を分けて数える", () => {
+		const rows = summarizeMonthlyActiveUsers([
+			{ userId: "u1", at: new Date("2026-07-01T01:00:00Z"), kind: "create" },
+			{ userId: "u2", at: new Date("2026-07-02T01:00:00Z"), kind: "favorite" },
+			{ userId: "u2", at: new Date("2026-07-03T01:00:00Z"), kind: "like" },
+		]);
+		expect(rows).toEqual([{ month: "2026-07", users: 2, creators: 1 }]);
+	});
+});
+
+describe("summarizePlayback", () => {
+	it("合計・平均・中央値・0再生数を出す", () => {
+		const summary = summarizePlayback([
+			button({ id: "a", playCount: 0, createdAt: new Date("2026-07-01T01:00:00Z") }),
+			button({ id: "b", playCount: 10, createdAt: new Date("2026-07-01T01:00:00Z") }),
+			button({ id: "c", playCount: 50, createdAt: new Date("2026-07-01T01:00:00Z") }),
+		]);
+		expect(summary).toEqual({
+			buttons: 3,
+			totalPlays: 60,
+			meanPlays: 20,
+			medianPlays: 10,
+			zeroPlayButtons: 1,
+			maxPlays: 50,
+		});
+	});
+
+	it("空入力でも 0 で割らない", () => {
+		expect(summarizePlayback([])).toEqual({
+			buttons: 0,
+			totalPlays: 0,
+			meanPlays: 0,
+			medianPlays: 0,
+			zeroPlayButtons: 0,
+			maxPlays: 0,
+		});
+	});
+});

--- a/apps/functions/src/tools/success-metrics/__tests__/aggregate.test.ts
+++ b/apps/functions/src/tools/success-metrics/__tests__/aggregate.test.ts
@@ -11,6 +11,7 @@ import {
 	summarizeMonthlyActiveUsers,
 	summarizePlayback,
 	summarizeUserActivity,
+	toButtonRecord,
 	toJstDateKey,
 	toJstMonthKey,
 } from "../aggregate";
@@ -58,6 +59,86 @@ describe("parseTimestamp", () => {
 		expect(parseTimestamp(new Date("invalid"))).toBeNull();
 		expect(parseTimestamp({})).toBeNull();
 		expect(parseTimestamp(123)).toBeNull();
+	});
+});
+
+describe("toButtonRecord", () => {
+	const current = {
+		creatorId: "u1",
+		creatorName: "みなせ",
+		createdAt: "2026-07-31T11:09:04.384Z",
+		stats: { playCount: 10, likeCount: 2, favoriteCount: 1 },
+		videoId: "vid",
+	};
+
+	it("現行形式をそのまま読む", () => {
+		const result = toButtonRecord("b1", current);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.record).toMatchObject({
+			id: "b1",
+			creatorId: "u1",
+			creatorName: "みなせ",
+			playCount: 10,
+			likeCount: 2,
+			favoriteCount: 1,
+			videoId: "vid",
+		});
+	});
+
+	it("旧形式の createdBy / createdByName / フラット stats を吸収する", () => {
+		const result = toButtonRecord("b2", {
+			createdBy: "old-user",
+			createdByName: "旧名",
+			createdAt: "2025-07-01T00:00:00.000Z",
+			playCount: 7,
+			likeCount: 3,
+			favoriteCount: 2,
+			sourceVideoId: "old-vid",
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.record).toMatchObject({
+			creatorId: "old-user",
+			creatorName: "旧名",
+			playCount: 7,
+			likeCount: 3,
+			favoriteCount: 2,
+			videoId: "old-vid",
+		});
+	});
+
+	it("新形式が空文字なら旧形式へフォールバックする", () => {
+		const result = toButtonRecord("b3", { ...current, creatorId: "", createdBy: "fallback" });
+		expect(result.ok && result.record.creatorId).toBe("fallback");
+	});
+
+	it("creator を決められない場合は既定値へ丸めず落とす（別人が1人に集約されるのを防ぐ）", () => {
+		const result = toButtonRecord("b4", { ...current, creatorId: undefined });
+		expect(result).toEqual({ ok: false, reason: "creatorId" });
+	});
+
+	it("createdAt が読めない場合も落とす", () => {
+		const result = toButtonRecord("b5", { ...current, createdAt: undefined });
+		expect(result).toEqual({ ok: false, reason: "createdAt" });
+	});
+
+	it("createdAt と creatorId が両方欠けたら createdAt を理由に返す", () => {
+		const result = toButtonRecord("b6", {});
+		expect(result).toEqual({ ok: false, reason: "createdAt" });
+	});
+
+	it("stats が欠けていても 0 で埋める（落とさない）", () => {
+		const result = toButtonRecord("b7", { creatorId: "u1", createdAt: current.createdAt });
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.record).toMatchObject({
+			playCount: 0,
+			likeCount: 0,
+			favoriteCount: 0,
+			videoId: "",
+		});
+		expect(result.record.creatorName).toBe("(不明)");
 	});
 });
 

--- a/apps/functions/src/tools/success-metrics/aggregate.ts
+++ b/apps/functions/src/tools/success-metrics/aggregate.ts
@@ -124,6 +124,60 @@ export function parseTimestamp(value: unknown): Date | null {
 	return null;
 }
 
+/** audioButtons ドキュメントの正規化結果。失敗は理由つきで返し、レポートに件数を出す */
+export type ButtonRecordResult =
+	| { ok: true; record: ButtonRecord }
+	| { ok: false; reason: "createdAt" | "creatorId" };
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+	for (const value of values) {
+		if (typeof value === "string" && value !== "") return value;
+	}
+	return null;
+}
+
+function firstNumber(...values: unknown[]): number {
+	for (const value of values) {
+		if (typeof value === "number" && Number.isFinite(value)) return value;
+	}
+	return 0;
+}
+
+/**
+ * Firestore の audioButtons ドキュメントを ButtonRecord に正規化する。
+ *
+ * 旧形式のフィールド揺れ（`createdBy` / `createdByName` / フラットな `playCount`）を吸収する。
+ * 正本の変換は `@suzumina.click/shared-types` の `audioButtonTransformers.fromFirestore` だが、
+ * **ここでは意図的に流用しない**。あちらは creator を決められないとき `"unknown"` に丸めるため、
+ * 作成者不明のドキュメントが複数あると全部 1 人の偽クリエイターに集約され、
+ * セッション分割と作成者数が歪む（このレポートの主目的そのものが壊れる）。
+ * 表示用には妥当な既定値でも、集計用には**丸めずに落として件数を報告する**のが正しい。
+ *
+ * 実測（2026-08-02・本番132件）では旧形式は0件だが、静かに壊れる経路を残さないために防御する。
+ */
+export function toButtonRecord(id: string, data: Record<string, unknown>): ButtonRecordResult {
+	const createdAt = parseTimestamp(data.createdAt);
+	if (!createdAt) return { ok: false, reason: "createdAt" };
+
+	const creatorId = firstNonEmptyString(data.creatorId, data.createdBy);
+	if (!creatorId) return { ok: false, reason: "creatorId" };
+
+	const stats = (data.stats ?? {}) as Record<string, unknown>;
+	return {
+		ok: true,
+		record: {
+			id,
+			creatorId,
+			creatorName: firstNonEmptyString(data.creatorName, data.createdByName) ?? "(不明)",
+			createdAt,
+			playCount: firstNumber(stats.playCount, data.playCount),
+			likeCount: firstNumber(stats.likeCount, data.likeCount),
+			favoriteCount: firstNumber(stats.favoriteCount, data.favoriteCount),
+			videoId: firstNonEmptyString(data.videoId, data.sourceVideoId) ?? "",
+		},
+	};
+}
+
 /** JST の日付キー（YYYY-MM-DD） */
 export function toJstDateKey(date: Date): string {
 	return new Intl.DateTimeFormat("en-CA", {

--- a/apps/functions/src/tools/success-metrics/aggregate.ts
+++ b/apps/functions/src/tools/success-metrics/aggregate.ts
@@ -1,0 +1,307 @@
+/**
+ * SPR-137 の成功指標を算出する純関数群（SPR-298）。
+ *
+ * GA4 のカスタムイベントは consent ゲートにより本番で0件（SPR-281 で確定・同意率 3.3%）。
+ * そのため成功指標は **同意に依存しない Firestore のサーバー側データ**から算出する。
+ * ここには Firestore I/O を持ち込まない（読み取りは report.ts が行い、ここは値の変換だけ）。
+ *
+ * SPR-137 が再定義した指標は 2 つ:
+ *   - 「労力あたりの作成ボタン数」 → 作成バースト（セッション）と連続作成間隔で近似する
+ *   - 「常連の継続利用」           → 書き込み行動の活動日で近似する
+ */
+
+/** 集計の時間軸は JST 固定（運用者・配信の生活時間に合わせる） */
+const JST_TIME_ZONE = "Asia/Tokyo";
+
+/**
+ * 作成セッションの区切り（分）。
+ * これ以上間隔が空いたら「別の機会に座り直した」とみなす。
+ * SPR-145 実測の作成フロー（動画を開く→頭出し→保存）は数分単位のため、
+ * 30 分は「同じ作業のつもりで続けている」と読める上限として置いた閾値であり、実測由来ではない。
+ */
+export const DEFAULT_SESSION_GAP_MINUTES = 30;
+
+export type ActivityKind = "create" | "favorite" | "like" | "dislike" | "draft" | "evaluation";
+
+/** audioButtons/{id} の集計に必要な部分だけを取り出した形 */
+export interface ButtonRecord {
+	id: string;
+	creatorId: string;
+	creatorName: string;
+	createdAt: Date;
+	playCount: number;
+	likeCount: number;
+	favoriteCount: number;
+	videoId: string;
+}
+
+/** ユーザーの書き込み行動 1 件（作成・お気に入り・リアクション・下書き・作品評価） */
+export interface ActivityRecord {
+	userId: string;
+	at: Date;
+	kind: ActivityKind;
+}
+
+/** 連続して作られたボタンのまとまり＝「一度座って作った分」 */
+export interface CreationSession {
+	creatorId: string;
+	startedAt: Date;
+	endedAt: Date;
+	buttonCount: number;
+	/** セッション内の連続作成間隔（秒）。要素数は buttonCount - 1 */
+	intervalsSeconds: number[];
+}
+
+export interface EffortSummary {
+	sessions: number;
+	buttons: number;
+	/** 1 セッション（＝一度の作業）あたり何個作れたか */
+	buttonsPerSession: number;
+	/**
+	 * 連続作成間隔の中央値（秒）＝ 1 ボタンあたりの実作業時間の代理。
+	 * 単独作成しかない期間は間隔が存在しないため null。
+	 */
+	medianIntervalSeconds: number | null;
+}
+
+export interface MonthlyCreation {
+	month: string;
+	buttons: number;
+	creators: number;
+	/**
+	 * 作成があった日数（JST）。セッション閾値に依存しない分母で、
+	 * DEFAULT_SESSION_GAP_MINUTES の取り方に結論が左右されていないかの裏取りに使う。
+	 */
+	days: number;
+}
+
+export interface UserActivitySummary {
+	userId: string;
+	firstAt: Date;
+	lastAt: Date;
+	/** 何らかの書き込みをした日の数（JST 日付のユニーク数） */
+	activeDays: number;
+	activeMonths: number;
+	counts: Record<ActivityKind, number>;
+}
+
+export interface MonthlyActiveUsers {
+	month: string;
+	users: number;
+	/** その月に「作成」を行ったユーザー数（消費だけの月と区別する） */
+	creators: number;
+}
+
+export interface PlaybackSummary {
+	buttons: number;
+	totalPlays: number;
+	meanPlays: number;
+	medianPlays: number;
+	zeroPlayButtons: number;
+	maxPlays: number;
+}
+
+/**
+ * 日時フィールドを Date に正規化する。
+ *
+ * このプロジェクトの日時は型が混在している（CLAUDE.md §1・SPR-75 実測）:
+ *   string ISO … audioButtons.createdAt / favorites.addedAt / likes.createdAt / users.*
+ *   Timestamp … buttonDrafts.createdAt / evaluations.createdAt
+ * 一括移行はしない方針なので、**読み取り側で吸収する**のが正しい置き場所。
+ * 解釈できない値は捨てずに null を返し、呼び出し側で件数を報告する（黙って0件にしない）。
+ */
+export function parseTimestamp(value: unknown): Date | null {
+	if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+	if (typeof value === "string") {
+		const parsed = new Date(value);
+		return Number.isNaN(parsed.getTime()) ? null : parsed;
+	}
+	if (typeof value === "object" && value !== null) {
+		const candidate = value as { toDate?: () => Date; _seconds?: number };
+		if (typeof candidate.toDate === "function") return parseTimestamp(candidate.toDate());
+		if (typeof candidate._seconds === "number") return new Date(candidate._seconds * 1000);
+	}
+	return null;
+}
+
+/** JST の日付キー（YYYY-MM-DD） */
+export function toJstDateKey(date: Date): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: JST_TIME_ZONE,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+/** JST の月キー（YYYY-MM） */
+export function toJstMonthKey(date: Date): string {
+	return toJstDateKey(date).slice(0, 7);
+}
+
+export function median(values: number[]): number | null {
+	if (values.length === 0) return null;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	if (sorted.length % 2 === 1) return sorted[mid] as number;
+	return ((sorted[mid - 1] as number) + (sorted[mid] as number)) / 2;
+}
+
+/**
+ * 作成を creator ごとの「セッション」に切り分ける。
+ * gapMinutes 以上間隔が空いたら別セッションとして扱う。
+ */
+export function detectCreationSessions(
+	buttons: ButtonRecord[],
+	gapMinutes: number = DEFAULT_SESSION_GAP_MINUTES,
+): CreationSession[] {
+	const gapMs = gapMinutes * 60_000;
+	const byCreator = new Map<string, ButtonRecord[]>();
+	for (const button of buttons) {
+		const list = byCreator.get(button.creatorId);
+		if (list) list.push(button);
+		else byCreator.set(button.creatorId, [button]);
+	}
+
+	const sessions: CreationSession[] = [];
+	for (const [creatorId, records] of byCreator) {
+		const sorted = [...records].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+		let current: CreationSession | null = null;
+		let previousAt: number | null = null;
+
+		for (const record of sorted) {
+			const at = record.createdAt.getTime();
+			if (current && previousAt !== null && at - previousAt < gapMs) {
+				current.buttonCount += 1;
+				current.endedAt = record.createdAt;
+				current.intervalsSeconds.push((at - previousAt) / 1000);
+			} else {
+				current = {
+					creatorId,
+					startedAt: record.createdAt,
+					endedAt: record.createdAt,
+					buttonCount: 1,
+					intervalsSeconds: [],
+				};
+				sessions.push(current);
+			}
+			previousAt = at;
+		}
+	}
+
+	return sessions.sort((a, b) => a.startedAt.getTime() - b.startedAt.getTime());
+}
+
+export function summarizeEffort(sessions: CreationSession[]): EffortSummary {
+	const buttons = sessions.reduce((sum, s) => sum + s.buttonCount, 0);
+	const intervals = sessions.flatMap((s) => s.intervalsSeconds);
+	return {
+		sessions: sessions.length,
+		buttons,
+		buttonsPerSession: sessions.length === 0 ? 0 : buttons / sessions.length,
+		medianIntervalSeconds: median(intervals),
+	};
+}
+
+/** セッションを開始月（JST）で束ねて労力指標を出す。作成コストの推移を見るための軸 */
+export function summarizeEffortByMonth(
+	sessions: CreationSession[],
+): Array<{ month: string } & EffortSummary> {
+	const byMonth = new Map<string, CreationSession[]>();
+	for (const session of sessions) {
+		const month = toJstMonthKey(session.startedAt);
+		const list = byMonth.get(month);
+		if (list) list.push(session);
+		else byMonth.set(month, [session]);
+	}
+	return [...byMonth.entries()]
+		.map(([month, list]) => ({ month, ...summarizeEffort(list) }))
+		.sort((a, b) => a.month.localeCompare(b.month));
+}
+
+export function summarizeCreationByMonth(buttons: ButtonRecord[]): MonthlyCreation[] {
+	const byMonth = new Map<string, { creators: Set<string>; days: Set<string>; buttons: number }>();
+	for (const button of buttons) {
+		const month = toJstMonthKey(button.createdAt);
+		const entry = byMonth.get(month) ?? {
+			creators: new Set<string>(),
+			days: new Set<string>(),
+			buttons: 0,
+		};
+		entry.creators.add(button.creatorId);
+		entry.days.add(toJstDateKey(button.createdAt));
+		entry.buttons += 1;
+		byMonth.set(month, entry);
+	}
+	return [...byMonth.entries()]
+		.map(([month, entry]) => ({
+			month,
+			buttons: entry.buttons,
+			creators: entry.creators.size,
+			days: entry.days.size,
+		}))
+		.sort((a, b) => a.month.localeCompare(b.month));
+}
+
+function emptyCounts(): Record<ActivityKind, number> {
+	return { create: 0, favorite: 0, like: 0, dislike: 0, draft: 0, evaluation: 0 };
+}
+
+export function summarizeUserActivity(activities: ActivityRecord[]): UserActivitySummary[] {
+	const byUser = new Map<
+		string,
+		{ days: Set<string>; months: Set<string>; counts: Record<ActivityKind, number>; ats: number[] }
+	>();
+
+	for (const activity of activities) {
+		const entry = byUser.get(activity.userId) ?? {
+			days: new Set<string>(),
+			months: new Set<string>(),
+			counts: emptyCounts(),
+			ats: [],
+		};
+		entry.days.add(toJstDateKey(activity.at));
+		entry.months.add(toJstMonthKey(activity.at));
+		entry.counts[activity.kind] += 1;
+		entry.ats.push(activity.at.getTime());
+		byUser.set(activity.userId, entry);
+	}
+
+	return [...byUser.entries()]
+		.map(([userId, entry]) => ({
+			userId,
+			firstAt: new Date(Math.min(...entry.ats)),
+			lastAt: new Date(Math.max(...entry.ats)),
+			activeDays: entry.days.size,
+			activeMonths: entry.months.size,
+			counts: entry.counts,
+		}))
+		.sort((a, b) => b.activeDays - a.activeDays);
+}
+
+export function summarizeMonthlyActiveUsers(activities: ActivityRecord[]): MonthlyActiveUsers[] {
+	const byMonth = new Map<string, { users: Set<string>; creators: Set<string> }>();
+	for (const activity of activities) {
+		const month = toJstMonthKey(activity.at);
+		const entry = byMonth.get(month) ?? { users: new Set<string>(), creators: new Set<string>() };
+		entry.users.add(activity.userId);
+		if (activity.kind === "create") entry.creators.add(activity.userId);
+		byMonth.set(month, entry);
+	}
+	return [...byMonth.entries()]
+		.map(([month, entry]) => ({ month, users: entry.users.size, creators: entry.creators.size }))
+		.sort((a, b) => a.month.localeCompare(b.month));
+}
+
+export function summarizePlayback(buttons: ButtonRecord[]): PlaybackSummary {
+	const plays = buttons.map((b) => b.playCount);
+	const total = plays.reduce((sum, n) => sum + n, 0);
+	return {
+		buttons: buttons.length,
+		totalPlays: total,
+		meanPlays: buttons.length === 0 ? 0 : total / buttons.length,
+		medianPlays: median(plays) ?? 0,
+		zeroPlayButtons: plays.filter((n) => n === 0).length,
+		maxPlays: plays.length === 0 ? 0 : Math.max(...plays),
+	};
+}

--- a/apps/functions/src/tools/success-metrics/report.ts
+++ b/apps/functions/src/tools/success-metrics/report.ts
@@ -30,7 +30,10 @@ import {
 	toJstDateKey,
 } from "./aggregate";
 
-/** 日時が読めなかったドキュメントの件数。黙って捨てず末尾で報告する */
+/**
+ * 集計に載せられなかったドキュメントの件数（日時が読めない / 作成者を特定できない）。
+ * 黙って捨てず末尾で報告する。サンプルは `パス（理由）` の形で理由を自己記述させる。
+ */
 interface SkipCounter {
 	count: number;
 	samples: string[];
@@ -74,7 +77,7 @@ async function loadUserSubcollection(
 		for (const doc of snapshot.docs) {
 			const at = parseTimestamp(doc.data()[timestampField]);
 			if (!at) {
-				noteSkip(skipped, `users/${userId}/${subcollection}/${doc.id}`);
+				noteSkip(skipped, `users/${userId}/${subcollection}/${doc.id}（${timestampField} 不明）`);
 				continue;
 			}
 			records.push({ userId, at, kind });
@@ -90,7 +93,7 @@ async function loadEvaluations(skipped: SkipCounter): Promise<ActivityRecord[]> 
 		const data = doc.data();
 		const at = parseTimestamp(data.createdAt);
 		if (!at) {
-			noteSkip(skipped, `evaluations/${doc.id}`);
+			noteSkip(skipped, `evaluations/${doc.id}（createdAt 不明）`);
 			continue;
 		}
 		records.push({ userId: String(data.userId ?? ""), at, kind: "evaluation" });
@@ -199,7 +202,7 @@ function renderReport(input: {
 		lines.push("## 除外");
 		lines.push("");
 		lines.push(
-			`日時が解釈できず集計から除外: ${skipped.count}件（例: ${skipped.samples.join(", ")}）`,
+			`日時または作成者を特定できず集計から除外: ${skipped.count}件（括弧内が理由。例: ${skipped.samples.join(", ")}）`,
 		);
 		lines.push("");
 	}

--- a/apps/functions/src/tools/success-metrics/report.ts
+++ b/apps/functions/src/tools/success-metrics/report.ts
@@ -1,0 +1,259 @@
+/**
+ * SPR-137 の成功指標レポート（SPR-298）。
+ *
+ *   pnpm --filter @suzumina.click/functions metrics
+ *
+ * 本番 Firestore を **読み取りのみ**で集計し、Markdown をそのまま標準出力に吐く
+ * （Linear へ貼れる形が最終成果物。自動化するかは数字を見てから判断する＝SPR-298）。
+ * GA4 に依存しないため consent 同意率（3.3%・SPR-281）の影響を受けない。
+ *
+ * 読むコレクション:
+ *   audioButtons                     作成・再生
+ *   users/{id}/{favorites,likes,dislikes,buttonDrafts}   継続利用
+ *   evaluations                      継続利用（DLsite 作品評価）
+ */
+
+import firestore from "../../infrastructure/database/firestore";
+import {
+	type ActivityRecord,
+	type ButtonRecord,
+	DEFAULT_SESSION_GAP_MINUTES,
+	detectCreationSessions,
+	parseTimestamp,
+	summarizeCreationByMonth,
+	summarizeEffort,
+	summarizeEffortByMonth,
+	summarizeMonthlyActiveUsers,
+	summarizePlayback,
+	summarizeUserActivity,
+	toJstDateKey,
+} from "./aggregate";
+
+/** 日時が読めなかったドキュメントの件数。黙って捨てず末尾で報告する */
+interface SkipCounter {
+	count: number;
+	samples: string[];
+}
+
+function noteSkip(skipped: SkipCounter, path: string): void {
+	skipped.count += 1;
+	if (skipped.samples.length < 5) skipped.samples.push(path);
+}
+
+async function loadButtons(skipped: SkipCounter): Promise<ButtonRecord[]> {
+	const snapshot = await firestore.collection("audioButtons").get();
+	const records: ButtonRecord[] = [];
+	for (const doc of snapshot.docs) {
+		const data = doc.data();
+		const createdAt = parseTimestamp(data.createdAt);
+		if (!createdAt) {
+			noteSkip(skipped, `audioButtons/${doc.id}`);
+			continue;
+		}
+		records.push({
+			id: doc.id,
+			creatorId: String(data.creatorId ?? ""),
+			creatorName: String(data.creatorName ?? "(不明)"),
+			createdAt,
+			playCount: Number(data.stats?.playCount ?? 0),
+			likeCount: Number(data.stats?.likeCount ?? 0),
+			favoriteCount: Number(data.stats?.favoriteCount ?? 0),
+			videoId: String(data.videoId ?? ""),
+		});
+	}
+	return records;
+}
+
+/** users 配下のサブコレクションを 1 種類読み、活動レコードに変換する */
+async function loadUserSubcollection(
+	userIds: string[],
+	subcollection: string,
+	timestampField: string,
+	kind: ActivityRecord["kind"],
+	skipped: SkipCounter,
+): Promise<ActivityRecord[]> {
+	const records: ActivityRecord[] = [];
+	for (const userId of userIds) {
+		const snapshot = await firestore
+			.collection("users")
+			.doc(userId)
+			.collection(subcollection)
+			.get();
+		for (const doc of snapshot.docs) {
+			const at = parseTimestamp(doc.data()[timestampField]);
+			if (!at) {
+				noteSkip(skipped, `users/${userId}/${subcollection}/${doc.id}`);
+				continue;
+			}
+			records.push({ userId, at, kind });
+		}
+	}
+	return records;
+}
+
+async function loadEvaluations(skipped: SkipCounter): Promise<ActivityRecord[]> {
+	const snapshot = await firestore.collection("evaluations").get();
+	const records: ActivityRecord[] = [];
+	for (const doc of snapshot.docs) {
+		const data = doc.data();
+		const at = parseTimestamp(data.createdAt);
+		if (!at) {
+			noteSkip(skipped, `evaluations/${doc.id}`);
+			continue;
+		}
+		records.push({ userId: String(data.userId ?? ""), at, kind: "evaluation" });
+	}
+	return records;
+}
+
+function formatInterval(seconds: number | null): string {
+	if (seconds === null) return "—";
+	if (seconds < 90) return `${Math.round(seconds)}秒`;
+	return `${(seconds / 60).toFixed(1)}分`;
+}
+
+function renderReport(input: {
+	buttons: ButtonRecord[];
+	activities: ActivityRecord[];
+	userCount: number;
+	skipped: SkipCounter;
+}): string {
+	const { buttons, activities, userCount, skipped } = input;
+	const lines: string[] = [];
+	const sessions = detectCreationSessions(buttons);
+	const effort = summarizeEffort(sessions);
+	const playback = summarizePlayback(buttons);
+	const creationDays = new Set(buttons.map((b) => toJstDateKey(b.createdAt)));
+
+	lines.push("# suzumina.click 成功指標レポート（Firestore 実測・GA4 非依存）");
+	lines.push("");
+	lines.push(
+		`集計日時: ${toJstDateKey(new Date())} (JST) ／ 対象: audioButtons ${buttons.length}件 / users ${userCount}人`,
+	);
+	lines.push("");
+
+	lines.push("## 1. 労力あたりの作成ボタン数");
+	lines.push("");
+	lines.push(
+		`作成セッションの区切り: 連続作成の間隔が ${DEFAULT_SESSION_GAP_MINUTES} 分以上空いたら別セッション`,
+	);
+	lines.push("");
+	lines.push("| 指標 | 値 |");
+	lines.push("|---|---|");
+	lines.push(`| 総作成数 | ${effort.buttons} |`);
+	lines.push(`| 作成セッション数 | ${effort.sessions} |`);
+	lines.push(`| セッションあたり作成数 | ${effort.buttonsPerSession.toFixed(2)} |`);
+	lines.push(`| 連続作成間隔の中央値 | ${formatInterval(effort.medianIntervalSeconds)} |`);
+	lines.push(`| 作成があった日数 | ${creationDays.size} |`);
+	lines.push(
+		`| 作成日あたり作成数 | ${creationDays.size === 0 ? "—" : (buttons.length / creationDays.size).toFixed(2)} |`,
+	);
+	lines.push("");
+	lines.push("### 月次の作成量と労力");
+	lines.push("");
+	lines.push(
+		"| 月 | 作成数 | 作成者 | 作成日数 | 作成日あたり | セッション | セッションあたり | 連続作成間隔の中央値 |",
+	);
+	lines.push("|---|---|---|---|---|---|---|---|");
+	const effortByMonth = new Map(summarizeEffortByMonth(sessions).map((row) => [row.month, row]));
+	for (const row of summarizeCreationByMonth(buttons)) {
+		const monthEffort = effortByMonth.get(row.month);
+		lines.push(
+			`| ${row.month} | ${row.buttons} | ${row.creators} | ${row.days} | ${(row.buttons / row.days).toFixed(2)} | ${monthEffort?.sessions ?? 0} | ${
+				monthEffort ? monthEffort.buttonsPerSession.toFixed(2) : "—"
+			} | ${formatInterval(monthEffort?.medianIntervalSeconds ?? null)} |`,
+		);
+	}
+	lines.push("");
+
+	lines.push("## 2. 常連の継続利用");
+	lines.push("");
+	lines.push("| 月 | 活動ユーザー | うち作成した人 |");
+	lines.push("|---|---|---|");
+	for (const row of summarizeMonthlyActiveUsers(activities)) {
+		lines.push(`| ${row.month} | ${row.users} | ${row.creators} |`);
+	}
+	lines.push("");
+	lines.push("### ユーザー別の活動（活動日数の多い順）");
+	lines.push("");
+	lines.push(
+		"| ユーザー | 活動日数 | 活動月数 | 初回 | 最終 | 作成 | お気に入り | 高評価 | 下書き | 作品評価 |",
+	);
+	lines.push("|---|---|---|---|---|---|---|---|---|---|");
+	for (const user of summarizeUserActivity(activities)) {
+		lines.push(
+			`| ${user.userId} | ${user.activeDays} | ${user.activeMonths} | ${toJstDateKey(user.firstAt)} | ${toJstDateKey(user.lastAt)} | ${user.counts.create} | ${user.counts.favorite} | ${user.counts.like} | ${user.counts.draft} | ${user.counts.evaluation} |`,
+		);
+	}
+	lines.push("");
+
+	lines.push("## 3. 再生（消費）");
+	lines.push("");
+	lines.push("| 指標 | 値 |");
+	lines.push("|---|---|");
+	lines.push(`| 総再生数 | ${playback.totalPlays} |`);
+	lines.push(`| ボタンあたり平均 | ${playback.meanPlays.toFixed(1)} |`);
+	lines.push(`| ボタンあたり中央値 | ${playback.medianPlays} |`);
+	lines.push(`| 最大 | ${playback.maxPlays} |`);
+	lines.push(`| 再生0のボタン | ${playback.zeroPlayButtons} |`);
+	lines.push("");
+	lines.push(
+		"> ⚠️ `stats.playCount` は**累積カウンタで時系列を持たない**ため、「今月の再生数」は算出できない。",
+	);
+	lines.push("> 期間で見られるのは作成・お気に入り・リアクション・下書き・作品評価のみ。");
+	lines.push("");
+
+	if (skipped.count > 0) {
+		lines.push("## 除外");
+		lines.push("");
+		lines.push(
+			`日時が解釈できず集計から除外: ${skipped.count}件（例: ${skipped.samples.join(", ")}）`,
+		);
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}
+
+export async function runSuccessMetricsReport(): Promise<string> {
+	const skipped: SkipCounter = { count: 0, samples: [] };
+	const buttons = await loadButtons(skipped);
+
+	const userSnapshot = await firestore.collection("users").get();
+	const userIds = userSnapshot.docs.map((doc) => doc.id);
+
+	const [favorites, likes, dislikes, drafts, evaluations] = await Promise.all([
+		loadUserSubcollection(userIds, "favorites", "addedAt", "favorite", skipped),
+		loadUserSubcollection(userIds, "likes", "createdAt", "like", skipped),
+		loadUserSubcollection(userIds, "dislikes", "createdAt", "dislike", skipped),
+		loadUserSubcollection(userIds, "buttonDrafts", "createdAt", "draft", skipped),
+		loadEvaluations(skipped),
+	]);
+
+	const activities: ActivityRecord[] = [
+		...buttons.map((button) => ({
+			userId: button.creatorId,
+			at: button.createdAt,
+			kind: "create" as const,
+		})),
+		...favorites,
+		...likes,
+		...dislikes,
+		...drafts,
+		...evaluations,
+	];
+
+	return renderReport({ buttons, activities, userCount: userIds.length, skipped });
+}
+
+if (require.main === module) {
+	runSuccessMetricsReport()
+		.then((report) => {
+			process.stdout.write(`${report}\n`);
+			process.exit(0);
+		})
+		.catch((error) => {
+			process.stderr.write(`成功指標レポートの生成に失敗: ${error}\n`);
+			process.exit(1);
+		});
+}

--- a/apps/functions/src/tools/success-metrics/report.ts
+++ b/apps/functions/src/tools/success-metrics/report.ts
@@ -26,6 +26,7 @@ import {
 	summarizeMonthlyActiveUsers,
 	summarizePlayback,
 	summarizeUserActivity,
+	toButtonRecord,
 	toJstDateKey,
 } from "./aggregate";
 
@@ -44,22 +45,13 @@ async function loadButtons(skipped: SkipCounter): Promise<ButtonRecord[]> {
 	const snapshot = await firestore.collection("audioButtons").get();
 	const records: ButtonRecord[] = [];
 	for (const doc of snapshot.docs) {
-		const data = doc.data();
-		const createdAt = parseTimestamp(data.createdAt);
-		if (!createdAt) {
-			noteSkip(skipped, `audioButtons/${doc.id}`);
+		const result = toButtonRecord(doc.id, doc.data());
+		if (!result.ok) {
+			// creator 不明を既定値へ丸めると別人が 1 人に集約されて集計が歪むため、落として報告する
+			noteSkip(skipped, `audioButtons/${doc.id}（${result.reason} 不明）`);
 			continue;
 		}
-		records.push({
-			id: doc.id,
-			creatorId: String(data.creatorId ?? ""),
-			creatorName: String(data.creatorName ?? "(不明)"),
-			createdAt,
-			playCount: Number(data.stats?.playCount ?? 0),
-			likeCount: Number(data.stats?.likeCount ?? 0),
-			favoriteCount: Number(data.stats?.favoriteCount ?? 0),
-			videoId: String(data.videoId ?? ""),
-		});
+		records.push(result.record);
 	}
 	return records;
 }


### PR DESCRIPTION
## 背景

GA4 のカスタムイベントは consent ゲートにより本番で0件（[SPR-281](https://linear.app/nothink/issue/SPR-281) で確定・**同意率 3.3%**）。[SPR-137](https://linear.app/nothink/issue/SPR-137) が再定義した成功指標「労力あたりの作成ボタン数」「常連の継続利用」が構造的に測れていなかった。

同意に依存しない **Firestore のサーバー側データ**から算出する経路を用意する（SPR-281 の選択肢3）。

## 変更

```bash
pnpm --filter @suzumina.click/functions metrics
```

- `src/tools/success-metrics/aggregate.ts` — 純関数のみ（Firestore I/O なし）。作成セッションの検出 / 労力指標 / 活動集計 / 再生集計
- `src/tools/success-metrics/report.ts` — 読み取りと Markdown 出力の薄いシェル
- テストは `__tests__/aggregate.test.ts`（aggregate.ts のカバレッジ 98%）

読み取り専用。Markdown を stdout に出すので Linear にそのまま貼れる。

## 設計上の判断

- **「労力」の近似**: 連続作成をセッションに切り、セッションあたり作成数と連続作成間隔の中央値で測る。セッション区切り（30分）は**実測由来でない恣意的な閾値**なので、閾値非依存の「作成日あたり作成数」も併記し、結論が閾値の取り方に依存していないか裏を取れるようにした。
- **日時型の混在を読み取り側で吸収**: audioButtons/favorites/likes は ISO string、buttonDrafts/evaluations は Firestore Timestamp（CLAUDE.md §1・SPR-75）。一括移行しない方針なので `parseTimestamp` で吸収する。解釈できない値は黙って捨てずレポート末尾に件数を報告する。
- **非正規化フィールドを追加していない**（整合性 cron の負債を増やさない）。
- **新規クエリを足していない**（全件取得 + in-memory 集計）ため**複合インデックスの追加も不要**。

## 初回実測（2026-08-02・本番）

作成コスト削減の施策が効いていることが確認できた。ローンチ期との比較:

| 指標 | 2025-07 | 2026-07 |
|---|---|---|
| セッションあたり作成数 | 1.38 | **9.50**（6.9倍） |
| 作成日あたり作成数 | 2.35 | **14.25**（6.1倍） |
| 連続作成間隔の中央値 | 7.9分 | **1.8分**（4.4倍速） |

閾値依存の指標と閾値非依存の指標が同じ方向・同じ倍率を示している。

一方で「常連の継続利用」は未改善で、2026-07 の活動ユーザーはオーナー1人。詳細は [SPR-298 のコメント](https://linear.app/nothink/issue/SPR-298)。

## 既知の制約

`stats.playCount` は累積カウンタで時系列を持たないため「今月の再生数」は算出できない。期間で見られるのは作成・お気に入り・リアクション・下書き・作品評価のみ。時系列が要るなら日次スナップショット（＝非正規化の追加）が必要になるため本 PR では踏み込んでいない。

## 検証

- `pnpm verify` EXIT=0
- 本番 Firestore に対して実行し、レポートが出力されることを確認済み

## Two-Way Door 判定

読み取り専用のローカル運用ツールの追加。Firestore スキーマ・認証・Terraform・CI・shared-types のいずれにも触れないため Two-Way Door。

🤖 Generated with [Claude Code](https://claude.com/claude-code)