### PR TITLE
docs(development): Entity/Value Object 節を関数型の実態に合わせる

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -174,50 +174,26 @@ export function isValidVideoId(id: string): boolean {
 }
 ```
 
-#### **4. DDD (Domain-Driven Design) 原則**
-**原則**: ドメインモデルを中心に設計し、エンティティと値オブジェクトを明確に分離する
+#### **4. ドメインモデルの扱い**
+**原則**: ドメイン概念は「型 + Zod スキーマ + 純関数」で表す。クラスは使わない
 
-**Entity（エンティティ）**: 識別可能でライフサイクルを持つオブジェクト
-- IDによって一意に識別される
-- 時間の経過とともに状態が変化する
-- 例: Work, User, AudioButton, Video, Contact
-
-**Value Object（値オブジェクト）**: 不変で識別子を持たないオブジェクト
-- 値によってのみ識別される
-- 一度作成されたら変更されない
-- ビジネスロジックをカプセル化
-- 例: Price, Rating, DateRange, CreatorType
+`Work` / `Video` / `AudioButton` のような概念は、永続形（Firestore Document + Zod スキーマ）と
+RSC 境界を越える表示形（PlainObject）の 2 つの姿を持ち、その間を `transformers/` の純関数がつなぐ。
+メソッドを持つクラス Entity・クラス値オブジェクトは撤去済み（ADR-006 / SPR-181）。
+層の意図は後述の「アーキテクチャ原則 / データ表現とレイヤ構成」、概念ごとの正本の在処は
+[domain-model.md](../reference/domain-model.md) を参照。
 
 ```typescript
-// ✅ 良い例: Value Object with ビジネスロジック
-import { Price, Rating } from '@suzumina.click/shared-types';
+// ✅ 良い例: PlainObject が持つ整形済みの値・判定フラグをそのまま読む
+import type { WorkPlainObject } from '@suzumina.click/shared-types';
 
-// Priceの使用例
-const price: Price = {
-  amount: 1980,
-  currency: 'JPY'
-};
-
-console.log(price.format()); // ¥1,980
-console.log(price.isFree()); // false
-
-// ✅ 良い例: Entity
-import { Work } from '@suzumina.click/shared-types';
-
-const work: Work = {
-  id: 'RJ01234567',
-  title: 'サンプル作品',
-  price: { amount: 1980, currency: 'JPY' },
-  rating: { value: 4.5, count: 100 },
-  // その他のプロパティ
-};
-
-// ❌ 悪い例: ビジネスロジックが散在
-function formatPrice(work: Work) {
-  return `${work.price.toLocaleString()}円`; // Priceオブジェクトのformat()を使うべき
+function renderPrice(work: WorkPlainObject) {
+  return work.price.formattedPrice;       // 整形は transformer が済ませている
 }
-function isDiscounted(work: Work) {
-  return work.originalPrice > work.price; // Priceオブジェクトのメソッドを使うべき
+
+// ❌ 悪い例: 既にフィールドで提供されている判定を各所で書き直す
+function isFree(work: WorkPlainObject) {
+  return work.price.current === 0;        // price.isFree がある
 }
 ```
 
@@ -255,16 +231,12 @@ function processData(data: any) { ... }
 - **単一責任原則**: 明確で理解しやすい関数名
 
 ```typescript
-// ✅ 良い例: 純粋関数（Value Objectの活用）
-import { Price } from '@suzumina.click/shared-types';
+// ✅ 良い例: PlainObject を受け取り値だけを返す純粋関数
+import { type VideoPlainObject, canCreateAudioButton } from '@suzumina.click/shared-types';
 
-export function createPrice(amount: number, currency = 'JPY'): Price {
-  return { amount, currency };
+export function getCreateButtonLabel(video: VideoPlainObject): string {
+  return canCreateAudioButton(video) ? '音声ボタンを作成' : '作成できません';
 }
-
-// Value Objectメソッドの活用
-const price = createPrice(1980);
-console.log(price.format()); // ¥1,980（純粋関数）
 
 // ❌ 悪い例: 副作用のある関数
 function updateAndLog(data: any) {
@@ -991,156 +963,61 @@ pre-push hook（lefthook）は変更パッケージの `typecheck:fast` のみ�
 
 ## 🏗️ アーキテクチャ原則
 
-### 1. Entity/Value Object アーキテクチャ
+### 1. データ表現とレイヤ構成（shared-types）
 
-**ドメインモデル設計原則**
+**正本は [packages/shared-types/src/](../../packages/shared-types/src/) のツリーそのもの**で、概念ごとの
+正本の在処は [domain-model.md](../reference/domain-model.md) が索引になっている。ここには層の**意図**だけを
+書き、ファイル一覧・型 shape は転記しない（転記した瞬間からリネームで drift するため）。
 
-```text
-packages/shared-types/src/
-├── entities/                    # エンティティ層
-│   ├── work.ts                 # ID管理・状態変化
-│   ├── user.ts                 # ライフサイクル管理
-│   ├── audio-button.ts         # 永続化対象
-│   ├── video.ts                # 動画エンティティ
-│   ├── circle-creator.ts       # サークル・クリエイター
-│   └── ...(その他のエンティティ)
-├── value-objects/              # 値オブジェクト層
-│   ├── price.ts               # 不変・ビジネスロジック
-│   ├── rating.ts              # 計算・検証ロジック
-│   ├── date-range.ts          # ドメイン固有処理
-│   └── creator-type.ts        # クリエイタータイプ
-├── api-schemas/               # API抽象化層
-│   └── dlsite-raw.ts         # 薄い型定義のみ
-└── utilities/                 # インフラ層
-    └── firestore-utils.ts    # 永続化変換
-```
+**層の分割軸は「何に対して責務を負うか」**:
 
-**設計原則**:
-- **Entity**: IDで識別、状態変化、永続化対象
-- **Value Object**: 不変、値で比較、ビジネスロジック内包
-- **API Schema**: 外部APIの薄い抽象化、変換ロジックなし
-- **Domain Service**: 複数エンティティにまたがるロジック
+| 層 | 責務 | 参照してよい層 |
+|---|---|---|
+| `api-schemas/` | 外部 API レスポンスの薄い写し取り。変換ロジックを持たない | — |
+| `entities/` | 永続データ（Firestore Document）の Zod スキーマと型 | `core` / `utilities` |
+| `plain-objects/` | RSC 境界を越えるデータ形。整形済みの値と派生値（`_computed`）を含む | `entities`（型参照のみ） |
+| `transformers/` | Firestore Document ⇄ PlainObject の純関数変換 | `entities` / `plain-objects` |
+| `operations/` | PlainObject に対する判定・表示の純関数 | `plain-objects` |
+| `utilities/` | ドメイン非依存の検証・整形（ID 検証・日付正規化・フォーマッタ） | `core` |
+| `core/` | 型システム基盤（branded types・`Result`） | — |
 
-**インポート方法**:
+**クラス Entity もクラス値オブジェクトも存在しない**（ADR-006 / SPR-181 で撤去済み）。「値オブジェクト」は
+PlainObject のネストしたプロパティ群を指す概念表記であって、メソッドを持つオブジェクトではない。
+整形済み文字列や判定フラグは **transformer が変換時に算出して PlainObject のフィールドに載せる**
+（`work.price.formattedPrice` のように読むだけ）。フィールドに載らない判定は `operations/` の純関数に置く。
+
+Document ⇄ PlainObject の変換層は RSC 境界に強制された冗長であり、**ここに新しい変換層・抽象を足さない**
+（CLAUDE.md 軸2）。新規ドメインを追加するときは CLAUDE.md「Entity 化のゲート」を先に通す。
+
+**インポートはルートバレルからのみ**（`package.json` の `exports` は `"."` だけで、サブパスは解決できない）:
+
 ```typescript
-// ✅ 推奨: ルートからの統一インポート
-import { 
-  Work, 
-  Price, 
-  Rating, 
-  AudioButton,
-  VideoSchema 
+// ✅ 唯一の入口
+import {
+  type WorkPlainObject,
+  type VideoPlainObject,
+  workTransformers,
+  canCreateAudioButton,
 } from '@suzumina.click/shared-types';
 
-// ❌ 非推奨: サブディレクトリからの直接インポート
-import { Work } from '@suzumina.click/shared-types/entities/work';
-import { Price } from '@suzumina.click/shared-types/value-objects/price';
+// ❌ 解決されない（exports に無い）
+import { workTransformers } from '@suzumina.click/shared-types/transformers/work-firestore';
 ```
 
-**Value Object使用例**:
+**読み取り境界の典型**（Firestore Document → Zod で検証 → transformer で PlainObject → 表示・判定）:
+
 ```typescript
-// ✅ 良い例: Value Object with ビジネスロジック
-import { Price, Rating } from '@suzumina.click/shared-types';
-
-// Priceの活用
-const price: Price = { amount: 1980, currency: 'JPY' };
-console.log(price.format());     // ¥1,980
-console.log(price.isFree());     // false
-console.log(price.isDiscounted()); // 割引判定
-
-// Ratingの活用
-const rating: Rating = { value: 4.5, count: 100 };
-console.log(rating.getStarRating());  // 5つ星評価
-console.log(rating.isHighlyRated());  // 高評価判定
+const doc = parseWorkDocument(snapshot.data());     // Zod safeParse の漏斗（apps/web 側の実装が正本）
+const work = workTransformers.fromFirestore(doc);   // WorkPlainObject
+work.price.formattedPrice;                          // 整形は変換時に済んでいる
+canCreateAudioButton(video);                        // 判定は operations の純関数
 ```
 
-**Mapper実装例**:
-```typescript
-// ✅ 良い例: Thin Mapper (functions/src/services/mappers/work-mapper.ts)
-import { Work, Price, Rating } from '@suzumina.click/shared-types';
-import type { DLsiteRawApiResponse } from '@suzumina.click/shared-types';
+**書き込み方向**（収集パイプライン）は shared-types の外にある。DLsite raw API → `WorkDocument` の写し替えは
+functions 側の薄い mapper が担い（[work-mapper.ts](../../apps/functions/src/services/mappers/work-mapper.ts)）、
+ドメイン判定を mapper に持ち込まない。
 
-export class WorkMapper {
-  static toWork(raw: DLsiteRawApiResponse): Work {
-    return {
-      id: raw.id,
-      title: raw.work_name,
-      price: this.toPrice(raw),
-      rating: this.toRating(raw),
-      // 薄い変換のみ、ビジネスロジックはValue Objectに
-    };
-  }
-  
-  private static toPrice(raw: DLsiteRawApiResponse): Price {
-    return {
-      amount: raw.price,
-      currency: 'JPY',
-      originalAmount: raw.price_without_campaign
-    };
-  }
-}
-```
-
-### 2. Value Object活用のベストプラクティス
-
-**Value Objectの設計指針**:
-
-1. **不変性の保証**
-   ```typescript
-   // ✅ 良い例: 不変のValue Object
-   const price1: Price = { amount: 1000, currency: 'JPY' };
-   const price2 = { ...price1, amount: 2000 }; // 新しいオブジェクトを作成
-   
-   // ❌ 悪い例: 直接変更
-   price1.amount = 2000; // Value Objectは変更不可
-   ```
-
-2. **ビジネスロジックのカプセル化**
-   ```typescript
-   // ✅ 良い例: ロジックをValue Object内に
-   const price: Price = { amount: 1980, currency: 'JPY' };
-   if (price.isFree()) {
-     // 無料作品の処理
-   }
-   
-   // ❌ 悪い例: 外部でロジックを実装
-   if (work.price === 0) { // Value Objectのメソッドを使うべき
-     // 無料作品の処理
-   }
-   ```
-
-3. **適切な粒度の維持**
-   ```typescript
-   // ✅ 良い例: 関連する概念をまとめる
-   const dateRange: DateRange = {
-     start: '2025-07-01',
-     end: '2025-07-31'
-   };
-   console.log(dateRange.getDays()); // 期間の日数
-   console.log(dateRange.includes('2025-07-15')); // 日付の包含判定
-   
-   // ❌ 悪い例: 過度に細分化
-   const startDate: Date = new Date('2025-07-01');
-   const endDate: Date = new Date('2025-07-31');
-   // ロジックが散在してしまう
-   ```
-
-4. **Domain Serviceとの使い分け**
-   ```typescript
-   // ✅ 良い例: 複数エンティティにまたがる処理はDomain Service
-   import { PriceCalculationService } from './domain/price-calculation-service';
-   
-   const finalPrice = PriceCalculationService.calculateWithCampaign(
-     work.price,
-     campaign,
-     user.membershipLevel
-   );
-   
-   // ❌ 悪い例: Value Object内で他のエンティティを参照
-   // Price Value Object内でユーザー情報を参照するのは不適切
-   ```
-
-### 3. 責任分離
+### 2. 責任分離
 
 **実装済みレイヤー構造**
 
@@ -1165,7 +1042,7 @@ apps/functions/src/
 
 ※ 各ディレクトリの中身（ファイル一覧）は転記しない。正本はツリーそのもの。
 
-### 2. 依存関係管理
+### 3. 依存関係管理
 
 **依存関係の方向**
 
@@ -1177,7 +1054,7 @@ UI層 → ビジネスロジック層 → データアクセス層
 - 下位層は上位層に依存しない
 - 循環依存を禁止
 
-### 3. エラーハンドリング
+### 4. エラーハンドリング
 
 **階層別エラー処理**
 

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -971,15 +971,22 @@ pre-push hook（lefthook）は変更パッケージの `typecheck:fast` のみ�
 
 **層の分割軸は「何に対して責務を負うか」**:
 
-| 層 | 責務 | 参照してよい層 |
-|---|---|---|
-| `api-schemas/` | 外部 API レスポンスの薄い写し取り。変換ロジックを持たない | — |
-| `entities/` | 永続データ（Firestore Document）の Zod スキーマと型 | `core` / `utilities` |
-| `plain-objects/` | RSC 境界を越えるデータ形。整形済みの値と派生値（`_computed`）を含む | `entities`（型参照のみ） |
-| `transformers/` | Firestore Document ⇄ PlainObject の純関数変換 | `entities` / `plain-objects` |
-| `operations/` | PlainObject に対する判定・表示の純関数 | `plain-objects` |
-| `utilities/` | ドメイン非依存の検証・整形（ID 検証・日付正規化・フォーマッタ） | `core` |
-| `core/` | 型システム基盤（branded types・`Result`） | — |
+| 層 | 責務 |
+|---|---|
+| `api-schemas/` | 外部 API レスポンスの薄い写し取り。変換ロジックを持たない |
+| `entities/` | 永続データ（Firestore Document）の Zod スキーマと、そこから導く型・定数 |
+| `types/` | Zod を持たない概念の型定義と型ガード（Firestore Document 形を含む） |
+| `plain-objects/` | RSC 境界を越えるデータ形。整形済みの値と派生値（`_computed`）を含む |
+| `transformers/` | Firestore Document ⇄ PlainObject の純関数変換 |
+| `operations/` | PlainObject に対する判定・表示の純関数 |
+| `utilities/` | 検証・整形（ID 検証・日付正規化・フォーマッタ・Document ⇄ Plain の個別変換） |
+| `core/` | 型システム基盤（branded types・`Result`） |
+
+層をまたぐ import に**一方向の制約は課していない**（`utilities/` が `entities/` の型を参照する、
+`transformers/` が `operations/` を呼ぶ等は実在する）。Document ⇄ PlainObject の変換も
+`transformers/` に集約しきれてはおらず、Circle だけ
+[circle-conversions.ts](../../packages/shared-types/src/utilities/circle-conversions.ts) にある。
+新しい変換を書く前に、対象ドメインの既存の変換がどこにあるかを確認すること。
 
 **クラス Entity もクラス値オブジェクトも存在しない**（ADR-006 / SPR-181 で撤去済み）。「値オブジェクト」は
 PlainObject のネストしたプロパティ群を指す概念表記であって、メソッドを持つオブジェクトではない。
@@ -1013,9 +1020,10 @@ work.price.formattedPrice;                          // 整形は変換時に済�
 canCreateAudioButton(video);                        // 判定は operations の純関数
 ```
 
-**書き込み方向**（収集パイプライン）は shared-types の外にある。DLsite raw API → `WorkDocument` の写し替えは
-functions 側の薄い mapper が担い（[work-mapper.ts](../../apps/functions/src/services/mappers/work-mapper.ts)）、
-ドメイン判定を mapper に持ち込まない。
+**書き込み方向は Work だけ非対称**。Video / AudioButton は `transformers/` に `toFirestore` を持つが、
+Work は持たず、DLsite raw API → `WorkDocument` の写し替えは functions 側の薄い mapper が担う
+（[work-mapper.ts](../../apps/functions/src/services/mappers/work-mapper.ts)）。mapper が行うのは
+フィールドの写し替えと正規化までで、ドメイン判定は持ち込まない。
 
 ### 2. 責任分離
 


### PR DESCRIPTION
## 背景

`docs/guides/development.md` の「### 1. Entity/Value Object アーキテクチャ」節が、現在の
`packages/shared-types` に存在しない構造を前提に書かれていた。

- `packages/shared-types/src/` に `value-objects/` ディレクトリが無い（実際は
  `api-schemas` / `core` / `entities` / `operations` / `plain-objects` / `transformers` /
  `types` / `utilities`）
- `Price` / `Rating` は `index.ts` から一切 export されていない。示された `price.format()` /
  `price.isFree()` / `rating.getStarRating()` / `rating.isHighlyRated()` / `dateRange.getDays()`
  は全て存在しないメソッドで、節の大半（「Value Object活用のベストプラクティス」4項目）が
  これに依存していた
- tree が `entities/` 配下に挙げた `audio-button.ts` / `video.ts` は実際には
  `types/audio-button.ts`・`types/video-types.ts`・`plain-objects/video-plain.ts`
- Mapper 実装例の `class WorkMapper` は実際には const オブジェクトで、戻り値も `Work` ではなく
  `WorkDocument`

クラス Entity・クラス値オブジェクトは ADR-006 / SPR-181 で撤去済みで、整形済み文字列や判定
フラグは transformer が変換時に算出して PlainObject のフィールドに載せる形
（`work.price.formattedPrice`）に置き換わっている。節が丸ごと撤去前のアーキテクチャを
説明していた。

#903 と同じ扱いで、列挙をやめて構成の意図だけを残す。

## 変更

- 「1. Entity/Value Object アーキテクチャ」と「2. Value Object活用のベストプラクティス」を
  「1. データ表現とレイヤ構成（shared-types）」に統合。ツリーと型 shape の転記をやめ、正本を
  `packages/shared-types/src/` と `docs/reference/domain-model.md` へのリンクに。残したのは
  層ごとの責務、変換層を足さない原則、読み取り境界の流れ、書き込み方向の非対称
- import 節の「非推奨: サブディレクトリからの直接インポート」を「解決されない」に訂正
  （`package.json` の `exports` は `"."` のみで、サブパスは非推奨ではなく不可）
- 250 行付近の「純粋関数」例と 177 行の「DDD 原則」節も同じ `import { Price, Rating }` で
  破綻していたため実態に合わせた
- 統合で崩れた見出し番号を修正（元から 2 と 3 が重複していた）

## レビュー指摘への対応（dd8a9641）

初回コミットで新設した表に「参照してよい層」列を置いていたが、これはコードから読み取った事実では
なく層の名前からの推測で、実際の import と合っていなかった。

- `utilities/` は `core` のみ、と書いたが `entities` / `types` / `plain-objects` を参照している（7 箇所）
- `transformers/` は `operations` も呼ぶ（`video-firestore.ts:7`）
- `plain-objects/` は `types/firestore/video` も参照（`video-plain.ts:7`）
- `entities/` は同層の `user-evaluation` を参照（`work-document-schema.ts:9`。AI レビューの minor 指摘）
- `types/` 層自体が表から抜けていた

読み手は表の列を守るべき制約と読むため、これは #903 のバレルエクスポート節と同じクラスの欠陥で、
実在しない構造を排する PR で新たな実在しない構造を持ち込んでいた。実装側を表に合わせる選択は
取らない（`utilities/age-rating.ts` が `WorkDocument` を型参照するのは自然で、直す理由が doc の
記述しかない）。列を削除し、一方向の依存制約を課していないことと、Document ⇄ PlainObject の変換が
`transformers/` に集約しきれておらず Circle だけ `utilities/circle-conversions.ts` にある事実を明記した。

同じ検証で、書き込み方向の記述も不正確だったため訂正（Video / AudioButton は `transformers/` に
`toFirestore` を持ち、Work だけ持たない非対称）。

## 残課題

「🔄 Entity/Value Object移行完了に関する重要事項」節は移行の向きが逆に書かれている
（「Entity/Value Object構造への完全移行」＝ ADR-006 で撤去した方向と逆）。「全569テスト合格」
「323行の薄いマッパー」（実際は 475 行）も古い。履歴記述のため本 PR では据え置き。

## 確認

- `pnpm lint:docs` ✓（links: 200 / transcription: 0）
- `pnpm verify` ✓ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

