### PR TITLE
feat(seo): works 詳細に価格推移サマリーをサーバー描画する (SPR-302)

### DIFF
--- a/apps/web/src/app/works/[workId]/__tests__/price-summary.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/price-summary.test.ts
@@ -1,0 +1,104 @@
+import type { PriceHistoryDocument } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { summarizePriceHistory } from "../price-summary";
+
+function entry(overrides: Partial<PriceHistoryDocument> & { date: string }): PriceHistoryDocument {
+	return {
+		workId: "RJ01616204",
+		capturedAt: `${overrides.date}T03:00:00.000Z`,
+		price: 1760,
+		officialPrice: 1760,
+		localePrice: {},
+		localeOfficialPrice: {},
+		discountRate: 0,
+		...overrides,
+	};
+}
+
+describe("summarizePriceHistory", () => {
+	it("最安値・最高値・セール日数・最大割引率を出す", () => {
+		const summary = summarizePriceHistory([
+			entry({ date: "2026-07-01", price: 1760, discountRate: 0 }),
+			entry({ date: "2026-07-02", price: 1232, discountRate: 30 }),
+			entry({ date: "2026-07-03", price: 1232, discountRate: 30 }),
+			entry({ date: "2026-07-04", price: 1760, discountRate: 0 }),
+		]);
+
+		expect(summary).toEqual({
+			observedDays: 4,
+			startDate: "2026-07-01",
+			endDate: "2026-07-04",
+			currentPrice: 1760,
+			lowestPrice: 1232,
+			lowestDate: "2026-07-02",
+			highestPrice: 1760,
+			saleDays: 2,
+			maxDiscountRate: 30,
+			isCurrentlyLowest: false,
+		});
+	});
+
+	it("入力順が日付順でなくても日付で並べ直す", () => {
+		const summary = summarizePriceHistory([
+			entry({ date: "2026-07-04", price: 1500 }),
+			entry({ date: "2026-07-01", price: 1760 }),
+		]);
+		expect(summary?.startDate).toBe("2026-07-01");
+		expect(summary?.endDate).toBe("2026-07-04");
+		expect(summary?.currentPrice).toBe(1500);
+	});
+
+	it("最安値が同値なら古い方の日付を残す", () => {
+		const summary = summarizePriceHistory([
+			entry({ date: "2026-07-01", price: 1232, discountRate: 30 }),
+			entry({ date: "2026-07-05", price: 1232, discountRate: 30 }),
+			entry({ date: "2026-07-09", price: 1760 }),
+		]);
+		expect(summary?.lowestDate).toBe("2026-07-01");
+	});
+
+	it("現在が最安なら isCurrentlyLowest が true", () => {
+		const summary = summarizePriceHistory([
+			entry({ date: "2026-07-01", price: 1760 }),
+			entry({ date: "2026-07-02", price: 1232, discountRate: 30 }),
+		]);
+		expect(summary?.isCurrentlyLowest).toBe(true);
+	});
+
+	it("price が無い日は officialPrice で代替する", () => {
+		const summary = summarizePriceHistory([
+			entry({ date: "2026-07-01", price: null, officialPrice: 1980 }),
+		]);
+		expect(summary?.currentPrice).toBe(1980);
+	});
+
+	it("price も officialPrice も無い日は集計から外す", () => {
+		const summary = summarizePriceHistory([
+			entry({ date: "2026-07-01", price: null, officialPrice: null }),
+			entry({ date: "2026-07-02", price: 1760 }),
+		]);
+		expect(summary?.observedDays).toBe(1);
+		expect(summary?.startDate).toBe("2026-07-02");
+	});
+
+	it("価格を取り出せる日が1日も無ければ null", () => {
+		expect(
+			summarizePriceHistory([entry({ date: "2026-07-01", price: null, officialPrice: null })]),
+		).toBeNull();
+	});
+
+	it("空配列は null", () => {
+		expect(summarizePriceHistory([])).toBeNull();
+	});
+
+	it("1日分しか無くても成立する", () => {
+		const summary = summarizePriceHistory([entry({ date: "2026-07-01", price: 1760 })]);
+		expect(summary).toMatchObject({
+			observedDays: 1,
+			lowestPrice: 1760,
+			highestPrice: 1760,
+			isCurrentlyLowest: true,
+			saleDays: 0,
+		});
+	});
+});

--- a/apps/web/src/app/works/[workId]/__tests__/price-summary.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/price-summary.test.ts
@@ -1,6 +1,12 @@
 import type { PriceHistoryDocument } from "@suzumina.click/shared-types";
 import { describe, expect, it } from "vitest";
-import { summarizePriceHistory } from "../price-summary";
+import {
+	describePriceSummary,
+	describePriceSummaryPeriod,
+	formatPrice,
+	formatSummaryDate,
+	summarizePriceHistory,
+} from "../price-summary";
 
 function entry(overrides: Partial<PriceHistoryDocument> & { date: string }): PriceHistoryDocument {
 	return {
@@ -100,5 +106,81 @@ describe("summarizePriceHistory", () => {
 			isCurrentlyLowest: true,
 			saleDays: 0,
 		});
+	});
+});
+
+describe("formatPrice", () => {
+	it("3桁区切りの円表記にする", () => {
+		expect(formatPrice(1760)).toBe("¥1,760");
+		expect(formatPrice(0)).toBe("¥0");
+	});
+});
+
+describe("formatSummaryDate", () => {
+	it("ゼロ埋めを外した和式表記にする", () => {
+		expect(formatSummaryDate("2026-07-02")).toBe("2026年7月2日");
+		expect(formatSummaryDate("2026-12-25")).toBe("2026年12月25日");
+	});
+
+	it("想定外の形式は壊さずそのまま返す", () => {
+		expect(formatSummaryDate("2026-07")).toBe("2026-07");
+		expect(formatSummaryDate("")).toBe("");
+		expect(formatSummaryDate("aaaa-bb-cc")).toBe("aaaa-bb-cc");
+	});
+});
+
+describe("describePriceSummary", () => {
+	function summaryOf(history: Parameters<typeof summarizePriceHistory>[0]) {
+		const summary = summarizePriceHistory(history);
+		if (!summary) throw new Error("サマリーが作れませんでした");
+		return summary;
+	}
+
+	it("セールがあった期間は最安日・最大割引率・セール日数を述べる", () => {
+		const text = describePriceSummary(
+			summaryOf([
+				entry({ date: "2026-07-01", price: 1760 }),
+				entry({ date: "2026-07-02", price: 1232, discountRate: 30 }),
+				entry({ date: "2026-07-03", price: 1760 }),
+			]),
+		);
+		expect(text).toContain("最も安かったのは2026年7月2日の¥1,232で、最大30%OFFでした。");
+		expect(text).toContain("3日間のうち1日がセール価格です。");
+		expect(text).toContain("現在の価格は最安値より¥528高い状態です。");
+	});
+
+	it("セールが無い期間は据え置きである旨を述べる", () => {
+		const text = describePriceSummary(
+			summaryOf([
+				entry({ date: "2026-07-01", price: 1760 }),
+				entry({ date: "2026-07-02", price: 1760 }),
+			]),
+		);
+		expect(text).toContain("観測した2日間はセールがなく、¥1,760のまま推移しています。");
+		expect(text).toContain("現在の価格は、この期間の最安値と同じです。");
+	});
+
+	it("現在が最安なら差額ではなく一致を述べる", () => {
+		const text = describePriceSummary(
+			summaryOf([
+				entry({ date: "2026-07-01", price: 1760 }),
+				entry({ date: "2026-07-02", price: 1232, discountRate: 30 }),
+			]),
+		);
+		expect(text).toContain("現在の価格は、この期間の最安値と同じです。");
+		expect(text).not.toContain("高い状態です");
+	});
+
+	it("期間のリード文に作品名と観測日数が入る", () => {
+		const text = describePriceSummaryPeriod(
+			summaryOf([
+				entry({ date: "2026-07-01", price: 1760 }),
+				entry({ date: "2026-07-31", price: 1760 }),
+			]),
+			"テスト作品",
+		);
+		expect(text).toBe(
+			"2026年7月1日〜2026年7月31日の2日間、当サイトが記録した「テスト作品」の価格です。",
+		);
 	});
 });

--- a/apps/web/src/app/works/[workId]/components/work-price-summary.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-price-summary.tsx
@@ -1,19 +1,28 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
 import { cacheLife } from "next/cache";
 import { getRecentPriceHistory } from "@/actions/price-history";
-import { type PriceHistorySummary, summarizePriceHistory } from "../price-summary";
+import {
+	describePriceSummary,
+	describePriceSummaryPeriod,
+	formatPrice,
+	type PriceHistorySummary,
+	summarizePriceHistory,
+} from "../price-summary";
 
 /**
  * 価格推移サマリー（SPR-302）。**Server Component であることが要件**。
  *
  * 同じデータを描く `PriceHistory` は非アクティブなタブの中の client component（SWR fetch）で、
- * 初期 HTML に一切現れない＝クローラからは存在しないのと同じだった。works 詳細は検索流入の
- * 8割を占めるのに HTML の固有テキストが約1,000文字しかなく、その大半が DLsite の作品説明の
- * 写しという状態だったため、**DLsite が公開していない価格推移をサーバー側で出す**ことで
- * 重複ページから脱却させるのが狙い。タブの中には置かない（描画されなくなる）。
+ * `Tabs defaultValue="overview"` のため DOM にマウントすらされず、初期 HTML に一切現れない
+ * ＝クローラからは存在しないのと同じだった。works 詳細は検索流入の8割を占めるのに HTML の
+ * 固有テキストが約1,000文字しかなく、その大半が DLsite の作品説明の写しという状態だったため、
+ * **DLsite が公開していない価格推移をサーバー側で出す**ことで重複ページから脱却させる。
+ * タブの中には置かない（描画されなくなる）。
  *
  * 読み取りコスト: priceHistory は 1 作品 90 日分＝最大90 read。Firestore reads は課金上位のため
  * `use cache` + `cacheLife("days")` で 1 作品 1 日 1 回に抑える（元データの更新も日次 cron）。
+ *
+ * 表示文言の分岐は `price-summary.ts` の純関数に寄せてある（ここは JSX の組み立てのみ）。
  */
 async function loadPriceSummary(workId: string): Promise<PriceHistorySummary | null> {
 	"use cache";
@@ -21,17 +30,6 @@ async function loadPriceSummary(workId: string): Promise<PriceHistorySummary | n
 
 	const history = await getRecentPriceHistory(workId);
 	return summarizePriceHistory(history);
-}
-
-function formatPrice(value: number): string {
-	return `¥${value.toLocaleString("ja-JP")}`;
-}
-
-/** YYYY-MM-DD を「2026年7月2日」にする（date-format は Date 前提のためここで完結させる） */
-function formatDate(date: string): string {
-	const [year, month, day] = date.split("-");
-	if (!year || !month || !day) return date;
-	return `${year}年${Number(month)}月${Number(day)}日`;
 }
 
 export default async function WorkPriceSummary({
@@ -44,51 +42,31 @@ export default async function WorkPriceSummary({
 	const summary = await loadPriceSummary(workId);
 	if (!summary) return null;
 
-	const hasSale = summary.saleDays > 0;
+	const stats = [
+		{ label: "現在の価格", value: formatPrice(summary.currentPrice) },
+		{ label: "期間中の最安値", value: formatPrice(summary.lowestPrice) },
+		{ label: "期間中の最高値", value: formatPrice(summary.highestPrice) },
+		{ label: "セールだった日数", value: `${summary.saleDays}日` },
+	];
 
 	return (
 		<Card className="mt-6">
 			<CardHeader>
 				<CardTitle className="text-lg">価格の推移</CardTitle>
 				<p className="text-sm text-muted-foreground">
-					{formatDate(summary.startDate)}〜{formatDate(summary.endDate)}の{summary.observedDays}
-					日間、当サイトが記録した「{title}」の価格です。
+					{describePriceSummaryPeriod(summary, title)}
 				</p>
 			</CardHeader>
 			<CardContent className="space-y-4">
 				<dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-					<div>
-						<dt className="text-xs text-muted-foreground">現在の価格</dt>
-						<dd className="text-base font-semibold text-foreground">
-							{formatPrice(summary.currentPrice)}
-						</dd>
-					</div>
-					<div>
-						<dt className="text-xs text-muted-foreground">期間中の最安値</dt>
-						<dd className="text-base font-semibold text-foreground">
-							{formatPrice(summary.lowestPrice)}
-						</dd>
-					</div>
-					<div>
-						<dt className="text-xs text-muted-foreground">期間中の最高値</dt>
-						<dd className="text-base font-semibold text-foreground">
-							{formatPrice(summary.highestPrice)}
-						</dd>
-					</div>
-					<div>
-						<dt className="text-xs text-muted-foreground">セールだった日数</dt>
-						<dd className="text-base font-semibold text-foreground">{summary.saleDays}日</dd>
-					</div>
+					{stats.map((stat) => (
+						<div key={stat.label}>
+							<dt className="text-xs text-muted-foreground">{stat.label}</dt>
+							<dd className="text-base font-semibold text-foreground">{stat.value}</dd>
+						</div>
+					))}
 				</dl>
-
-				<p className="text-sm text-foreground">
-					{hasSale
-						? `最も安かったのは${formatDate(summary.lowestDate)}の${formatPrice(summary.lowestPrice)}で、最大${summary.maxDiscountRate}%OFFでした。${summary.observedDays}日間のうち${summary.saleDays}日がセール価格です。`
-						: `観測した${summary.observedDays}日間はセールがなく、${formatPrice(summary.currentPrice)}のまま推移しています。`}
-					{summary.isCurrentlyLowest
-						? "現在の価格は、この期間の最安値と同じです。"
-						: `現在の価格は最安値より${formatPrice(summary.currentPrice - summary.lowestPrice)}高い状態です。`}
-				</p>
+				<p className="text-sm text-foreground">{describePriceSummary(summary)}</p>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/app/works/[workId]/components/work-price-summary.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-price-summary.tsx
@@ -1,0 +1,95 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
+import { cacheLife } from "next/cache";
+import { getRecentPriceHistory } from "@/actions/price-history";
+import { type PriceHistorySummary, summarizePriceHistory } from "../price-summary";
+
+/**
+ * 価格推移サマリー（SPR-302）。**Server Component であることが要件**。
+ *
+ * 同じデータを描く `PriceHistory` は非アクティブなタブの中の client component（SWR fetch）で、
+ * 初期 HTML に一切現れない＝クローラからは存在しないのと同じだった。works 詳細は検索流入の
+ * 8割を占めるのに HTML の固有テキストが約1,000文字しかなく、その大半が DLsite の作品説明の
+ * 写しという状態だったため、**DLsite が公開していない価格推移をサーバー側で出す**ことで
+ * 重複ページから脱却させるのが狙い。タブの中には置かない（描画されなくなる）。
+ *
+ * 読み取りコスト: priceHistory は 1 作品 90 日分＝最大90 read。Firestore reads は課金上位のため
+ * `use cache` + `cacheLife("days")` で 1 作品 1 日 1 回に抑える（元データの更新も日次 cron）。
+ */
+async function loadPriceSummary(workId: string): Promise<PriceHistorySummary | null> {
+	"use cache";
+	cacheLife("days");
+
+	const history = await getRecentPriceHistory(workId);
+	return summarizePriceHistory(history);
+}
+
+function formatPrice(value: number): string {
+	return `¥${value.toLocaleString("ja-JP")}`;
+}
+
+/** YYYY-MM-DD を「2026年7月2日」にする（date-format は Date 前提のためここで完結させる） */
+function formatDate(date: string): string {
+	const [year, month, day] = date.split("-");
+	if (!year || !month || !day) return date;
+	return `${year}年${Number(month)}月${Number(day)}日`;
+}
+
+export default async function WorkPriceSummary({
+	workId,
+	title,
+}: {
+	workId: string;
+	title: string;
+}) {
+	const summary = await loadPriceSummary(workId);
+	if (!summary) return null;
+
+	const hasSale = summary.saleDays > 0;
+
+	return (
+		<Card className="mt-6">
+			<CardHeader>
+				<CardTitle className="text-lg">価格の推移</CardTitle>
+				<p className="text-sm text-muted-foreground">
+					{formatDate(summary.startDate)}〜{formatDate(summary.endDate)}の{summary.observedDays}
+					日間、当サイトが記録した「{title}」の価格です。
+				</p>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+					<div>
+						<dt className="text-xs text-muted-foreground">現在の価格</dt>
+						<dd className="text-base font-semibold text-foreground">
+							{formatPrice(summary.currentPrice)}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">期間中の最安値</dt>
+						<dd className="text-base font-semibold text-foreground">
+							{formatPrice(summary.lowestPrice)}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">期間中の最高値</dt>
+						<dd className="text-base font-semibold text-foreground">
+							{formatPrice(summary.highestPrice)}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">セールだった日数</dt>
+						<dd className="text-base font-semibold text-foreground">{summary.saleDays}日</dd>
+					</div>
+				</dl>
+
+				<p className="text-sm text-foreground">
+					{hasSale
+						? `最も安かったのは${formatDate(summary.lowestDate)}の${formatPrice(summary.lowestPrice)}で、最大${summary.maxDiscountRate}%OFFでした。${summary.observedDays}日間のうち${summary.saleDays}日がセール価格です。`
+						: `観測した${summary.observedDays}日間はセールがなく、${formatPrice(summary.currentPrice)}のまま推移しています。`}
+					{summary.isCurrentlyLowest
+						? "現在の価格は、この期間の最安値と同じです。"
+						: `現在の価格は最安値より${formatPrice(summary.currentPrice - summary.lowestPrice)}高い状態です。`}
+				</p>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/app/works/[workId]/page.tsx
+++ b/apps/web/src/app/works/[workId]/page.tsx
@@ -1,6 +1,8 @@
 import { notFound } from "next/navigation";
+import { Suspense } from "react";
 import { getWorkById } from "../actions";
 import WorkDetail from "./components/work-detail";
+import WorkPriceSummary from "./components/work-price-summary";
 
 interface WorkDetailPageProps {
 	params: Promise<{
@@ -24,6 +26,11 @@ export default async function WorkDetailPage({ params }: WorkDetailPageProps) {
 		<div className="min-h-screen bg-muted">
 			<main className="max-w-7xl mx-auto px-4 py-8">
 				<WorkDetail work={work} />
+				{/* 価格推移は WorkDetail（client・タブ内）ではなくここで**サーバー描画**する。
+					タブ内の client fetch では初期 HTML に出ずクローラから見えないため（SPR-302） */}
+				<Suspense fallback={null}>
+					<WorkPriceSummary workId={work.productId} title={work.title} />
+				</Suspense>
 			</main>
 		</div>
 	);

--- a/apps/web/src/app/works/[workId]/price-summary.ts
+++ b/apps/web/src/app/works/[workId]/price-summary.ts
@@ -1,0 +1,84 @@
+import type { PriceHistoryDocument } from "@suzumina.click/shared-types";
+
+/**
+ * 価格推移のサマリー（SPR-302）。
+ *
+ * なぜサーバー側で出すのか:
+ * works 詳細は検索流入の 8割（6/15-7/14 で clicks 90/124・impressions 3,669/4,612）を占める一方、
+ * HTML に出ている固有テキストは約1,000文字で、その大半が DLsite の作品説明の写しだった。
+ * 価格推移は **DLsite が過去のセール履歴を公開していない**このサイト固有のデータで、
+ * かつ「RJ番号 セール」「安く買う」といった検索意図に直接答える。
+ * しかし従来は非アクティブなタブの中の client component（SWR fetch）にあり、
+ * 初期 HTML に一切現れていなかった＝クローラからは存在しないのと同じだった。
+ */
+export interface PriceHistorySummary {
+	/** 観測できた日数 */
+	observedDays: number;
+	/** 期間の開始日（YYYY-MM-DD） */
+	startDate: string;
+	/** 期間の終了日（YYYY-MM-DD） */
+	endDate: string;
+	/** 最新の実売価格 */
+	currentPrice: number;
+	/** 期間中の最安値 */
+	lowestPrice: number;
+	/** 最安値を記録した日 */
+	lowestDate: string;
+	/** 期間中の最高値 */
+	highestPrice: number;
+	/** セール（割引あり）だった日数 */
+	saleDays: number;
+	/** 期間中の最大割引率（%） */
+	maxDiscountRate: number;
+	/** 現在価格が期間中の最安値と同じか */
+	isCurrentlyLowest: boolean;
+}
+
+/** 実売価格を取り出す。price が無い日は officialPrice で代替し、どちらも無ければ対象外 */
+function resolvePrice(entry: PriceHistoryDocument): number | null {
+	if (typeof entry.price === "number") return entry.price;
+	if (typeof entry.officialPrice === "number") return entry.officialPrice;
+	return null;
+}
+
+/**
+ * 価格履歴からサマリーを計算する（純関数）。
+ * 価格を取り出せる日が 1 日も無ければ null（呼び出し側はセクションごと描画しない）。
+ */
+export function summarizePriceHistory(history: PriceHistoryDocument[]): PriceHistorySummary | null {
+	const entries = history
+		.map((entry) => ({ entry, price: resolvePrice(entry) }))
+		.filter((row): row is { entry: PriceHistoryDocument; price: number } => row.price !== null)
+		.sort((a, b) => a.entry.date.localeCompare(b.entry.date));
+
+	if (entries.length === 0) return null;
+
+	const first = entries[0] as (typeof entries)[number];
+	const last = entries[entries.length - 1] as (typeof entries)[number];
+
+	let lowest = first;
+	let highestPrice = first.price;
+	let saleDays = 0;
+	let maxDiscountRate = 0;
+
+	for (const row of entries) {
+		// 同値なら先に出た日（＝古い方）を残す。「いつ最安だったか」は初出の方が情報量が多い
+		if (row.price < lowest.price) lowest = row;
+		if (row.price > highestPrice) highestPrice = row.price;
+		if (row.entry.discountRate > 0) saleDays += 1;
+		if (row.entry.discountRate > maxDiscountRate) maxDiscountRate = row.entry.discountRate;
+	}
+
+	return {
+		observedDays: entries.length,
+		startDate: first.entry.date,
+		endDate: last.entry.date,
+		currentPrice: last.price,
+		lowestPrice: lowest.price,
+		lowestDate: lowest.entry.date,
+		highestPrice,
+		saleDays,
+		maxDiscountRate,
+		isCurrentlyLowest: last.price === lowest.price,
+	};
+}

--- a/apps/web/src/app/works/[workId]/price-summary.ts
+++ b/apps/web/src/app/works/[workId]/price-summary.ts
@@ -82,3 +82,41 @@ export function summarizePriceHistory(history: PriceHistoryDocument[]): PriceHis
 		isCurrentlyLowest: last.price === lowest.price,
 	};
 }
+
+export function formatPrice(value: number): string {
+	return `¥${value.toLocaleString("ja-JP")}`;
+}
+
+/** YYYY-MM-DD を「2026年7月2日」にする。想定外の形式はそのまま返す（表示を壊さない） */
+export function formatSummaryDate(date: string): string {
+	const [year, month, day] = date.split("-");
+	if (!year || !month || !day) return date;
+	const monthNumber = Number(month);
+	const dayNumber = Number(day);
+	if (!Number.isInteger(monthNumber) || !Number.isInteger(dayNumber)) return date;
+	return `${year}年${monthNumber}月${dayNumber}日`;
+}
+
+/**
+ * サマリーを人が読む文章にする。
+ *
+ * 表示文言をコンポーネントではなくここに置くのは、**ユーザーに見える文章こそテストしたい**ため
+ * （Server Component 側は JSX の組み立てだけにして、分岐は純関数に寄せる・SPR-302 レビュー指摘）。
+ */
+export function describePriceSummary(summary: PriceHistorySummary): string {
+	const trend =
+		summary.saleDays > 0
+			? `最も安かったのは${formatSummaryDate(summary.lowestDate)}の${formatPrice(summary.lowestPrice)}で、最大${summary.maxDiscountRate}%OFFでした。${summary.observedDays}日間のうち${summary.saleDays}日がセール価格です。`
+			: `観測した${summary.observedDays}日間はセールがなく、${formatPrice(summary.currentPrice)}のまま推移しています。`;
+
+	const position = summary.isCurrentlyLowest
+		? "現在の価格は、この期間の最安値と同じです。"
+		: `現在の価格は最安値より${formatPrice(summary.currentPrice - summary.lowestPrice)}高い状態です。`;
+
+	return `${trend}${position}`;
+}
+
+/** 期間の説明文（見出し直下のリード） */
+export function describePriceSummaryPeriod(summary: PriceHistorySummary, title: string): string {
+	return `${formatSummaryDate(summary.startDate)}〜${formatSummaryDate(summary.endDate)}の${summary.observedDays}日間、当サイトが記録した「${title}」の価格です。`;
+}


### PR DESCRIPTION
## 背景

[SPR-302](https://linear.app/nothink/issue/SPR-302) の第1弾。Search Console を接続（SPR-301）して判明した事実に基づく。

works 詳細は**検索流入の8割**を占める（6/15–7/14 で clicks 90/124・impressions 3,669/4,612）。にもかかわらず HTML に出ている固有テキストは**約1,000文字**しかなく、その大半が DLsite の作品説明の写しだった。

6/15 の #662（canonical 修正）で約1,000ページがインデックスされ試験的な露出を得たが、CTR が順位期待値を下回り **7/15 に降格**された（掲載順位 7.0 → 17.6 → 37 → 87、impressions 396→5）。手動対策・セキュリティ問題はなく、インデックス登録数（1,060）も維持されている。

## なぜ価格推移か

**DLsite は過去のセール履歴を公開していない**ため、このサイトが持つ最も差別化できるデータ。「RJ番号 セール」「安く買う」という検索意図にも直接答える。

しかし従来は**非アクティブなタブ内の client component（SWR fetch）**にあり、初期 HTML に一切現れていなかった。`Tabs defaultValue="overview"` のため DOM にすらマウントされず、**クローラからは存在しないのと同じ**だった。

## 変更

- `price-summary.ts` — 履歴からサマリーを出す**純関数**（Firestore I/O なし・テスト9件）
- `components/work-price-summary.tsx` — **Server Component**。タブの外に置く
- `page.tsx` — `WorkDetail` の兄弟として描画

出力内容（実データ）:

> **価格の推移** — 2026年5月4日〜2026年8月2日の91日間、当サイトが記録した「…」の価格です。
> 現在の価格 ¥1,237 / 期間中の最安値 ¥1,237 / 期間中の最高値 ¥1,650 / セールだった日数 75日
> 最も安かったのは2026年7月4日の¥1,237で、最大25%OFFでした。91日間のうち75日がセール価格です。現在の価格は、この期間の最安値と同じです。

## 設計上の判断

- **読み取りコスト**: priceHistory は 1作品90日分＝最大90 read。Firestore reads は課金上位（SPR-83）のため `"use cache"` + `cacheLife("days")` で**1作品1日1回**に抑える。元データの更新も日次 cron なので鮮度は落ちない。
- **非正規化フィールドを追加していない**（整合性 cron の負債を増やさない）。集計は読み取り側で行う。
- **新規クエリを足していない**（既存の `getRecentPriceHistory` を再利用）ため**複合インデックスの追加も不要**。
- 既存の `PriceHistory`（タブ内・チャート）は**残す**。あちらは通貨切替とチャートを持つ操作系で、こちらは静的サマリー。役割が違う。

## 検証

- `pnpm verify` EXIT=0
- **本番データ直結の dev で `curl`（JS 実行なし）**し、初期 HTML にサマリーが出ることを2作品で確認
  - RJ01616204: 32日間・最安 ¥1,056・最大40%OFF
  - RJ01610616: 91日間・最安 ¥1,237・現在が最安の分岐も正常
- 可視テキスト **1,042 → 1,310 文字**
- DOM 描画・コンソールエラー無しを確認

## 効果測定

マージ後、`pnpm report:search-console` で works ページの impressions / 掲載順位が回復するかを追う。**これは施策であると同時に「薄い重複コンテンツゆえの降格」という仮説の検証でもある**。再インデックスは不要（1,060ページがインデックスに残っている）。

## Two-Way Door

Firestore スキーマ・認証・Terraform・CI・shared-types のいずれにも触れない。表示の追加のみで、問題があれば戻せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)