### PR TITLE
feat(analytics): Search Console を API から読めるようにする (SPR-301)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"lint:ga4": "node scripts/lint-ga4-params.mjs",
 		"check:index-drift": "node scripts/check-firestore-index-drift.mjs",
 		"check:ga4-drift": "node scripts/check-ga4-drift.mjs",
+		"report:search-console": "node scripts/search-console-report.mjs",
 		"format": "pnpm -r format",
 		"check": "pnpm -r check",
 		"secretlint": "secretlint \"**/*\"",

--- a/scripts/search-console-report.mjs
+++ b/scripts/search-console-report.mjs
@@ -123,12 +123,20 @@ async function main() {
 	const endDate = process.argv[3] ?? daysAgo(3);
 	const token = accessToken();
 
+	// 権限が無い SA でも sites.list は 403 ではなく 200 + 空リストを返す。
+	// そのため「まだプロパティに追加していない」と「URL の形式違い」は別々に案内する
+	// （同じ文言にすると、最も起きやすい前者に対して誤った対処法を出してしまう）。
 	const sites = await callApi("sites", token);
-	const entry = (sites.siteEntry ?? []).find((s) => s.siteUrl === SITE_URL);
-	if (!entry) {
-		const available = (sites.siteEntry ?? []).map((s) => s.siteUrl).join(", ") || "(なし)";
+	const siteEntries = sites.siteEntry ?? [];
+	if (siteEntries.length === 0) {
 		abort(
-			`${SITE_URL} にアクセスできません。SEARCH_CONSOLE_SITE_URL で指定し直してください。${TARGET_SA} に見えているプロパティ: ${available}`,
+			`${TARGET_SA} はまだどの Search Console プロパティにも追加されていません。Search Console 管理画面の「設定 → ユーザーと権限」で追加してください（制限付きユーザーで足ります。API では付与できません）`,
+		);
+	}
+	const entry = siteEntries.find((s) => s.siteUrl === SITE_URL);
+	if (!entry) {
+		abort(
+			`${SITE_URL} が見つかりません。SEARCH_CONSOLE_SITE_URL で指定し直してください。${TARGET_SA} に見えているプロパティ: ${siteEntries.map((s) => s.siteUrl).join(", ")}`,
 		);
 	}
 

--- a/scripts/search-console-report.mjs
+++ b/scripts/search-console-report.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+// scripts/search-console-report.mjs
+//
+// Search Console の検索流入を実測する（SPR-301 / SPR-137 §6-4 の集客判断）。
+// check-ga4-drift.mjs と同じ認証方式（ADC → SA を impersonate・npm 依存なし）。
+//
+// 何のためにあるか:
+//   GA4 は「どのチャネルから来たか」までしか分からず、**どの検索語で・何位で・
+//   何回表示されたか**は Search Console にしかない。2026-07 に Organic Search が
+//   月9→61 に跳ねた原因が再現可能なレバーなのか偶発なのかは、この差でしか判別できない。
+//
+// 使い方:
+//   node scripts/search-console-report.mjs                      # 直近約1ヶ月
+//   node scripts/search-console-report.mjs 2026-07-01 2026-07-31
+//
+// 前提（どれか欠けると止まる。エラー文に対処法を出す）:
+//   1. searchconsole.googleapis.com が有効（terraform: api_services.tf）
+//   2. search-console-reader@ が Search Console のプロパティに追加済み（**管理画面で手動**）
+//   3. 実行者に roles/iam.serviceAccountTokenCreator（同 SA 宛）が付与済み（手動）
+// 終了コード: 0=成功 / 2=実行エラー
+
+import { execFileSync } from "node:child_process";
+
+const SITE_URL = process.env.SEARCH_CONSOLE_SITE_URL ?? "sc-domain:suzumina.click";
+const TARGET_SA =
+	process.env.SEARCH_CONSOLE_SA ?? "search-console-reader@suzumina-click.iam.gserviceaccount.com";
+const SCOPE = "https://www.googleapis.com/auth/webmasters.readonly";
+const API_BASE = "https://searchconsole.googleapis.com/webmasters/v3";
+
+function abort(message) {
+	console.error(`✗ ${message}`);
+	process.exit(2);
+}
+
+/** ADC から SA を impersonate してトークンを取る（トークンは一切出力しない） */
+function accessToken() {
+	try {
+		return execFileSync(
+			"gcloud",
+			[
+				"auth",
+				"print-access-token",
+				`--impersonate-service-account=${TARGET_SA}`,
+				`--scopes=${SCOPE}`,
+			],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		).trim();
+	} catch (e) {
+		const detail = String(e.stderr || e.message)
+			.trim()
+			.split("\n")
+			.at(-1);
+		return abort(
+			`アクセストークンを取得できませんでした（ADC 未設定 / SA 未作成 / impersonate 権限なし）: ${detail}`,
+		);
+	}
+}
+
+async function callApi(path, token, body) {
+	const res = await fetch(`${API_BASE}/${path}`, {
+		method: body ? "POST" : "GET",
+		headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+		body: body ? JSON.stringify(body) : undefined,
+	});
+	const json = await res.json().catch(() => ({}));
+	if (!res.ok) {
+		const message = json.error?.message ?? "(詳細不明)";
+		if (res.status === 403 && message.includes("has not been used in project")) {
+			abort(
+				`Search Console API が未有効です。terraform の google_project_service.searchconsole を apply してください\n  ${message}`,
+			);
+		}
+		if (res.status === 403) {
+			abort(
+				`アクセスを拒否されました。${TARGET_SA} を Search Console 管理画面でプロパティのユーザーに追加してください（API では付与できません）\n  ${message}`,
+			);
+		}
+		abort(`HTTP ${res.status}: ${message}`);
+	}
+	return json;
+}
+
+function daysAgo(n) {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() - n);
+	return d.toISOString().slice(0, 10);
+}
+
+async function query(token, { startDate, endDate, dimensions, rowLimit = 25 }) {
+	const encoded = encodeURIComponent(SITE_URL);
+	const result = await callApi(`sites/${encoded}/searchAnalytics/query`, token, {
+		startDate,
+		endDate,
+		dimensions,
+		rowLimit,
+	});
+	return result.rows ?? [];
+}
+
+function printRows(title, dimensionNames, rows) {
+	console.log(`\n### ${title}`);
+	if (rows.length === 0) {
+		console.log("  (0 行)");
+		return;
+	}
+	console.log(`  ${[...dimensionNames, "clicks", "impressions", "ctr", "position"].join(" | ")}`);
+	for (const row of rows) {
+		console.log(
+			`  ${[
+				...(row.keys ?? []),
+				row.clicks,
+				row.impressions,
+				`${(row.ctr * 100).toFixed(1)}%`,
+				row.position.toFixed(1),
+			].join(" | ")}`,
+		);
+	}
+}
+
+async function main() {
+	// Search Console のデータは概ね2〜3日遅れる
+	const startDate = process.argv[2] ?? daysAgo(33);
+	const endDate = process.argv[3] ?? daysAgo(3);
+	const token = accessToken();
+
+	const sites = await callApi("sites", token);
+	const entry = (sites.siteEntry ?? []).find((s) => s.siteUrl === SITE_URL);
+	if (!entry) {
+		const available = (sites.siteEntry ?? []).map((s) => s.siteUrl).join(", ") || "(なし)";
+		abort(
+			`${SITE_URL} にアクセスできません。SEARCH_CONSOLE_SITE_URL で指定し直してください。${TARGET_SA} に見えているプロパティ: ${available}`,
+		);
+	}
+
+	console.log("# Search Console レポート");
+	console.log(
+		`プロパティ: ${SITE_URL}（権限: ${entry.permissionLevel}）／ 期間: ${startDate} 〜 ${endDate}`,
+	);
+
+	printRows(
+		"日別",
+		["date"],
+		await query(token, { startDate, endDate, dimensions: ["date"], rowLimit: 100 }),
+	);
+	printRows(
+		"検索語 上位25",
+		["query"],
+		await query(token, { startDate, endDate, dimensions: ["query"] }),
+	);
+	printRows(
+		"ページ 上位25",
+		["page"],
+		await query(token, { startDate, endDate, dimensions: ["page"] }),
+	);
+	printRows(
+		"デバイス",
+		["device"],
+		await query(token, { startDate, endDate, dimensions: ["device"] }),
+	);
+	printRows(
+		"国 上位10",
+		["country"],
+		await query(token, { startDate, endDate, dimensions: ["country"], rowLimit: 10 }),
+	);
+}
+
+main().catch((e) => abort(String(e?.message ?? e)));

--- a/terraform/analytics_search_console.tf
+++ b/terraform/analytics_search_console.tf
@@ -1,0 +1,23 @@
+# ------------------------------------------------------------------------------
+# Search Console 連携用サービスアカウント（SPR-301 / SPR-137 §6-4 の集客判断）
+# ------------------------------------------------------------------------------
+# analytics_ga4.tf と同型の制約を持つ。terraform が管理できるのは **API を叩く GCP 側の
+# identity だけ**で、次は terraform の管轄外なので変更したらこのコメントも更新すること:
+#   - Search Console プロパティ側のアクセス権（オーナー/フルユーザー/制限付きユーザー）は
+#     Search Console 管理画面でしか付与できない。google_project_iam_* では届かない
+#   - ローカルで impersonate するために個人アカウントへ付与する
+#     roles/iam.serviceAccountTokenCreator（search_console_reader 宛）は手動
+#
+# API の有効化は api_services.tf の google_project_service.searchconsole 側。
+#
+# なぜ ga4-reader@ を流用しないか: あちらは名前と description が GA4 の Admin/Data API 用と
+# 宣言しており、Search Console を相乗りさせると「名前の約束と実際の権限」がずれる
+# （CLAUDE.md 軸3）。プロパティへの手動追加はどちらにせよ SA 単位で必要なので、
+# 流用しても手作業は減らない。
+
+resource "google_service_account" "search_console_reader" {
+  project      = var.gcp_project_id
+  account_id   = "search-console-reader"
+  display_name = "Search Console API SA (read-only)"
+  description  = "Search Analytics API 用の SA。Search Console では制限付きユーザー（権限付与は Search Console 管理画面・手動）"
+}

--- a/terraform/api_services.tf
+++ b/terraform/api_services.tf
@@ -90,3 +90,13 @@ resource "google_project_service" "eventarc" {
   service            = "eventarc.googleapis.com"
   disable_on_destroy = false # イベント処理基盤を維持するためAPIを無効化しない
 }
+
+# Google Search Console API を有効化 (検索流入の実測。SPR-301 / SPR-137 §6-4 の集客判断に使う)
+# GA4 と同じく **プロパティ側のアクセス権は API では付与できず Search Console 管理画面のみ**。
+# ここで有効化するのは GCP 側の API だけで、search-console-reader@ をプロパティの
+# ユーザーとして追加する作業は手動（terraform の管轄外・analytics_search_console.tf を参照）。
+resource "google_project_service" "searchconsole" {
+  project            = var.gcp_project_id
+  service            = "searchconsole.googleapis.com"
+  disable_on_destroy = false # 無効化すると検索流入の観測経路が失われるため
+}


### PR DESCRIPTION
## 背景

[SPR-137 §6-4](https://linear.app/nothink/issue/SPR-137) の選択肢1（集客を勝利条件に戻すか）を判断するための前提作業。

2026-08-02 の GA4 実測で、集客エンジンが **X → 検索**に入れ替わっていることが分かった。

| チャネル | 2025-08 | 2026-07 |
|---|---|---|
| Organic Social（≒X） | 56 | **7** |
| Organic Search | 9 | **61** |

GA4 では「どのチャネルから来たか」までしか分からず、**どの検索語で・何位で・何回表示されたか**は Search Console にしかない。7月の跳ね上がりが再現可能なレバーか偶発かを判別できない（日別に割ると前半4〜7/日・7/14に突発11・後半1/日に戻っており、持続的なステップ変化には見えない）。

## 変更

```bash
pnpm report:search-console 2026-07-01 2026-07-31
```

- `terraform/api_services.tf` — `searchconsole.googleapis.com` の有効化
- `terraform/analytics_search_console.tf` — `search-console-reader@` SA（読み取り専用）
- `scripts/search-console-report.mjs` — 日別 / 検索語 / ページ / デバイス / 国

認証は `check-ga4-drift.mjs` と同じ ADC → SA impersonate（npm 依存なし）。probe で **impersonation + webmasters スコープのトークン取得は成功する**ことを確認済み（残る 403 は API 未有効のみ）。

## 設計上の判断

- **ga4-reader@ を流用しない**。あちらは名前と description が GA4 の Admin/Data API 用と宣言しており、Search Console を相乗りさせると名前の約束と実際の権限がずれる（CLAUDE.md 軸3）。プロパティへの手動追加はどちらにせよ SA 単位で必要で、流用しても手作業は減らない。
- **GA4 と同型の制約を両ファイルのコメントに明記**。Search Console プロパティ側のアクセス権は terraform では付与できず管理画面のみ（`analytics_ga4.tf` と同じ構造）。
- スクリプトは 403 の内容で「**API 未有効**」と「**プロパティ未追加**」を出し分け、それぞれ次にすべきことをエラー文に出す。プロパティが見つからない場合は SA から見えているプロパティ一覧を出す。

## ⚠️ apply 後に人手が必要（API では代替不能）

- [ ] Search Console 管理画面で `search-console-reader@suzumina-click.iam.gserviceaccount.com` をプロパティのユーザーに追加（制限付きユーザーで足りる）
- [ ] 個人アカウントに `roles/iam.serviceAccountTokenCreator`（`search_console_reader` 宛）を付与（ga4-reader@ と同じく手動）

**未確認**: suzumina.click が Search Console に登録・所有権確認済みかどうかは API 未有効のため確認できていない。プロパティ URL の形式（`sc-domain:` かホスト形式か）も未確認で、`SEARCH_CONSOLE_SITE_URL` で上書きできるようにしてある。

## 検証

- `pnpm verify` EXIT=0
- `terraform fmt -check` / `terraform validate` 通過
- `pnpm report:search-console` が想定どおり「SA 未作成」のエラーで停止することを確認

## ⚠️ One-Way Door

**Terraform / GCP インフラの変更を含むため、CLAUDE.md のセルフマージ・ポリシーにより AI レビュー任せにせず人がレビューすること。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)