### PR TITLE
docs(development): Entity/Value Object 移行完了節を削除する

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -1273,31 +1273,6 @@ export async function fetchDLsiteWorks(page: number): Promise<WorkData[]> {
 - 破壊的変更は移行ガイドを作成
 - API変更はCHANGELOG.mdに記録
 
-## 🔄 Entity/Value Object移行完了に関する重要事項
-
-### 移行の成果
-- **全569テスト合格**: Entity/Value Object構造への完全移行
-- **レガシーフィールド削除**: 下位互換性のための冗長フィールドを完全削除
-- **統一インポートパス**: `@suzumina.click/shared-types`からの一元化
-
-### 移行後の型構造
-
-型名の一覧はここに転記しない（SPR-205: 転記は必ず drift する。旧記載は実在しない型名を含んでいた）。
-概念 → 型の対応の正本は [domain-model.md](../reference/domain-model.md)、
-実体は [packages/shared-types/src/](../../packages/shared-types/src/) を直接参照すること。
-
-### 削除されたレガシーフィールド
-以下のフィールドはコードベースから完全に削除されました：
-- `salesCount` - 販売数（2025年7月に廃止）
-- `reviewCount` - レビュー数（rating.countに統合）
-- `ratingAverage` - 平均評価（rating.valueに統合）
-- その他の重複フィールド
-
-### マッパーの統合
-- `work-mapper.ts`に全機能を統合（323行の薄いマッパー）
-- レガシーマッパーファイルは全て削除
-- エラー処理とフォールバック処理を含む堅牢な実装
-
 ## 🚀 デプロイメント原則
 
 ### 1. 環境分離


### PR DESCRIPTION
#905 で「履歴記述のため据え置き」とした残課題。節全体が古い実測値と誤った記述で、現存する情報が無い。

## 各項目の検証結果

**「移行の成果」— 移行の向きが逆**

「全569テスト合格: Entity/Value Object構造への完全移行」と書いてあるが、ADR-006 / SPR-181 は
クラス Entity・クラス値オブジェクトを**撤去**した移行。#905 で書き直した「1. データ表現とレイヤ構成」と
正面から矛盾する。テスト数も現状と合わず、doc に数値を固定していること自体が drift 源。

**「削除されたレガシーフィールド」— 3 件中 1 件が現存**

| フィールド | doc の記述 | 実際 |
|---|---|---|
| `salesCount` | 完全に削除 | 不在 ✓ |
| `reviewCount` | 完全に削除・`rating.count` に統合 | **現存**（`work-schemas.ts:96` の `RatingInfo`、`WorkRatingPlain`、`work-firestore.ts:111` が写している）。`count` とは別フィールドで併存しており「統合」も誤り |
| `ratingAverage` | 完全に削除 | 不在 ✓ |

**「マッパーの統合」— 行数が古い**

「323行の薄いマッパー」は実際は 475 行。

**「移行後の型構造」— 重複**

SPR-205 で既にポインタ化済みだが、同じ 2 本のリンク（`domain-model.md` /
`packages/shared-types/src/`）を #905 の新節が持っている。

## 変更

節ごと削除（25 行）。移行の履歴は `docs/operations/changelog.md`（v0.3.7 Entity System Unification）と
ADR-006、および git history が正本で、guide が二重に持つ必要がない。

## 確認

- `pnpm lint:docs` ✓（links 199 / transcription 0。削除でリンク 2 本減、破断なし）
- `pnpm verify` ✓ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
