### PR TITLE
fix(works): 作品詳細の星評価を 0-5 スケールで表示する

### DIFF
--- a/apps/functions/src/tools/firestore-local/fixtures/audioButtons.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/audioButtons.json
@@ -2,6 +2,60 @@
   "collection": "audioButtons",
   "docs": [
     {
+      "id": "0wHX2PKQmUpHBBuCNEAd",
+      "data": {
+        "buttonText": "やっぱ一馬ってイケメンだね、こう見ると",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 2532.2,
+        "endTime": 2535.4,
+        "duration": 3.200000000000273,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:09:04.384Z",
+        "updatedAt": "2026-07-31T11:09:04.384Z"
+      }
+    },
+    {
+      "id": "3HMkQIxPFvaohCheedJs",
+      "data": {
+        "buttonText": "なんだぁ？",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 1024.3,
+        "endTime": 1025.3,
+        "duration": 1,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-23T10:06:29.618Z",
+        "updatedAt": "2026-07-23T10:06:29.618Z"
+      }
+    },
+    {
       "id": "3TTkeWwxByhqtcggDe7i",
       "data": {
         "buttonText": "ベイリース、来い",
@@ -43,18 +97,126 @@
         "isPublic": true,
         "createdAt": "2026-06-26T08:11:57.605Z",
         "id": "3ZQGfMT0ufuoZPFIo3nf",
+        "tags": [
+          "龍が如く極",
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 11
+          "playCount": 12
         },
+        "updatedAt": "2026-07-23T09:59:48.467Z"
+      }
+    },
+    {
+      "id": "4t9XBuL4H4BKw1ISfeol",
+      "data": {
+        "buttonText": "そのチンキックで…すまん、なんか",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 12785.2,
+        "endTime": 12790.2,
+        "duration": 5,
         "tags": [
-          "龍が如く極",
-          "名言・迷言"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-31T11:51:32.208Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-31T22:05:33.200Z"
+      }
+    },
+    {
+      "id": "53aRiTlfhjLKFDiJUOaX",
+      "data": {
+        "buttonText": "めっちゃおっぱい見てる！",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 10369.8,
+        "endTime": 10371.6,
+        "duration": 1.8000000000010914,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-31T11:41:43.054Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-31T22:05:58.218Z"
+      }
+    },
+    {
+      "id": "5MHPV5mKqDGP3aFuRP7T",
+      "data": {
+        "buttonText": "うっひょー",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 9287.3,
+        "endTime": 9288.3,
+        "duration": 1,
+        "tags": [
+          "擬音・音ネタ",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:35:07.349Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 2
+        },
+        "updatedAt": "2026-07-26T16:11:58.693Z"
+      }
+    },
+    {
+      "id": "5upa0yx1AN0D2U1PpckM",
+      "data": {
+        "buttonText": "竜刺繍、竜刺繍のシャツ",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 1377.9,
+        "endTime": 1382.2,
+        "duration": 4.2999999999999545,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T10:56:27.778Z",
+        "updatedAt": "2026-07-31T10:56:27.778Z"
       }
     },
     {
@@ -114,6 +276,33 @@
       }
     },
     {
+      "id": "6kkPUqX44nxcJTvcgczw",
+      "data": {
+        "buttonText": "いやー！痛えー！",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 4810,
+        "endTime": 4815.1,
+        "duration": 5.100000000000364,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:22:58.938Z",
+        "updatedAt": "2026-07-31T11:22:58.938Z"
+      }
+    },
+    {
       "id": "7Jf6iiLUd25eu3NfhL9X",
       "data": {
         "buttonText": "一緒に手繋いで飛び降りよ？",
@@ -127,17 +316,44 @@
         "isPublic": true,
         "createdAt": "2026-06-20T16:15:57.059Z",
         "id": "7Jf6iiLUd25eu3NfhL9X",
+        "tags": [
+          "名言・迷言"
+        ],
         "stats": {
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
           "likeCount": 1,
-          "playCount": 9
+          "playCount": 10
         },
+        "updatedAt": "2026-07-20T14:11:32.839Z"
+      }
+    },
+    {
+      "id": "83c6tSoPW40QpviJvV9N",
+      "data": {
+        "buttonText": "がんばれー〇〇くんがんばれーやばーいみんな倒されてくんだけどーえーやばくなーいウチら逃げるー？",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 3678.9,
+        "endTime": 3689.8,
+        "duration": 10.900000000000091,
         "tags": [
-          "名言・迷言"
+          "ツッコミ・煽り",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-31T11:17:37.843Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-31T11:42:09.894Z"
       }
     },
     {
@@ -167,6 +383,83 @@
           "名言・迷言"
         ],
         "updatedAt": "2026-07-19T01:07:02.335Z"
+      }
+    },
+    {
+      "id": "9A8SUnZtb4ifnNk96j5y",
+      "data": {
+        "buttonText": "第十一章・仁義",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 12921.2,
+        "endTime": 12924.4,
+        "duration": 3.1999999999989086,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:52:44.779Z",
+        "updatedAt": "2026-07-31T11:52:44.779Z"
+      }
+    },
+    {
+      "id": "Aukk80AjYSYYjRxDccTx",
+      "data": {
+        "buttonText": "あのチャンネーいいケツしてるわ、みたいな",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 668.2,
+        "endTime": 672.2,
+        "duration": 4,
+        "tags": [
+          "名言・迷言"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:03:31.374Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-26T10:27:27.478Z"
+      }
+    },
+    {
+      "id": "B9pyzenvLcAaNrXsjQ24",
+      "data": {
+        "buttonText": "にゃんにゃん！にゃん！にゃんにゃんにゃんにゃん！",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 7667.9,
+        "endTime": 7674.9,
+        "duration": 7,
+        "tags": [
+          "擬音・音ネタ",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:33:40.150Z",
+        "updatedAt": "2026-07-31T11:33:40.150Z"
       }
     },
     {
@@ -263,18 +556,18 @@
         "isPublic": true,
         "createdAt": "2025-11-19T10:47:18.068Z",
         "id": "Bx5JTdWBxffX61Nww6w4",
+        "tags": [
+          "ゲーム",
+          "応援・褒め"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "engagementRate": 0,
           "favoriteCount": 0,
-          "playCount": 58
+          "playCount": 59
         },
-        "tags": [
-          "ゲーム",
-          "応援・褒め"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-20T14:11:39.990Z"
       }
     },
     {
@@ -360,6 +653,33 @@
       }
     },
     {
+      "id": "Ckm6GRV1JabdVkHMz3vE",
+      "data": {
+        "buttonText": "コロっといっちゃう？",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 9245.3,
+        "endTime": 9247.1,
+        "duration": 1.8000000000010914,
+        "tags": [
+          "ツッコミ・煽り",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-23T10:33:51.326Z",
+        "updatedAt": "2026-07-23T10:33:51.326Z"
+      }
+    },
+    {
       "id": "D57byuHyRJnvUB3rLuFJ",
       "data": {
         "buttonText": "やべ、気まずい",
@@ -388,6 +708,60 @@
       }
     },
     {
+      "id": "DTPZNVuw7inVDWJ6MuKz",
+      "data": {
+        "buttonText": "いやコイツだろ絶対蜂使いこいつだろ絶対",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 12499.2,
+        "endTime": 12507,
+        "duration": 7.799999999999272,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-31T11:46:51.834Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-31T22:05:43.080Z"
+      }
+    },
+    {
+      "id": "ENY2ONHn8LXVXaxAg61n",
+      "data": {
+        "buttonText": "みーたんにはわかる、この邪悪なオーラが",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 5054.3,
+        "endTime": 5058,
+        "duration": 3.699999999999818,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:24:39.543Z",
+        "updatedAt": "2026-07-31T11:24:39.543Z"
+      }
+    },
+    {
       "id": "EVQnDbgb9redMu2WMp8D",
       "data": {
         "buttonText": "ち○ち○",
@@ -400,18 +774,18 @@
         "creatorName": "Siang*",
         "isPublic": true,
         "createdAt": "2025-08-01T18:07:49.106Z",
+        "tags": [
+          "ウーマンコミュニケーション",
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 1,
           "dislikeCount": 0,
           "favoriteCount": 1,
           "engagementRate": 0.023809523809523808,
-          "playCount": 82
+          "playCount": 85
         },
-        "tags": [
-          "ウーマンコミュニケーション",
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-20T14:11:59.644Z"
       }
     },
     {
@@ -427,19 +801,19 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-07-23T23:50:05.422Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 119
-        },
         "tags": [
           "ゲーム",
           "ファンタジーライフ",
           "名言・迷言"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 120
+        },
+        "updatedAt": "2026-07-19T11:21:09.237Z"
       }
     },
     {
@@ -455,19 +829,19 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-07-24T03:42:19.410Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 156
-        },
         "tags": [
           "ゲーム",
           "ファンタジーライフ",
           "返事・リアクション"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 159
+        },
+        "updatedAt": "2026-07-23T15:01:06.664Z"
       }
     },
     {
@@ -509,17 +883,17 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-06-30T23:30:08.066Z",
+        "tags": [
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 34
+          "playCount": 35
         },
-        "tags": [
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-23T17:42:41.140Z"
       }
     },
     {
@@ -546,6 +920,33 @@
           "名言・迷言"
         ],
         "updatedAt": "2026-07-19T01:07:02.335Z"
+      }
+    },
+    {
+      "id": "G8OQt3JMJEdHWrMBIxQY",
+      "data": {
+        "buttonText": "今日は調子がいいみたい",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 4146.7,
+        "endTime": 4150,
+        "duration": 3.300000000000182,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:22:57.823Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-23T22:36:07.112Z"
       }
     },
     {
@@ -603,6 +1004,59 @@
       }
     },
     {
+      "id": "GuRt4swCjSrtqaczzT9k",
+      "data": {
+        "buttonText": "ブルーユ？　違うこれブルーZか！",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 2223.6,
+        "endTime": 2228.5,
+        "duration": 4.900000000000091,
+        "tags": [
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:07:06.122Z",
+        "updatedAt": "2026-07-31T11:07:06.122Z"
+      }
+    },
+    {
+      "id": "HHySSo1g88DKulOdScAK",
+      "data": {
+        "buttonText": "なんかこんなお父さんみたいな世代でもやっぱそういうのあんだねー",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 9985.8,
+        "endTime": 9989.4,
+        "duration": 3.600000000000364,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:38:13.243Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 2
+        },
+        "updatedAt": "2026-07-26T11:31:54.844Z"
+      }
+    },
+    {
       "id": "HWZW2xzrHNzIlKk0kBD6",
       "data": {
         "buttonText": "どうも、ぴぃですよ",
@@ -615,19 +1069,73 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-07-25T13:11:10.883Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 145
-        },
         "tags": [
           "ゲーム",
           "ファンタジーライフ",
           "あいさつ"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 146
+        },
+        "updatedAt": "2026-07-20T14:12:20.873Z"
+      }
+    },
+    {
+      "id": "HYTphe6vtdEyEf8N6oOb",
+      "data": {
+        "buttonText": "ち○こ…失礼",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 694.9,
+        "endTime": 699.8,
+        "duration": 4.899999999999977,
+        "tags": [
+          "龍が如く極",
+          "返事・リアクション"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T10:45:19.989Z",
+        "updatedAt": "2026-07-31T10:45:19.989Z"
+      }
+    },
+    {
+      "id": "IM8BI2oCjyl9XJxU03NA",
+      "data": {
+        "buttonText": "また俺の足の匂いを！",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 1556.7,
+        "endTime": 1560.5,
+        "duration": 3.7999999999999545,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-23T10:09:48.777Z",
+        "updatedAt": "2026-07-23T10:09:48.777Z"
       }
     },
     {
@@ -798,6 +1306,33 @@
       }
     },
     {
+      "id": "MwD1pbE8vQznamtDh4kZ",
+      "data": {
+        "buttonText": "ホストで流血だぞ！",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 2515.4,
+        "endTime": 2517.4,
+        "duration": 2,
+        "tags": [
+          "ツッコミ・煽り",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:18:00.369Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 4
+        },
+        "updatedAt": "2026-07-23T17:32:26.949Z"
+      }
+    },
+    {
       "id": "NAzoPoPMXT465hWKOtpB",
       "data": {
         "buttonText": "友達じゃないってこと？オレたち",
@@ -810,19 +1345,19 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-07-18T08:03:55.139Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 16
-        },
         "tags": [
           "ゲーム",
           "COFFEE TALK",
           "名言・迷言"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 17
+        },
+        "updatedAt": "2026-07-20T14:12:35.921Z"
       }
     },
     {
@@ -891,18 +1426,18 @@
         "isPublic": true,
         "createdAt": "2026-06-26T07:59:14.864Z",
         "id": "NadVf6t5ruaf4GQCctpP",
+        "tags": [
+          "龍が如く極",
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 10
+          "playCount": 11
         },
-        "tags": [
-          "龍が如く極",
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-20T14:11:01.972Z"
       }
     },
     {
@@ -919,18 +1454,72 @@
         "isPublic": true,
         "createdAt": "2026-06-26T08:05:59.437Z",
         "id": "OhoTxRzPfFiG5pOKgYsy",
+        "tags": [
+          "龍が如く極",
+          "ツッコミ・煽り"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 10
+          "playCount": 13
         },
+        "updatedAt": "2026-07-23T15:00:43.267Z"
+      }
+    },
+    {
+      "id": "Oz3mO8amo0UAOd4d6fD1",
+      "data": {
+        "buttonText": "釘バット",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 1712,
+        "endTime": 1713.6,
+        "duration": 1.599999999999909,
         "tags": [
-          "龍が如く極",
-          "ツッコミ・煽り"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-23T10:11:26.685Z",
+        "updatedAt": "2026-07-23T10:11:26.685Z"
+      }
+    },
+    {
+      "id": "PN8mNOPgl4uW8wWxGDrC",
+      "data": {
+        "buttonText": "腹いせパンチ！",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 1841.8,
+        "endTime": 1843.4,
+        "duration": 1.6000000000001364,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-23T10:12:49.497Z",
+        "updatedAt": "2026-07-23T10:12:49.497Z"
       }
     },
     {
@@ -946,19 +1535,19 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-08-12T12:01:21.406Z",
-        "stats": {
-          "likeCount": 1,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0.1,
-          "playCount": 43
-        },
         "tags": [
           "ゲーム",
           "COFFEE TALK",
           "あまあま"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0.1,
+          "playCount": 44
+        },
+        "updatedAt": "2026-07-20T14:11:21.139Z"
       }
     },
     {
@@ -974,18 +1563,18 @@
         "creatorName": "Siang*",
         "isPublic": true,
         "createdAt": "2025-08-01T18:03:04.002Z",
+        "tags": [
+          "クリスマス",
+          "うた"
+        ],
         "stats": {
           "likeCount": 1,
           "dislikeCount": 0,
           "favoriteCount": 1,
           "engagementRate": 0.047619047619047616,
-          "playCount": 33
+          "playCount": 34
         },
-        "tags": [
-          "クリスマス",
-          "うた"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-20T14:12:05.331Z"
       }
     },
     {
@@ -1027,17 +1616,17 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2026-07-18T14:04:04.727Z",
+        "tags": [
+          "返事・リアクション"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 2
+          "playCount": 6
         },
-        "tags": [
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-20T10:16:38.718Z"
       }
     },
     {
@@ -1080,17 +1669,71 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-06-30T12:46:34.571Z",
+        "tags": [
+          "応援・褒め"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 22
+          "playCount": 23
         },
+        "updatedAt": "2026-07-23T17:42:54.772Z"
+      }
+    },
+    {
+      "id": "SLB6iN4NKDgqvw4jvjCh",
+      "data": {
+        "buttonText": "トー横じゃん",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 3707.4,
+        "endTime": 3708.7,
+        "duration": 1.2999999999997272,
         "tags": [
-          "応援・褒め"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:19:19.205Z",
+        "updatedAt": "2026-07-31T11:19:19.205Z"
+      }
+    },
+    {
+      "id": "SaYztZGMNVwCj6gbcq2c",
+      "data": {
+        "buttonText": "伝家の宝刀の傘",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 4346.6,
+        "endTime": 4349.5,
+        "duration": 2.899999999999636,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:21:47.087Z",
+        "updatedAt": "2026-07-31T11:21:47.087Z"
       }
     },
     {
@@ -1106,17 +1749,41 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2026-07-18T01:21:36.180Z",
+        "tags": [
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 2
+          "playCount": 6
         },
-        "tags": [
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-20T14:10:34.593Z"
+      }
+    },
+    {
+      "id": "TDxQNiOafYEx3Ls8RTlv",
+      "data": {
+        "buttonText": "俺にとってはBB弾だあれは",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 12679.6,
+        "endTime": 12685,
+        "duration": 5.399999999999636,
+        "tags": [],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:48:44.492Z",
+        "updatedAt": "2026-07-31T11:48:44.492Z"
       }
     },
     {
@@ -1145,6 +1812,114 @@
           "名言・迷言"
         ],
         "updatedAt": "2026-07-19T01:07:02.335Z"
+      }
+    },
+    {
+      "id": "UV8viAFiO3eDHYmBh5YW",
+      "data": {
+        "buttonText": "ちょっとちょっとちょっと！？",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 1160.7,
+        "endTime": 1162.4,
+        "duration": 1.7000000000000455,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-23T10:08:32.816Z",
+        "updatedAt": "2026-07-23T10:08:32.816Z"
+      }
+    },
+    {
+      "id": "VD0Ku5m4yaA5BNUHNASH",
+      "data": {
+        "buttonText": "普通じゃねえかよ！",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 1477.5,
+        "endTime": 1480.7,
+        "duration": 3.2000000000000455,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T10:59:58.017Z",
+        "updatedAt": "2026-07-31T10:59:58.017Z"
+      }
+    },
+    {
+      "id": "VQrLMDmxbDvIr2ZSW94i",
+      "data": {
+        "buttonText": "ごわみー",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 12435.3,
+        "endTime": 12438.4,
+        "duration": 3.100000000000364,
+        "tags": [
+          "擬音・音ネタ",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:40:22.388Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 5
+        },
+        "updatedAt": "2026-07-26T11:31:49.944Z"
+      }
+    },
+    {
+      "id": "VRWo3r4LunS2MyjS7cJk",
+      "data": {
+        "buttonText": "お\"お\"っ…ハハハ",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 1385.3,
+        "endTime": 1389.7,
+        "duration": 4.400000000000091,
+        "tags": [
+          "笑い",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T10:58:27.605Z",
+        "updatedAt": "2026-07-31T10:58:27.605Z"
       }
     },
     {
@@ -1187,17 +1962,17 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-06-30T12:54:41.215Z",
+        "tags": [
+          "返事・リアクション"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 38
+          "playCount": 39
         },
-        "tags": [
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-23T17:42:49.359Z"
       }
     },
     {
@@ -1224,6 +1999,33 @@
           "名言・迷言"
         ],
         "updatedAt": "2026-07-19T01:07:02.335Z"
+      }
+    },
+    {
+      "id": "ZUFIZIg4eXjnMVkw5Ck7",
+      "data": {
+        "buttonText": "あの女のお姉さんのパンツこんな匂いなんだ",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 5194.2,
+        "endTime": 5205.9,
+        "duration": 11.699999999999818,
+        "tags": [
+          "ツッコミ・煽り",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-31T11:26:45.501Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-31T22:06:02.179Z"
       }
     },
     {
@@ -1282,6 +2084,33 @@
       }
     },
     {
+      "id": "c2OQKqgNMceVsLJQcGdy",
+      "data": {
+        "buttonText": "ホワイトホワイトちいかわゾンビ",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 1129.4,
+        "endTime": 1133.8,
+        "duration": 4.399999999999864,
+        "tags": [
+          "ツッコミ・煽り",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T10:50:22.014Z",
+        "updatedAt": "2026-07-31T10:50:22.014Z"
+      }
+    },
+    {
       "id": "cdr2QzdF5gmkuqAXyyoL",
       "data": {
         "buttonText": "うふふ(笑)",
@@ -1305,6 +2134,33 @@
           "笑い"
         ],
         "updatedAt": "2026-07-19T01:07:02.335Z"
+      }
+    },
+    {
+      "id": "d2Zmk9xFGkE5FeTXGbgK",
+      "data": {
+        "buttonText": "俺だよ！俺だ！みこしーじゃねえ！",
+        "videoId": "2ztGtmc_6bI",
+        "videoTitle": "小人窃盗団参上～！！人間の家から盗みまくるゲーム😎【どろぼうノーム／浅木式・雲八はち・御子柴泉】",
+        "startTime": 3644.2,
+        "endTime": 3650.5,
+        "duration": 6.300000000000182,
+        "tags": [
+          "返事・リアクション",
+          "どろぼうノーム"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-26T11:27:04.808Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 11
+        },
+        "updatedAt": "2026-07-30T11:29:59.857Z"
       }
     },
     {
@@ -1346,6 +2202,36 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2026-07-18T01:28:07.658Z",
+        "tags": [
+          "名言・迷言"
+        ],
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 10
+        },
+        "updatedAt": "2026-07-23T10:11:33.826Z"
+      }
+    },
+    {
+      "id": "eZxdUfYv2moqYvxL4kAW",
+      "data": {
+        "buttonText": "ウインウインウインウインウインウインウインウインってやつ？",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 5991.6,
+        "endTime": 5996.1,
+        "duration": 4.5,
+        "tags": [
+          "擬音・音ネタ",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:26:09.754Z",
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
@@ -1353,10 +2239,7 @@
           "engagementRate": 0,
           "playCount": 5
         },
-        "tags": [
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "updatedAt": "2026-07-26T11:32:09.741Z"
       }
     },
     {
@@ -1400,17 +2283,44 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2026-07-18T01:25:34.194Z",
+        "tags": [
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 1
+          "playCount": 7
         },
+        "updatedAt": "2026-07-23T10:11:48.541Z"
+      }
+    },
+    {
+      "id": "fJg1IXphqQJN4glwlmaG",
+      "data": {
+        "buttonText": "また攻略サイト疑惑でちゃうやん、ねえ、これ",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 3411.5,
+        "endTime": 3418.4,
+        "duration": 6.900000000000091,
         "tags": [
-          "名言・迷言"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-31T11:13:31.555Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 2
+        },
+        "updatedAt": "2026-07-31T11:58:30.559Z"
       }
     },
     {
@@ -1426,18 +2336,45 @@
         "creatorName": "gagacrow",
         "isPublic": true,
         "createdAt": "2025-07-27T04:41:27.924Z",
+        "tags": [
+          "ファンタジーライフ",
+          "笑い"
+        ],
         "stats": {
           "likeCount": 1,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0.006896551724137931,
-          "playCount": 151
+          "playCount": 154
         },
+        "updatedAt": "2026-07-26T11:33:06.078Z"
+      }
+    },
+    {
+      "id": "gEgGtEQqRZMg88GFenWC",
+      "data": {
+        "buttonText": "痛ぁい！？",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 7940.4,
+        "endTime": 7941.8,
+        "duration": 1.4000000000005457,
         "tags": [
-          "ファンタジーライフ",
-          "笑い"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:29:29.196Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 2
+        },
+        "updatedAt": "2026-07-30T11:30:09.106Z"
       }
     },
     {
@@ -1453,19 +2390,19 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-07-26T14:48:20.586Z",
-        "stats": {
-          "likeCount": 1,
-          "dislikeCount": 0,
-          "favoriteCount": 1,
-          "engagementRate": 0.005319148936170213,
-          "playCount": 197
-        },
         "tags": [
           "ゲーム",
           "ファンタジーライフ",
           "名言・迷言"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 1,
+          "dislikeCount": 0,
+          "favoriteCount": 1,
+          "engagementRate": 0.005319148936170213,
+          "playCount": 201
+        },
+        "updatedAt": "2026-07-26T11:31:14.182Z"
       }
     },
     {
@@ -1497,6 +2434,60 @@
       }
     },
     {
+      "id": "hW0H2AxRclYoTaT4quMV",
+      "data": {
+        "buttonText": "オッサンって言うな！オッサンじゃないよ！",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 2217.5,
+        "endTime": 2222.6,
+        "duration": 5.099999999999909,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T11:04:43.309Z",
+        "updatedAt": "2026-07-31T11:04:43.309Z"
+      }
+    },
+    {
+      "id": "imC8RYl0kmmBbO7zGRgq",
+      "data": {
+        "buttonText": "オトメタール",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 4117.3,
+        "endTime": 4119.1,
+        "duration": 1.800000000000182,
+        "tags": [
+          "擬音・音ネタ",
+          "龍が如く極"
+        ],
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:21:21.651Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 2
+        },
+        "updatedAt": "2026-07-26T10:27:19.231Z"
+      }
+    },
+    {
       "id": "jKasN6FfALO922utZz19",
       "data": {
         "buttonText": "がんばるよーフィーバーフィーバー",
@@ -1509,19 +2500,19 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-07-26T13:47:33.476Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 144
-        },
         "tags": [
           "ゲーム",
           "ファンタジーライフ",
           "名言・迷言"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 148
+        },
+        "updatedAt": "2026-07-23T15:01:22.601Z"
       }
     },
     {
@@ -1538,18 +2529,45 @@
         "isPublic": true,
         "createdAt": "2026-06-26T07:43:27.650Z",
         "id": "kCeaYC2sVulAD9hqg2Xi",
+        "tags": [
+          "龍が如く極",
+          "名言・迷言"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 4
+          "playCount": 8
         },
+        "updatedAt": "2026-07-26T11:32:47.266Z"
+      }
+    },
+    {
+      "id": "kV8w7DT5mvLW7dzsNTmx",
+      "data": {
+        "buttonText": "策謀",
+        "videoId": "hHa69OJyXl0",
+        "videoTitle": "100億どうなったん…？第7章途中から！！【龍が如く極 #5／この配信はゲームのネタバレを含みます】",
+        "startTime": 8512.6,
+        "endTime": 8516.8,
+        "duration": 4.199999999998909,
         "tags": [
-          "龍が如く極",
-          "名言・迷言"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "createdAt": "2026-07-23T10:31:01.844Z",
+        "stats": {
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0,
+          "playCount": 1
+        },
+        "updatedAt": "2026-07-23T13:55:14.219Z"
       }
     },
     {
@@ -1592,17 +2610,44 @@
         "creatorName": "がこんがこん",
         "isPublic": true,
         "createdAt": "2025-06-30T12:48:38.369Z",
+        "tags": [
+          "あまあま"
+        ],
         "stats": {
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
           "engagementRate": 0,
-          "playCount": 29
+          "playCount": 30
         },
+        "updatedAt": "2026-07-23T17:42:11.144Z"
+      }
+    },
+    {
+      "id": "ktYJRiiRL03P7BvwcvU1",
+      "data": {
+        "buttonText": "そうそうセカストよ、セカストなんかウチよく行ったぞ、昔、高校生の時とか",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 1271.6,
+        "endTime": 1283.3,
+        "duration": 11.700000000000045,
         "tags": [
-          "あまあま"
+          "返事・リアクション",
+          "龍が如く極"
         ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "creatorId": "REDACTED",
+        "creatorName": "がこんがこん",
+        "isPublic": true,
+        "stats": {
+          "playCount": 0,
+          "likeCount": 0,
+          "dislikeCount": 0,
+          "favoriteCount": 0,
+          "engagementRate": 0
+        },
+        "createdAt": "2026-07-31T10:53:50.949Z",
+        "updatedAt": "2026-07-31T10:53:50.949Z"
       }
     },
     {
@@ -1632,552 +2677,30 @@
       }
     },
     {
-      "id": "lplSH14aSgptgueC687X",
+      "id": "l9AO51ZlxZtJjZ8nmNEg",
       "data": {
-        "buttonText": "Open",
-        "videoId": "aoWkEzZD8zA",
-        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
-        "startTime": 13575.1,
-        "endTime": 13576.7,
-        "duration": 1.6000000000003638,
+        "buttonText": "え？あたしってもしかして、ほんとに顔しかみてない女ってこと？",
+        "videoId": "jBSYmvU8gCg",
+        "videoTitle": "錦、、、俺お前と仲直りしたいよ、、、；；第八章途中から…！！【龍が如く極 #6／この配信はゲームのネタバレを含みます】",
+        "startTime": 5427.6,
+        "endTime": 5432.9,
+        "duration": 5.299999999999272,
+        "tags": [
+          "返事・リアクション",
+          "龍が如く極"
+        ],
         "creatorId": "REDACTED",
         "creatorName": "がこんがこん",
         "isPublic": true,
-        "createdAt": "2026-06-27T01:31:03.983Z",
-        "id": "lplSH14aSgptgueC687X",
         "stats": {
+          "playCount": 0,
           "likeCount": 0,
           "dislikeCount": 0,
           "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 16
+          "engagementRate": 0
         },
-        "tags": [
-          "龍が如く極",
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "m7cApOwwbj6tkJT9B6lp",
-      "data": {
-        "buttonText": "泣いてるよ",
-        "videoId": "ds8nkv4LW_8",
-        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
-        "startTime": 2309,
-        "endTime": 2311.3,
-        "duration": 2.300000000000182,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-18T05:14:57.365Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 16
-        },
-        "tags": [
-          "ゲーム",
-          "COFFEE TALK",
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "mJtBdtQweZSeixjPgA76",
-      "data": {
-        "buttonText": "あんたいいやつじゃん…すりすり",
-        "videoId": "S534eutWhUY",
-        "videoTitle": "今日はどんなお客さんが来るかな…☕？【COFFEE TALK #6／物語のネタバレを含みます】",
-        "startTime": 5924.4,
-        "endTime": 5927.6,
-        "duration": 3.2000000000007276,
-        "creatorId": "REDACTED",
-        "creatorName": "ivan",
-        "isPublic": true,
-        "createdAt": "2025-08-21T01:02:51.250Z",
-        "id": "mJtBdtQweZSeixjPgA76",
-        "stats": {
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "likeCount": 2,
-          "playCount": 71
-        },
-        "tags": [
-          "ゲーム",
-          "COFFEE TALK",
-          "あまあま"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "qJxXRSS7Cek5HMQhR6bZ",
-      "data": {
-        "buttonText": "改めまして涼花みなせです",
-        "videoId": "GJZQPvOYXyY",
-        "videoTitle": "【みやぢ×みなせ】怖がり2人で初見協力プレイ。【BIOHAZARD 5】",
-        "startTime": 1131,
-        "endTime": 1134,
-        "duration": 3,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-12T03:41:37.916Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": -1,
-          "engagementRate": 0,
-          "playCount": 50
-        },
-        "tags": [
-          "ゲーム",
-          "バイオハザード5",
-          "あいさつ"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "rPAGgplNWYbhKC9gHAyG",
-      "data": {
-        "buttonText": "このキャバクラで誕生日迎えることになる！",
-        "videoId": "aoWkEzZD8zA",
-        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
-        "startTime": 2797.4,
-        "endTime": 2802.8,
-        "duration": 5.400000000000091,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2026-06-21T11:15:15.702Z",
-        "id": "rPAGgplNWYbhKC9gHAyG",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 7
-        },
-        "tags": [
-          "龍が如く極",
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "s016OX6i1gtylTFr0qe9",
-      "data": {
-        "buttonText": "あらあら〜　歯医者のこと聞きたいんだ〜　そうかそうか〜",
-        "videoId": "FeZ3F5dr6H8",
-        "videoTitle": "ざつだん🌟",
-        "startTime": 971,
-        "endTime": 980,
-        "duration": 9,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-06-30T12:34:41.082Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 1,
-          "engagementRate": 0,
-          "playCount": 30
-        },
-        "tags": [
-          "あまあま"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "sFCVeD8ywqYsJPitFADk",
-      "data": {
-        "buttonText": "こんばんはー",
-        "videoId": "ds8nkv4LW_8",
-        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
-        "startTime": 20.1,
-        "endTime": 22.7,
-        "duration": 2.599999999999998,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-18T07:20:02.049Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 16
-        },
-        "tags": [
-          "ゲーム",
-          "あいさつ",
-          "COFFEE TALK"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "sMqrHeNEuOOUHflC0AzB",
-      "data": {
-        "buttonText": "カンニングするなってこと！？",
-        "videoId": "S534eutWhUY",
-        "videoTitle": "今日はどんなお客さんが来るかな…☕？【COFFEE TALK #6／物語のネタバレを含みます】",
-        "startTime": 4078.8,
-        "endTime": 4081.2,
-        "duration": 2.399999999999636,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-08-19T23:31:02.139Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 25
-        },
-        "tags": [
-          "ゲーム",
-          "COFFEE TALK",
-          "ツッコミ・煽り"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "sNgTr6YLSFOsMXx19NL0",
-      "data": {
-        "buttonText": "やべえ！",
-        "videoId": "4puiyit3sp0",
-        "videoTitle": "世界を滅亡から救うか寄り道するのか...自由だぁ～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#8】",
-        "startTime": 3195,
-        "endTime": 3197,
-        "duration": 2,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-08T12:48:57.115Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 17
-        },
-        "tags": [
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "t7iLQ2POVXdg8yGuHxCJ",
-      "data": {
-        "buttonText": "そんでさあ…え、あ、な、なに？",
-        "videoId": "B20PhTUzSrQ",
-        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
-        "startTime": 284.4,
-        "endTime": 288.3,
-        "duration": 3.900000000000034,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-24T03:51:45.649Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 135
-        },
-        "tags": [
-          "ゲーム",
-          "ファンタジーライフ",
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "tD2Vh18xqywurfUzuKmz",
-      "data": {
-        "buttonText": "腹減ったー",
-        "videoId": "iCZxh1oyLKg",
-        "videoTitle": "お喋りと歌のリハビリ😎🌸",
-        "startTime": 4782,
-        "endTime": 4784,
-        "duration": 2,
-        "creatorId": "REDACTED",
-        "creatorName": "ivan",
-        "isPublic": true,
-        "createdAt": "2025-07-07T02:47:20.828Z",
-        "stats": {
-          "likeCount": 1,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0.05555555555555555,
-          "playCount": 20
-        },
-        "tags": [
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "uKVVbvmKgJnvAG8QHrLY",
-      "data": {
-        "buttonText": "あたまいてぇ",
-        "videoId": "rUKrc8czZj0",
-        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
-        "startTime": 2235,
-        "endTime": 2238,
-        "duration": 3,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-06-29T13:35:37.825Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 18
-        },
-        "tags": [
-          "返事・リアクション"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "v9ZvWQ6DHmaga31OBaJr",
-      "data": {
-        "buttonText": "闇のあるストーリー、読ませて欲しい、あたしに",
-        "videoId": "ds8nkv4LW_8",
-        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
-        "startTime": 5010.4,
-        "endTime": 5013.9,
-        "duration": 3.5,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-18T10:55:58.279Z",
-        "stats": {
-          "likeCount": 1,
-          "dislikeCount": 0,
-          "favoriteCount": 1,
-          "engagementRate": 0.02127659574468085,
-          "playCount": 54
-        },
-        "tags": [
-          "ゲーム",
-          "COFFEE TALK",
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "vA49RzYP9CUqrg5la4bx",
-      "data": {
-        "buttonText": "なぁ～～～～～～～～～～",
-        "videoId": "B20PhTUzSrQ",
-        "videoTitle": "ストーリーすすめる！！世界救うぞ～～！！！【ファンタジーライフｉ グルグルの竜と時をぬすむ少女#10】",
-        "startTime": 7747.5,
-        "endTime": 7751.6,
-        "duration": 4.100000000000364,
-        "creatorId": "REDACTED",
-        "creatorName": "Siang*",
-        "isPublic": true,
-        "createdAt": "2025-07-24T17:45:59.144Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 1,
-          "engagementRate": 0,
-          "playCount": 142
-        },
-        "tags": [
-          "ファンタジーライフ",
-          "擬音・音ネタ"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "xLOcSm24HACc1u1CQ4Tf",
-      "data": {
-        "buttonText": "ちゅ、ちゅぱ？",
-        "videoId": "aoWkEzZD8zA",
-        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
-        "startTime": 2048,
-        "endTime": 2050.1,
-        "duration": 2.099999999999909,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2026-06-21T10:54:45.322Z",
-        "id": "xLOcSm24HACc1u1CQ4Tf",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 8
-        },
-        "tags": [
-          "龍が如く極",
-          "擬音・音ネタ"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "xP98sGmfFvZXqeBZKAUr",
-      "data": {
-        "buttonText": "斜にかまえてさぁ",
-        "videoId": "rUKrc8czZj0",
-        "videoTitle": "お誕生日だあ！！今年もみんなでケーキ食べよ🍰♡",
-        "startTime": 1136,
-        "endTime": 1138,
-        "duration": 2,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-06-29T01:40:17.967Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 22
-        },
-        "tags": [
-          "名言・迷言"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "xwx7ItC3hCXIpbdEJTsU",
-      "data": {
-        "buttonText": "開店前待機ありがとう",
-        "videoId": "S534eutWhUY",
-        "videoTitle": "今日はどんなお客さんが来るかな…☕？【COFFEE TALK #6／物語のネタバレを含みます】",
-        "startTime": 32,
-        "endTime": 38.7,
-        "duration": 6.700000000000003,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-08-20T03:57:52.305Z",
-        "id": "xwx7ItC3hCXIpbdEJTsU",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 23
-        },
-        "tags": [
-          "ゲーム",
-          "COFFEE TALK",
-          "あいさつ"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "xxOUWJnipXcQ7k1TJbO9",
-      "data": {
-        "buttonText": "いらっしゃい",
-        "videoId": "ds8nkv4LW_8",
-        "videoTitle": "ちるいコーヒーショップの店長さんになる。【COFFEE TALK／物語のネタバレを含みます】",
-        "startTime": 4289.6,
-        "endTime": 4291.7,
-        "duration": 2.0999999999994543,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2025-07-16T13:14:15.795Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 15
-        },
-        "tags": [
-          "ゲーム",
-          "COFFEE TALK",
-          "あいさつ"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "you1gqnpbSNsjqfcHaFv",
-      "data": {
-        "buttonText": "あーたたちー",
-        "videoId": "owvN0dZ1w6s",
-        "videoTitle": "お話しよ♡あーたたちとしゃべりたい！！",
-        "startTime": 36,
-        "endTime": 41,
-        "duration": 5,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2026-07-17T23:28:02.977Z",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 4
-        },
-        "tags": [
-          "あいさつ"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
-      }
-    },
-    {
-      "id": "zps859BKdOqSq22ONtGo",
-      "data": {
-        "buttonText": "ナマをカタカナをやめなさい！",
-        "videoId": "aoWkEzZD8zA",
-        "videoTitle": "錦、、、俺のこと錦山組に、入れてくれるんだよね😎？【龍が如く極 #2／この配信はゲームのネタバレを含みます】",
-        "startTime": 2426,
-        "endTime": 2429.4,
-        "duration": 3.400000000000091,
-        "creatorId": "REDACTED",
-        "creatorName": "がこんがこん",
-        "isPublic": true,
-        "createdAt": "2026-06-21T11:03:18.090Z",
-        "id": "zps859BKdOqSq22ONtGo",
-        "stats": {
-          "likeCount": 0,
-          "dislikeCount": 0,
-          "favoriteCount": 0,
-          "engagementRate": 0,
-          "playCount": 9
-        },
-        "tags": [
-          "龍が如く極",
-          "ツッコミ・煽り"
-        ],
-        "updatedAt": "2026-07-19T01:07:02.335Z"
+        "createdAt": "2026-07-31T11:29:18.997Z",
+        "updatedAt": "2026-07-31T11:29:18.997Z"
       }
     }
   ]

--- a/apps/functions/src/tools/firestore-local/fixtures/circles.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/circles.json
@@ -144,12 +144,13 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1781975014,
-          "nanoseconds": 190000000
+          "seconds": 1784991827,
+          "nanoseconds": 2000000
         },
         "workIds": [
           "RJ01609516",
-          "RJ01634555"
+          "RJ01634555",
+          "RJ01668211"
         ]
       }
     },
@@ -271,6 +272,27 @@
       }
     },
     {
+      "id": "RG01009531",
+      "data": {
+        "circleId": "RG01009531",
+        "name": "一番乳搾り",
+        "nameEn": "ichibanchichishibori",
+        "workIds": [
+          "RJ01662170"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1784991826,
+          "nanoseconds": 918000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1784991826,
+          "nanoseconds": 918000000
+        }
+      }
+    },
+    {
       "id": "RG01010711",
       "data": {
         "circleId": "RG01010711",
@@ -283,8 +305,8 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1778864637,
-          "nanoseconds": 782000000
+          "seconds": 1785510226,
+          "nanoseconds": 427000000
         },
         "workIds": [
           "RJ01208576",
@@ -301,7 +323,10 @@
           "RJ01561427",
           "RJ01567789",
           "RJ01598466",
-          "RJ01618548"
+          "RJ01618548",
+          "RJ01682424",
+          "RJ01682417",
+          "RJ01672799"
         ]
       }
     },
@@ -493,12 +518,13 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1781888634,
-          "nanoseconds": 625000000
+          "seconds": 1784905429,
+          "nanoseconds": 945000000
         },
         "workIds": [
           "RJ01496560",
-          "RJ01647085"
+          "RJ01647085",
+          "RJ01673205"
         ]
       }
     },
@@ -578,9 +604,6 @@
         "circleId": "RG01020596",
         "name": "Curiocity",
         "nameEn": "Curiocity",
-        "workIds": [
-          "RJ01558759"
-        ],
         "createdAt": {
           "__type__": "timestamp",
           "seconds": 1772219358,
@@ -588,9 +611,13 @@
         },
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1772219358,
-          "nanoseconds": 579000000
-        }
+          "seconds": 1784819029,
+          "nanoseconds": 161000000
+        },
+        "workIds": [
+          "RJ01558759",
+          "RJ01653631"
+        ]
       }
     },
     {
@@ -975,6 +1002,27 @@
       }
     },
     {
+      "id": "RG01064570",
+      "data": {
+        "circleId": "RG01064570",
+        "name": "くりぃむ船長",
+        "nameEn": "",
+        "workIds": [
+          "RJ01663609"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1785510226,
+          "nanoseconds": 425000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785510226,
+          "nanoseconds": 425000000
+        }
+      }
+    },
+    {
       "id": "RG01064888",
       "data": {
         "circleId": "RG01064888",
@@ -1013,6 +1061,27 @@
           "__type__": "timestamp",
           "seconds": 1779390213,
           "nanoseconds": 802000000
+        }
+      }
+    },
+    {
+      "id": "RG01076099",
+      "data": {
+        "circleId": "RG01076099",
+        "name": "桃色アルカディア",
+        "nameEn": "Rosy Arcadia",
+        "workIds": [
+          "RJ01443068"
+        ],
+        "createdAt": {
+          "__type__": "timestamp",
+          "seconds": 1784912739,
+          "nanoseconds": 292000000
+        },
+        "updatedAt": {
+          "__type__": "timestamp",
+          "seconds": 1784912739,
+          "nanoseconds": 292000000
         }
       }
     },
@@ -2197,77 +2266,6 @@
           "__type__": "timestamp",
           "seconds": 1753876124,
           "nanoseconds": 97000000
-        }
-      }
-    },
-    {
-      "id": "RG31459",
-      "data": {
-        "circleId": "RG31459",
-        "name": "メロイック",
-        "nameEn": "maloik",
-        "createdAt": {
-          "__type__": "timestamp",
-          "seconds": 1753876103,
-          "nanoseconds": 412000000
-        },
-        "workIds": [
-          "RJ267411",
-          "RJ300506"
-        ],
-        "updatedAt": {
-          "__type__": "timestamp",
-          "seconds": 1753876114,
-          "nanoseconds": 372000000
-        }
-      }
-    },
-    {
-      "id": "RG32060",
-      "data": {
-        "circleId": "RG32060",
-        "name": "足跡の水たまり",
-        "nameEn": "Footprint Puddle",
-        "workIds": [
-          "RJ344634"
-        ],
-        "createdAt": {
-          "__type__": "timestamp",
-          "seconds": 1753876127,
-          "nanoseconds": 99000000
-        },
-        "updatedAt": {
-          "__type__": "timestamp",
-          "seconds": 1753876127,
-          "nanoseconds": 99000000
-        }
-      }
-    },
-    {
-      "id": "RG32840",
-      "data": {
-        "circleId": "RG32840",
-        "name": "ダチュラスクリプト",
-        "nameEn": "DaturaScript",
-        "createdAt": {
-          "__type__": "timestamp",
-          "seconds": 1753876108,
-          "nanoseconds": 4000000
-        },
-        "workIds": [
-          "RJ282228",
-          "RJ299286",
-          "RJ316490",
-          "RJ362811",
-          "RJ395367",
-          "RJ01012291",
-          "RJ01151712",
-          "RJ01218581"
-        ],
-        "updatedAt": {
-          "__type__": "timestamp",
-          "seconds": 1753876191,
-          "nanoseconds": 63000000
         }
       }
     }

--- a/apps/functions/src/tools/firestore-local/fixtures/creators.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/creators.json
@@ -18,8 +18,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 885000000
+          "seconds": 1784999050,
+          "nanoseconds": 669000000
         }
       }
     },
@@ -40,8 +40,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300766,
-          "nanoseconds": 777000000
+          "seconds": 1784941507,
+          "nanoseconds": 213000000
         }
       }
     },
@@ -62,8 +62,8 @@
         "workCount": 11,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307969,
-          "nanoseconds": 569000000
+          "seconds": 1784948657,
+          "nanoseconds": 453000000
         }
       }
     },
@@ -84,8 +84,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300793,
-          "nanoseconds": 635000000
+          "seconds": 1784941520,
+          "nanoseconds": 894000000
         }
       }
     },
@@ -106,8 +106,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300868,
-          "nanoseconds": 375000000
+          "seconds": 1784999029,
+          "nanoseconds": 362000000
         }
       }
     },
@@ -128,8 +128,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 896000000
+          "seconds": 1784999054,
+          "nanoseconds": 881000000
         }
       }
     },
@@ -150,8 +150,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1781197526,
-          "nanoseconds": 391000000
+          "seconds": 1784941499,
+          "nanoseconds": 83000000
         }
       }
     },
@@ -172,8 +172,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300734,
-          "nanoseconds": 374000000
+          "seconds": 1784941476,
+          "nanoseconds": 302000000
         }
       }
     },
@@ -194,8 +194,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1783263892,
-          "nanoseconds": 68000000
+          "seconds": 1784999002,
+          "nanoseconds": 360000000
         }
       }
     },
@@ -216,8 +216,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300713,
-          "nanoseconds": 376000000
+          "seconds": 1784941463,
+          "nanoseconds": 891000000
         }
       }
     },
@@ -238,8 +238,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307936,
-          "nanoseconds": 763000000
+          "seconds": 1784948625,
+          "nanoseconds": 688000000
         }
       }
     },
@@ -260,8 +260,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971204,
-          "nanoseconds": 890000000
+          "seconds": 1784999054,
+          "nanoseconds": 868000000
         }
       }
     },
@@ -282,8 +282,8 @@
         "workCount": 27,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784387145,
-          "nanoseconds": 434000000
+          "seconds": 1784999040,
+          "nanoseconds": 861000000
         }
       }
     },
@@ -301,11 +301,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 27,
+        "workCount": 32,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307935,
-          "nanoseconds": 775000000
+          "seconds": 1785524830,
+          "nanoseconds": 726000000
         }
       }
     },
@@ -326,8 +326,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307935,
-          "nanoseconds": 746000000
+          "seconds": 1784948625,
+          "nanoseconds": 166000000
         }
       }
     },
@@ -348,8 +348,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300763,
-          "nanoseconds": 573000000
+          "seconds": 1784941497,
+          "nanoseconds": 806000000
         }
       }
     },
@@ -370,8 +370,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784214313,
-          "nanoseconds": 929000000
+          "seconds": 1784999029,
+          "nanoseconds": 562000000
         }
       }
     },
@@ -389,11 +389,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 16,
+        "workCount": 18,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307983,
-          "nanoseconds": 55000000
+          "seconds": 1785481416,
+          "nanoseconds": 361000000
         }
       }
     },
@@ -414,8 +414,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300764,
-          "nanoseconds": 478000000
+          "seconds": 1784941498,
+          "nanoseconds": 108000000
         }
       }
     },
@@ -436,8 +436,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300738,
-          "nanoseconds": 94000000
+          "seconds": 1784941486,
+          "nanoseconds": 711000000
         }
       }
     },
@@ -459,8 +459,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300859,
-          "nanoseconds": 303000000
+          "seconds": 1784941600,
+          "nanoseconds": 717000000
         }
       }
     },
@@ -481,8 +481,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1783191791,
-          "nanoseconds": 264000000
+          "seconds": 1784999066,
+          "nanoseconds": 564000000
         }
       }
     },
@@ -503,8 +503,8 @@
         "workCount": 7,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300782,
-          "nanoseconds": 77000000
+          "seconds": 1785474674,
+          "nanoseconds": 872000000
         }
       }
     },
@@ -525,8 +525,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784301677,
-          "nanoseconds": 469000000
+          "seconds": 1784941600,
+          "nanoseconds": 414000000
         }
       }
     },
@@ -547,8 +547,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300877,
-          "nanoseconds": 285000000
+          "seconds": 1784941588,
+          "nanoseconds": 91000000
         }
       }
     },
@@ -569,8 +569,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300737,
-          "nanoseconds": 882000000
+          "seconds": 1784941486,
+          "nanoseconds": 489000000
         }
       }
     },
@@ -591,8 +591,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300683,
-          "nanoseconds": 75000000
+          "seconds": 1784941441,
+          "nanoseconds": 105000000
         }
       }
     },
@@ -613,8 +613,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1781809558,
-          "nanoseconds": 529000000
+          "seconds": 1784999039,
+          "nanoseconds": 975000000
         }
       }
     },
@@ -635,8 +635,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 19000000
+          "seconds": 1784999054,
+          "nanoseconds": 820000000
         }
       }
     },
@@ -657,8 +657,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300735,
-          "nanoseconds": 999000000
+          "seconds": 1784941484,
+          "nanoseconds": 92000000
         }
       }
     },
@@ -679,8 +679,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300749,
-          "nanoseconds": 392000000
+          "seconds": 1784941496,
+          "nanoseconds": 507000000
         }
       }
     },
@@ -701,8 +701,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784214333,
-          "nanoseconds": 372000000
+          "seconds": 1785474301,
+          "nanoseconds": 551000000
         }
       }
     },
@@ -723,8 +723,8 @@
         "workCount": 11,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300672,
-          "nanoseconds": 573000000
+          "seconds": 1784999028,
+          "nanoseconds": 595000000
         }
       }
     },
@@ -745,8 +745,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300715,
-          "nanoseconds": 274000000
+          "seconds": 1784941466,
+          "nanoseconds": 198000000
         }
       }
     },
@@ -767,8 +767,8 @@
         "workCount": 6,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307993,
-          "nanoseconds": 269000000
+          "seconds": 1784948691,
+          "nanoseconds": 956000000
         }
       }
     },
@@ -789,8 +789,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300661,
-          "nanoseconds": 992000000
+          "seconds": 1784941427,
+          "nanoseconds": 285000000
         }
       }
     },
@@ -811,8 +811,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300725,
-          "nanoseconds": 991000000
+          "seconds": 1784941473,
+          "nanoseconds": 887000000
         }
       }
     },
@@ -833,8 +833,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1783263866,
-          "nanoseconds": 448000000
+          "seconds": 1784998991,
+          "nanoseconds": 99000000
         }
       }
     },
@@ -855,8 +855,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300704,
-          "nanoseconds": 876000000
+          "seconds": 1784941462,
+          "nanoseconds": 223000000
         }
       }
     },
@@ -877,8 +877,8 @@
         "workCount": 11,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784301151,
-          "nanoseconds": 169000000
+          "seconds": 1785596874,
+          "nanoseconds": 743000000
         }
       }
     },
@@ -899,8 +899,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784214253,
-          "nanoseconds": 755000000
+          "seconds": 1785474241,
+          "nanoseconds": 373000000
         }
       }
     },
@@ -921,8 +921,8 @@
         "workCount": 9,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307973,
-          "nanoseconds": 257000000
+          "seconds": 1784948661,
+          "nanoseconds": 367000000
         }
       }
     },
@@ -943,8 +943,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784214333,
-          "nanoseconds": 347000000
+          "seconds": 1785474301,
+          "nanoseconds": 529000000
         }
       }
     },
@@ -965,8 +965,8 @@
         "workCount": 7,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307935,
-          "nanoseconds": 853000000
+          "seconds": 1784999071,
+          "nanoseconds": 65000000
         }
       }
     },
@@ -987,8 +987,8 @@
         "workCount": 3,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1783263982,
-          "nanoseconds": 755000000
+          "seconds": 1784999038,
+          "nanoseconds": 266000000
         }
       }
     },
@@ -1009,8 +1009,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300683,
-          "nanoseconds": 103000000
+          "seconds": 1784999001,
+          "nanoseconds": 469000000
         }
       }
     },
@@ -1031,8 +1031,8 @@
         "workCount": 23,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784387153,
-          "nanoseconds": 525000000
+          "seconds": 1784948714,
+          "nanoseconds": 651000000
         }
       }
     },
@@ -1053,8 +1053,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784394235,
-          "nanoseconds": 871000000
+          "seconds": 1784948672,
+          "nanoseconds": 357000000
         }
       }
     },
@@ -1075,8 +1075,8 @@
         "workCount": 7,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784221477,
-          "nanoseconds": 878000000
+          "seconds": 1784999062,
+          "nanoseconds": 590000000
         }
       }
     },
@@ -1097,8 +1097,8 @@
         "workCount": 4,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307802,
-          "nanoseconds": 257000000
+          "seconds": 1784998991,
+          "nanoseconds": 170000000
         }
       }
     },
@@ -1119,8 +1119,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300791,
-          "nanoseconds": 175000000
+          "seconds": 1784941518,
+          "nanoseconds": 598000000
         }
       }
     },
@@ -1139,11 +1139,11 @@
           "illustration",
           "scenario"
         ],
-        "workCount": 13,
+        "workCount": 14,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1782975894,
-          "nanoseconds": 790000000
+          "seconds": 1784999073,
+          "nanoseconds": 804000000
         }
       }
     },
@@ -1164,8 +1164,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307994,
-          "nanoseconds": 853000000
+          "seconds": 1784948682,
+          "nanoseconds": 52000000
         }
       }
     },
@@ -1186,8 +1186,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300672,
-          "nanoseconds": 616000000
+          "seconds": 1784941431,
+          "nanoseconds": 82000000
         }
       }
     },
@@ -1208,8 +1208,8 @@
         "workCount": 3,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300791,
-          "nanoseconds": 877000000
+          "seconds": 1784941519,
+          "nanoseconds": 683000000
         }
       }
     },
@@ -1230,8 +1230,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784214272,
-          "nanoseconds": 136000000
+          "seconds": 1785474253,
+          "nanoseconds": 536000000
         }
       }
     },
@@ -1252,8 +1252,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300703,
-          "nanoseconds": 835000000
+          "seconds": 1784998998,
+          "nanoseconds": 557000000
         }
       }
     },
@@ -1272,11 +1272,11 @@
           "voice",
           "music"
         ],
-        "workCount": 59,
+        "workCount": 62,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307981,
-          "nanoseconds": 361000000
+          "seconds": 1785661634,
+          "nanoseconds": 696000000
         }
       }
     },
@@ -1297,8 +1297,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300633,
-          "nanoseconds": 291000000
+          "seconds": 1784999065,
+          "nanoseconds": 167000000
         }
       }
     },
@@ -1319,8 +1319,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784387127,
-          "nanoseconds": 966000000
+          "seconds": 1784941518,
+          "nanoseconds": 595000000
         }
       }
     },
@@ -1341,8 +1341,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300682,
-          "nanoseconds": 373000000
+          "seconds": 1784941440,
+          "nanoseconds": 5000000
         }
       }
     },
@@ -1363,8 +1363,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300748,
-          "nanoseconds": 797000000
+          "seconds": 1784941496,
+          "nanoseconds": 7000000
         }
       }
     },
@@ -1385,8 +1385,8 @@
         "workCount": 14,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307950,
-          "nanoseconds": 373000000
+          "seconds": 1784999061,
+          "nanoseconds": 273000000
         }
       }
     },
@@ -1407,8 +1407,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307802,
-          "nanoseconds": 448000000
+          "seconds": 1784941608,
+          "nanoseconds": 807000000
         }
       }
     },
@@ -1426,11 +1426,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 56,
+        "workCount": 57,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307983,
-          "nanoseconds": 63000000
+          "seconds": 1785603820,
+          "nanoseconds": 362000000
         }
       }
     },
@@ -1449,11 +1449,11 @@
           "illustration",
           "scenario"
         ],
-        "workCount": 7,
+        "workCount": 8,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1783264035,
-          "nanoseconds": 57000000
+          "seconds": 1784999073,
+          "nanoseconds": 717000000
         }
       }
     },
@@ -1474,8 +1474,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307802,
-          "nanoseconds": 172000000
+          "seconds": 1784941608,
+          "nanoseconds": 601000000
         }
       }
     },
@@ -1496,8 +1496,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300663,
-          "nanoseconds": 107000000
+          "seconds": 1785474301,
+          "nanoseconds": 505000000
         }
       }
     },
@@ -1518,8 +1518,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300672,
-          "nanoseconds": 588000000
+          "seconds": 1784941430,
+          "nanoseconds": 809000000
         }
       }
     },
@@ -1540,8 +1540,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300672,
-          "nanoseconds": 604000000
+          "seconds": 1784948690,
+          "nanoseconds": 850000000
         }
       }
     },
@@ -1562,8 +1562,8 @@
         "workCount": 7,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300859,
-          "nanoseconds": 387000000
+          "seconds": 1785474267,
+          "nanoseconds": 126000000
         }
       }
     },
@@ -1582,11 +1582,11 @@
           "voice",
           "music"
         ],
-        "workCount": 231,
+        "workCount": 233,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784394235,
-          "nanoseconds": 775000000
+          "seconds": 1785524830,
+          "nanoseconds": 663000000
         }
       }
     },
@@ -1607,8 +1607,8 @@
         "workCount": 34,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307970,
-          "nanoseconds": 751000000
+          "seconds": 1785661634,
+          "nanoseconds": 658000000
         }
       }
     },
@@ -1627,11 +1627,11 @@
           "illustration",
           "scenario"
         ],
-        "workCount": 5,
+        "workCount": 6,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307971,
-          "nanoseconds": 471000000
+          "seconds": 1784999073,
+          "nanoseconds": 886000000
         }
       }
     },
@@ -1652,8 +1652,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307802,
-          "nanoseconds": 48000000
+          "seconds": 1784941608,
+          "nanoseconds": 494000000
         }
       }
     },
@@ -1674,8 +1674,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784214358,
-          "nanoseconds": 449000000
+          "seconds": 1785474267,
+          "nanoseconds": 142000000
         }
       }
     },
@@ -1693,11 +1693,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 124,
+        "workCount": 127,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784394235,
-          "nanoseconds": 792000000
+          "seconds": 1785661634,
+          "nanoseconds": 708000000
         }
       }
     },
@@ -1718,8 +1718,8 @@
         "workCount": 5,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300815,
-          "nanoseconds": 298000000
+          "seconds": 1784941532,
+          "nanoseconds": 706000000
         }
       }
     },
@@ -1741,8 +1741,8 @@
         "workCount": 35,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307950,
-          "nanoseconds": 46000000
+          "seconds": 1785603820,
+          "nanoseconds": 293000000
         }
       }
     },
@@ -1763,8 +1763,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300736,
-          "nanoseconds": 890000000
+          "seconds": 1784941485,
+          "nanoseconds": 106000000
         }
       }
     },
@@ -1785,8 +1785,8 @@
         "workCount": 3,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1783695914,
-          "nanoseconds": 696000000
+          "seconds": 1784999037,
+          "nanoseconds": 175000000
         }
       }
     },
@@ -1804,11 +1804,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 32,
+        "workCount": 34,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307993,
-          "nanoseconds": 259000000
+          "seconds": 1785553634,
+          "nanoseconds": 266000000
         }
       }
     },
@@ -1829,8 +1829,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784221538,
-          "nanoseconds": 905000000
+          "seconds": 1784999066,
+          "nanoseconds": 385000000
         }
       }
     },
@@ -1852,8 +1852,8 @@
         "workCount": 42,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307949,
-          "nanoseconds": 766000000
+          "seconds": 1785424031,
+          "nanoseconds": 634000000
         }
       }
     },
@@ -1874,8 +1874,8 @@
         "workCount": 16,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1782975884,
-          "nanoseconds": 843000000
+          "seconds": 1784999072,
+          "nanoseconds": 860000000
         }
       }
     },
@@ -1896,8 +1896,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300705,
-          "nanoseconds": 101000000
+          "seconds": 1785424031,
+          "nanoseconds": 280000000
         }
       }
     },
@@ -1915,11 +1915,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 39,
+        "workCount": 40,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307971,
-          "nanoseconds": 560000000
+          "seconds": 1785603813,
+          "nanoseconds": 477000000
         }
       }
     },
@@ -1940,8 +1940,8 @@
         "workCount": 51,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307971,
-          "nanoseconds": 447000000
+          "seconds": 1785481390,
+          "nanoseconds": 165000000
         }
       }
     },
@@ -1963,8 +1963,8 @@
         "workCount": 29,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300878,
-          "nanoseconds": 681000000
+          "seconds": 1784999073,
+          "nanoseconds": 568000000
         }
       }
     },
@@ -1985,8 +1985,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1779971205,
-          "nanoseconds": 351000000
+          "seconds": 1784999049,
+          "nanoseconds": 162000000
         }
       }
     },
@@ -2007,8 +2007,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300748,
-          "nanoseconds": 278000000
+          "seconds": 1784941495,
+          "nanoseconds": 96000000
         }
       }
     },
@@ -2029,8 +2029,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307801,
-          "nanoseconds": 949000000
+          "seconds": 1784941608,
+          "nanoseconds": 395000000
         }
       }
     },
@@ -2051,8 +2051,8 @@
         "workCount": 1,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300661,
-          "nanoseconds": 208000000
+          "seconds": 1784941427,
+          "nanoseconds": 302000000
         }
       }
     },
@@ -2071,11 +2071,11 @@
           "voice",
           "music"
         ],
-        "workCount": 167,
+        "workCount": 169,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784394228,
-          "nanoseconds": 775000000
+          "seconds": 1785661634,
+          "nanoseconds": 682000000
         }
       }
     },
@@ -2096,8 +2096,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300806,
-          "nanoseconds": 975000000
+          "seconds": 1784941531,
+          "nanoseconds": 3000000
         }
       }
     },
@@ -2118,8 +2118,8 @@
         "workCount": 84,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307997,
-          "nanoseconds": 357000000
+          "seconds": 1785603812,
+          "nanoseconds": 462000000
         }
       }
     },
@@ -2141,8 +2141,8 @@
         "workCount": 12,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307937,
-          "nanoseconds": 259000000
+          "seconds": 1784998991,
+          "nanoseconds": 184000000
         }
       }
     },
@@ -2163,8 +2163,8 @@
         "workCount": 4,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307972,
-          "nanoseconds": 352000000
+          "seconds": 1784999065,
+          "nanoseconds": 166000000
         }
       }
     },
@@ -2185,8 +2185,8 @@
         "workCount": 2,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784300693,
-          "nanoseconds": 881000000
+          "seconds": 1785474301,
+          "nanoseconds": 107000000
         }
       }
     },
@@ -2204,11 +2204,11 @@
         "types": [
           "voice"
         ],
-        "workCount": 40,
+        "workCount": 41,
         "updatedAt": {
           "__type__": "timestamp",
-          "seconds": 1784307971,
-          "nanoseconds": 649000000
+          "seconds": 1785524830,
+          "nanoseconds": 725000000
         }
       }
     }

--- a/apps/functions/src/tools/firestore-local/fixtures/videos.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/videos.json
@@ -63,16 +63,16 @@
           "ファンタジーライフｉ グルグルの竜と時をぬすむ少女",
           "🎮ゲーム💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785598205,
+          "nanoseconds": 835000000
+        },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 14,
-          "likeCount": 336,
-          "viewCount": 9583
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1773063017,
-          "nanoseconds": 216000000
+          "likeCount": 337,
+          "viewCount": 9724
         }
       }
     },
@@ -139,13 +139,13 @@
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
-          "likeCount": 231,
-          "viewCount": 5340
+          "viewCount": 5340,
+          "likeCount": 230
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 328000000
+          "seconds": 1785616206,
+          "nanoseconds": 538000000
         }
       }
     },
@@ -265,11 +265,6 @@
         "videoType": "archived",
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/-THFpqKVvMs/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 12,
-          "likeCount": 240,
-          "viewCount": 6063
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
@@ -277,8 +272,13 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 119000000
+          "seconds": 1785641406,
+          "nanoseconds": 188000000
+        },
+        "statistics": {
+          "commentCount": 12,
+          "likeCount": 239,
+          "viewCount": 6109
         }
       }
     },
@@ -342,16 +342,16 @@
         "playlistTags": [
           "🎧ASMR💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785601806,
+          "nanoseconds": 118000000
+        },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 24,
-          "likeCount": 951,
-          "viewCount": 48852
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 585000000
+          "likeCount": 954,
+          "viewCount": 49169
         }
       }
     },
@@ -410,13 +410,13 @@
         },
         "statistics": {
           "commentCount": 16,
-          "likeCount": 240,
-          "viewCount": 3795
+          "viewCount": 3796,
+          "likeCount": 239
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 119000000
+          "seconds": 1785641406,
+          "nanoseconds": 188000000
         }
       }
     },
@@ -475,15 +475,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
-        "statistics": {
-          "commentCount": 16,
-          "likeCount": 201,
-          "viewCount": 5362
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 74000000
+          "seconds": 1785637805,
+          "nanoseconds": 997000000
+        },
+        "statistics": {
+          "commentCount": 16,
+          "likeCount": 200,
+          "viewCount": 5428
         }
       }
     },
@@ -549,16 +549,16 @@
         "id": "-nC6dZ6c6zI",
         "thumbnailUrl": "https://i.ytimg.com/vi/-nC6dZ6c6zI/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.637Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785616206,
+          "nanoseconds": 538000000
+        },
         "statistics": {
           "commentCount": 12,
           "favoriteCount": 0,
-          "likeCount": 638,
-          "viewCount": 20573
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 327000000
+          "likeCount": 639,
+          "viewCount": 20605
         }
       }
     },
@@ -618,12 +618,12 @@
         "statistics": {
           "commentCount": 15,
           "likeCount": 192,
-          "viewCount": 3367
+          "viewCount": 3396
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 74000000
+          "seconds": 1785637805,
+          "nanoseconds": 997000000
         }
       }
     },
@@ -695,8 +695,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 585000000
+          "seconds": 1785605406,
+          "nanoseconds": 447000000
         }
       }
     },
@@ -758,12 +758,12 @@
         "statistics": {
           "commentCount": 14,
           "likeCount": 248,
-          "viewCount": 5657
+          "viewCount": 5687
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 74000000
+          "seconds": 1785637805,
+          "nanoseconds": 997000000
         }
       }
     },
@@ -822,15 +822,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
-        "statistics": {
-          "likeCount": 564,
-          "commentCount": 13,
-          "viewCount": 18115
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 117000000
+          "seconds": 1785637805,
+          "nanoseconds": 995000000
+        },
+        "statistics": {
+          "commentCount": 14,
+          "likeCount": 563,
+          "viewCount": 18264
         }
       }
     },
@@ -894,16 +894,16 @@
         "id": "0_Kphqg9wkE",
         "thumbnailUrl": "https://i.ytimg.com/vi/0_Kphqg9wkE/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.722Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
+        },
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
           "likeCount": 319,
-          "viewCount": 9379
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222217,
-          "nanoseconds": 998000000
+          "viewCount": 9386
         }
       }
     },
@@ -967,16 +967,16 @@
         "id": "0aRj4WfpnOA",
         "thumbnailUrl": "https://i.ytimg.com/vi/0aRj4WfpnOA/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.760Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785598205,
+          "nanoseconds": 834000000
+        },
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
-          "likeCount": 214,
-          "viewCount": 5400
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1764322218,
-          "nanoseconds": 983000000
+          "likeCount": 213,
+          "viewCount": 5414
         }
       }
     },
@@ -1040,16 +1040,16 @@
         "playlistTags": [
           "🎧ASMR💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785605406,
+          "nanoseconds": 447000000
+        },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 9,
-          "likeCount": 953,
-          "viewCount": 49164
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 586000000
+          "likeCount": 957,
+          "viewCount": 49348
         }
       }
     },
@@ -1108,13 +1108,13 @@
         },
         "statistics": {
           "commentCount": 14,
-          "likeCount": 143,
-          "viewCount": 3579
+          "likeCount": 142,
+          "viewCount": 3593
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 117000000
+          "seconds": 1785641406,
+          "nanoseconds": 190000000
         }
       }
     },
@@ -1168,11 +1168,6 @@
         "videoType": "archived",
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/0oyDpEWxG4w/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 11,
-          "likeCount": 131,
-          "viewCount": 2424
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
@@ -1180,8 +1175,13 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783225818,
-          "nanoseconds": 868000000
+          "seconds": 1785623406,
+          "nanoseconds": 396000000
+        },
+        "statistics": {
+          "commentCount": 11,
+          "likeCount": 130,
+          "viewCount": 2444
         }
       }
     },
@@ -1250,14 +1250,14 @@
         "updatedAt": "2025-08-22T04:05:12.875Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783233019,
-          "nanoseconds": 13000000
+          "seconds": 1785630605,
+          "nanoseconds": 392000000
         },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 15,
-          "likeCount": 519,
-          "viewCount": 13968
+          "likeCount": 518,
+          "viewCount": 14020
         }
       }
     },
@@ -1323,16 +1323,16 @@
           "⭐雑談💗",
           "🎧ASMR💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
+        },
         "statistics": {
           "commentCount": 2,
           "favoriteCount": 0,
           "likeCount": 169,
-          "viewCount": 4106
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 2000000
+          "viewCount": 4107
         }
       }
     },
@@ -1391,16 +1391,16 @@
         "id": "16lqmbQuGv4",
         "thumbnailUrl": "https://i.ytimg.com/vi/16lqmbQuGv4/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.954Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
+        },
         "statistics": {
           "commentCount": 2,
           "favoriteCount": 0,
           "likeCount": 146,
-          "viewCount": 3928
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 1000000
+          "viewCount": 3934
         }
       }
     },
@@ -1464,16 +1464,16 @@
         "id": "17kk23ZYs8c",
         "thumbnailUrl": "https://i.ytimg.com/vi/17kk23ZYs8c/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:12.990Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785630605,
+          "nanoseconds": 392000000
+        },
         "statistics": {
           "commentCount": 14,
           "favoriteCount": 0,
-          "likeCount": 412,
-          "viewCount": 12893
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783233019,
-          "nanoseconds": 14000000
+          "likeCount": 411,
+          "viewCount": 12918
         }
       }
     },
@@ -1541,14 +1541,14 @@
         "updatedAt": "2025-08-22T04:05:13.009Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 328000000
+          "seconds": 1785627006,
+          "nanoseconds": 292000000
         },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 18,
-          "likeCount": 678,
-          "viewCount": 23024
+          "likeCount": 679,
+          "viewCount": 23071
         }
       }
     },
@@ -1612,16 +1612,16 @@
         "id": "1GFc0dqmyXg",
         "thumbnailUrl": "https://i.ytimg.com/vi/1GFc0dqmyXg/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.035Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785634206,
+          "nanoseconds": 18000000
+        },
         "statistics": {
           "commentCount": 19,
           "favoriteCount": 0,
-          "likeCount": 1436,
-          "viewCount": 54825
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783233019,
-          "nanoseconds": 16000000
+          "likeCount": 1437,
+          "viewCount": 54916
         }
       }
     },
@@ -1685,16 +1685,16 @@
         "id": "1GULxYNC1Ls",
         "thumbnailUrl": "https://i.ytimg.com/vi/1GULxYNC1Ls/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.085Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1764271813,
-          "nanoseconds": 990000000
-        },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 12,
-          "likeCount": 370,
-          "viewCount": 12757
+          "likeCount": 372,
+          "viewCount": 12909
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785598205,
+          "nanoseconds": 833000000
         }
       }
     },
@@ -1746,20 +1746,20 @@
         "videoType": "archived",
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/1P2Kqh5GgDE/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 13,
-          "likeCount": 173,
-          "viewCount": 3563
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
         },
+        "statistics": {
+          "commentCount": 13,
+          "likeCount": 174,
+          "viewCount": 3568
+        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 119000000
+          "seconds": 1785641406,
+          "nanoseconds": 189000000
         }
       }
     },
@@ -1818,16 +1818,16 @@
         "id": "1Zirz4ZEHRk",
         "thumbnailUrl": "https://i.ytimg.com/vi/1Zirz4ZEHRk/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.119Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 2000000
-        },
         "statistics": {
           "commentCount": 6,
           "favoriteCount": 0,
-          "likeCount": 280,
-          "viewCount": 8808
+          "likeCount": 279,
+          "viewCount": 8855
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
         }
       }
     },
@@ -1885,15 +1885,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
-        "statistics": {
-          "likeCount": 265,
-          "commentCount": 17,
-          "viewCount": 5477
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 117000000
+          "seconds": 1785637805,
+          "nanoseconds": 995000000
+        },
+        "statistics": {
+          "commentCount": 17,
+          "likeCount": 264,
+          "viewCount": 5528
         }
       }
     },
@@ -1965,8 +1965,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 586000000
+          "seconds": 1785605406,
+          "nanoseconds": 447000000
         }
       }
     },
@@ -2025,15 +2025,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785634206,
+          "nanoseconds": 21000000
+        },
         "statistics": {
           "commentCount": 11,
           "likeCount": 192,
-          "viewCount": 4392
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 72000000
+          "viewCount": 4466
         }
       }
     },
@@ -2099,16 +2099,16 @@
           "モンスターハンターワイルズ",
           "🎮ゲーム💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785634206,
+          "nanoseconds": 19000000
+        },
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
-          "likeCount": 218,
-          "viewCount": 5255
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783233019,
-          "nanoseconds": 15000000
+          "likeCount": 217,
+          "viewCount": 5257
         }
       }
     },
@@ -2167,15 +2167,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
-        "statistics": {
-          "commentCount": 13,
-          "likeCount": 427,
-          "viewCount": 12749
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 74000000
+          "seconds": 1785637805,
+          "nanoseconds": 997000000
+        },
+        "statistics": {
+          "commentCount": 13,
+          "likeCount": 426,
+          "viewCount": 12971
         }
       }
     },
@@ -2239,16 +2239,16 @@
         "id": "271MuZk01NE",
         "thumbnailUrl": "https://i.ytimg.com/vi/271MuZk01NE/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.216Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785616206,
+          "nanoseconds": 539000000
+        },
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
           "likeCount": 229,
-          "viewCount": 4260
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 325000000
+          "viewCount": 4268
         }
       }
     },
@@ -2299,20 +2299,20 @@
           "🎧ASMR💗"
         ],
         "thumbnailUrl": "https://i.ytimg.com/vi/2BoVRWXykkE/maxresdefault.jpg",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783213325,
-          "nanoseconds": 926000000
-        },
-        "statistics": {
-          "commentCount": 11,
-          "likeCount": 523,
-          "viewCount": 22922
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785612606,
+          "nanoseconds": 64000000
+        },
+        "statistics": {
+          "commentCount": 11,
+          "likeCount": 523,
+          "viewCount": 22938
         }
       }
     },
@@ -2381,13 +2381,13 @@
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
-          "likeCount": 374,
-          "viewCount": 9567
+          "likeCount": 375,
+          "viewCount": 9595
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 328000000
+          "seconds": 1785616206,
+          "nanoseconds": 538000000
         }
       }
     },
@@ -2448,13 +2448,13 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 72000000
+          "seconds": 1785641406,
+          "nanoseconds": 188000000
         },
         "statistics": {
-          "likeCount": 185,
           "commentCount": 15,
-          "viewCount": 4973
+          "likeCount": 190,
+          "viewCount": 5231
         }
       }
     },
@@ -2515,13 +2515,13 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 74000000
+          "seconds": 1785637805,
+          "nanoseconds": 997000000
         },
         "statistics": {
           "commentCount": 23,
-          "likeCount": 447,
-          "viewCount": 12405
+          "likeCount": 452,
+          "viewCount": 12809
         }
       }
     },
@@ -2589,14 +2589,14 @@
         "updatedAt": "2025-08-22T04:05:13.268Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1779204618,
-          "nanoseconds": 442000000
+          "seconds": 1785601806,
+          "nanoseconds": 118000000
         },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 48,
-          "likeCount": 3533,
-          "viewCount": 206616
+          "likeCount": 3535,
+          "viewCount": 208296
         }
       }
     },
@@ -2664,27 +2664,91 @@
         "id": "2sdE7dqP5L0",
         "thumbnailUrl": "https://i.ytimg.com/vi/2sdE7dqP5L0/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.291Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 329000000
-        },
         "statistics": {
           "commentCount": 22,
           "favoriteCount": 0,
-          "likeCount": 858,
-          "viewCount": 20941
+          "likeCount": 856,
+          "viewCount": 21018
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785627006,
+          "nanoseconds": 291000000
+        }
+      }
+    },
+    {
+      "id": "2ztGtmc_6bI",
+      "data": {
+        "description": "浅木式ちゃん🩷　@asagishiki00 \n雲八はちちゃん🩷　@CV_kumoyahachi \n御子柴泉ちゃん🩷　@御子柴泉 \n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "2ztGtmc_6bI",
+        "title": "小人窃盗団参上～！！人間の家から盗みまくるゲーム😎【どろぼうノーム／浅木式・雲八はち・御子柴泉】",
+        "userTags": [],
+        "id": "2ztGtmc_6bI",
+        "categoryId": "20",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "duration": "PT2H11M8S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1784989526,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1784980800,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1784981173,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 178,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1784989052,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/2ztGtmc_6bI/maxresdefault.jpg",
+        "status": {
+          "privacyStatus": "public",
+          "embeddable": true,
+          "uploadStatus": "processed"
+        },
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "🎮ゲーム💗",
+            "🐱コラボ配信💗"
+          ]
+        },
+        "playlistTags": [
+          "🎮ゲーム💗",
+          "🐱コラボ配信💗"
+        ],
+        "audioButtonCount": 2,
+        "updatedAt": "2026-07-26T11:27:04.916Z",
+        "statistics": {
+          "commentCount": 14,
+          "likeCount": 210,
+          "viewCount": 4470
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785670206,
+          "nanoseconds": 79000000
         }
       }
     },
     {
       "id": "3Rb-c54D20o",
       "data": {
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783942219,
-          "nanoseconds": 636000000
-        },
         "publishedAt": {
           "__type__": "timestamp",
           "seconds": 1783940402,
@@ -2708,15 +2772,20 @@
         "channelTitle": "涼花みなせ / Suzuka Minase",
         "playlistTags": [],
         "thumbnailUrl": "https://i.ytimg.com/vi/3Rb-c54D20o/maxresdefault.jpg",
-        "statistics": {
-          "likeCount": 58,
-          "viewCount": 426,
-          "commentCount": 20
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
+        },
+        "statistics": {
+          "commentCount": 75,
+          "likeCount": 565,
+          "viewCount": 11323
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785670206,
+          "nanoseconds": 78000000
         }
       }
     },
@@ -2784,12 +2853,12 @@
           "commentCount": 8,
           "favoriteCount": 0,
           "likeCount": 333,
-          "viewCount": 8551
+          "viewCount": 8552
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 329000000
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
         }
       }
     },
@@ -2861,8 +2930,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 617000000
+          "seconds": 1785609005,
+          "nanoseconds": 149000000
         }
       }
     },
@@ -2928,14 +2997,14 @@
         ],
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1781130617,
-          "nanoseconds": 451000000
+          "seconds": 1785601806,
+          "nanoseconds": 118000000
         },
         "statistics": {
           "commentCount": 12,
           "favoriteCount": 0,
           "likeCount": 924,
-          "viewCount": 48055
+          "viewCount": 48078
         }
       }
     },
@@ -3001,16 +3070,16 @@
         "id": "3z8nA77BaRw",
         "thumbnailUrl": "https://i.ytimg.com/vi/3z8nA77BaRw/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.385Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
+        },
         "statistics": {
           "commentCount": 5,
           "favoriteCount": 0,
-          "viewCount": 6800,
-          "likeCount": 224
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 2000000
+          "likeCount": 224,
+          "viewCount": 6805
         }
       }
     },
@@ -3074,16 +3143,16 @@
         "thumbnailUrl": "https://i.ytimg.com/vi/44sdknho7e4/maxresdefault.jpg",
         "audioButtonCount": 1,
         "updatedAt": "2025-08-22T04:05:13.409Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785630605,
+          "nanoseconds": 391000000
+        },
         "statistics": {
           "commentCount": 10,
           "favoriteCount": 0,
-          "likeCount": 289,
-          "viewCount": 5306
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 332000000
+          "likeCount": 288,
+          "viewCount": 5315
         }
       }
     },
@@ -3153,12 +3222,12 @@
           "favoriteCount": 0,
           "commentCount": 1,
           "likeCount": 207,
-          "viewCount": 7392
+          "viewCount": 7400
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 617000000
+          "seconds": 1785609005,
+          "nanoseconds": 149000000
         }
       }
     },
@@ -3225,13 +3294,13 @@
         "statistics": {
           "commentCount": 3,
           "favoriteCount": 0,
-          "likeCount": 206,
-          "viewCount": 5587
+          "likeCount": 207,
+          "viewCount": 5600
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 586000000
+          "seconds": 1785605406,
+          "nanoseconds": 447000000
         }
       }
     },
@@ -3297,14 +3366,14 @@
         "updatedAt": "2025-08-22T04:05:13.481Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1762583414,
-          "nanoseconds": 536000000
+          "seconds": 1785598205,
+          "nanoseconds": 834000000
         },
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
-          "likeCount": 562,
-          "viewCount": 20693
+          "likeCount": 559,
+          "viewCount": 20759
         }
       }
     },
@@ -3372,12 +3441,12 @@
           "likeCount": 135,
           "commentCount": 2,
           "favoriteCount": 0,
-          "viewCount": 2889
+          "viewCount": 2891
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 587000000
+          "seconds": 1785605406,
+          "nanoseconds": 446000000
         }
       }
     },
@@ -3441,16 +3510,16 @@
         "id": "4WIJsFr8M7E",
         "thumbnailUrl": "https://i.ytimg.com/vi/4WIJsFr8M7E/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.529Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1779906617,
-          "nanoseconds": 359000000
-        },
         "statistics": {
           "commentCount": 6,
           "favoriteCount": 0,
-          "likeCount": 330,
-          "viewCount": 8349
+          "likeCount": 327,
+          "viewCount": 8352
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785601806,
+          "nanoseconds": 117000000
         }
       }
     },
@@ -3520,12 +3589,12 @@
           "commentCount": 10,
           "favoriteCount": 0,
           "likeCount": 145,
-          "viewCount": 2572
+          "viewCount": 2578
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 328000000
+          "seconds": 1785627006,
+          "nanoseconds": 291000000
         }
       }
     },
@@ -3591,16 +3660,16 @@
           "JUDGE EYES：死神の遺言 Remastered",
           "🎮ゲーム💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785630605,
+          "nanoseconds": 391000000
+        },
         "statistics": {
           "commentCount": 11,
           "favoriteCount": 0,
-          "likeCount": 195,
-          "viewCount": 5067
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 332000000
+          "likeCount": 194,
+          "viewCount": 5083
         }
       }
     },
@@ -3652,20 +3721,20 @@
         "videoType": "archived",
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/53OgUWeyYpY/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 11,
-          "likeCount": 381,
-          "viewCount": 8237
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
         },
+        "statistics": {
+          "commentCount": 11,
+          "likeCount": 381,
+          "viewCount": 8273
+        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 117000000
+          "seconds": 1785637805,
+          "nanoseconds": 995000000
         }
       }
     },
@@ -3718,11 +3787,6 @@
           "🎮ゲーム💗"
         ],
         "thumbnailUrl": "https://i.ytimg.com/vi/58rXqPmJPXY/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 8,
-          "likeCount": 152,
-          "viewCount": 2792
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
@@ -3730,8 +3794,13 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 119000000
+          "seconds": 1785641406,
+          "nanoseconds": 188000000
+        },
+        "statistics": {
+          "commentCount": 8,
+          "likeCount": 152,
+          "viewCount": 2796
         }
       }
     },
@@ -3795,16 +3864,16 @@
         "id": "5CB8CDH5h4w",
         "thumbnailUrl": "https://i.ytimg.com/vi/5CB8CDH5h4w/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.614Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1763440214,
-          "nanoseconds": 798000000
-        },
         "statistics": {
           "likeCount": 229,
           "commentCount": 3,
           "favoriteCount": 0,
-          "viewCount": 4862
+          "viewCount": 4887
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785598205,
+          "nanoseconds": 834000000
         }
       }
     },
@@ -3867,12 +3936,12 @@
           "commentCount": 14,
           "favoriteCount": 0,
           "likeCount": 479,
-          "viewCount": 9269
+          "viewCount": 9270
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 329000000
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
         }
       }
     },
@@ -3944,8 +4013,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 616000000
+          "seconds": 1785609005,
+          "nanoseconds": 150000000
         }
       }
     },
@@ -4007,13 +4076,13 @@
         "statistics": {
           "commentCount": 10,
           "favoriteCount": 0,
-          "likeCount": 132,
-          "viewCount": 2490
+          "likeCount": 131,
+          "viewCount": 2496
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 328000000
+          "seconds": 1785616206,
+          "nanoseconds": 536000000
         }
       }
     },
@@ -4077,16 +4146,16 @@
         "id": "5ahWwNInun0",
         "thumbnailUrl": "https://i.ytimg.com/vi/5ahWwNInun0/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.697Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785619805,
+          "nanoseconds": 985000000
+        },
         "statistics": {
           "commentCount": 22,
           "favoriteCount": 0,
           "likeCount": 1489,
-          "viewCount": 80011
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222217,
-          "nanoseconds": 999000000
+          "viewCount": 80112
         }
       }
     },
@@ -4152,16 +4221,16 @@
         "id": "5mKrbnUh3bk",
         "thumbnailUrl": "https://i.ytimg.com/vi/5mKrbnUh3bk/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.721Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785609005,
+          "nanoseconds": 150000000
+        },
         "statistics": {
           "commentCount": 1,
           "favoriteCount": 0,
-          "likeCount": 265,
-          "viewCount": 9851
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 616000000
+          "likeCount": 266,
+          "viewCount": 9868
         }
       }
     },
@@ -4233,8 +4302,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 587000000
+          "seconds": 1785605406,
+          "nanoseconds": 446000000
         }
       }
     },
@@ -4300,14 +4369,14 @@
         "updatedAt": "2025-08-22T04:05:13.773Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783222217,
-          "nanoseconds": 998000000
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
         },
         "statistics": {
           "favoriteCount": 0,
-          "commentCount": 104,
-          "likeCount": 9285,
-          "viewCount": 843552
+          "commentCount": 103,
+          "likeCount": 9308,
+          "viewCount": 846647
         }
       }
     },
@@ -4366,15 +4435,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
-        "statistics": {
-          "likeCount": 827,
-          "commentCount": 26,
-          "viewCount": 29209
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 116000000
+          "seconds": 1785637805,
+          "nanoseconds": 996000000
+        },
+        "statistics": {
+          "commentCount": 27,
+          "likeCount": 838,
+          "viewCount": 30315
         }
       }
     },
@@ -4440,16 +4509,16 @@
           "モンスターハンターワイルズ",
           "🎮ゲーム💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785634206,
+          "nanoseconds": 19000000
+        },
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
-          "likeCount": 205,
-          "viewCount": 4511
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783233019,
-          "nanoseconds": 15000000
+          "likeCount": 204,
+          "viewCount": 4513
         }
       }
     },
@@ -4514,15 +4583,15 @@
         "thumbnailUrl": "https://i.ytimg.com/vi/6hEwXuTu038/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:13.833Z",
         "statistics": {
-          "likeCount": 151,
           "commentCount": 3,
           "favoriteCount": 0,
-          "viewCount": 3567
+          "likeCount": 150,
+          "viewCount": 3591
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1768141815,
-          "nanoseconds": 569000000
+          "seconds": 1785598205,
+          "nanoseconds": 834000000
         }
       }
     },
@@ -4591,13 +4660,13 @@
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 5,
-          "likeCount": 325,
-          "viewCount": 9371
+          "likeCount": 326,
+          "viewCount": 9384
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 2000000
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
         }
       }
     },
@@ -4665,12 +4734,12 @@
           "favoriteCount": 0,
           "likeCount": 222,
           "commentCount": 4,
-          "viewCount": 5225
+          "viewCount": 5226
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 587000000
+          "seconds": 1785605406,
+          "nanoseconds": 446000000
         }
       }
     },
@@ -4738,12 +4807,12 @@
           "commentCount": 1,
           "favoriteCount": 0,
           "likeCount": 177,
-          "viewCount": 4281
+          "viewCount": 4282
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 616000000
+          "seconds": 1785609005,
+          "nanoseconds": 150000000
         }
       }
     },
@@ -4795,20 +4864,20 @@
         "videoType": "archived",
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/71lGXP2gJFs/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 17,
-          "likeCount": 158,
-          "viewCount": 3212
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
         },
+        "statistics": {
+          "commentCount": 17,
+          "likeCount": 158,
+          "viewCount": 3218
+        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 117000000
+          "seconds": 1785637805,
+          "nanoseconds": 996000000
         }
       }
     },
@@ -4876,14 +4945,14 @@
         "updatedAt": "2025-08-22T04:05:13.940Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 329000000
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
         },
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 16,
-          "likeCount": 734,
-          "viewCount": 25493
+          "likeCount": 733,
+          "viewCount": 25502
         }
       }
     },
@@ -4949,16 +5018,16 @@
           "JUDGE EYES：死神の遺言 Remastered",
           "🎮ゲーム💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785630605,
+          "nanoseconds": 391000000
+        },
         "statistics": {
           "commentCount": 12,
           "favoriteCount": 0,
-          "likeCount": 174,
-          "viewCount": 3855
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 332000000
+          "likeCount": 173,
+          "viewCount": 3868
         }
       }
     },
@@ -5015,15 +5084,82 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785634206,
+          "nanoseconds": 21000000
+        },
         "statistics": {
           "commentCount": 15,
-          "likeCount": 302,
-          "viewCount": 7653
+          "likeCount": 304,
+          "viewCount": 8066
+        }
+      }
+    },
+    {
+      "id": "7RBjaVnJjBw",
+      "data": {
+        "description": "｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
+        "videoId": "7RBjaVnJjBw",
+        "title": "みみかき雑談♡【ASMR／耳かき・囁き】",
+        "tags": {
+          "userTags": [],
+          "contentTags": [],
+          "playlistTags": [
+            "⭐雑談💗",
+            "🎧ASMR💗"
+          ]
+        },
+        "userTags": [],
+        "id": "7RBjaVnJjBw",
+        "categoryId": "24",
+        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
+        "channelTitle": "涼花みなせ / Suzuka Minase",
+        "playlistTags": [
+          "⭐雑談💗",
+          "🎧ASMR💗"
+        ],
+        "duration": "PT2H4M21S",
+        "publishedAt": {
+          "__type__": "timestamp",
+          "seconds": 1784733097,
+          "nanoseconds": 0
+        },
+        "liveStreamingDetails": {
+          "scheduledStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1784725200,
+            "nanoseconds": 0
+          },
+          "actualStartTime": {
+            "__type__": "timestamp",
+            "seconds": 1784725213,
+            "nanoseconds": 0
+          },
+          "concurrentViewers": 1098,
+          "actualEndTime": {
+            "__type__": "timestamp",
+            "seconds": 1784732690,
+            "nanoseconds": 0
+          }
+        },
+        "videoType": "archived",
+        "liveBroadcastContent": "none",
+        "thumbnailUrl": "https://i.ytimg.com/vi/7RBjaVnJjBw/maxresdefault.jpg",
+        "status": {
+          "privacyStatus": "public",
+          "embeddable": true,
+          "uploadStatus": "processed"
+        },
+        "statistics": {
+          "commentCount": 22,
+          "likeCount": 822,
+          "viewCount": 29199
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 72000000
+          "seconds": 1785670206,
+          "nanoseconds": 79000000
         }
       }
     },
@@ -5090,13 +5226,13 @@
         "statistics": {
           "commentCount": 4,
           "favoriteCount": 0,
-          "viewCount": 4843,
-          "likeCount": 201
+          "likeCount": 201,
+          "viewCount": 4844
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 2000000
+          "seconds": 1785623406,
+          "nanoseconds": 395000000
         }
       }
     },
@@ -5142,13 +5278,13 @@
         "statistics": {
           "favoriteCount": 0,
           "commentCount": 4,
-          "likeCount": 49,
-          "viewCount": 2003
+          "likeCount": 50,
+          "viewCount": 2028
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 617000000
+          "seconds": 1785609005,
+          "nanoseconds": 149000000
         }
       }
     },
@@ -5212,16 +5348,16 @@
         "id": "83T29piiz5E",
         "thumbnailUrl": "https://i.ytimg.com/vi/83T29piiz5E/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:14.043Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1764311414,
-          "nanoseconds": 636000000
-        },
         "statistics": {
           "commentCount": 3,
           "favoriteCount": 0,
-          "likeCount": 142,
-          "viewCount": 3995
+          "likeCount": 141,
+          "viewCount": 4015
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785598205,
+          "nanoseconds": 834000000
         }
       }
     },
@@ -5288,13 +5424,13 @@
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
-          "likeCount": 302,
-          "viewCount": 7846
+          "likeCount": 301,
+          "viewCount": 7848
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 325000000
+          "seconds": 1785616206,
+          "nanoseconds": 539000000
         }
       }
     },
@@ -5353,15 +5489,15 @@
           "uploadStatus": "processed",
           "embeddable": true
         },
-        "statistics": {
-          "commentCount": 13,
-          "likeCount": 212,
-          "viewCount": 5244
-        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783236622,
-          "nanoseconds": 74000000
+          "seconds": 1785637805,
+          "nanoseconds": 997000000
+        },
+        "statistics": {
+          "commentCount": 13,
+          "likeCount": 211,
+          "viewCount": 5358
         }
       }
     },
@@ -5410,14 +5546,14 @@
         "updatedAt": "2025-08-22T04:05:14.092Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 329000000
+          "seconds": 1785627006,
+          "nanoseconds": 291000000
         },
         "statistics": {
           "favoriteCount": 0,
-          "likeCount": 518,
-          "commentCount": 36,
-          "viewCount": 15636
+          "commentCount": 38,
+          "likeCount": 526,
+          "viewCount": 15963
         }
       }
     },
@@ -5484,8 +5620,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 587000000
+          "seconds": 1785605406,
+          "nanoseconds": 446000000
         }
       }
     },
@@ -5513,11 +5649,6 @@
           "🐱コラボ配信💗"
         ],
         "duration": "PT4H53M12S",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1784219418,
-          "nanoseconds": 196000000
-        },
         "publishedAt": {
           "__type__": "timestamp",
           "seconds": 1784218181,
@@ -5544,15 +5675,20 @@
         "videoType": "archived",
         "liveBroadcastContent": "none",
         "thumbnailUrl": "https://i.ytimg.com/vi/8B-m-zmP9p8/maxresdefault.jpg",
-        "statistics": {
-          "likeCount": 141,
-          "viewCount": 2183,
-          "commentCount": 11
-        },
         "status": {
           "privacyStatus": "public",
           "embeddable": true,
           "uploadStatus": "processed"
+        },
+        "statistics": {
+          "commentCount": 12,
+          "likeCount": 152,
+          "viewCount": 3421
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785670206,
+          "nanoseconds": 78000000
         }
       }
     },
@@ -5616,13 +5752,13 @@
         "statistics": {
           "commentCount": 5,
           "favoriteCount": 0,
-          "viewCount": 7208,
-          "likeCount": 312
+          "likeCount": 312,
+          "viewCount": 7209
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783222217,
-          "nanoseconds": 999000000
+          "seconds": 1785619805,
+          "nanoseconds": 985000000
         }
       }
     },
@@ -5686,16 +5822,16 @@
         "id": "8J0alaI_r6Q",
         "thumbnailUrl": "https://i.ytimg.com/vi/8J0alaI_r6Q/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:14.171Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 587000000
-        },
         "statistics": {
           "commentCount": 1,
           "favoriteCount": 0,
           "likeCount": 205,
-          "viewCount": 5314
+          "viewCount": 5324
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785605406,
+          "nanoseconds": 446000000
         }
       }
     },
@@ -5761,16 +5897,16 @@
           "🎧ASMR💗",
           "🐱コラボ配信💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785601806,
+          "nanoseconds": 118000000
+        },
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
-          "likeCount": 660,
-          "viewCount": 24023
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1776969017,
-          "nanoseconds": 531000000
+          "likeCount": 659,
+          "viewCount": 24124
         }
       }
     },
@@ -5837,13 +5973,13 @@
         "statistics": {
           "commentCount": 7,
           "favoriteCount": 0,
-          "viewCount": 11446,
-          "likeCount": 423
+          "likeCount": 422,
+          "viewCount": 11448
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 329000000
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
         }
       }
     },
@@ -5910,13 +6046,13 @@
         "statistics": {
           "commentCount": 7,
           "favoriteCount": 0,
-          "likeCount": 369,
-          "viewCount": 13233
+          "likeCount": 366,
+          "viewCount": 13296
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1767565814,
-          "nanoseconds": 306000000
+          "seconds": 1785598205,
+          "nanoseconds": 834000000
         }
       }
     },
@@ -5982,16 +6118,16 @@
           "JUDGE EYES：死神の遺言 Remastered",
           "🎮ゲーム💗"
         ],
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785630605,
+          "nanoseconds": 391000000
+        },
         "statistics": {
           "commentCount": 12,
           "favoriteCount": 0,
-          "likeCount": 155,
-          "viewCount": 3484
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 332000000
+          "likeCount": 154,
+          "viewCount": 3501
         }
       }
     },
@@ -6057,14 +6193,14 @@
         "updatedAt": "2025-08-22T04:05:14.310Z",
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1767677416,
-          "nanoseconds": 342000000
+          "seconds": 1785598205,
+          "nanoseconds": 835000000
         },
         "statistics": {
           "commentCount": 15,
           "favoriteCount": 0,
           "likeCount": 1247,
-          "viewCount": 40638
+          "viewCount": 40876
         }
       }
     },
@@ -6117,20 +6253,20 @@
           "🎮ゲーム💗"
         ],
         "thumbnailUrl": "https://i.ytimg.com/vi/8hcFhjECMaM/maxresdefault.jpg",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783213325,
-          "nanoseconds": 927000000
-        },
-        "statistics": {
-          "likeCount": 166,
-          "commentCount": 14,
-          "viewCount": 3514
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
+        },
+        "statistics": {
+          "commentCount": 14,
+          "likeCount": 167,
+          "viewCount": 3531
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785612606,
+          "nanoseconds": 65000000
         }
       }
     },
@@ -6196,16 +6332,16 @@
         "id": "8n9e9qSldMI",
         "thumbnailUrl": "https://i.ytimg.com/vi/8n9e9qSldMI/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:14.332Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785634206,
+          "nanoseconds": 19000000
+        },
         "statistics": {
           "commentCount": 13,
           "favoriteCount": 0,
-          "likeCount": 471,
-          "viewCount": 11610
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783233019,
-          "nanoseconds": 16000000
+          "likeCount": 470,
+          "viewCount": 11641
         }
       }
     },
@@ -6264,16 +6400,16 @@
         "id": "8qejVCB9PT8",
         "thumbnailUrl": "https://i.ytimg.com/vi/8qejVCB9PT8/sddefault.jpg",
         "updatedAt": "2025-08-22T04:05:14.401Z",
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
+        },
         "statistics": {
           "commentCount": 9,
           "favoriteCount": 0,
-          "viewCount": 5231,
-          "likeCount": 232
-        },
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 329000000
+          "likeCount": 232,
+          "viewCount": 5240
         }
       }
     },
@@ -6340,13 +6476,13 @@
         "statistics": {
           "commentCount": 8,
           "favoriteCount": 0,
-          "likeCount": 234,
-          "viewCount": 8670
+          "viewCount": 8671,
+          "likeCount": 233
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783222217,
-          "nanoseconds": 998000000
+          "seconds": 1785619805,
+          "nanoseconds": 986000000
         }
       }
     },
@@ -6418,8 +6554,8 @@
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 585000000
+          "seconds": 1785605406,
+          "nanoseconds": 447000000
         }
       }
     },
@@ -6483,16 +6619,16 @@
         "playlistTags": [
           "🎧ASMR💗"
         ],
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 3000000
-        },
         "statistics": {
           "commentCount": 13,
           "favoriteCount": 0,
           "likeCount": 666,
-          "viewCount": 27338
+          "viewCount": 27351
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785623406,
+          "nanoseconds": 394000000
         }
       }
     },
@@ -6563,12 +6699,12 @@
           "favoriteCount": 0,
           "commentCount": 10,
           "likeCount": 136,
-          "viewCount": 2431
+          "viewCount": 2433
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783229418,
-          "nanoseconds": 325000000
+          "seconds": 1785627006,
+          "nanoseconds": 292000000
         }
       }
     },
@@ -6619,20 +6755,20 @@
           "nanoseconds": 0
         },
         "thumbnailUrl": "https://i.ytimg.com/vi/9LnnOkucuUs/maxresdefault.jpg",
-        "statistics": {
-          "commentCount": 12,
-          "likeCount": 255,
-          "viewCount": 5866
-        },
         "status": {
           "privacyStatus": "public",
           "uploadStatus": "processed",
           "embeddable": true
         },
+        "statistics": {
+          "commentCount": 12,
+          "likeCount": 254,
+          "viewCount": 5874
+        },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783225818,
-          "nanoseconds": 869000000
+          "seconds": 1785623406,
+          "nanoseconds": 396000000
         }
       }
     },
@@ -6690,13 +6826,13 @@
         "statistics": {
           "commentCount": 7,
           "favoriteCount": 0,
-          "likeCount": 266,
-          "viewCount": 5420
+          "viewCount": 5420,
+          "likeCount": 265
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783218619,
-          "nanoseconds": 325000000
+          "seconds": 1785616206,
+          "nanoseconds": 539000000
         }
       }
     },
@@ -6764,12 +6900,12 @@
           "likeCount": 118,
           "commentCount": 1,
           "favoriteCount": 0,
-          "viewCount": 2387
+          "viewCount": 2389
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1783204218,
-          "nanoseconds": 616000000
+          "seconds": 1785609005,
+          "nanoseconds": 151000000
         }
       }
     },
@@ -6833,27 +6969,22 @@
         "id": "9gOkCti2I2w",
         "thumbnailUrl": "https://i.ytimg.com/vi/9gOkCti2I2w/maxresdefault.jpg",
         "updatedAt": "2025-08-22T04:05:14.782Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1779906617,
-          "nanoseconds": 358000000
-        },
         "statistics": {
           "commentCount": 1,
           "favoriteCount": 0,
           "likeCount": 204,
-          "viewCount": 4311
+          "viewCount": 4312
+        },
+        "lastFetchedAt": {
+          "__type__": "timestamp",
+          "seconds": 1785601806,
+          "nanoseconds": 117000000
         }
       }
     },
     {
       "id": "9kMBmEvhwUk",
       "data": {
-        "publishedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783672375,
-          "nanoseconds": 0
-        },
         "description": "｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせオリジナル音声作品\n「望月明奈は恋を知る。～やさぐれJKと猫とあなたの青春記録～」販売中です…！！\n\n🐰詳細🌸▷ https://x.com/suzuka_minase/status/2020038625023705293\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日は、23:00から限定放送でお会いしましょう💗\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\nニコニコチャンネル　▶　https://ch.nicovideo.jp/suzuka-minase\nOPENREC　▶　https://www.openrec.tv/user/Suzuka_minase\nニコニコチャンネル・OPENRECの同時配信です🌸同じコンテンツをお届けしてるので、お好きな方の配信サイトでお楽しみください🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://x.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nみやぢさんとのOPENREC公式番組「みやみなはっぴーちゃんねる」開設しました🌟！\n2人のシチュエーションASMRやラジオ番組、毎月第4日曜日に生放送中です(՞ ܸ. .ܸ ՞)\n\nhttps://www.openrec.tv/user/miyaminahappych\n\nここでしか聞けない両耳かきや両耳○め、番組終了後のお電話企画などなど、特典盛りだくさんです🌸\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【Live2D】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用①)】\nillust　：　華秀てんま様　https://x.com/tenma_ka\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用②)】\nllust　：　佐藤べに仔様　https://x.com/beni_0214\nmodeling　：　浅木式様　https://x.com/asagishiki00\n\n【Live2D(ASMR用③)】\nillust／clothes design　：　ギャラクシー伊藤様　https://x.com/Galaxy_ito\nmodeling　：　月夜見ロキ様　https://x.com/Roki_Tsukuyomi\n\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nX　　https://X.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
         "videoId": "9kMBmEvhwUk",
         "title": "お耳さわさわしながらひそひそお喋り♡【ASMR／囁き】",
@@ -6874,18 +7005,6 @@
           "⭐雑談💗",
           "🎧ASMR💗"
         ],
-        "thumbnailUrl": "https://i.ytimg.com/vi/9kMBmEvhwUk/maxresdefault_live.jpg",
-        "status": {
-          "privacyStatus": "public",
-          "uploadStatus": "uploaded",
-          "embeddable": true
-        },
-        "duration": "PT1H23M53S",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783690218,
-          "nanoseconds": 322000000
-        },
         "liveStreamingDetails": {
           "scheduledStartTime": {
             "__type__": "timestamp",
@@ -6906,151 +7025,27 @@
         },
         "videoType": "archived",
         "liveBroadcastContent": "none",
-        "statistics": {
-          "likeCount": 272,
-          "viewCount": 2948,
-          "commentCount": 2
-        }
-      }
-    },
-    {
-      "id": "9sX3eGSqUAc",
-      "data": {
+        "duration": "PT1H23M41S",
         "publishedAt": {
           "__type__": "timestamp",
-          "seconds": 1681480799,
+          "seconds": 1783691990,
           "nanoseconds": 0
         },
-        "caption": false,
-        "description": "【129】\nご視聴ありがとうございます(◍´͈ ᵕ `͈ ◍)💗雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/status/1509547916209262599\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【サムネイル】\n華秀てんま様　https://twitter.com/tenma_ka\n素敵に描いていただきました💞\n\n【Live2D】\nillust／clothes design　：　姫野アラタ様　https://twitter.com/ARThimeno\nmodeling　：　浅木式様　https://twitter.com/asagishiki00\n素敵なモデルありがとうございます💗\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
-        "videoId": "9sX3eGSqUAc",
-        "title": "全編無声音囁き💞吐息多めの囁き雑談でお耳と心を癒すASMR👂🌸【binaural／KU100】",
-        "liveBroadcastContent": "none",
-        "duration": "PT1H38M25S",
-        "audioButtonCount": 0,
-        "liveStreamingDetails": {
-          "actualStartTime": {
-            "__type__": "timestamp",
-            "seconds": 1681473581,
-            "nanoseconds": 0
-          },
-          "scheduledStartTime": {
-            "__type__": "timestamp",
-            "seconds": 1681473600,
-            "nanoseconds": 0
-          },
-          "actualEndTime": {
-            "__type__": "timestamp",
-            "seconds": 1681479484,
-            "nanoseconds": 0
-          }
-        },
-        "definition": "hd",
-        "dimension": "2d",
-        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
-        "channelTitle": "涼花みなせ / Suzuka Minase",
-        "player": {
-          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/9sX3eGSqUAc\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
-        },
-        "categoryId": "24",
+        "thumbnailUrl": "https://i.ytimg.com/vi/9kMBmEvhwUk/maxresdefault.jpg",
         "status": {
           "privacyStatus": "public",
-          "uploadStatus": "processed",
-          "embeddable": true
-        },
-        "tags": {
-          "playlistTags": [
-            "🎧ASMR💗"
-          ],
-          "userTags": [],
-          "contentTags": []
-        },
-        "playlistTags": [
-          "🎧ASMR💗"
-        ],
-        "videoType": "archived",
-        "userTags": [],
-        "id": "9sX3eGSqUAc",
-        "thumbnailUrl": "https://i.ytimg.com/vi/9sX3eGSqUAc/maxresdefault.jpg",
-        "updatedAt": "2025-08-22T04:05:14.816Z",
-        "lastFetchedAt": {
-          "__type__": "timestamp",
-          "seconds": 1783222218,
-          "nanoseconds": 0
-        },
-        "statistics": {
-          "commentCount": 15,
-          "favoriteCount": 0,
-          "likeCount": 827,
-          "viewCount": 38908
-        }
-      }
-    },
-    {
-      "id": "ABSbeZIjrD0",
-      "data": {
-        "publishedAt": {
-          "__type__": "timestamp",
-          "seconds": 1713088012,
-          "nanoseconds": 0
-        },
-        "caption": false,
-        "description": "ご視聴ありがとうございます(´ω`*)💛雑談、ASMR、ゲームなどなど、まったり配信していきます✨\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\nCi-enにてファンクラブ運営中です🌸\nオリジナルのえちち……💗なボイスや、ディスコサーバーでの不定期音声配信、季節のおハガキのお届けなど……いろんな特典をお届けしてます✨\n詳細は下記をご覧くださいっ🌟\nhttps://twitter.com/suzuka_minase/sta...\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n毎週金曜日の定期配信のあとは、23:00からニコニコチャンネル会員様限定放送でお会いしましょう💗\n＊すずみなちゃんねる＊　▶　https://ch.nicovideo.jp/suzuka-minase\n「もっとぐっと近い距離で、お耳に幸せをお届け♪」をコンセプトに、距離の近い密着感のあるコンテンツをご提供🤍\nASMR・耳○め放送や、チャンネルオリジナルキャラクターとあまあまな時間を過ごせるシチュエーション放送がメインコンテンツ🌟\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n＊お誕生日が近づいてきたリスナー様へ＊\n配信内の「ひとことお誕生日お祝い」コーナーにて、お名前・お誕生日の読み上げをご希望の際はこちらのフォームをご使用ください(▽`*)\nhttps://form.run/@szk-minase-1605250970\n読み漏れ防止のため、お誕生日が近づいてから（1～2週間前）お送り頂くようお願いいたします……！\n基本的にはお誕生日後の最初の定期配信にて読み上げをさせていただきます。\n※簡易的なものとなりますので、ボイスのリクエストはご遠慮ください※\n※いたずらでの送信はご遠慮ください※\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n【BGM】\nにっこりさん　  https://www.youtube.com/@niccori_3\nからお借りしています🎼🎶\n\n｡*⑅୨୧┈┈┈┈┈┈┈┈┈┈┈┈୨୧⑅*｡\n\n涼花みなせ\nTwitter　　https://twitter.com/suzuka_minase\nHP　　　https://www.szkminase.com/\nPOTOFU　https://potofu.me/suzuka-minase",
-        "videoId": "ABSbeZIjrD0",
-        "title": "【龍が如く0】第十二章から！どきどき…🔥【ストーリーのネタバレ含みます🌸】",
-        "liveBroadcastContent": "none",
-        "duration": "PT1H58M53S",
-        "audioButtonCount": 0,
-        "liveStreamingDetails": {
-          "actualStartTime": {
-            "__type__": "timestamp",
-            "seconds": 1713078298,
-            "nanoseconds": 0
-          },
-          "actualEndTime": {
-            "__type__": "timestamp",
-            "seconds": 1713085428,
-            "nanoseconds": 0
-          }
-        },
-        "definition": "hd",
-        "dimension": "2d",
-        "channelId": "UChiMMOhl6FpzjoRqvZ5rcaA",
-        "channelTitle": "涼花みなせ / Suzuka Minase",
-        "player": {
-          "embedHtml": "<iframe width=\"480\" height=\"270\" src=\"//www.youtube.com/embed/ABSbeZIjrD0\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
-        },
-        "categoryId": "20",
-        "status": {
-          "privacyStatus": "public",
-          "uploadStatus": "processed",
-          "embeddable": true
-        },
-        "tags": {
-          "playlistTags": [
-            "🎮ゲーム💗"
-          ],
-          "userTags": [],
-          "contentTags": []
-        },
-        "playlistTags": [
-          "🎮ゲーム💗"
-        ],
-        "videoType": "archived",
-        "userTags": [],
-        "id": "ABSbeZIjrD0",
-        "thumbnailUrl": "https://i.ytimg.com/vi/ABSbeZIjrD0/maxresdefault.jpg",
-        "updatedAt": "2025-08-22T04:05:14.850Z",
-        "statistics": {
-          "commentCount": 10,
-          "favoriteCount": 0,
-          "likeCount": 163,
-          "viewCount": 3408
+          "embeddable": true,
+          "uploadStatus": "processed"
         },
         "lastFetchedAt": {
           "__type__": "timestamp",
-          "seconds": 1782329417,
-          "nanoseconds": 679000000
+          "seconds": 1785670206,
+          "nanoseconds": 77000000
+        },
+        "statistics": {
+          "commentCount": 20,
+          "likeCount": 422,
+          "viewCount": 13415
         }
       }
     }

--- a/apps/functions/src/tools/firestore-local/fixtures/works.json
+++ b/apps/functions/src/tools/firestore-local/fixtures/works.json
@@ -110,55 +110,87 @@
             "name": "フェラチオ"
           }
         ],
-        "createdAt": "2026-07-17T15:06:22.311Z",
-        "lastFetchedAt": "2026-07-17T15:06:22.311Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.128Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.128Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1188,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 10,
-          "localePrices": {
-            "it_IT": 6.39,
-            "sv_SE": 70.53,
-            "id_ID": 131649,
-            "pt_BR": 6.39,
-            "vi_VN": 191644,
-            "th_TH": 245.66,
-            "fr_FR": 6.39,
-            "de_DE": 6.39,
-            "zh_TW": 236,
-            "ko_KR": 10839,
-            "en_US": 7.32,
-            "es_ES": 6.39,
-            "zh_CN": 49.61,
-            "ar_AE": 7.32
+          "point": 54,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 54
+          "localePrices": {
+            "zh_TW": 235,
+            "it_IT": 6.37,
+            "sv_SE": 70.48,
+            "id_ID": 129794,
+            "pt_BR": 6.37,
+            "vi_VN": 190660,
+            "th_TH": 244.4,
+            "fr_FR": 6.37,
+            "de_DE": 6.37,
+            "ko_KR": 10617,
+            "en_US": 7.25,
+            "es_ES": 6.37,
+            "zh_CN": 49.17,
+            "ar_AE": 7.25
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 4,
+              "ratio": 11
+            },
+            {
+              "review_point": 4,
+              "count": 6,
+              "ratio": 16
+            },
+            {
+              "review_point": 5,
+              "count": 27,
+              "ratio": 73
+            }
+          ],
+          "count": 37,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:22.311Z"
+            "lastFetched": "2026-07-25T01:05:10.128Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:22.311Z"
+        "updatedAt": "2026-07-25T01:05:10.128Z"
       }
     },
     {
@@ -276,55 +308,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:21.693Z",
-        "lastFetchedAt": "2026-07-17T15:06:21.693Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:09.295Z",
+        "lastFetchedAt": "2026-07-25T01:05:09.295Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 44,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 123,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 789,
+              "ratio": 82
+            }
+          ],
+          "count": 961,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:21.693Z"
+            "lastFetched": "2026-07-25T01:05:09.295Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:21.693Z"
+        "updatedAt": "2026-07-25T01:05:09.295Z"
       }
     },
     {
@@ -488,53 +562,95 @@
             "name": "処女"
           }
         ],
-        "createdAt": "2026-06-18T07:07:02.362Z",
-        "lastFetchedAt": "2026-06-18T07:07:02.362Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1540,
+          "point": 70,
           "localeOfficialPrices": {
-            "it_IT": 8.31,
-            "pt_BR": 8.31,
-            "fr_FR": 8.31,
-            "de_DE": 8.31,
             "zh_TW": 304,
-            "en_US": 9.6,
-            "es_ES": 8.31,
-            "ar_AE": 9.6,
-            "sv_SE": 90.68,
-            "ko_KR": 14570,
-            "id_ID": 170543,
-            "vi_VN": 251799,
-            "zh_CN": 65,
-            "th_TH": 312.87
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           },
           "localePrices": {
-            "it_IT": 8.31,
-            "sv_SE": 90.68,
-            "id_ID": 170543,
-            "pt_BR": 8.31,
-            "vi_VN": 251799,
-            "th_TH": 312.87,
-            "fr_FR": 8.31,
-            "de_DE": 8.31,
             "zh_TW": 304,
-            "ko_KR": 14570,
-            "en_US": 9.6,
-            "es_ES": 8.31,
-            "zh_CN": 65,
-            "ar_AE": 9.6
-          },
-          "point": 70
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 8,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 13,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 169,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 486,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 3980,
+              "ratio": 85
+            }
+          ],
+          "count": 4656,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-06-18T07:07:02.362Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2026-06-18T07:07:02.362Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -698,53 +814,95 @@
             "name": "処女"
           }
         ],
-        "createdAt": "2026-06-18T07:06:24.517Z",
-        "lastFetchedAt": "2026-06-18T07:06:24.517Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1540,
+          "point": 70,
           "localeOfficialPrices": {
-            "it_IT": 8.31,
-            "pt_BR": 8.31,
-            "fr_FR": 8.31,
-            "de_DE": 8.31,
             "zh_TW": 304,
-            "en_US": 9.6,
-            "es_ES": 8.31,
-            "ar_AE": 9.6,
-            "sv_SE": 90.68,
-            "ko_KR": 14570,
-            "id_ID": 170543,
-            "vi_VN": 251799,
-            "zh_CN": 65,
-            "th_TH": 312.87
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           },
           "localePrices": {
-            "it_IT": 8.31,
-            "sv_SE": 90.68,
-            "id_ID": 170543,
-            "pt_BR": 8.31,
-            "vi_VN": 251799,
-            "th_TH": 312.87,
-            "fr_FR": 8.31,
-            "de_DE": 8.31,
             "zh_TW": 304,
-            "ko_KR": 14570,
-            "en_US": 9.6,
-            "es_ES": 8.31,
-            "zh_CN": 65,
-            "ar_AE": 9.6
-          },
-          "point": 70
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 8,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 13,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 169,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 486,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 3980,
+              "ratio": 85
+            }
+          ],
+          "count": 4656,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-06-18T07:06:24.517Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2026-06-18T07:06:24.517Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -844,55 +1002,87 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.264Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.264Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.912Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.912Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 825,
           "original": 1650,
-          "localeOfficialPrices": {
-            "it_IT": 8.88,
-            "sv_SE": 97.96,
-            "id_ID": 182846,
-            "pt_BR": 8.88,
-            "vi_VN": 266172,
-            "th_TH": 341.2,
-            "fr_FR": 8.88,
-            "de_DE": 8.88,
-            "zh_TW": 328,
-            "ko_KR": 15055,
-            "en_US": 10.16,
-            "es_ES": 8.88,
-            "zh_CN": 68.91,
-            "ar_AE": 10.16
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 4.44,
-            "sv_SE": 48.98,
-            "id_ID": 91423,
-            "pt_BR": 4.44,
-            "vi_VN": 133086,
-            "th_TH": 170.6,
-            "fr_FR": 4.44,
-            "de_DE": 4.44,
-            "zh_TW": 164,
-            "ko_KR": 7527,
-            "en_US": 5.08,
-            "es_ES": 4.44,
-            "zh_CN": 34.45,
-            "ar_AE": 5.08
+          "point": 37,
+          "localeOfficialPrices": {
+            "it_IT": 8.85,
+            "pt_BR": 8.85,
+            "fr_FR": 8.85,
+            "de_DE": 8.85,
+            "zh_TW": 326,
+            "es_ES": 8.85,
+            "sv_SE": 97.88,
+            "ko_KR": 14745,
+            "en_US": 10.07,
+            "id_ID": 180269,
+            "vi_VN": 264805,
+            "zh_CN": 68.29,
+            "th_TH": 339.44,
+            "ar_AE": 10.07
           },
-          "point": 37
+          "localePrices": {
+            "it_IT": 4.43,
+            "pt_BR": 4.43,
+            "fr_FR": 4.43,
+            "de_DE": 4.43,
+            "zh_TW": 163,
+            "en_US": 5.04,
+            "es_ES": 4.43,
+            "ar_AE": 5.04,
+            "sv_SE": 48.94,
+            "ko_KR": 7373,
+            "id_ID": 90134,
+            "vi_VN": 132403,
+            "zh_CN": 34.14,
+            "th_TH": 169.72
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 11,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 31,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 198,
+              "ratio": 83
+            }
+          ],
+          "count": 240,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.264Z"
+            "lastFetched": "2026-07-25T01:05:10.912Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.264Z"
+        "updatedAt": "2026-07-25T01:05:10.912Z"
       }
     },
     {
@@ -1000,53 +1190,87 @@
         ],
         "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01003000/RJ01002873_img_main.jpg",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01003000/RJ01002873_img_sam.jpg",
-        "createdAt": "2026-07-16T15:05:57.657Z",
-        "lastFetchedAt": "2026-07-16T15:05:57.657Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.128Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.128Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "current": 1320,
+          "current": 924,
+          "original": 1320,
+          "discount": 30,
+          "point": 42,
           "localeOfficialPrices": {
-            "it_IT": 7.11,
-            "sv_SE": 78.36,
-            "id_ID": 147026,
-            "pt_BR": 7.11,
-            "vi_VN": 213109,
-            "th_TH": 273.3,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "zh_TW": 262,
-            "ko_KR": 12121,
-            "en_US": 8.14,
-            "es_ES": 7.11,
-            "zh_CN": 55.16,
-            "ar_AE": 8.14
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
           "localePrices": {
-            "it_IT": 7.11,
-            "sv_SE": 78.36,
-            "id_ID": 147026,
-            "pt_BR": 7.11,
-            "vi_VN": 213109,
-            "th_TH": 273.3,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "zh_TW": 262,
-            "ko_KR": 12121,
-            "en_US": 8.14,
-            "es_ES": 7.11,
-            "zh_CN": 55.16,
-            "ar_AE": 8.14
-          },
-          "point": 60
+            "it_IT": 4.96,
+            "pt_BR": 4.96,
+            "fr_FR": 4.96,
+            "de_DE": 4.96,
+            "zh_TW": 182,
+            "en_US": 5.64,
+            "es_ES": 4.96,
+            "ar_AE": 5.64,
+            "sv_SE": 54.81,
+            "ko_KR": 8257,
+            "id_ID": 100951,
+            "vi_VN": 148291,
+            "zh_CN": 38.24,
+            "th_TH": 190.09
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 6,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 14,
+              "ratio": 8
+            },
+            {
+              "review_point": 5,
+              "count": 146,
+              "ratio": 88
+            }
+          ],
+          "count": 166,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-16T15:05:57.657Z"
+            "lastFetched": "2026-07-25T01:05:10.128Z"
           }
         },
-        "updatedAt": "2026-07-16T15:05:57.657Z"
+        "updatedAt": "2026-07-25T01:05:10.128Z"
       }
     },
     {
@@ -1191,55 +1415,97 @@
           }
         ],
         "circle": "See you.",
-        "createdAt": "2026-07-17T15:06:21.693Z",
-        "lastFetchedAt": "2026-07-17T15:06:21.693Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:09.296Z",
+        "lastFetchedAt": "2026-07-25T01:05:09.295Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 23,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 51,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 368,
+              "ratio": 83
+            }
+          ],
+          "count": 445,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:21.693Z"
+            "lastFetched": "2026-07-25T01:05:09.295Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:21.693Z"
+        "updatedAt": "2026-07-25T01:05:09.296Z"
       }
     },
     {
@@ -1394,55 +1660,97 @@
             "displayOrder": 7
           }
         ],
-        "createdAt": "2026-07-17T15:06:22.310Z",
-        "lastFetchedAt": "2026-07-17T15:06:22.310Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:09.296Z",
+        "lastFetchedAt": "2026-07-25T01:05:09.296Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 605,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.26,
-            "sv_SE": 35.92,
-            "id_ID": 67043,
-            "pt_BR": 3.26,
-            "vi_VN": 97596,
-            "th_TH": 125.11,
-            "fr_FR": 3.26,
-            "de_DE": 3.26,
-            "zh_TW": 120,
-            "ko_KR": 5520,
-            "en_US": 3.73,
-            "es_ES": 3.26,
-            "zh_CN": 25.27,
-            "ar_AE": 3.73
+          "point": 27,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "pt_BR": 6.49,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "ar_AE": 7.39,
+            "sv_SE": 71.78,
+            "ko_KR": 10813,
+            "id_ID": 132197,
+            "vi_VN": 194190,
+            "zh_CN": 50.08,
+            "th_TH": 248.93
           },
-          "point": 27
+          "localePrices": {
+            "it_IT": 3.25,
+            "pt_BR": 3.25,
+            "fr_FR": 3.25,
+            "de_DE": 3.25,
+            "zh_TW": 119,
+            "es_ES": 3.25,
+            "sv_SE": 35.89,
+            "ko_KR": 5407,
+            "en_US": 3.69,
+            "id_ID": 66099,
+            "vi_VN": 97095,
+            "zh_CN": 25.04,
+            "th_TH": 124.46,
+            "ar_AE": 3.69
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 6,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 45,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 141,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 1009,
+              "ratio": 84
+            }
+          ],
+          "count": 1204,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:22.310Z"
+            "lastFetched": "2026-07-25T01:05:09.296Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:22.310Z"
+        "updatedAt": "2026-07-25T01:05:09.296Z"
       }
     },
     {
@@ -1572,53 +1880,92 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-06-18T07:06:30.933Z",
-        "lastFetchedAt": "2026-06-18T07:06:30.933Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "current": 1320,
+          "current": 660,
+          "original": 1320,
+          "discount": 50,
+          "point": 30,
           "localeOfficialPrices": {
-            "zh_TW": 260,
-            "en_US": 8.23,
-            "ar_AE": 8.23,
-            "it_IT": 7.12,
-            "sv_SE": 77.72,
-            "ko_KR": 12488,
-            "id_ID": 146179,
-            "pt_BR": 7.12,
-            "vi_VN": 215827,
-            "es_ES": 7.12,
-            "zh_CN": 55.71,
-            "th_TH": 268.18,
-            "fr_FR": 7.12,
-            "de_DE": 7.12
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
           "localePrices": {
-            "it_IT": 7.12,
-            "sv_SE": 77.72,
-            "id_ID": 146179,
-            "pt_BR": 7.12,
-            "vi_VN": 215827,
-            "th_TH": 268.18,
-            "fr_FR": 7.12,
-            "de_DE": 7.12,
-            "zh_TW": 260,
-            "ko_KR": 12488,
-            "en_US": 8.23,
-            "es_ES": 7.12,
-            "zh_CN": 55.71,
-            "ar_AE": 8.23
-          },
-          "point": 60
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 33,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 95,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 628,
+              "ratio": 83
+            }
+          ],
+          "count": 757,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-06-18T07:06:30.933Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-06-18T07:06:30.933Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -1775,53 +2122,95 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-05T15:05:30.095Z",
-        "lastFetchedAt": "2026-07-05T15:05:30.095Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:34.200Z",
+        "lastFetchedAt": "2026-07-25T17:03:34.200Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1540,
           "point": 70,
           "localeOfficialPrices": {
-            "it_IT": 8.35,
-            "pt_BR": 8.35,
-            "fr_FR": 8.35,
-            "de_DE": 8.35,
-            "es_ES": 8.35,
-            "zh_TW": 305,
-            "sv_SE": 92.17,
-            "ko_KR": 14639,
-            "en_US": 9.55,
-            "id_ID": 171626,
-            "vi_VN": 250407,
-            "zh_CN": 64.84,
-            "th_TH": 316.72,
-            "ar_AE": 9.55
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "zh_TW": 304,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           },
           "localePrices": {
-            "it_IT": 8.35,
-            "pt_BR": 8.35,
-            "fr_FR": 8.35,
-            "de_DE": 8.35,
-            "es_ES": 8.35,
-            "zh_TW": 305,
-            "sv_SE": 92.17,
-            "ko_KR": 14639,
-            "en_US": 9.55,
-            "id_ID": 171626,
-            "vi_VN": 250407,
-            "zh_CN": 64.84,
-            "th_TH": 316.72,
-            "ar_AE": 9.55
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "zh_TW": 304,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 11,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 78,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 242,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 2392,
+              "ratio": 88
+            }
+          ],
+          "count": 2724,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-05T15:05:30.095Z"
+            "lastFetched": "2026-07-25T17:03:34.200Z"
           }
         },
-        "updatedAt": "2026-07-05T15:05:30.095Z"
+        "updatedAt": "2026-07-25T17:03:34.200Z"
       }
     },
     {
@@ -1864,16 +2253,6 @@
         "titleMasked": "【英語版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
         "ageCategory": 3,
         "title": "【英語版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "ASMR",
-          "手コキ",
-          "中出し",
-          "フェラチオ",
-          "複数プレイ/乱交",
-          "耳舐め",
-          "巨乳/爆乳"
-        ],
         "id": "RJ01006704",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ425000/RJ424363_img_sam.jpg",
@@ -1933,14 +2312,48 @@
         "productId": "RJ01006704",
         "releaseDate": "2023-01-17 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年1月17日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006704.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-01-17 00:00:00",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "複数プレイ/乱交",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "releaseDateISO": "2023-01-17T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
-          {
-            "genre_key": "496",
-            "name": "バイノーラル/ダミヘ"
-          },
           {
             "genre_key": "497",
             "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
           },
           {
             "genre_key": "124",
@@ -1967,66 +2380,84 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2023年1月17日",
-        "workType": "SOU",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006704.html",
-        "circleId": "RG60289",
-        "category": "SOU",
-        "circle": "みんなで翻訳",
-        "sampleImages": [],
-        "workFormat": "ボイス・ASMR",
-        "fileFormat": "WAV",
-        "fileType": "WAV",
-        "registDate": "2023-01-17 00:00:00",
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "current": 110,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 10,
+          "point": 5,
           "localeOfficialPrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           },
           "localePrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           }
         },
-        "releaseDateISO": "2023-01-16T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.342Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 36,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 53,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 469,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 1286,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 8543,
+              "ratio": 82
+            }
+          ],
+          "count": 10387,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.342Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.342Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -2069,16 +2500,6 @@
         "titleMasked": "【繁体中文版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
         "ageCategory": 3,
         "title": "【繁体中文版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "ASMR",
-          "手コキ",
-          "中出し",
-          "フェラチオ",
-          "複数プレイ/乱交",
-          "耳舐め",
-          "巨乳/爆乳"
-        ],
         "id": "RJ01006896",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ425000/RJ424363_img_sam.jpg",
@@ -2138,14 +2559,48 @@
         "productId": "RJ01006896",
         "releaseDate": "2022-12-28 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2022年12月28日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006896.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2022-12-28 00:00:00",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "複数プレイ/乱交",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "releaseDateISO": "2022-12-28T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
-          {
-            "genre_key": "496",
-            "name": "バイノーラル/ダミヘ"
-          },
           {
             "genre_key": "497",
             "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
           },
           {
             "genre_key": "124",
@@ -2172,66 +2627,84 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2022年12月28日",
-        "workType": "SOU",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006896.html",
-        "circleId": "RG60289",
-        "category": "SOU",
-        "circle": "みんなで翻訳",
-        "sampleImages": [],
-        "workFormat": "ボイス・ASMR",
-        "fileFormat": "WAV",
-        "fileType": "WAV",
-        "registDate": "2022-12-28 00:00:00",
+        "createdAt": "2026-07-25T17:03:34.200Z",
+        "lastFetchedAt": "2026-07-25T17:03:34.200Z",
         "price": {
           "current": 110,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 10,
+          "point": 5,
           "localeOfficialPrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           },
           "localePrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           }
         },
-        "releaseDateISO": "2022-12-27T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.341Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.341Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 36,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 53,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 469,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 1286,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 8543,
+              "ratio": 82
+            }
+          ],
+          "count": 10387,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.341Z"
+            "lastFetched": "2026-07-25T17:03:34.200Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.341Z"
+        "updatedAt": "2026-07-25T17:03:34.200Z"
       }
     },
     {
@@ -2274,16 +2747,6 @@
         "titleMasked": "【簡体中文版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
         "ageCategory": 3,
         "title": "【簡体中文版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "ASMR",
-          "手コキ",
-          "中出し",
-          "フェラチオ",
-          "複数プレイ/乱交",
-          "耳舐め",
-          "巨乳/爆乳"
-        ],
         "id": "RJ01006911",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ425000/RJ424363_img_sam.jpg",
@@ -2343,14 +2806,48 @@
         "productId": "RJ01006911",
         "releaseDate": "2023-01-17 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年1月17日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006911.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-01-17 00:00:00",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "複数プレイ/乱交",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "releaseDateISO": "2023-01-17T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
-          {
-            "genre_key": "496",
-            "name": "バイノーラル/ダミヘ"
-          },
           {
             "genre_key": "497",
             "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
           },
           {
             "genre_key": "124",
@@ -2377,66 +2874,84 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2023年1月17日",
-        "workType": "SOU",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01006911.html",
-        "circleId": "RG60289",
-        "category": "SOU",
-        "circle": "みんなで翻訳",
-        "sampleImages": [],
-        "workFormat": "ボイス・ASMR",
-        "fileFormat": "WAV",
-        "fileType": "WAV",
-        "registDate": "2023-01-17 00:00:00",
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "current": 110,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 10,
+          "point": 5,
           "localeOfficialPrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           },
           "localePrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           }
         },
-        "releaseDateISO": "2023-01-16T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.342Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 36,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 53,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 469,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 1286,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 8543,
+              "ratio": 82
+            }
+          ],
+          "count": 10387,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.342Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.342Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -2575,55 +3090,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:07:06.203Z",
-        "lastFetchedAt": "2026-07-17T15:07:06.203Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 880,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 20,
-          "localePrices": {
-            "it_IT": 4.73,
-            "sv_SE": 52.24,
-            "id_ID": 97518,
-            "pt_BR": 4.73,
-            "vi_VN": 141958,
-            "th_TH": 181.97,
-            "fr_FR": 4.73,
-            "de_DE": 4.73,
-            "zh_TW": 175,
-            "ko_KR": 8029,
-            "en_US": 5.42,
-            "es_ES": 4.73,
-            "zh_CN": 36.75,
-            "ar_AE": 5.42
+          "point": 40,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "sv_SE": 65.51,
+            "id_ID": 120219,
+            "pt_BR": 5.9,
+            "vi_VN": 176452,
+            "th_TH": 227.32,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "ko_KR": 9910,
+            "en_US": 6.72,
+            "es_ES": 5.9,
+            "zh_CN": 45.58,
+            "ar_AE": 6.72
           },
-          "point": 40
+          "localePrices": {
+            "it_IT": 4.72,
+            "sv_SE": 52.41,
+            "id_ID": 96175,
+            "pt_BR": 4.72,
+            "vi_VN": 141161,
+            "th_TH": 181.86,
+            "fr_FR": 4.72,
+            "de_DE": 4.72,
+            "zh_TW": 174,
+            "ko_KR": 7928,
+            "en_US": 5.38,
+            "es_ES": 4.72,
+            "zh_CN": 36.46,
+            "ar_AE": 5.38
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:43.705Z",
+        "lastFetchedAt": "2026-07-25T01:05:43.705Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 7,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 40,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 148,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 1297,
+              "ratio": 87
+            }
+          ],
+          "count": 1495,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:06.203Z"
+            "lastFetched": "2026-07-25T01:05:43.705Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:06.203Z"
+        "updatedAt": "2026-07-25T01:05:43.705Z"
       }
     },
     {
@@ -2666,16 +3223,6 @@
         "titleMasked": "【韓国語版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
         "ageCategory": 3,
         "title": "【韓国語版】【サークル1周年記念/ず～っと100円!】耳舐めリフレWペロペロ&セックスコース",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "ASMR",
-          "手コキ",
-          "中出し",
-          "フェラチオ",
-          "複数プレイ/乱交",
-          "耳舐め",
-          "巨乳/爆乳"
-        ],
         "id": "RJ01007010",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ425000/RJ424363_img_sam.jpg",
@@ -2735,14 +3282,48 @@
         "productId": "RJ01007010",
         "releaseDate": "2023-04-01 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年4月1日",
+        "workType": "SOU",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01007010.html",
+        "circleId": "RG60289",
+        "category": "SOU",
+        "circle": "みんなで翻訳",
+        "sampleImages": [],
+        "workFormat": "ボイス・ASMR",
+        "fileFormat": "WAV",
+        "fileType": "WAV",
+        "registDate": "2023-04-01 00:00:00",
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "手コキ",
+          "中出し",
+          "フェラチオ",
+          "複数プレイ/乱交",
+          "耳舐め",
+          "巨乳/爆乳"
+        ],
+        "releaseDateISO": "2023-04-01T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
-          {
-            "genre_key": "496",
-            "name": "バイノーラル/ダミヘ"
-          },
           {
             "genre_key": "497",
             "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
           },
           {
             "genre_key": "124",
@@ -2769,66 +3350,84 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2023年4月1日",
-        "workType": "SOU",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01007010.html",
-        "circleId": "RG60289",
-        "category": "SOU",
-        "circle": "みんなで翻訳",
-        "sampleImages": [],
-        "workFormat": "ボイス・ASMR",
-        "fileFormat": "WAV",
-        "fileType": "WAV",
-        "registDate": "2023-04-01 00:00:00",
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
         "price": {
           "current": 110,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 10,
+          "point": 5,
           "localeOfficialPrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           },
           "localePrices": {
             "zh_TW": 22,
-            "en_US": 0.74,
-            "ar_AE": 0.74,
-            "it_IT": 0.64,
-            "pt_BR": 0.64,
-            "es_ES": 0.64,
-            "zh_CN": 5.32,
-            "fr_FR": 0.64,
-            "de_DE": 0.64,
-            "sv_SE": 7.15,
-            "ko_KR": 1030,
-            "id_ID": 12141,
-            "vi_VN": 19363,
-            "th_TH": 24.01
+            "it_IT": 0.59,
+            "pt_BR": 0.59,
+            "fr_FR": 0.59,
+            "de_DE": 0.59,
+            "en_US": 0.67,
+            "es_ES": 0.59,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           }
         },
-        "releaseDateISO": "2023-03-31T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.343Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.343Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 36,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 53,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 469,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 1286,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 8543,
+              "ratio": 82
+            }
+          ],
+          "count": 10387,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.343Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.343Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -2970,53 +3569,90 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-17T15:06:22.311Z",
-        "lastFetchedAt": "2026-07-17T15:06:22.311Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:34.200Z",
+        "lastFetchedAt": "2026-07-25T17:03:34.200Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1430,
+          "point": 65,
           "localeOfficialPrices": {
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "zh_TW": 284,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
+            "it_IT": 7.67,
+            "pt_BR": 7.67,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "es_ES": 7.67,
+            "sv_SE": 84.83,
+            "ko_KR": 12779,
+            "en_US": 8.73,
+            "id_ID": 156233,
+            "vi_VN": 229498,
+            "zh_CN": 59.18,
+            "th_TH": 294.18,
+            "ar_AE": 8.73
           },
           "localePrices": {
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "zh_TW": 284,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
-          },
-          "point": 65
+            "it_IT": 7.67,
+            "pt_BR": 7.67,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "es_ES": 7.67,
+            "sv_SE": 84.83,
+            "ko_KR": 12779,
+            "en_US": 8.73,
+            "id_ID": 156233,
+            "vi_VN": 229498,
+            "zh_CN": 59.18,
+            "th_TH": 294.18,
+            "ar_AE": 8.73
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 11,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 36,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 330,
+              "ratio": 87
+            }
+          ],
+          "count": 378,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:22.311Z"
+            "lastFetched": "2026-07-25T17:03:34.200Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:22.311Z"
+        "updatedAt": "2026-07-25T17:03:34.200Z"
       }
     },
     {
@@ -3131,55 +3767,92 @@
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008335_img_smp2.jpg"
           }
         ],
-        "createdAt": "2026-07-17T15:06:46.118Z",
-        "lastFetchedAt": "2026-07-17T15:06:46.118Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 605,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.26,
-            "sv_SE": 35.92,
-            "id_ID": 67043,
-            "pt_BR": 3.26,
-            "vi_VN": 97596,
-            "th_TH": 125.11,
-            "fr_FR": 3.26,
-            "de_DE": 3.26,
-            "zh_TW": 120,
-            "ko_KR": 5520,
-            "en_US": 3.73,
-            "es_ES": 3.26,
-            "zh_CN": 25.27,
-            "ar_AE": 3.73
+          "point": 27,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "sv_SE": 72.06,
+            "id_ID": 132240,
+            "pt_BR": 6.49,
+            "vi_VN": 194097,
+            "th_TH": 250.06,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "ko_KR": 10901,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "zh_CN": 50.14,
+            "ar_AE": 7.39
           },
-          "point": 27
+          "localePrices": {
+            "it_IT": 3.25,
+            "sv_SE": 36.03,
+            "id_ID": 66120,
+            "pt_BR": 3.25,
+            "vi_VN": 97048,
+            "th_TH": 125.03,
+            "fr_FR": 3.25,
+            "de_DE": 3.25,
+            "zh_TW": 119,
+            "ko_KR": 5450,
+            "en_US": 3.7,
+            "es_ES": 3.25,
+            "zh_CN": 25.07,
+            "ar_AE": 3.7
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:29.237Z",
+        "lastFetchedAt": "2026-07-25T01:05:29.237Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 19,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 54,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 533,
+              "ratio": 88
+            }
+          ],
+          "count": 609,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:46.118Z"
+            "lastFetched": "2026-07-25T01:05:29.237Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:46.118Z"
+        "updatedAt": "2026-07-25T01:05:29.237Z"
       }
     },
     {
@@ -3322,16 +3995,6 @@
         "titleMasked": "[ENG TL Patch] Clash of the G.O.A.T. Games ~Trading x Death Game~",
         "ageCategory": 3,
         "title": "[ENG TL Patch] Clash of the G.O.A.T. Games ~Trading x Death Game~",
-        "genres": [
-          "女主人公",
-          "人外娘/モンスター娘",
-          "売春/援交",
-          "レズ/女同士",
-          "陵辱",
-          "レイプ",
-          "異種姦",
-          "フタナリ"
-        ],
         "price": {
           "current": 0,
           "localeOfficialPrices": {
@@ -3372,12 +4035,44 @@
         },
         "id": "RJ01008336",
         "ageCategoryString": "adult",
-        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_sam.jpg",
         "languageDownloads": [],
         "originalCategoryText": "ロールプレイング",
         "productId": "RJ01008336",
         "releaseDate": "2022-12-26 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2022年12月26日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01008336.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2022-12-26 00:00:00",
+        "genres": [
+          "女主人公",
+          "人外娘/モンスター娘",
+          "売春/援交",
+          "異種姦",
+          "陵辱",
+          "レイプ",
+          "レズ/女同士",
+          "フタナリ"
+        ],
+        "releaseDateISO": "2022-12-26T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": true,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
           {
             "genre_key": "432",
@@ -3392,8 +4087,8 @@
             "name": "売春/援交"
           },
           {
-            "genre_key": "118",
-            "name": "レズ/女同士"
+            "genre_key": "324",
+            "name": "異種姦"
           },
           {
             "genre_key": "134",
@@ -3404,21 +4099,14 @@
             "name": "レイプ"
           },
           {
-            "genre_key": "324",
-            "name": "異種姦"
+            "genre_key": "118",
+            "name": "レズ/女同士"
           },
           {
             "genre_key": "190",
             "name": "フタナリ"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2022年12月26日",
-        "workType": "RPG",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01008336.html",
-        "circleId": "RG53217",
-        "category": "RPG",
-        "circle": "萌工房",
         "sampleImages": [
           {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp1.jpg"
@@ -3427,13 +4115,7 @@
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp2.jpg"
           },
           {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp3.jpg"
-          },
-          {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp4.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp5.jpg"
           },
           {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp6.jpg"
@@ -3446,25 +4128,44 @@
           },
           {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp9.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01009000/RJ01008336_img_smp10.jpg"
           }
         ],
-        "workFormat": "ロールプレイング",
-        "fileFormat": "アプリケーション",
-        "fileType": "EXE",
-        "registDate": "2022-12-26 00:00:00",
-        "releaseDateISO": "2022-12-25T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.341Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.341Z",
+        "thumbnailUrl": "https://www.dlsite.com/images/web/home/no_img_sam.gif",
+        "createdAt": "2026-07-25T17:03:34.200Z",
+        "lastFetchedAt": "2026-07-25T17:03:34.200Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 3,
+              "ratio": 4
+            },
+            {
+              "review_point": 3,
+              "count": 10,
+              "ratio": 14
+            },
+            {
+              "review_point": 4,
+              "count": 11,
+              "ratio": 15
+            },
+            {
+              "review_point": 5,
+              "count": 49,
+              "ratio": 67
+            }
+          ],
+          "count": 73,
+          "stars": 4.5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.341Z"
+            "lastFetched": "2026-07-25T17:03:34.200Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.341Z"
+        "updatedAt": "2026-07-25T17:03:34.200Z"
       }
     },
     {
@@ -3622,55 +4323,97 @@
             "name": "手コキ"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.264Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.264Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.408Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.408Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 528,
           "original": 880,
-          "localeOfficialPrices": {
-            "sv_SE": 52.24,
-            "zh_TW": 175,
-            "it_IT": 4.73,
-            "ko_KR": 8029,
-            "en_US": 5.42,
-            "id_ID": 97518,
-            "pt_BR": 4.73,
-            "vi_VN": 141958,
-            "es_ES": 4.73,
-            "zh_CN": 36.75,
-            "th_TH": 181.97,
-            "fr_FR": 4.73,
-            "ar_AE": 5.42,
-            "de_DE": 4.73
-          },
           "discount": 40,
-          "localePrices": {
-            "it_IT": 2.84,
-            "sv_SE": 31.35,
-            "id_ID": 58511,
-            "pt_BR": 2.84,
-            "vi_VN": 85175,
-            "th_TH": 109.18,
-            "fr_FR": 2.84,
-            "de_DE": 2.84,
-            "zh_TW": 105,
-            "ko_KR": 4818,
-            "en_US": 3.25,
-            "es_ES": 2.84,
-            "zh_CN": 22.05,
-            "ar_AE": 3.25
+          "point": 24,
+          "localeOfficialPrices": {
+            "it_IT": 4.72,
+            "pt_BR": 4.72,
+            "fr_FR": 4.72,
+            "de_DE": 4.72,
+            "zh_TW": 174,
+            "es_ES": 4.72,
+            "sv_SE": 52.2,
+            "ko_KR": 7864,
+            "en_US": 5.37,
+            "id_ID": 96143,
+            "vi_VN": 141229,
+            "zh_CN": 36.42,
+            "th_TH": 181.04,
+            "ar_AE": 5.37
           },
-          "point": 24
+          "localePrices": {
+            "it_IT": 2.83,
+            "pt_BR": 2.83,
+            "fr_FR": 2.83,
+            "de_DE": 2.83,
+            "zh_TW": 104,
+            "es_ES": 2.83,
+            "sv_SE": 31.32,
+            "ko_KR": 4718,
+            "en_US": 3.22,
+            "id_ID": 57686,
+            "vi_VN": 84738,
+            "zh_CN": 21.85,
+            "th_TH": 108.62,
+            "ar_AE": 3.22
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 1
+            },
+            {
+              "review_point": 2,
+              "count": 6,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 31,
+              "ratio": 6
+            },
+            {
+              "review_point": 4,
+              "count": 78,
+              "ratio": 14
+            },
+            {
+              "review_point": 5,
+              "count": 430,
+              "ratio": 78
+            }
+          ],
+          "count": 549,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.264Z"
+            "lastFetched": "2026-07-25T01:05:17.408Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.264Z"
+        "updatedAt": "2026-07-25T01:05:17.408Z"
       }
     },
     {
@@ -3799,55 +4542,87 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.141Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.141Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1078,
           "original": 1540,
-          "localeOfficialPrices": {
-            "it_IT": 8.29,
-            "pt_BR": 8.29,
-            "fr_FR": 8.29,
-            "de_DE": 8.29,
-            "es_ES": 8.29,
-            "zh_TW": 306,
-            "sv_SE": 91.43,
-            "ko_KR": 14051,
-            "en_US": 9.49,
-            "id_ID": 170656,
-            "vi_VN": 248427,
-            "zh_CN": 64.31,
-            "th_TH": 318.45,
-            "ar_AE": 9.49
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 5.8,
-            "sv_SE": 64,
-            "id_ID": 119459,
-            "pt_BR": 5.8,
-            "vi_VN": 173899,
-            "th_TH": 222.92,
-            "fr_FR": 5.8,
-            "de_DE": 5.8,
-            "zh_TW": 214,
-            "ko_KR": 9836,
-            "en_US": 6.64,
-            "es_ES": 5.8,
-            "zh_CN": 45.02,
-            "ar_AE": 6.64
+          "point": 49,
+          "localeOfficialPrices": {
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "zh_TW": 304,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           },
-          "point": 49
+          "localePrices": {
+            "it_IT": 5.78,
+            "pt_BR": 5.78,
+            "fr_FR": 5.78,
+            "de_DE": 5.78,
+            "zh_TW": 213,
+            "es_ES": 5.78,
+            "sv_SE": 63.95,
+            "ko_KR": 9634,
+            "en_US": 6.58,
+            "id_ID": 117776,
+            "vi_VN": 173006,
+            "zh_CN": 44.62,
+            "th_TH": 221.77,
+            "ar_AE": 6.58
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 4,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 24,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 211,
+              "ratio": 88
+            }
+          ],
+          "count": 239,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.141Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.141Z"
       }
     },
     {
@@ -3980,55 +4755,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:23.117Z",
-        "lastFetchedAt": "2026-07-17T15:06:23.117Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.128Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.128Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 6,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 36,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 105,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 763,
+              "ratio": 84
+            }
+          ],
+          "count": 912,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:23.117Z"
+            "lastFetched": "2026-07-25T01:05:10.128Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:23.117Z"
+        "updatedAt": "2026-07-25T01:05:10.128Z"
       }
     },
     {
@@ -4223,55 +5040,97 @@
             "displayOrder": 13
           }
         ],
-        "createdAt": "2026-07-17T15:06:23.117Z",
-        "lastFetchedAt": "2026-07-17T15:06:23.117Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.128Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.128Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 495,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 55,
+          "point": 22,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
+          },
           "localePrices": {
             "it_IT": 2.66,
-            "sv_SE": 29.39,
-            "id_ID": 54854,
             "pt_BR": 2.66,
-            "vi_VN": 79852,
-            "th_TH": 102.36,
             "fr_FR": 2.66,
             "de_DE": 2.66,
             "zh_TW": 98,
-            "ko_KR": 4516,
-            "en_US": 3.05,
             "es_ES": 2.66,
-            "zh_CN": 20.67,
-            "ar_AE": 3.05
-          },
-          "point": 22
+            "en_US": 3.02,
+            "ar_AE": 3.02,
+            "sv_SE": 29.37,
+            "ko_KR": 4424,
+            "id_ID": 54081,
+            "vi_VN": 79442,
+            "zh_CN": 20.49,
+            "th_TH": 101.83
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 6,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 21,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 191,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 612,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 4276,
+              "ratio": 84
+            }
+          ],
+          "count": 5106,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:23.117Z"
+            "lastFetched": "2026-07-25T01:05:10.128Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:23.117Z"
+        "updatedAt": "2026-07-25T01:05:10.128Z"
       }
     },
     {
@@ -4430,55 +5289,97 @@
             "name": "ささやき"
           }
         ],
-        "createdAt": "2026-07-17T15:06:54.073Z",
-        "lastFetchedAt": "2026-07-17T15:06:54.073Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:31.439Z",
+        "lastFetchedAt": "2026-07-25T01:05:31.439Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 9,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 94,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 279,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 2047,
+              "ratio": 84
+            }
+          ],
+          "count": 2433,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:54.073Z"
+            "lastFetched": "2026-07-25T01:05:31.439Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:54.073Z"
+        "updatedAt": "2026-07-25T01:05:31.439Z"
       }
     },
     {
@@ -4627,55 +5528,97 @@
         "fileType": "WAV",
         "registDate": "2023-01-25 00:00:00",
         "releaseDateISO": "2023-01-25T00:00:00.000Z",
-        "createdAt": "2026-07-17T15:06:23.540Z",
-        "lastFetchedAt": "2026-07-17T15:06:23.540Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 49,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 124,
+              "ratio": 8
+            },
+            {
+              "review_point": 5,
+              "count": 1371,
+              "ratio": 88
+            }
+          ],
+          "count": 1551,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:23.540Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:23.540Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -4787,55 +5730,97 @@
             "name": "メス堕ち"
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.141Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.141Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 17,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 40,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 320,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 898,
+              "ratio": 14
+            },
+            {
+              "review_point": 5,
+              "count": 5064,
+              "ratio": 80
+            }
+          ],
+          "count": 6339,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.141Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.141Z"
       }
     },
     {
@@ -4983,53 +5968,95 @@
             "name": "処女"
           }
         ],
-        "createdAt": "2026-06-18T07:06:24.517Z",
-        "lastFetchedAt": "2026-06-18T07:06:24.517Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1320,
+          "point": 60,
           "localeOfficialPrices": {
-            "zh_TW": 260,
-            "en_US": 8.23,
-            "ar_AE": 8.23,
-            "it_IT": 7.12,
-            "sv_SE": 77.72,
-            "ko_KR": 12488,
-            "id_ID": 146179,
-            "pt_BR": 7.12,
-            "vi_VN": 215827,
-            "es_ES": 7.12,
-            "zh_CN": 55.71,
-            "th_TH": 268.18,
-            "fr_FR": 7.12,
-            "de_DE": 7.12
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
           "localePrices": {
-            "it_IT": 7.12,
-            "sv_SE": 77.72,
-            "id_ID": 146179,
-            "pt_BR": 7.12,
-            "vi_VN": 215827,
-            "th_TH": 268.18,
-            "fr_FR": 7.12,
-            "de_DE": 7.12,
-            "zh_TW": 260,
-            "ko_KR": 12488,
-            "en_US": 8.23,
-            "es_ES": 7.12,
-            "zh_CN": 55.71,
-            "ar_AE": 8.23
-          },
-          "point": 60
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 7,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 11,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 127,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 380,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 3486,
+              "ratio": 87
+            }
+          ],
+          "count": 4011,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-06-18T07:06:24.517Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2026-06-18T07:06:24.517Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -5147,55 +6174,97 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-18T15:05:20.622Z",
-        "lastFetchedAt": "2026-07-18T15:05:20.622Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "it_IT": 7.11,
-            "sv_SE": 78.43,
-            "id_ID": 145985,
-            "pt_BR": 7.11,
-            "vi_VN": 213041,
-            "th_TH": 273.25,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "zh_TW": 263,
-            "ko_KR": 12088,
-            "en_US": 8.13,
-            "es_ES": 7.11,
-            "zh_CN": 55.13,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.21,
-            "id_ID": 72993,
-            "pt_BR": 3.55,
-            "vi_VN": 106520,
-            "th_TH": 136.63,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6044,
-            "en_US": 4.06,
-            "es_ES": 3.55,
-            "zh_CN": 27.57,
-            "ar_AE": 4.06
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.128Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.128Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 5,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 36,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 139,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 1328,
+              "ratio": 88
+            }
+          ],
+          "count": 1510,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-18T15:05:20.622Z"
+            "lastFetched": "2026-07-25T01:05:10.128Z"
           }
         },
-        "updatedAt": "2026-07-18T15:05:20.622Z"
+        "updatedAt": "2026-07-25T01:05:10.128Z"
       }
     },
     {
@@ -5251,16 +6320,6 @@
         "titleMasked": "【フォーリーサウンド】パパ活したら生徒が来た～生意気ロリ処女金髪jkの場合～",
         "ageCategory": 3,
         "title": "【フォーリーサウンド】パパ活したら生徒が来た～生意気ロリ処女金髪jkの場合～",
-        "genres": [
-          "学生",
-          "学校/学園",
-          "陵辱",
-          "調教",
-          "奴隷",
-          "羞恥/恥辱",
-          "強制/無理矢理",
-          "処女"
-        ],
         "id": "RJ01011411",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01012000/RJ01011411_img_sam.jpg",
@@ -5269,44 +6328,9 @@
         "productId": "RJ01011411",
         "releaseDate": "2023-01-10 00:00:00",
         "ageRating": "R18",
-        "customGenres": [
-          {
-            "genre_key": "400",
-            "name": "学生"
-          },
-          {
-            "genre_key": "001",
-            "name": "学校/学園"
-          },
-          {
-            "genre_key": "134",
-            "name": "陵辱"
-          },
-          {
-            "genre_key": "140",
-            "name": "調教"
-          },
-          {
-            "genre_key": "147",
-            "name": "奴隷"
-          },
-          {
-            "genre_key": "149",
-            "name": "羞恥/恥辱"
-          },
-          {
-            "genre_key": "114",
-            "name": "強制/無理矢理"
-          },
-          {
-            "genre_key": "193",
-            "name": "処女"
-          }
-        ],
         "fileSize": null,
         "releaseDateDisplay": "2023年1月10日",
         "workType": "SOU",
-        "releaseDateISO": "2023-01-09T15:00:00.000Z",
         "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01011411.html",
         "circleId": "RG57194",
         "category": "SOU",
@@ -5326,53 +6350,140 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-01-10 00:00:00",
+        "genres": [
+          "学生",
+          "学校/学園",
+          "強制/無理矢理",
+          "羞恥/恥辱",
+          "調教",
+          "奴隷",
+          "陵辱",
+          "処女"
+        ],
+        "releaseDateISO": "2023-01-10T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "customGenres": [
+          {
+            "genre_key": "400",
+            "name": "学生"
+          },
+          {
+            "genre_key": "001",
+            "name": "学校/学園"
+          },
+          {
+            "genre_key": "114",
+            "name": "強制/無理矢理"
+          },
+          {
+            "genre_key": "149",
+            "name": "羞恥/恥辱"
+          },
+          {
+            "genre_key": "140",
+            "name": "調教"
+          },
+          {
+            "genre_key": "147",
+            "name": "奴隷"
+          },
+          {
+            "genre_key": "134",
+            "name": "陵辱"
+          },
+          {
+            "genre_key": "193",
+            "name": "処女"
+          }
+        ],
+        "createdAt": "2026-07-25T17:03:34.200Z",
+        "lastFetchedAt": "2026-07-25T17:03:34.200Z",
         "price": {
           "current": 1320,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 120,
+          "point": 60,
           "localeOfficialPrices": {
-            "zh_TW": 264,
-            "it_IT": 7.69,
-            "sv_SE": 85.78,
-            "id_ID": 145695,
-            "pt_BR": 7.69,
-            "vi_VN": 232353,
-            "th_TH": 288.16,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 12360,
-            "en_US": 8.89,
-            "es_ES": 7.69,
-            "zh_CN": 63.81,
-            "ar_AE": 8.89
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
           "localePrices": {
-            "zh_TW": 264,
-            "it_IT": 7.69,
-            "sv_SE": 85.78,
-            "id_ID": 145695,
-            "pt_BR": 7.69,
-            "vi_VN": 232353,
-            "th_TH": 288.16,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 12360,
-            "en_US": 8.89,
-            "es_ES": 7.69,
-            "zh_CN": 63.81,
-            "ar_AE": 8.89
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           }
         },
-        "createdAt": "2025-07-30T15:13:27.342Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 17,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 58,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 356,
+              "ratio": 82
+            }
+          ],
+          "count": 434,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.342Z"
+            "lastFetched": "2026-07-25T17:03:34.200Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.342Z"
+        "updatedAt": "2026-07-25T17:03:34.200Z"
       }
     },
     {
@@ -5521,55 +6632,92 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T17:03:19.597Z",
-        "lastFetchedAt": "2026-07-17T17:03:19.597Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 847,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 4.56,
-            "sv_SE": 50.28,
-            "id_ID": 93861,
-            "pt_BR": 4.56,
-            "vi_VN": 136635,
-            "th_TH": 175.15,
-            "fr_FR": 4.56,
-            "de_DE": 4.56,
-            "zh_TW": 168,
-            "ko_KR": 7728,
-            "en_US": 5.22,
-            "es_ES": 4.56,
-            "zh_CN": 35.37,
-            "ar_AE": 5.22
+          "point": 38,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "sv_SE": 72.06,
+            "id_ID": 132240,
+            "pt_BR": 6.49,
+            "vi_VN": 194097,
+            "th_TH": 250.06,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "ko_KR": 10901,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "zh_CN": 50.14,
+            "ar_AE": 7.39
           },
-          "point": 38
+          "localePrices": {
+            "it_IT": 4.55,
+            "sv_SE": 50.44,
+            "id_ID": 92568,
+            "pt_BR": 4.55,
+            "vi_VN": 135868,
+            "th_TH": 175.04,
+            "fr_FR": 4.55,
+            "de_DE": 4.55,
+            "zh_TW": 167,
+            "ko_KR": 7631,
+            "en_US": 5.17,
+            "es_ES": 4.55,
+            "zh_CN": 35.1,
+            "ar_AE": 5.17
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:41.043Z",
+        "lastFetchedAt": "2026-07-25T01:06:41.043Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 21,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 59,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 401,
+              "ratio": 83
+            }
+          ],
+          "count": 484,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T17:03:19.597Z"
+            "lastFetched": "2026-07-25T01:06:41.043Z"
           }
         },
-        "updatedAt": "2026-07-17T17:03:19.597Z"
+        "updatedAt": "2026-07-25T01:06:41.043Z"
       }
     },
     {
@@ -5699,55 +6847,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:23.540Z",
-        "lastFetchedAt": "2026-07-17T15:06:23.540Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 907,
           "original": 1650,
-          "localeOfficialPrices": {
-            "it_IT": 8.88,
-            "sv_SE": 97.96,
-            "id_ID": 182846,
-            "pt_BR": 8.88,
-            "vi_VN": 266172,
-            "th_TH": 341.2,
-            "fr_FR": 8.88,
-            "de_DE": 8.88,
-            "zh_TW": 328,
-            "ko_KR": 15055,
-            "en_US": 10.16,
-            "es_ES": 8.88,
-            "zh_CN": 68.91,
-            "ar_AE": 10.16
-          },
           "discount": 45,
-          "localePrices": {
-            "it_IT": 4.88,
-            "sv_SE": 53.85,
-            "id_ID": 100510,
-            "pt_BR": 4.88,
-            "vi_VN": 146314,
-            "th_TH": 187.56,
-            "fr_FR": 4.88,
-            "de_DE": 4.88,
-            "zh_TW": 180,
-            "ko_KR": 8276,
-            "en_US": 5.59,
-            "es_ES": 4.88,
-            "zh_CN": 37.88,
-            "ar_AE": 5.59
+          "point": 41,
+          "localeOfficialPrices": {
+            "it_IT": 8.85,
+            "pt_BR": 8.85,
+            "fr_FR": 8.85,
+            "de_DE": 8.85,
+            "zh_TW": 326,
+            "es_ES": 8.85,
+            "sv_SE": 97.88,
+            "ko_KR": 14745,
+            "en_US": 10.07,
+            "id_ID": 180269,
+            "vi_VN": 264805,
+            "zh_CN": 68.29,
+            "th_TH": 339.44,
+            "ar_AE": 10.07
           },
-          "point": 41
+          "localePrices": {
+            "it_IT": 4.87,
+            "pt_BR": 4.87,
+            "fr_FR": 4.87,
+            "de_DE": 4.87,
+            "zh_TW": 179,
+            "en_US": 5.54,
+            "es_ES": 4.87,
+            "ar_AE": 5.54,
+            "sv_SE": 53.81,
+            "ko_KR": 8105,
+            "id_ID": 99093,
+            "vi_VN": 145563,
+            "zh_CN": 37.54,
+            "th_TH": 186.59
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 35,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 109,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 760,
+              "ratio": 84
+            }
+          ],
+          "count": 908,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:23.540Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:23.540Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -5889,55 +7079,97 @@
           }
         ],
         "circle": "See you.",
-        "createdAt": "2026-07-17T15:06:23.117Z",
-        "lastFetchedAt": "2026-07-17T15:06:23.117Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.129Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.129Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 19,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 67,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 507,
+              "ratio": 85
+            }
+          ],
+          "count": 595,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:23.117Z"
+            "lastFetched": "2026-07-25T01:05:10.129Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:23.117Z"
+        "updatedAt": "2026-07-25T01:05:10.129Z"
       }
     },
     {
@@ -5999,16 +7231,6 @@
         "titleMasked": "【総集編】ふたなり逆アナルでメス堕ち♪3作品まとめパックVol.2【KU100】",
         "ageCategory": 3,
         "title": "【総集編】ふたなり逆アナルでメス堕ち♪3作品まとめパックVol.2【KU100】",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "中出し",
-          "SM",
-          "言葉責め",
-          "男性受け",
-          "アナル",
-          "乳首/乳輪",
-          "フタナリ"
-        ],
         "id": "RJ01014157",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01015000/RJ01014157_img_sam.jpg",
@@ -6017,40 +7239,6 @@
         "productId": "RJ01014157",
         "releaseDate": "2023-02-01 00:00:00",
         "ageRating": "R18",
-        "customGenres": [
-          {
-            "genre_key": "496",
-            "name": "バイノーラル/ダミヘ"
-          },
-          {
-            "genre_key": "128",
-            "name": "中出し"
-          },
-          {
-            "genre_key": "136",
-            "name": "SM"
-          },
-          {
-            "genre_key": "144",
-            "name": "言葉責め"
-          },
-          {
-            "genre_key": "156",
-            "name": "男性受け"
-          },
-          {
-            "genre_key": "160",
-            "name": "アナル"
-          },
-          {
-            "genre_key": "185",
-            "name": "乳首/乳輪"
-          },
-          {
-            "genre_key": "190",
-            "name": "フタナリ"
-          }
-        ],
         "fileSize": null,
         "releaseDateDisplay": "2023年2月1日",
         "workType": "SOU",
@@ -6073,54 +7261,130 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-02-01 00:00:00",
+        "genres": [
+          "バイノーラル/ダミヘ",
+          "SM",
+          "アナル",
+          "言葉責め",
+          "男性受け",
+          "中出し",
+          "乳首/乳輪",
+          "フタナリ"
+        ],
+        "releaseDateISO": "2023-02-01T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "customGenres": [
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "136",
+            "name": "SM"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "144",
+            "name": "言葉責め"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "185",
+            "name": "乳首/乳輪"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "current": 3410,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 310,
+          "point": 155,
           "localeOfficialPrices": {
-            "it_IT": 19.88,
-            "sv_SE": 221.61,
-            "id_ID": 376380,
-            "pt_BR": 19.88,
-            "vi_VN": 600246,
-            "th_TH": 744.41,
-            "fr_FR": 19.88,
-            "de_DE": 19.88,
-            "zh_TW": 682,
-            "ko_KR": 31929,
-            "en_US": 22.96,
-            "es_ES": 19.88,
-            "zh_CN": 164.84,
-            "ar_AE": 22.96
+            "it_IT": 18.3,
+            "pt_BR": 18.3,
+            "fr_FR": 18.3,
+            "de_DE": 18.3,
+            "zh_TW": 673,
+            "es_ES": 18.3,
+            "sv_SE": 202.29,
+            "ko_KR": 30474,
+            "en_US": 20.82,
+            "id_ID": 372555,
+            "vi_VN": 547264,
+            "zh_CN": 141.13,
+            "th_TH": 701.52,
+            "ar_AE": 20.82
           },
           "localePrices": {
-            "it_IT": 19.88,
-            "sv_SE": 221.61,
-            "id_ID": 376380,
-            "pt_BR": 19.88,
-            "vi_VN": 600246,
-            "th_TH": 744.41,
-            "fr_FR": 19.88,
-            "de_DE": 19.88,
-            "zh_TW": 682,
-            "ko_KR": 31929,
-            "en_US": 22.96,
-            "es_ES": 19.88,
-            "zh_CN": 164.84,
-            "ar_AE": 22.96
+            "it_IT": 18.3,
+            "pt_BR": 18.3,
+            "fr_FR": 18.3,
+            "de_DE": 18.3,
+            "zh_TW": 673,
+            "es_ES": 18.3,
+            "sv_SE": 202.29,
+            "ko_KR": 30474,
+            "en_US": 20.82,
+            "id_ID": 372555,
+            "vi_VN": 547264,
+            "zh_CN": 141.13,
+            "th_TH": 701.52,
+            "ar_AE": 20.82
           }
         },
-        "releaseDateISO": "2023-01-31T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.342Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 2,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 2,
+              "ratio": 4
+            },
+            {
+              "review_point": 5,
+              "count": 52,
+              "ratio": 93
+            }
+          ],
+          "count": 56,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.342Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.342Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -6258,55 +7522,97 @@
             "name": "レイプ"
           }
         ],
-        "createdAt": "2026-07-17T15:07:37.594Z",
-        "lastFetchedAt": "2026-07-17T15:07:37.594Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:13.543Z",
+        "lastFetchedAt": "2026-07-25T01:06:13.543Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 23,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 51,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 368,
+              "ratio": 83
+            }
+          ],
+          "count": 445,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:37.594Z"
+            "lastFetched": "2026-07-25T01:06:13.543Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:37.594Z"
+        "updatedAt": "2026-07-25T01:06:13.543Z"
       }
     },
     {
@@ -6481,55 +7787,97 @@
             "name": "妊娠/孕ませ"
           }
         ],
-        "createdAt": "2026-07-17T17:04:52.644Z",
-        "lastFetchedAt": "2026-07-17T17:04:52.644Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:12:46.182Z",
+        "lastFetchedAt": "2026-07-25T01:12:46.182Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 786,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 35,
-          "localePrices": {
-            "it_IT": 4.23,
-            "sv_SE": 46.66,
-            "id_ID": 87101,
-            "pt_BR": 4.23,
-            "vi_VN": 126795,
-            "th_TH": 162.53,
-            "fr_FR": 4.23,
-            "de_DE": 4.23,
-            "zh_TW": 156,
-            "ko_KR": 7172,
-            "en_US": 4.84,
-            "es_ES": 4.23,
-            "zh_CN": 32.82,
-            "ar_AE": 4.84
+          "point": 35,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "pt_BR": 6.49,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "ar_AE": 7.39,
+            "sv_SE": 71.78,
+            "ko_KR": 10813,
+            "id_ID": 132197,
+            "vi_VN": 194190,
+            "zh_CN": 50.08,
+            "th_TH": 248.93
           },
-          "point": 35
+          "localePrices": {
+            "it_IT": 4.22,
+            "pt_BR": 4.22,
+            "fr_FR": 4.22,
+            "de_DE": 4.22,
+            "zh_TW": 155,
+            "en_US": 4.8,
+            "es_ES": 4.22,
+            "ar_AE": 4.8,
+            "sv_SE": 46.63,
+            "ko_KR": 7024,
+            "id_ID": 85873,
+            "vi_VN": 126143,
+            "zh_CN": 32.53,
+            "th_TH": 161.7
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 18,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 32,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 247,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 746,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 5371,
+              "ratio": 84
+            }
+          ],
+          "count": 6414,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T17:04:52.644Z"
+            "lastFetched": "2026-07-25T01:12:46.182Z"
           }
         },
-        "updatedAt": "2026-07-17T17:04:52.644Z"
+        "updatedAt": "2026-07-25T01:12:46.182Z"
       }
     },
     {
@@ -6667,55 +8015,97 @@
             "name": "妊娠/孕ませ"
           }
         ],
-        "createdAt": "2026-07-17T15:07:37.594Z",
-        "lastFetchedAt": "2026-07-17T15:07:37.594Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:13.544Z",
+        "lastFetchedAt": "2026-07-25T01:06:13.544Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "zh_TW": 218,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 7,
+              "ratio": 1
+            },
+            {
+              "review_point": 2,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 41,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 85,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 692,
+              "ratio": 83
+            }
+          ],
+          "count": 829,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:37.594Z"
+            "lastFetched": "2026-07-25T01:06:13.544Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:37.594Z"
+        "updatedAt": "2026-07-25T01:06:13.544Z"
       }
     },
     {
@@ -6837,55 +8227,97 @@
             "name": "調教"
           }
         ],
-        "createdAt": "2026-07-17T17:03:55.945Z",
-        "lastFetchedAt": "2026-07-17T17:03:55.945Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 693,
           "original": 990,
-          "localeOfficialPrices": {
-            "it_IT": 5.33,
-            "sv_SE": 58.77,
-            "pt_BR": 5.33,
-            "fr_FR": 5.33,
-            "de_DE": 5.33,
-            "es_ES": 5.33,
-            "zh_TW": 197,
-            "ko_KR": 9033,
-            "en_US": 6.1,
-            "id_ID": 109707,
-            "vi_VN": 159703,
-            "zh_CN": 41.34,
-            "th_TH": 204.72,
-            "ar_AE": 6.1
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 3.73,
-            "sv_SE": 41.14,
-            "id_ID": 76795,
-            "pt_BR": 3.73,
-            "vi_VN": 111792,
-            "th_TH": 143.3,
-            "fr_FR": 3.73,
-            "de_DE": 3.73,
-            "zh_TW": 138,
-            "ko_KR": 6323,
-            "en_US": 4.27,
-            "es_ES": 3.73,
-            "zh_CN": 28.94,
-            "ar_AE": 4.27
+          "point": 31,
+          "localeOfficialPrices": {
+            "it_IT": 5.31,
+            "sv_SE": 58.96,
+            "id_ID": 108197,
+            "pt_BR": 5.31,
+            "vi_VN": 158807,
+            "th_TH": 204.59,
+            "fr_FR": 5.31,
+            "de_DE": 5.31,
+            "zh_TW": 196,
+            "ko_KR": 8919,
+            "en_US": 6.05,
+            "es_ES": 5.31,
+            "zh_CN": 41.02,
+            "ar_AE": 6.05
           },
-          "point": 31
+          "localePrices": {
+            "it_IT": 3.72,
+            "sv_SE": 41.27,
+            "id_ID": 75738,
+            "pt_BR": 3.72,
+            "vi_VN": 111165,
+            "th_TH": 143.21,
+            "fr_FR": 3.72,
+            "de_DE": 3.72,
+            "zh_TW": 137,
+            "ko_KR": 6243,
+            "en_US": 4.23,
+            "es_ES": 3.72,
+            "zh_CN": 28.72,
+            "ar_AE": 4.23
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:07:12.095Z",
+        "lastFetchedAt": "2026-07-25T01:07:12.095Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 13,
+              "ratio": 2
+            },
+            {
+              "review_point": 3,
+              "count": 35,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 110,
+              "ratio": 15
+            },
+            {
+              "review_point": 5,
+              "count": 586,
+              "ratio": 78
+            }
+          ],
+          "count": 747,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T17:03:55.945Z"
+            "lastFetched": "2026-07-25T01:07:12.095Z"
           }
         },
-        "updatedAt": "2026-07-17T17:03:55.945Z"
+        "updatedAt": "2026-07-25T01:07:12.095Z"
       }
     },
     {
@@ -6893,50 +8325,12 @@
       "data": {
         "workTypeString": "ボイス・ASMR",
         "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ435000/RJ434500_img_main.jpg",
-        "creators": {
-          "others_by": [],
-          "scenario_by": [
-            {
-              "id": "56121",
-              "name": "辺村 始",
-              "classification": "scenario_by",
-              "sub_classification": null
-            }
-          ],
-          "voice_by": [
-            {
-              "id": "28165",
-              "name": "涼花みなせ",
-              "classification": "voice_by",
-              "sub_classification": null
-            }
-          ],
-          "illust_by": [
-            {
-              "id": "42488",
-              "name": "秋乃える",
-              "classification": "illust_by",
-              "sub_classification": null
-            }
-          ],
-          "created_by": [],
-          "music_by": []
-        },
         "fileTypeSpecial": "MP3同梱",
         "description": "優しい妹に慰められたい方へ。マイペースでかわいい妹が恥じらいながらHな慰めをしちゃいます。",
         "fileTypeString": "WAV",
         "titleMasked": "【簡体中文版】【KU100】マイペースかわいい妹に慰められるASMR",
         "ageCategory": 3,
         "title": "【簡体中文版】【KU100】マイペースかわいい妹に慰められるASMR",
-        "genres": [
-          "バイノーラル/ダミヘ",
-          "ASMR",
-          "妹",
-          "日常/生活",
-          "同居",
-          "ショートカット",
-          "処女"
-        ],
         "id": "RJ01015613",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ435000/RJ434500_img_sam.jpg",
@@ -6976,36 +8370,6 @@
         "productId": "RJ01015613",
         "releaseDate": "2023-05-04 00:00:00",
         "ageRating": "R18",
-        "customGenres": [
-          {
-            "genre_key": "496",
-            "name": "バイノーラル/ダミヘ"
-          },
-          {
-            "genre_key": "497",
-            "name": "ASMR"
-          },
-          {
-            "genre_key": "212",
-            "name": "妹"
-          },
-          {
-            "genre_key": "008",
-            "name": "日常/生活"
-          },
-          {
-            "genre_key": "031",
-            "name": "同居"
-          },
-          {
-            "genre_key": "166",
-            "name": "ショートカット"
-          },
-          {
-            "genre_key": "193",
-            "name": "処女"
-          }
-        ],
         "fileSize": null,
         "releaseDateDisplay": "2023年5月4日",
         "workType": "SOU",
@@ -7018,54 +8382,159 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-05-04 00:00:00",
+        "creators": {
+          "others_by": [],
+          "voice_by": [
+            {
+              "id": "28165",
+              "name": "涼花みなせ",
+              "classification": "voice_by",
+              "sub_classification": null
+            }
+          ],
+          "created_by": [],
+          "music_by": [],
+          "scenario_by": [
+            {
+              "id": "56121",
+              "name": "辺村始",
+              "classification": "scenario_by",
+              "sub_classification": null
+            }
+          ],
+          "illust_by": [
+            {
+              "id": "41582",
+              "name": "秋乃える",
+              "classification": "illust_by",
+              "sub_classification": null
+            }
+          ]
+        },
+        "genres": [
+          "ASMR",
+          "バイノーラル/ダミヘ",
+          "妹",
+          "同居",
+          "日常/生活",
+          "ショートカット",
+          "処女"
+        ],
+        "releaseDateISO": "2023-05-04T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 0,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "customGenres": [
+          {
+            "genre_key": "497",
+            "name": "ASMR"
+          },
+          {
+            "genre_key": "496",
+            "name": "バイノーラル/ダミヘ"
+          },
+          {
+            "genre_key": "212",
+            "name": "妹"
+          },
+          {
+            "genre_key": "031",
+            "name": "同居"
+          },
+          {
+            "genre_key": "008",
+            "name": "日常/生活"
+          },
+          {
+            "genre_key": "166",
+            "name": "ショートカット"
+          },
+          {
+            "genre_key": "193",
+            "name": "処女"
+          }
+        ],
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
         "price": {
           "current": 1320,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 120,
+          "point": 60,
           "localeOfficialPrices": {
-            "zh_TW": 264,
-            "it_IT": 7.69,
-            "sv_SE": 85.78,
-            "id_ID": 145695,
-            "pt_BR": 7.69,
-            "vi_VN": 232353,
-            "th_TH": 288.16,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 12360,
-            "en_US": 8.89,
-            "es_ES": 7.69,
-            "zh_CN": 63.81,
-            "ar_AE": 8.89
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
           "localePrices": {
-            "zh_TW": 264,
-            "it_IT": 7.69,
-            "sv_SE": 85.78,
-            "id_ID": 145695,
-            "pt_BR": 7.69,
-            "vi_VN": 232353,
-            "th_TH": 288.16,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 12360,
-            "en_US": 8.89,
-            "es_ES": 7.69,
-            "zh_CN": 63.81,
-            "ar_AE": 8.89
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           }
         },
-        "releaseDateISO": "2023-05-03T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.344Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.344Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 10,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 32,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 243,
+              "ratio": 85
+            }
+          ],
+          "count": 287,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.344Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.344Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -7210,55 +8679,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.263Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.263Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 13,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 85,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 219,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 1466,
+              "ratio": 82
+            }
+          ],
+          "count": 1785,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.263Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.263Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -7417,55 +8928,97 @@
         "fileType": "WAV",
         "registDate": "2024-03-09 00:00:00",
         "releaseDateISO": "2024-03-09T00:00:00.000Z",
-        "createdAt": "2026-07-17T15:07:37.594Z",
-        "lastFetchedAt": "2026-07-17T15:07:37.594Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 605,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.26,
-            "sv_SE": 35.92,
-            "id_ID": 67043,
-            "pt_BR": 3.26,
-            "vi_VN": 97596,
-            "th_TH": 125.11,
-            "fr_FR": 3.26,
-            "de_DE": 3.26,
-            "zh_TW": 120,
-            "ko_KR": 5520,
-            "en_US": 3.73,
-            "es_ES": 3.26,
-            "zh_CN": 25.27,
-            "ar_AE": 3.73
+          "point": 27,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "sv_SE": 72.06,
+            "id_ID": 132240,
+            "pt_BR": 6.49,
+            "vi_VN": 194097,
+            "th_TH": 250.06,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "ko_KR": 10901,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "zh_CN": 50.14,
+            "ar_AE": 7.39
           },
-          "point": 27
+          "localePrices": {
+            "it_IT": 3.25,
+            "sv_SE": 36.03,
+            "id_ID": 66120,
+            "pt_BR": 3.25,
+            "vi_VN": 97048,
+            "th_TH": 125.03,
+            "fr_FR": 3.25,
+            "de_DE": 3.25,
+            "zh_TW": 119,
+            "ko_KR": 5450,
+            "en_US": 3.7,
+            "es_ES": 3.25,
+            "zh_CN": 25.07,
+            "ar_AE": 3.7
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:14.998Z",
+        "lastFetchedAt": "2026-07-25T01:06:14.998Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 7,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 15,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 85,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 258,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 2178,
+              "ratio": 86
+            }
+          ],
+          "count": 2543,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:37.594Z"
+            "lastFetched": "2026-07-25T01:06:14.998Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:37.594Z"
+        "updatedAt": "2026-07-25T01:06:14.998Z"
       }
     },
     {
@@ -7622,53 +9175,95 @@
             "name": "男性受け"
           }
         ],
-        "createdAt": "2026-07-02T05:05:29.017Z",
-        "lastFetchedAt": "2026-07-02T05:05:29.017Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1650,
+          "point": 75,
           "localeOfficialPrices": {
-            "it_IT": 8.91,
-            "sv_SE": 98.75,
-            "id_ID": 182079,
-            "pt_BR": 8.91,
-            "vi_VN": 266258,
-            "th_TH": 338.29,
-            "fr_FR": 8.91,
-            "de_DE": 8.91,
-            "zh_TW": 323,
-            "ko_KR": 15774,
-            "en_US": 10.15,
-            "es_ES": 8.91,
-            "zh_CN": 69.02,
-            "ar_AE": 10.15
+            "it_IT": 8.85,
+            "pt_BR": 8.85,
+            "fr_FR": 8.85,
+            "de_DE": 8.85,
+            "zh_TW": 326,
+            "es_ES": 8.85,
+            "sv_SE": 97.88,
+            "ko_KR": 14745,
+            "en_US": 10.07,
+            "id_ID": 180269,
+            "vi_VN": 264805,
+            "zh_CN": 68.29,
+            "th_TH": 339.44,
+            "ar_AE": 10.07
           },
           "localePrices": {
-            "it_IT": 8.91,
-            "sv_SE": 98.75,
-            "id_ID": 182079,
-            "pt_BR": 8.91,
-            "vi_VN": 266258,
-            "th_TH": 338.29,
-            "fr_FR": 8.91,
-            "de_DE": 8.91,
-            "zh_TW": 323,
-            "ko_KR": 15774,
-            "en_US": 10.15,
-            "es_ES": 8.91,
-            "zh_CN": 69.02,
-            "ar_AE": 10.15
-          },
-          "point": 75
+            "it_IT": 8.85,
+            "pt_BR": 8.85,
+            "fr_FR": 8.85,
+            "de_DE": 8.85,
+            "zh_TW": 326,
+            "es_ES": 8.85,
+            "sv_SE": 97.88,
+            "ko_KR": 14745,
+            "en_US": 10.07,
+            "id_ID": 180269,
+            "vi_VN": 264805,
+            "zh_CN": 68.29,
+            "th_TH": 339.44,
+            "ar_AE": 10.07
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 43,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 117,
+              "ratio": 7
+            },
+            {
+              "review_point": 5,
+              "count": 1411,
+              "ratio": 89
+            }
+          ],
+          "count": 1579,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-02T05:05:29.017Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2026-07-02T05:05:29.017Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -7804,55 +9399,97 @@
         "fileType": "WAV",
         "registDate": "2023-05-12 00:00:00",
         "releaseDateISO": "2023-05-12T00:00:00.000Z",
-        "createdAt": "2026-07-17T15:06:45.557Z",
-        "lastFetchedAt": "2026-07-17T15:06:45.557Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:21.799Z",
+        "lastFetchedAt": "2026-07-25T01:05:21.799Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 110,
           "original": 220,
+          "discount": 50,
+          "point": 5,
           "localeOfficialPrices": {
-            "zh_TW": 44,
-            "en_US": 1.36,
-            "ar_AE": 1.36,
             "it_IT": 1.18,
-            "sv_SE": 13.06,
             "pt_BR": 1.18,
             "es_ES": 1.18,
-            "zh_CN": 9.19,
             "fr_FR": 1.18,
             "de_DE": 1.18,
-            "ko_KR": 2007,
-            "id_ID": 24379,
-            "vi_VN": 35490,
-            "th_TH": 45.49
+            "zh_TW": 43,
+            "en_US": 1.34,
+            "ar_AE": 1.34,
+            "sv_SE": 13.05,
+            "ko_KR": 1966,
+            "id_ID": 24036,
+            "vi_VN": 35307,
+            "zh_CN": 9.11,
+            "th_TH": 45.26
           },
-          "discount": 50,
           "localePrices": {
             "it_IT": 0.59,
-            "sv_SE": 6.53,
-            "id_ID": 12190,
             "pt_BR": 0.59,
-            "vi_VN": 17745,
-            "th_TH": 22.75,
             "fr_FR": 0.59,
             "de_DE": 0.59,
             "zh_TW": 22,
-            "ko_KR": 1004,
-            "en_US": 0.68,
             "es_ES": 0.59,
-            "zh_CN": 4.59,
-            "ar_AE": 0.68
-          },
-          "point": 5
+            "en_US": 0.67,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 6,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 61,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 139,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 1050,
+              "ratio": 83
+            }
+          ],
+          "count": 1259,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:45.557Z"
+            "lastFetched": "2026-07-25T01:05:21.799Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:45.557Z"
+        "updatedAt": "2026-07-25T01:05:21.799Z"
       }
     },
     {
@@ -7990,55 +9627,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:07:37.594Z",
-        "lastFetchedAt": "2026-07-17T15:07:37.594Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:14.998Z",
+        "lastFetchedAt": "2026-07-25T01:06:14.998Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 19,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 67,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 507,
+              "ratio": 85
+            }
+          ],
+          "count": 595,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:37.594Z"
+            "lastFetched": "2026-07-25T01:06:14.998Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:37.594Z"
+        "updatedAt": "2026-07-25T01:06:14.998Z"
       }
     },
     {
@@ -8200,53 +9879,90 @@
         ],
         "titleMasked": "【Android版】Element Embrace エレメントエンブレイス",
         "title": "【Android版】Element Embrace エレメントエンブレイス",
-        "createdAt": "2026-07-05T15:06:14.042Z",
-        "lastFetchedAt": "2026-07-05T15:06:14.042Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:56.139Z",
+        "lastFetchedAt": "2026-07-25T17:03:56.139Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1980,
+          "point": 90,
           "localeOfficialPrices": {
-            "it_IT": 10.73,
-            "sv_SE": 118.51,
-            "id_ID": 220662,
-            "pt_BR": 10.73,
-            "vi_VN": 321951,
-            "th_TH": 407.21,
-            "fr_FR": 10.73,
-            "de_DE": 10.73,
-            "zh_TW": 392,
-            "ko_KR": 18821,
-            "en_US": 12.28,
-            "es_ES": 10.73,
-            "zh_CN": 83.37,
-            "ar_AE": 12.28
+            "zh_TW": 391,
+            "it_IT": 10.62,
+            "sv_SE": 117.46,
+            "id_ID": 216323,
+            "pt_BR": 10.62,
+            "vi_VN": 317766,
+            "th_TH": 407.33,
+            "fr_FR": 10.62,
+            "de_DE": 10.62,
+            "ko_KR": 17694,
+            "en_US": 12.09,
+            "es_ES": 10.62,
+            "zh_CN": 81.95,
+            "ar_AE": 12.09
           },
           "localePrices": {
-            "it_IT": 10.73,
-            "sv_SE": 118.51,
-            "id_ID": 220662,
-            "pt_BR": 10.73,
-            "vi_VN": 321951,
-            "th_TH": 407.21,
-            "fr_FR": 10.73,
-            "de_DE": 10.73,
-            "zh_TW": 392,
-            "ko_KR": 18821,
-            "en_US": 12.28,
-            "es_ES": 10.73,
-            "zh_CN": 83.37,
-            "ar_AE": 12.28
-          },
-          "point": 90
+            "zh_TW": 391,
+            "it_IT": 10.62,
+            "sv_SE": 117.46,
+            "id_ID": 216323,
+            "pt_BR": 10.62,
+            "vi_VN": 317766,
+            "th_TH": 407.33,
+            "fr_FR": 10.62,
+            "de_DE": 10.62,
+            "ko_KR": 17694,
+            "en_US": 12.09,
+            "es_ES": 10.62,
+            "zh_CN": 81.95,
+            "ar_AE": 12.09
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 3
+            },
+            {
+              "review_point": 3,
+              "count": 2,
+              "ratio": 6
+            },
+            {
+              "review_point": 4,
+              "count": 8,
+              "ratio": 24
+            },
+            {
+              "review_point": 5,
+              "count": 22,
+              "ratio": 67
+            }
+          ],
+          "count": 33,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-05T15:06:14.042Z"
+            "lastFetched": "2026-07-25T17:03:56.139Z"
           }
         },
-        "updatedAt": "2026-07-05T15:06:14.042Z"
+        "updatedAt": "2026-07-25T17:03:56.139Z"
       }
     },
     {
@@ -8401,55 +10117,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:23.540Z",
-        "lastFetchedAt": "2026-07-17T15:06:23.540Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 24,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 110,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 902,
+              "ratio": 87
+            }
+          ],
+          "count": 1039,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:23.540Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:23.540Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -8642,55 +10400,97 @@
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01022000/RJ01021775_img_smp5.jpg"
           }
         ],
-        "createdAt": "2026-07-17T15:06:33.777Z",
-        "lastFetchedAt": "2026-07-17T15:06:33.777Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:20.982Z",
+        "lastFetchedAt": "2026-07-25T01:05:20.982Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 924,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 4.97,
-            "sv_SE": 54.86,
-            "id_ID": 102394,
-            "pt_BR": 4.97,
-            "vi_VN": 149056,
-            "th_TH": 191.07,
-            "fr_FR": 4.97,
-            "de_DE": 4.97,
-            "zh_TW": 184,
-            "ko_KR": 8431,
-            "en_US": 5.69,
-            "es_ES": 4.97,
-            "zh_CN": 38.59,
-            "ar_AE": 5.69
+          "point": 42,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 42
+          "localePrices": {
+            "it_IT": 4.96,
+            "pt_BR": 4.96,
+            "fr_FR": 4.96,
+            "de_DE": 4.96,
+            "zh_TW": 182,
+            "en_US": 5.64,
+            "es_ES": 4.96,
+            "ar_AE": 5.64,
+            "sv_SE": 54.81,
+            "ko_KR": 8257,
+            "id_ID": 100951,
+            "vi_VN": 148291,
+            "zh_CN": 38.24,
+            "th_TH": 190.09
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 9,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 11,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 142,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 449,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 4063,
+              "ratio": 87
+            }
+          ],
+          "count": 4674,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:33.777Z"
+            "lastFetched": "2026-07-25T01:05:20.982Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:33.777Z"
+        "updatedAt": "2026-07-25T01:05:20.982Z"
       }
     },
     {
@@ -8833,16 +10633,6 @@
         "titleMasked": "【AI翻译补丁】神游戏世界大战 ～行商x死亡游戏～",
         "ageCategory": 3,
         "title": "【AI翻译补丁】神游戏世界大战 ～行商x死亡游戏～",
-        "genres": [
-          "女主人公",
-          "人外娘/モンスター娘",
-          "売春/援交",
-          "レズ/女同士",
-          "陵辱",
-          "レイプ",
-          "異種姦",
-          "フタナリ"
-        ],
         "price": {
           "current": 0,
           "localeOfficialPrices": {
@@ -8889,6 +10679,39 @@
         "productId": "RJ01022017",
         "releaseDate": "2023-01-30 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年1月30日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022017.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-01-30 00:00:00",
+        "genres": [
+          "女主人公",
+          "人外娘/モンスター娘",
+          "売春/援交",
+          "異種姦",
+          "陵辱",
+          "レイプ",
+          "レズ/女同士",
+          "フタナリ"
+        ],
+        "releaseDateISO": "2023-01-30T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": true,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
           {
             "genre_key": "432",
@@ -8903,8 +10726,8 @@
             "name": "売春/援交"
           },
           {
-            "genre_key": "118",
-            "name": "レズ/女同士"
+            "genre_key": "324",
+            "name": "異種姦"
           },
           {
             "genre_key": "134",
@@ -8915,25 +10738,15 @@
             "name": "レイプ"
           },
           {
-            "genre_key": "324",
-            "name": "異種姦"
+            "genre_key": "118",
+            "name": "レズ/女同士"
           },
           {
             "genre_key": "190",
             "name": "フタナリ"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2023年1月30日",
-        "workType": "RPG",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01022017.html",
-        "circleId": "RG53217",
-        "category": "RPG",
-        "circle": "萌工房",
         "sampleImages": [
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp1.jpg"
-          },
           {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp2.jpg"
           },
@@ -8962,20 +10775,46 @@
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01023000/RJ01022017_img_smp10.jpg"
           }
         ],
-        "workFormat": "ロールプレイング",
-        "fileFormat": "アプリケーション",
-        "fileType": "EXE",
-        "registDate": "2023-01-30 00:00:00",
-        "releaseDateISO": "2023-01-29T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.342Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 4
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 3
+            },
+            {
+              "review_point": 3,
+              "count": 3,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 5,
+              "ratio": 7
+            },
+            {
+              "review_point": 5,
+              "count": 59,
+              "ratio": 82
+            }
+          ],
+          "count": 72,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.342Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.342Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -9130,55 +10969,97 @@
             "displayOrder": 7
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.264Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.264Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 45,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 136,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 1108,
+              "ratio": 86
+            }
+          ],
+          "count": 1293,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.264Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.264Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -9332,55 +11213,92 @@
             "name": "メス堕ち"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.264Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.264Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.912Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.912Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 715,
           "original": 1430,
-          "localeOfficialPrices": {
-            "zh_TW": 284,
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.85,
-            "sv_SE": 42.45,
-            "id_ID": 79233,
-            "pt_BR": 3.85,
-            "vi_VN": 115341,
-            "th_TH": 147.85,
-            "fr_FR": 3.85,
-            "de_DE": 3.85,
-            "zh_TW": 142,
-            "ko_KR": 6524,
-            "en_US": 4.4,
-            "es_ES": 3.85,
-            "zh_CN": 29.86,
-            "ar_AE": 4.4
+          "point": 32,
+          "localeOfficialPrices": {
+            "it_IT": 7.67,
+            "pt_BR": 7.67,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "es_ES": 7.67,
+            "sv_SE": 84.83,
+            "ko_KR": 12779,
+            "en_US": 8.73,
+            "id_ID": 156233,
+            "vi_VN": 229498,
+            "zh_CN": 59.18,
+            "th_TH": 294.18,
+            "ar_AE": 8.73
           },
-          "point": 32
+          "localePrices": {
+            "it_IT": 3.84,
+            "pt_BR": 3.84,
+            "fr_FR": 3.84,
+            "de_DE": 3.84,
+            "zh_TW": 141,
+            "es_ES": 3.84,
+            "sv_SE": 42.42,
+            "ko_KR": 6390,
+            "en_US": 4.36,
+            "id_ID": 78116,
+            "vi_VN": 114749,
+            "zh_CN": 29.59,
+            "th_TH": 147.09,
+            "ar_AE": 4.36
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 18,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 46,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 449,
+              "ratio": 87
+            }
+          ],
+          "count": 514,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.264Z"
+            "lastFetched": "2026-07-25T01:05:10.912Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.264Z"
+        "updatedAt": "2026-07-25T01:05:10.912Z"
       }
     },
     {
@@ -9539,55 +11457,97 @@
             "name": "ささやき"
           }
         ],
-        "createdAt": "2026-07-17T15:06:46.619Z",
-        "lastFetchedAt": "2026-07-17T15:06:46.619Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:29.238Z",
+        "lastFetchedAt": "2026-07-25T01:05:29.238Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 9,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 94,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 279,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 2047,
+              "ratio": 84
+            }
+          ],
+          "count": 2433,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:46.619Z"
+            "lastFetched": "2026-07-25T01:05:29.238Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:46.619Z"
+        "updatedAt": "2026-07-25T01:05:29.238Z"
       }
     },
     {
@@ -9707,55 +11667,92 @@
             "name": "調教"
           }
         ],
-        "createdAt": "2026-07-17T15:06:33.777Z",
-        "lastFetchedAt": "2026-07-17T15:06:33.777Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 11,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 29,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 191,
+              "ratio": 82
+            }
+          ],
+          "count": 232,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:33.777Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:33.777Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -9937,55 +11934,87 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-18T15:05:27.394Z",
-        "lastFetchedAt": "2026-07-18T15:05:27.394Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.408Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.408Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 396,
           "original": 1320,
-          "localeOfficialPrices": {
-            "it_IT": 7.11,
-            "pt_BR": 7.11,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "es_ES": 7.11,
-            "zh_TW": 263,
-            "sv_SE": 78.43,
-            "ko_KR": 12088,
-            "en_US": 8.13,
-            "id_ID": 145985,
-            "vi_VN": 213041,
-            "zh_CN": 55.13,
-            "th_TH": 273.25,
-            "ar_AE": 8.13
-          },
           "discount": 70,
-          "localePrices": {
-            "it_IT": 2.13,
-            "sv_SE": 23.53,
-            "id_ID": 43796,
-            "pt_BR": 2.13,
-            "vi_VN": 63912,
-            "th_TH": 81.98,
-            "fr_FR": 2.13,
-            "de_DE": 2.13,
-            "zh_TW": 79,
-            "ko_KR": 3626,
-            "en_US": 2.44,
-            "es_ES": 2.13,
-            "zh_CN": 16.54,
-            "ar_AE": 2.44
+          "point": 18,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 18
+          "localePrices": {
+            "zh_TW": 78,
+            "en_US": 2.42,
+            "ar_AE": 2.42,
+            "it_IT": 2.12,
+            "sv_SE": 23.49,
+            "ko_KR": 3539,
+            "id_ID": 43265,
+            "pt_BR": 2.12,
+            "vi_VN": 63553,
+            "es_ES": 2.12,
+            "zh_CN": 16.39,
+            "th_TH": 81.47,
+            "fr_FR": 2.12,
+            "de_DE": 2.12
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 2,
+              "ratio": 3
+            },
+            {
+              "review_point": 5,
+              "count": 61,
+              "ratio": 95
+            }
+          ],
+          "count": 64,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-18T15:05:27.394Z"
+            "lastFetched": "2026-07-25T01:05:17.408Z"
           }
         },
-        "updatedAt": "2026-07-18T15:05:27.394Z"
+        "updatedAt": "2026-07-25T01:05:17.408Z"
       }
     },
     {
@@ -10105,53 +12134,97 @@
             "name": "中出し"
           }
         ],
-        "createdAt": "2026-07-16T15:05:58.178Z",
-        "lastFetchedAt": "2026-07-16T15:05:58.178Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:10.911Z",
+        "lastFetchedAt": "2026-07-25T01:05:10.911Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "current": 770,
+          "current": 115,
+          "original": 770,
+          "discount": 85,
+          "point": 5,
           "localeOfficialPrices": {
-            "it_IT": 4.15,
-            "sv_SE": 45.71,
-            "id_ID": 85765,
-            "pt_BR": 4.15,
-            "vi_VN": 124314,
-            "th_TH": 159.42,
-            "fr_FR": 4.15,
-            "de_DE": 4.15,
-            "zh_TW": 153,
-            "ko_KR": 7071,
-            "en_US": 4.75,
-            "es_ES": 4.15,
-            "zh_CN": 32.18,
-            "ar_AE": 4.75
+            "it_IT": 4.13,
+            "pt_BR": 4.13,
+            "fr_FR": 4.13,
+            "de_DE": 4.13,
+            "zh_TW": 152,
+            "en_US": 4.7,
+            "es_ES": 4.13,
+            "ar_AE": 4.7,
+            "sv_SE": 45.68,
+            "ko_KR": 6881,
+            "id_ID": 84125,
+            "vi_VN": 123576,
+            "zh_CN": 31.87,
+            "th_TH": 158.41
           },
           "localePrices": {
-            "it_IT": 4.15,
-            "sv_SE": 45.71,
-            "id_ID": 85765,
-            "pt_BR": 4.15,
-            "vi_VN": 124314,
-            "th_TH": 159.42,
-            "fr_FR": 4.15,
-            "de_DE": 4.15,
-            "zh_TW": 153,
-            "ko_KR": 7071,
-            "en_US": 4.75,
-            "es_ES": 4.15,
-            "zh_CN": 32.18,
-            "ar_AE": 4.75
-          },
-          "point": 35
+            "it_IT": 0.62,
+            "pt_BR": 0.62,
+            "fr_FR": 0.62,
+            "de_DE": 0.62,
+            "zh_TW": 23,
+            "es_ES": 0.62,
+            "en_US": 0.7,
+            "ar_AE": 0.7,
+            "sv_SE": 6.82,
+            "ko_KR": 1028,
+            "id_ID": 12564,
+            "vi_VN": 18456,
+            "zh_CN": 4.76,
+            "th_TH": 23.66
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 7,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 12,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 148,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 381,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 2408,
+              "ratio": 81
+            }
+          ],
+          "count": 2956,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-16T15:05:58.178Z"
+            "lastFetched": "2026-07-25T01:05:10.911Z"
           }
         },
-        "updatedAt": "2026-07-16T15:05:58.178Z"
+        "updatedAt": "2026-07-25T01:05:10.911Z"
       }
     },
     {
@@ -10252,55 +12325,92 @@
             "name": "童貞"
           }
         ],
-        "createdAt": "2026-07-17T15:06:47.373Z",
-        "lastFetchedAt": "2026-07-17T15:06:47.373Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:29.906Z",
+        "lastFetchedAt": "2026-07-25T01:05:29.906Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 924,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 4.97,
-            "sv_SE": 54.86,
-            "id_ID": 102394,
-            "pt_BR": 4.97,
-            "vi_VN": 149056,
-            "th_TH": 191.07,
-            "fr_FR": 4.97,
-            "de_DE": 4.97,
-            "zh_TW": 184,
-            "ko_KR": 8431,
-            "en_US": 5.69,
-            "es_ES": 4.97,
-            "zh_CN": 38.59,
-            "ar_AE": 5.69
+          "point": 42,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 42
+          "localePrices": {
+            "it_IT": 4.96,
+            "pt_BR": 4.96,
+            "fr_FR": 4.96,
+            "de_DE": 4.96,
+            "zh_TW": 182,
+            "en_US": 5.64,
+            "es_ES": 4.96,
+            "ar_AE": 5.64,
+            "sv_SE": 54.81,
+            "ko_KR": 8257,
+            "id_ID": 100951,
+            "vi_VN": 148291,
+            "zh_CN": 38.24,
+            "th_TH": 190.09
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 4,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 20,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 31,
+              "ratio": 6
+            },
+            {
+              "review_point": 5,
+              "count": 483,
+              "ratio": 90
+            }
+          ],
+          "count": 538,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:47.373Z"
+            "lastFetched": "2026-07-25T01:05:29.906Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:47.373Z"
+        "updatedAt": "2026-07-25T01:05:29.906Z"
       }
     },
     {
@@ -10477,55 +12587,97 @@
             "displayOrder": 9
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 924,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 4.97,
-            "sv_SE": 54.86,
-            "id_ID": 102394,
-            "pt_BR": 4.97,
-            "vi_VN": 149056,
-            "th_TH": 191.07,
-            "fr_FR": 4.97,
-            "de_DE": 4.97,
-            "zh_TW": 184,
-            "ko_KR": 8431,
-            "en_US": 5.69,
-            "es_ES": 4.97,
-            "zh_CN": 38.59,
-            "ar_AE": 5.69
+          "point": 42,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 42
+          "localePrices": {
+            "it_IT": 4.96,
+            "sv_SE": 55.03,
+            "id_ID": 100984,
+            "pt_BR": 4.96,
+            "vi_VN": 148219,
+            "th_TH": 190.95,
+            "fr_FR": 4.96,
+            "de_DE": 4.96,
+            "zh_TW": 182,
+            "ko_KR": 8324,
+            "en_US": 5.64,
+            "es_ES": 4.96,
+            "zh_CN": 38.29,
+            "ar_AE": 5.64
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.141Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.141Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 7,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 69,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 233,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 1886,
+              "ratio": 86
+            }
+          ],
+          "count": 2199,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.141Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.141Z"
       }
     },
     {
@@ -10633,53 +12785,95 @@
             "name": "フェラチオ"
           }
         ],
-        "createdAt": "2026-07-05T15:05:36.676Z",
-        "lastFetchedAt": "2026-07-05T15:05:36.676Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 220,
           "point": 10,
           "localeOfficialPrices": {
-            "zh_TW": 44,
-            "it_IT": 1.19,
-            "sv_SE": 13.17,
-            "id_ID": 24518,
-            "pt_BR": 1.19,
-            "vi_VN": 35772,
-            "th_TH": 45.25,
-            "fr_FR": 1.19,
-            "de_DE": 1.19,
-            "ko_KR": 2091,
-            "en_US": 1.36,
-            "es_ES": 1.19,
-            "zh_CN": 9.26,
-            "ar_AE": 1.36
+            "it_IT": 1.18,
+            "pt_BR": 1.18,
+            "fr_FR": 1.18,
+            "de_DE": 1.18,
+            "zh_TW": 43,
+            "en_US": 1.34,
+            "es_ES": 1.18,
+            "ar_AE": 1.34,
+            "sv_SE": 13.05,
+            "ko_KR": 1966,
+            "id_ID": 24036,
+            "vi_VN": 35307,
+            "zh_CN": 9.11,
+            "th_TH": 45.26
           },
           "localePrices": {
-            "zh_TW": 44,
-            "it_IT": 1.19,
-            "sv_SE": 13.17,
-            "id_ID": 24518,
-            "pt_BR": 1.19,
-            "vi_VN": 35772,
-            "th_TH": 45.25,
-            "fr_FR": 1.19,
-            "de_DE": 1.19,
-            "ko_KR": 2091,
-            "en_US": 1.36,
-            "es_ES": 1.19,
-            "zh_CN": 9.26,
-            "ar_AE": 1.36
+            "it_IT": 1.18,
+            "pt_BR": 1.18,
+            "fr_FR": 1.18,
+            "de_DE": 1.18,
+            "zh_TW": 43,
+            "en_US": 1.34,
+            "es_ES": 1.18,
+            "ar_AE": 1.34,
+            "sv_SE": 13.05,
+            "ko_KR": 1966,
+            "id_ID": 24036,
+            "vi_VN": 35307,
+            "zh_CN": 9.11,
+            "th_TH": 45.26
           }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 1
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 23,
+              "ratio": 6
+            },
+            {
+              "review_point": 4,
+              "count": 54,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 331,
+              "ratio": 80
+            }
+          ],
+          "count": 414,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-05T15:05:36.676Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2026-07-05T15:05:36.676Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -10905,53 +13099,95 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-05T15:05:36.676Z",
-        "lastFetchedAt": "2026-07-05T15:05:36.676Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1320,
           "point": 60,
           "localeOfficialPrices": {
-            "it_IT": 7.16,
-            "sv_SE": 79,
-            "id_ID": 147108,
-            "pt_BR": 7.16,
-            "vi_VN": 214634,
-            "th_TH": 271.47,
-            "fr_FR": 7.16,
-            "de_DE": 7.16,
             "zh_TW": 261,
-            "ko_KR": 12548,
-            "en_US": 8.18,
-            "es_ES": 7.16,
-            "zh_CN": 55.58,
-            "ar_AE": 8.18
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
           "localePrices": {
-            "it_IT": 7.16,
-            "sv_SE": 79,
-            "id_ID": 147108,
-            "pt_BR": 7.16,
-            "vi_VN": 214634,
-            "th_TH": 271.47,
-            "fr_FR": 7.16,
-            "de_DE": 7.16,
             "zh_TW": 261,
-            "ko_KR": 12548,
-            "en_US": 8.18,
-            "es_ES": 7.16,
-            "zh_CN": 55.58,
-            "ar_AE": 8.18
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 8,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 42,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 130,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 909,
+              "ratio": 83
+            }
+          ],
+          "count": 1090,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-05T15:05:36.676Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2026-07-05T15:05:36.676Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -11089,55 +13325,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:07:15.527Z",
-        "lastFetchedAt": "2026-07-17T15:07:15.527Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:53.086Z",
+        "lastFetchedAt": "2026-07-25T01:05:53.086Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 19,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 67,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 507,
+              "ratio": 85
+            }
+          ],
+          "count": 595,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:15.527Z"
+            "lastFetched": "2026-07-25T01:05:53.086Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:15.527Z"
+        "updatedAt": "2026-07-25T01:05:53.086Z"
       }
     },
     {
@@ -11268,16 +13546,6 @@
         "titleMasked": "[ENG TL Patch] Fallen Saint Yhoundeh",
         "ageCategory": 3,
         "title": "[ENG TL Patch] Fallen Saint Yhoundeh",
-        "genres": [
-          "女主人公",
-          "妊娠/孕ませ",
-          "陵辱",
-          "レイプ",
-          "輪姦",
-          "異種姦",
-          "獣耳",
-          "処女"
-        ],
         "price": {
           "current": 0,
           "localeOfficialPrices": {
@@ -11318,16 +13586,52 @@
         },
         "id": "RJ01024723",
         "ageCategoryString": "adult",
-        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_sam.jpg",
         "languageDownloads": [],
         "originalCategoryText": "ロールプレイング",
         "productId": "RJ01024723",
         "releaseDate": "2023-02-06 00:00:00",
         "ageRating": "R18",
+        "fileSize": null,
+        "releaseDateDisplay": "2023年2月6日",
+        "workType": "RPG",
+        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024723.html",
+        "circleId": "RG53217",
+        "category": "RPG",
+        "circle": "萌工房",
+        "workFormat": "ロールプレイング",
+        "fileFormat": "アプリケーション",
+        "fileType": "EXE",
+        "registDate": "2023-02-06 00:00:00",
+        "genres": [
+          "女主人公",
+          "異種姦",
+          "妊娠/孕ませ",
+          "陵辱",
+          "輪姦",
+          "レイプ",
+          "獣耳",
+          "処女"
+        ],
+        "releaseDateISO": "2023-02-06T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": true,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
         "customGenres": [
           {
             "genre_key": "432",
             "name": "女主人公"
+          },
+          {
+            "genre_key": "324",
+            "name": "異種姦"
           },
           {
             "genre_key": "129",
@@ -11338,16 +13642,12 @@
             "name": "陵辱"
           },
           {
-            "genre_key": "113",
-            "name": "レイプ"
-          },
-          {
             "genre_key": "121",
             "name": "輪姦"
           },
           {
-            "genre_key": "324",
-            "name": "異種姦"
+            "genre_key": "113",
+            "name": "レイプ"
           },
           {
             "genre_key": "176",
@@ -11358,59 +13658,55 @@
             "name": "処女"
           }
         ],
-        "fileSize": null,
-        "releaseDateDisplay": "2023年2月6日",
-        "workType": "RPG",
-        "workUrl": "https://www.dlsite.com/maniax/work/=/product_id/RJ01024723.html",
-        "circleId": "RG53217",
-        "category": "RPG",
-        "circle": "萌工房",
         "sampleImages": [
           {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp1.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp2.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp3.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp4.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp5.jpg"
-          },
-          {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp6.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp7.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp8.jpg"
-          },
-          {
-            "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp9.jpg"
           },
           {
             "thumb": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01025000/RJ01024723_img_smp10.jpg"
           }
         ],
-        "workFormat": "ロールプレイング",
-        "fileFormat": "アプリケーション",
-        "fileType": "EXE",
-        "registDate": "2023-02-06 00:00:00",
-        "releaseDateISO": "2023-02-05T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.342Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.342Z",
+        "thumbnailUrl": "https://www.dlsite.com/images/web/home/no_img_sam.gif",
+        "createdAt": "2026-07-25T17:03:35.563Z",
+        "lastFetchedAt": "2026-07-25T17:03:35.563Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 5
+            },
+            {
+              "review_point": 2,
+              "count": 4,
+              "ratio": 5
+            },
+            {
+              "review_point": 3,
+              "count": 5,
+              "ratio": 7
+            },
+            {
+              "review_point": 4,
+              "count": 13,
+              "ratio": 17
+            },
+            {
+              "review_point": 5,
+              "count": 50,
+              "ratio": 66
+            }
+          ],
+          "count": 76,
+          "stars": 4.5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.342Z"
+            "lastFetched": "2026-07-25T17:03:35.563Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.342Z"
+        "updatedAt": "2026-07-25T17:03:35.563Z"
       }
     },
     {
@@ -11592,55 +13888,82 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-18T15:05:27.716Z",
-        "lastFetchedAt": "2026-07-18T15:05:27.716Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.408Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.408Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 396,
           "original": 1320,
-          "localeOfficialPrices": {
-            "it_IT": 7.11,
-            "pt_BR": 7.11,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "es_ES": 7.11,
-            "zh_TW": 263,
-            "sv_SE": 78.43,
-            "ko_KR": 12088,
-            "en_US": 8.13,
-            "id_ID": 145985,
-            "vi_VN": 213041,
-            "zh_CN": 55.13,
-            "th_TH": 273.25,
-            "ar_AE": 8.13
-          },
           "discount": 70,
-          "localePrices": {
-            "it_IT": 2.13,
-            "sv_SE": 23.53,
-            "id_ID": 43796,
-            "pt_BR": 2.13,
-            "vi_VN": 63912,
-            "th_TH": 81.98,
-            "fr_FR": 2.13,
-            "de_DE": 2.13,
-            "zh_TW": 79,
-            "ko_KR": 3626,
-            "en_US": 2.44,
-            "es_ES": 2.13,
-            "zh_CN": 16.54,
-            "ar_AE": 2.44
+          "point": 18,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 18
+          "localePrices": {
+            "zh_TW": 78,
+            "en_US": 2.42,
+            "ar_AE": 2.42,
+            "it_IT": 2.12,
+            "sv_SE": 23.49,
+            "ko_KR": 3539,
+            "id_ID": 43265,
+            "pt_BR": 2.12,
+            "vi_VN": 63553,
+            "es_ES": 2.12,
+            "zh_CN": 16.39,
+            "th_TH": 81.47,
+            "fr_FR": 2.12,
+            "de_DE": 2.12
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 4,
+              "count": 1,
+              "ratio": 1
+            },
+            {
+              "review_point": 5,
+              "count": 96,
+              "ratio": 99
+            }
+          ],
+          "count": 97,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-18T15:05:27.716Z"
+            "lastFetched": "2026-07-25T01:05:17.408Z"
           }
         },
-        "updatedAt": "2026-07-18T15:05:27.716Z"
+        "updatedAt": "2026-07-25T01:05:17.408Z"
       }
     },
     {
@@ -11822,55 +14145,82 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-18T15:05:27.716Z",
-        "lastFetchedAt": "2026-07-18T15:05:27.716Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.408Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.408Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 396,
           "original": 1320,
-          "localeOfficialPrices": {
-            "it_IT": 7.11,
-            "pt_BR": 7.11,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "es_ES": 7.11,
-            "zh_TW": 263,
-            "sv_SE": 78.43,
-            "ko_KR": 12088,
-            "en_US": 8.13,
-            "id_ID": 145985,
-            "vi_VN": 213041,
-            "zh_CN": 55.13,
-            "th_TH": 273.25,
-            "ar_AE": 8.13
-          },
           "discount": 70,
-          "localePrices": {
-            "it_IT": 2.13,
-            "sv_SE": 23.53,
-            "id_ID": 43796,
-            "pt_BR": 2.13,
-            "vi_VN": 63912,
-            "th_TH": 81.98,
-            "fr_FR": 2.13,
-            "de_DE": 2.13,
-            "zh_TW": 79,
-            "ko_KR": 3626,
-            "en_US": 2.44,
-            "es_ES": 2.13,
-            "zh_CN": 16.54,
-            "ar_AE": 2.44
+          "point": 18,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 18
+          "localePrices": {
+            "zh_TW": 78,
+            "en_US": 2.42,
+            "ar_AE": 2.42,
+            "it_IT": 2.12,
+            "sv_SE": 23.49,
+            "ko_KR": 3539,
+            "id_ID": 43265,
+            "pt_BR": 2.12,
+            "vi_VN": 63553,
+            "es_ES": 2.12,
+            "zh_CN": 16.39,
+            "th_TH": 81.47,
+            "fr_FR": 2.12,
+            "de_DE": 2.12
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 4,
+              "count": 6,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 50,
+              "ratio": 89
+            }
+          ],
+          "count": 56,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-18T15:05:27.716Z"
+            "lastFetched": "2026-07-25T01:05:17.408Z"
           }
         },
-        "updatedAt": "2026-07-18T15:05:27.716Z"
+        "updatedAt": "2026-07-25T01:05:17.408Z"
       }
     },
     {
@@ -12052,55 +14402,82 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-18T15:05:27.716Z",
-        "lastFetchedAt": "2026-07-18T15:05:27.716Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.408Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.408Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 396,
           "original": 1320,
-          "localeOfficialPrices": {
-            "it_IT": 7.11,
-            "pt_BR": 7.11,
-            "fr_FR": 7.11,
-            "de_DE": 7.11,
-            "es_ES": 7.11,
-            "zh_TW": 263,
-            "sv_SE": 78.43,
-            "ko_KR": 12088,
-            "en_US": 8.13,
-            "id_ID": 145985,
-            "vi_VN": 213041,
-            "zh_CN": 55.13,
-            "th_TH": 273.25,
-            "ar_AE": 8.13
-          },
           "discount": 70,
-          "localePrices": {
-            "it_IT": 2.13,
-            "sv_SE": 23.53,
-            "id_ID": 43796,
-            "pt_BR": 2.13,
-            "vi_VN": 63912,
-            "th_TH": 81.98,
-            "fr_FR": 2.13,
-            "de_DE": 2.13,
-            "zh_TW": 79,
-            "ko_KR": 3626,
-            "en_US": 2.44,
-            "es_ES": 2.13,
-            "zh_CN": 16.54,
-            "ar_AE": 2.44
+          "point": 18,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 18
+          "localePrices": {
+            "zh_TW": 78,
+            "en_US": 2.42,
+            "ar_AE": 2.42,
+            "it_IT": 2.12,
+            "sv_SE": 23.49,
+            "ko_KR": 3539,
+            "id_ID": 43265,
+            "pt_BR": 2.12,
+            "vi_VN": 63553,
+            "es_ES": 2.12,
+            "zh_CN": 16.39,
+            "th_TH": 81.47,
+            "fr_FR": 2.12,
+            "de_DE": 2.12
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 4,
+              "count": 2,
+              "ratio": 6
+            },
+            {
+              "review_point": 5,
+              "count": 32,
+              "ratio": 94
+            }
+          ],
+          "count": 34,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-18T15:05:27.716Z"
+            "lastFetched": "2026-07-25T01:05:17.408Z"
           }
         },
-        "updatedAt": "2026-07-18T15:05:27.716Z"
+        "updatedAt": "2026-07-25T01:05:17.408Z"
       }
     },
     {
@@ -12270,55 +14647,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.852Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.852Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.409Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.409Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 34,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 93,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 942,
+              "ratio": 88
+            }
+          ],
+          "count": 1075,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.852Z"
+            "lastFetched": "2026-07-25T01:05:17.409Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.852Z"
+        "updatedAt": "2026-07-25T01:05:17.409Z"
       }
     },
     {
@@ -12534,55 +14953,97 @@
             "name": "ツルペタ"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.852Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.852Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.409Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.409Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1287,
           "original": 1430,
-          "localeOfficialPrices": {
-            "zh_TW": 284,
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
-          },
           "discount": 10,
-          "localePrices": {
-            "it_IT": 6.92,
-            "sv_SE": 76.41,
-            "id_ID": 142620,
-            "pt_BR": 6.92,
-            "vi_VN": 207614,
-            "th_TH": 266.13,
-            "fr_FR": 6.92,
-            "de_DE": 6.92,
-            "zh_TW": 256,
-            "ko_KR": 11743,
-            "en_US": 7.93,
-            "es_ES": 6.92,
-            "zh_CN": 53.75,
-            "ar_AE": 7.93
+          "point": 58,
+          "localeOfficialPrices": {
+            "it_IT": 7.67,
+            "pt_BR": 7.67,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "es_ES": 7.67,
+            "sv_SE": 84.83,
+            "ko_KR": 12779,
+            "en_US": 8.73,
+            "id_ID": 156233,
+            "vi_VN": 229498,
+            "zh_CN": 59.18,
+            "th_TH": 294.18,
+            "ar_AE": 8.73
           },
-          "point": 58
+          "localePrices": {
+            "it_IT": 6.91,
+            "pt_BR": 6.91,
+            "fr_FR": 6.91,
+            "de_DE": 6.91,
+            "zh_TW": 254,
+            "en_US": 7.86,
+            "es_ES": 6.91,
+            "ar_AE": 7.86,
+            "sv_SE": 76.35,
+            "ko_KR": 11501,
+            "id_ID": 140610,
+            "vi_VN": 206548,
+            "zh_CN": 53.27,
+            "th_TH": 264.77
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 32,
+              "ratio": 1
+            },
+            {
+              "review_point": 2,
+              "count": 49,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 278,
+              "ratio": 7
+            },
+            {
+              "review_point": 4,
+              "count": 752,
+              "ratio": 19
+            },
+            {
+              "review_point": 5,
+              "count": 2795,
+              "ratio": 72
+            }
+          ],
+          "count": 3906,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.852Z"
+            "lastFetched": "2026-07-25T01:05:17.409Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.852Z"
+        "updatedAt": "2026-07-25T01:05:17.409Z"
       }
     },
     {
@@ -12694,55 +15155,92 @@
             "name": "乳首/乳輪"
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.141Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.141Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 11,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 30,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 238,
+              "ratio": 85
+            }
+          ],
+          "count": 280,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.141Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.141Z"
       }
     },
     {
@@ -12847,55 +15345,97 @@
             "name": "燃え"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.852Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.852Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 110,
           "original": 220,
+          "discount": 50,
+          "point": 5,
           "localeOfficialPrices": {
-            "zh_TW": 44,
-            "en_US": 1.36,
-            "ar_AE": 1.36,
             "it_IT": 1.18,
-            "sv_SE": 13.06,
             "pt_BR": 1.18,
             "es_ES": 1.18,
-            "zh_CN": 9.19,
             "fr_FR": 1.18,
             "de_DE": 1.18,
-            "ko_KR": 2007,
-            "id_ID": 24379,
-            "vi_VN": 35490,
-            "th_TH": 45.49
+            "zh_TW": 43,
+            "sv_SE": 13.1,
+            "ko_KR": 1982,
+            "en_US": 1.34,
+            "id_ID": 24044,
+            "vi_VN": 35290,
+            "zh_CN": 9.12,
+            "th_TH": 45.46,
+            "ar_AE": 1.34
           },
-          "discount": 50,
           "localePrices": {
             "it_IT": 0.59,
-            "sv_SE": 6.53,
-            "id_ID": 12190,
             "pt_BR": 0.59,
-            "vi_VN": 17745,
-            "th_TH": 22.75,
             "fr_FR": 0.59,
             "de_DE": 0.59,
             "zh_TW": 22,
-            "ko_KR": 1004,
-            "en_US": 0.68,
             "es_ES": 0.59,
-            "zh_CN": 4.59,
-            "ar_AE": 0.68
-          },
-          "point": 5
+            "sv_SE": 6.55,
+            "ko_KR": 991,
+            "en_US": 0.67,
+            "id_ID": 12022,
+            "vi_VN": 17645,
+            "zh_CN": 4.56,
+            "th_TH": 22.73,
+            "ar_AE": 0.67
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.409Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.409Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 34,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 83,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 523,
+              "ratio": 81
+            }
+          ],
+          "count": 643,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.852Z"
+            "lastFetched": "2026-07-25T01:05:17.409Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.852Z"
+        "updatedAt": "2026-07-25T01:05:17.409Z"
       }
     },
     {
@@ -13105,53 +15645,95 @@
             "name": "露出"
           }
         ],
-        "createdAt": "2026-07-16T15:06:44.852Z",
-        "lastFetchedAt": "2026-07-16T15:06:44.852Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:46.057Z",
+        "lastFetchedAt": "2026-07-25T17:03:46.057Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 2970,
+          "point": 135,
           "localeOfficialPrices": {
-            "it_IT": 15.99,
-            "sv_SE": 176.31,
-            "id_ID": 330809,
-            "pt_BR": 15.99,
-            "vi_VN": 479496,
-            "th_TH": 614.92,
-            "fr_FR": 15.99,
-            "de_DE": 15.99,
-            "zh_TW": 589,
-            "ko_KR": 27273,
-            "en_US": 18.32,
-            "es_ES": 15.99,
-            "zh_CN": 124.12,
-            "ar_AE": 18.32
+            "it_IT": 15.94,
+            "pt_BR": 15.94,
+            "fr_FR": 15.94,
+            "de_DE": 15.94,
+            "zh_TW": 587,
+            "es_ES": 15.94,
+            "sv_SE": 176.19,
+            "ko_KR": 26542,
+            "en_US": 18.13,
+            "id_ID": 324484,
+            "vi_VN": 476649,
+            "zh_CN": 122.92,
+            "th_TH": 611,
+            "ar_AE": 18.13
           },
           "localePrices": {
-            "it_IT": 15.99,
-            "sv_SE": 176.31,
-            "id_ID": 330809,
-            "pt_BR": 15.99,
-            "vi_VN": 479496,
-            "th_TH": 614.92,
-            "fr_FR": 15.99,
-            "de_DE": 15.99,
-            "zh_TW": 589,
-            "ko_KR": 27273,
-            "en_US": 18.32,
-            "es_ES": 15.99,
-            "zh_CN": 124.12,
-            "ar_AE": 18.32
-          },
-          "point": 135
+            "it_IT": 15.94,
+            "pt_BR": 15.94,
+            "fr_FR": 15.94,
+            "de_DE": 15.94,
+            "zh_TW": 587,
+            "es_ES": 15.94,
+            "sv_SE": 176.19,
+            "ko_KR": 26542,
+            "en_US": 18.13,
+            "id_ID": 324484,
+            "vi_VN": 476649,
+            "zh_CN": 122.92,
+            "th_TH": 611,
+            "ar_AE": 18.13
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 103,
+              "ratio": 2
+            },
+            {
+              "review_point": 2,
+              "count": 141,
+              "ratio": 2
+            },
+            {
+              "review_point": 3,
+              "count": 680,
+              "ratio": 12
+            },
+            {
+              "review_point": 4,
+              "count": 1354,
+              "ratio": 23
+            },
+            {
+              "review_point": 5,
+              "count": 3528,
+              "ratio": 61
+            }
+          ],
+          "count": 5806,
+          "stars": 4.5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-16T15:06:44.852Z"
+            "lastFetched": "2026-07-25T17:03:46.057Z"
           }
         },
-        "updatedAt": "2026-07-16T15:06:44.852Z"
+        "updatedAt": "2026-07-25T17:03:46.057Z"
       }
     },
     {
@@ -13302,55 +15884,97 @@
             "displayOrder": 7
           }
         ],
-        "createdAt": "2026-07-17T15:06:33.777Z",
-        "lastFetchedAt": "2026-07-17T15:06:33.777Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 45,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 136,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 1108,
+              "ratio": 86
+            }
+          ],
+          "count": 1293,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:33.777Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:33.777Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -13498,55 +16122,92 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:47.373Z",
-        "lastFetchedAt": "2026-07-17T15:06:47.373Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 847,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 4.56,
-            "sv_SE": 50.28,
-            "id_ID": 93861,
-            "pt_BR": 4.56,
-            "vi_VN": 136635,
-            "th_TH": 175.15,
-            "fr_FR": 4.56,
-            "de_DE": 4.56,
-            "zh_TW": 168,
-            "ko_KR": 7728,
-            "en_US": 5.22,
-            "es_ES": 4.56,
-            "zh_CN": 35.37,
-            "ar_AE": 5.22
+          "point": 38,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "sv_SE": 72.06,
+            "id_ID": 132240,
+            "pt_BR": 6.49,
+            "vi_VN": 194097,
+            "th_TH": 250.06,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "ko_KR": 10901,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "zh_CN": 50.14,
+            "ar_AE": 7.39
           },
-          "point": 38
+          "localePrices": {
+            "it_IT": 4.55,
+            "sv_SE": 50.44,
+            "id_ID": 92568,
+            "pt_BR": 4.55,
+            "vi_VN": 135868,
+            "th_TH": 175.04,
+            "fr_FR": 4.55,
+            "de_DE": 4.55,
+            "zh_TW": 167,
+            "ko_KR": 7631,
+            "en_US": 5.17,
+            "es_ES": 4.55,
+            "zh_CN": 35.1,
+            "ar_AE": 5.17
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:31.439Z",
+        "lastFetchedAt": "2026-07-25T01:05:31.439Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 22,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 55,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 549,
+              "ratio": 87
+            }
+          ],
+          "count": 628,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:47.373Z"
+            "lastFetched": "2026-07-25T01:05:31.439Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:47.373Z"
+        "updatedAt": "2026-07-25T01:05:31.439Z"
       }
     },
     {
@@ -13664,55 +16325,87 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.917Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.917Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 5,
+              "ratio": 7
+            },
+            {
+              "review_point": 4,
+              "count": 6,
+              "ratio": 8
+            },
+            {
+              "review_point": 5,
+              "count": 60,
+              "ratio": 85
+            }
+          ],
+          "count": 71,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.917Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -13857,55 +16550,97 @@
             "name": "ネコミミ"
           }
         ],
-        "createdAt": "2026-07-17T15:06:30.852Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.852Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:17.408Z",
+        "lastFetchedAt": "2026-07-25T01:05:17.408Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 31,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 82,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 610,
+              "ratio": 84
+            }
+          ],
+          "count": 728,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.852Z"
+            "lastFetched": "2026-07-25T01:05:17.408Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.852Z"
+        "updatedAt": "2026-07-25T01:05:17.408Z"
       }
     },
     {
@@ -14056,55 +16791,87 @@
           }
         ],
         "thumbnailUrl": "https://www.dlsite.com/images/web/home/no_img_sam.gif",
-        "createdAt": "2026-07-17T15:06:30.852Z",
-        "lastFetchedAt": "2026-07-17T15:06:30.852Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 40,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "sv_SE": 65.51,
+            "id_ID": 120219,
+            "pt_BR": 5.9,
+            "vi_VN": 176452,
+            "th_TH": 227.32,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "ko_KR": 9910,
+            "en_US": 6.72,
+            "es_ES": 5.9,
+            "zh_CN": 45.58,
+            "ar_AE": 6.72
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.140Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.140Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 3,
+              "count": 6,
+              "ratio": 1
+            },
+            {
+              "review_point": 4,
+              "count": 35,
+              "ratio": 6
+            },
+            {
+              "review_point": 5,
+              "count": 521,
+              "ratio": 93
+            }
+          ],
+          "count": 562,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:30.852Z"
+            "lastFetched": "2026-07-25T01:05:19.140Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:30.852Z"
+        "updatedAt": "2026-07-25T01:05:19.140Z"
       }
     },
     {
@@ -14259,55 +17026,97 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2026-07-11 00:00:00",
-        "createdAt": "2026-07-17T01:04:14.416Z",
-        "lastFetchedAt": "2026-07-17T01:04:14.416Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T03:05:15.070Z",
+        "lastFetchedAt": "2026-07-25T03:05:15.070Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "en_US": 6.78,
-            "pt_BR": 5.92,
-            "es_ES": 5.92,
-            "fr_FR": 5.92,
-            "ar_AE": 6.78,
-            "de_DE": 5.92,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "pt_BR": 2.95,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "ar_AE": 3.36,
+            "sv_SE": 32.63,
+            "ko_KR": 4915,
+            "id_ID": 60090,
+            "vi_VN": 88268,
+            "zh_CN": 22.76,
+            "th_TH": 113.15
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 24,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 110,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 902,
+              "ratio": 87
+            }
+          ],
+          "count": 1039,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T01:04:14.416Z"
+            "lastFetched": "2026-07-25T03:05:15.070Z"
           }
         },
-        "updatedAt": "2026-07-17T01:04:14.416Z"
+        "updatedAt": "2026-07-25T03:05:15.070Z"
       }
     },
     {
@@ -14411,55 +17220,92 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 605,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.26,
-            "sv_SE": 35.92,
-            "id_ID": 67043,
-            "pt_BR": 3.26,
-            "vi_VN": 97596,
-            "th_TH": 125.11,
-            "fr_FR": 3.26,
-            "de_DE": 3.26,
-            "zh_TW": 120,
-            "ko_KR": 5520,
-            "en_US": 3.73,
-            "es_ES": 3.26,
-            "zh_CN": 25.27,
-            "ar_AE": 3.73
+          "point": 27,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "sv_SE": 72.06,
+            "id_ID": 132240,
+            "pt_BR": 6.49,
+            "vi_VN": 194097,
+            "th_TH": 250.06,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "ko_KR": 10901,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "zh_CN": 50.14,
+            "ar_AE": 7.39
           },
-          "point": 27
+          "localePrices": {
+            "it_IT": 3.25,
+            "sv_SE": 36.03,
+            "id_ID": 66120,
+            "pt_BR": 3.25,
+            "vi_VN": 97048,
+            "th_TH": 125.03,
+            "fr_FR": 3.25,
+            "de_DE": 3.25,
+            "zh_TW": 119,
+            "ko_KR": 5450,
+            "en_US": 3.7,
+            "es_ES": 3.25,
+            "zh_CN": 25.07,
+            "ar_AE": 3.7
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.141Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.141Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 17,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 65,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 463,
+              "ratio": 85
+            }
+          ],
+          "count": 547,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.141Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.141Z"
       }
     },
     {
@@ -14618,55 +17464,97 @@
             "name": "フェラチオ"
           }
         ],
-        "createdAt": "2026-07-17T17:04:49.950Z",
-        "lastFetchedAt": "2026-07-17T17:04:49.950Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:07:58.903Z",
+        "lastFetchedAt": "2026-07-25T01:07:58.903Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1001,
           "original": 1430,
-          "localeOfficialPrices": {
-            "zh_TW": 284,
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 5.39,
-            "sv_SE": 59.43,
-            "id_ID": 110926,
-            "pt_BR": 5.39,
-            "vi_VN": 161478,
-            "th_TH": 206.99,
-            "fr_FR": 5.39,
-            "de_DE": 5.39,
-            "zh_TW": 199,
-            "ko_KR": 9133,
-            "en_US": 6.17,
-            "es_ES": 5.39,
-            "zh_CN": 41.8,
-            "ar_AE": 6.17
+          "point": 45,
+          "localeOfficialPrices": {
+            "it_IT": 7.67,
+            "pt_BR": 7.67,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "es_ES": 7.67,
+            "sv_SE": 84.83,
+            "ko_KR": 12779,
+            "en_US": 8.73,
+            "id_ID": 156233,
+            "vi_VN": 229498,
+            "zh_CN": 59.18,
+            "th_TH": 294.18,
+            "ar_AE": 8.73
           },
-          "point": 45
+          "localePrices": {
+            "it_IT": 5.37,
+            "pt_BR": 5.37,
+            "fr_FR": 5.37,
+            "de_DE": 5.37,
+            "zh_TW": 198,
+            "es_ES": 5.37,
+            "sv_SE": 59.38,
+            "ko_KR": 8945,
+            "en_US": 6.11,
+            "id_ID": 109363,
+            "vi_VN": 160648,
+            "zh_CN": 41.43,
+            "th_TH": 205.93,
+            "ar_AE": 6.11
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 49,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 108,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 734,
+              "ratio": 82
+            }
+          ],
+          "count": 899,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T17:04:49.950Z"
+            "lastFetched": "2026-07-25T01:07:58.903Z"
           }
         },
-        "updatedAt": "2026-07-17T17:04:49.950Z"
+        "updatedAt": "2026-07-25T01:07:58.903Z"
       }
     },
     {
@@ -14795,55 +17683,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1001,
           "original": 1430,
-          "localeOfficialPrices": {
-            "zh_TW": 284,
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 5.39,
-            "sv_SE": 59.43,
-            "id_ID": 110926,
-            "pt_BR": 5.39,
-            "vi_VN": 161478,
-            "th_TH": 206.99,
-            "fr_FR": 5.39,
-            "de_DE": 5.39,
-            "zh_TW": 199,
-            "ko_KR": 9133,
-            "en_US": 6.17,
-            "es_ES": 5.39,
-            "zh_CN": 41.8,
-            "ar_AE": 6.17
+          "point": 45,
+          "localeOfficialPrices": {
+            "it_IT": 7.67,
+            "sv_SE": 85.16,
+            "id_ID": 156284,
+            "pt_BR": 7.67,
+            "vi_VN": 229387,
+            "th_TH": 295.52,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "ko_KR": 12883,
+            "en_US": 8.74,
+            "es_ES": 7.67,
+            "zh_CN": 59.25,
+            "ar_AE": 8.74
           },
-          "point": 45
+          "localePrices": {
+            "it_IT": 5.37,
+            "sv_SE": 59.61,
+            "id_ID": 109399,
+            "pt_BR": 5.37,
+            "vi_VN": 160571,
+            "th_TH": 206.87,
+            "fr_FR": 5.37,
+            "de_DE": 5.37,
+            "zh_TW": 198,
+            "ko_KR": 9018,
+            "en_US": 6.12,
+            "es_ES": 5.37,
+            "zh_CN": 41.48,
+            "ar_AE": 6.12
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.142Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.142Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 3,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 18,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 52,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 329,
+              "ratio": 82
+            }
+          ],
+          "count": 403,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.142Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.142Z"
       }
     },
     {
@@ -15009,55 +17939,97 @@
             "name": "ツインテール"
           }
         ],
-        "createdAt": "2026-07-17T15:06:46.619Z",
-        "lastFetchedAt": "2026-07-17T15:06:46.619Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:29.905Z",
+        "lastFetchedAt": "2026-07-25T01:05:29.905Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1386,
           "original": 1980,
-          "localeOfficialPrices": {
-            "zh_TW": 393,
-            "it_IT": 10.65,
-            "sv_SE": 117.55,
-            "id_ID": 219415,
-            "pt_BR": 10.65,
-            "vi_VN": 319406,
-            "th_TH": 409.44,
-            "fr_FR": 10.65,
-            "de_DE": 10.65,
-            "ko_KR": 18066,
-            "en_US": 12.2,
-            "es_ES": 10.65,
-            "zh_CN": 82.69,
-            "ar_AE": 12.2
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 7.46,
-            "sv_SE": 82.28,
-            "id_ID": 153590,
-            "pt_BR": 7.46,
-            "vi_VN": 223584,
-            "th_TH": 286.61,
-            "fr_FR": 7.46,
-            "de_DE": 7.46,
-            "zh_TW": 275,
-            "ko_KR": 12646,
-            "en_US": 8.54,
-            "es_ES": 7.46,
-            "zh_CN": 57.88,
-            "ar_AE": 8.54
+          "point": 63,
+          "localeOfficialPrices": {
+            "zh_TW": 391,
+            "it_IT": 10.62,
+            "sv_SE": 117.46,
+            "id_ID": 216323,
+            "pt_BR": 10.62,
+            "vi_VN": 317766,
+            "th_TH": 407.33,
+            "fr_FR": 10.62,
+            "de_DE": 10.62,
+            "ko_KR": 17694,
+            "en_US": 12.09,
+            "es_ES": 10.62,
+            "zh_CN": 81.95,
+            "ar_AE": 12.09
           },
-          "point": 63
+          "localePrices": {
+            "it_IT": 7.44,
+            "pt_BR": 7.44,
+            "fr_FR": 7.44,
+            "de_DE": 7.44,
+            "zh_TW": 274,
+            "es_ES": 7.44,
+            "sv_SE": 82.22,
+            "ko_KR": 12386,
+            "en_US": 8.46,
+            "id_ID": 151426,
+            "vi_VN": 222436,
+            "zh_CN": 57.36,
+            "th_TH": 285.13,
+            "ar_AE": 8.46
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 5,
+              "ratio": 3
+            },
+            {
+              "review_point": 2,
+              "count": 7,
+              "ratio": 4
+            },
+            {
+              "review_point": 3,
+              "count": 20,
+              "ratio": 11
+            },
+            {
+              "review_point": 4,
+              "count": 42,
+              "ratio": 23
+            },
+            {
+              "review_point": 5,
+              "count": 107,
+              "ratio": 59
+            }
+          ],
+          "count": 181,
+          "stars": 4.5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:46.619Z"
+            "lastFetched": "2026-07-25T01:05:29.905Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:46.619Z"
+        "updatedAt": "2026-07-25T01:05:29.905Z"
       }
     },
     {
@@ -15202,55 +18174,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T17:05:14.987Z",
-        "lastFetchedAt": "2026-07-17T17:05:14.987Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T03:03:24.369Z",
+        "lastFetchedAt": "2026-07-25T03:03:24.369Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 9,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 11,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 109,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 480,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 4190,
+              "ratio": 87
+            }
+          ],
+          "count": 4799,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T17:05:14.987Z"
+            "lastFetched": "2026-07-25T03:03:24.369Z"
           }
         },
-        "updatedAt": "2026-07-17T17:05:14.987Z"
+        "updatedAt": "2026-07-25T03:03:24.369Z"
       }
     },
     {
@@ -15306,16 +18320,6 @@
         "titleMasked": "ふたなり逆アナル3Pでメス堕ち♪-同棲中のふたなりJD2人に誘われてシェアハウスに→お互いの精液をベロキスでシェア&乳首責めいちゃいちゃアナルSEX♪-【KU100】",
         "ageCategory": 3,
         "title": "ふたなり逆アナル3Pでメス堕ち♪-同棲中のふたなりJD2人に誘われてシェアハウスに→お互いの精液をベロキスでシェア&乳首責めいちゃいちゃアナルSEX♪-【KU100】",
-        "genres": [
-          "ラブラブ/あまあま",
-          "ハーレム",
-          "中出し",
-          "男性受け",
-          "アナル",
-          "メス堕ち",
-          "乳首責め",
-          "フタナリ"
-        ],
         "id": "RJ01033611",
         "ageCategoryString": "adult",
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01034000/RJ01033611_img_sam.jpg",
@@ -15324,40 +18328,6 @@
         "productId": "RJ01033611",
         "releaseDate": "2023-03-08 00:00:00",
         "ageRating": "R18",
-        "customGenres": [
-          {
-            "genre_key": "004",
-            "name": "ラブラブ/あまあま"
-          },
-          {
-            "genre_key": "046",
-            "name": "ハーレム"
-          },
-          {
-            "genre_key": "128",
-            "name": "中出し"
-          },
-          {
-            "genre_key": "156",
-            "name": "男性受け"
-          },
-          {
-            "genre_key": "160",
-            "name": "アナル"
-          },
-          {
-            "genre_key": "522",
-            "name": "メス堕ち"
-          },
-          {
-            "genre_key": "523",
-            "name": "乳首責め"
-          },
-          {
-            "genre_key": "190",
-            "name": "フタナリ"
-          }
-        ],
         "fileSize": null,
         "releaseDateDisplay": "2023年3月8日",
         "workType": "SOU",
@@ -15370,54 +18340,135 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2023-03-08 00:00:00",
+        "genres": [
+          "ハーレム",
+          "ラブラブ/あまあま",
+          "アナル",
+          "男性受け",
+          "乳首責め",
+          "中出し",
+          "メス堕ち",
+          "フタナリ"
+        ],
+        "releaseDateISO": "2023-03-08T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "customGenres": [
+          {
+            "genre_key": "046",
+            "name": "ハーレム"
+          },
+          {
+            "genre_key": "004",
+            "name": "ラブラブ/あまあま"
+          },
+          {
+            "genre_key": "160",
+            "name": "アナル"
+          },
+          {
+            "genre_key": "156",
+            "name": "男性受け"
+          },
+          {
+            "genre_key": "523",
+            "name": "乳首責め"
+          },
+          {
+            "genre_key": "128",
+            "name": "中出し"
+          },
+          {
+            "genre_key": "522",
+            "name": "メス堕ち"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
         "price": {
           "current": 1870,
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
-          "point": 170,
+          "point": 85,
           "localeOfficialPrices": {
-            "it_IT": 10.9,
-            "sv_SE": 121.53,
-            "id_ID": 206402,
-            "pt_BR": 10.9,
-            "vi_VN": 329167,
-            "th_TH": 408.23,
-            "fr_FR": 10.9,
-            "de_DE": 10.9,
-            "zh_TW": 374,
-            "ko_KR": 17509,
-            "en_US": 12.59,
-            "es_ES": 10.9,
-            "zh_CN": 90.4,
-            "ar_AE": 12.59
+            "zh_TW": 369,
+            "it_IT": 10.03,
+            "sv_SE": 110.93,
+            "id_ID": 204305,
+            "pt_BR": 10.03,
+            "vi_VN": 300112,
+            "th_TH": 384.7,
+            "fr_FR": 10.03,
+            "de_DE": 10.03,
+            "ko_KR": 16711,
+            "en_US": 11.41,
+            "es_ES": 10.03,
+            "zh_CN": 77.39,
+            "ar_AE": 11.41
           },
           "localePrices": {
-            "it_IT": 10.9,
-            "sv_SE": 121.53,
-            "id_ID": 206402,
-            "pt_BR": 10.9,
-            "vi_VN": 329167,
-            "th_TH": 408.23,
-            "fr_FR": 10.9,
-            "de_DE": 10.9,
-            "zh_TW": 374,
-            "ko_KR": 17509,
-            "en_US": 12.59,
-            "es_ES": 10.9,
-            "zh_CN": 90.4,
-            "ar_AE": 12.59
+            "zh_TW": 369,
+            "it_IT": 10.03,
+            "sv_SE": 110.93,
+            "id_ID": 204305,
+            "pt_BR": 10.03,
+            "vi_VN": 300112,
+            "th_TH": 384.7,
+            "fr_FR": 10.03,
+            "de_DE": 10.03,
+            "ko_KR": 16711,
+            "en_US": 11.41,
+            "es_ES": 10.03,
+            "zh_CN": 77.39,
+            "ar_AE": 11.41
           }
         },
-        "releaseDateISO": "2023-03-07T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.343Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.343Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 9,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 34,
+              "ratio": 7
+            },
+            {
+              "review_point": 5,
+              "count": 430,
+              "ratio": 91
+            }
+          ],
+          "count": 474,
+          "stars": 5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.343Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.343Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -15559,55 +18610,92 @@
           }
         ],
         "circle": "See you.",
-        "createdAt": "2026-07-17T15:06:31.539Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.539Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.142Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.142Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 20,
+              "ratio": 6
+            },
+            {
+              "review_point": 4,
+              "count": 38,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 299,
+              "ratio": 84
+            }
+          ],
+          "count": 358,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.539Z"
+            "lastFetched": "2026-07-25T01:05:19.142Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.539Z"
+        "updatedAt": "2026-07-25T01:05:19.142Z"
       }
     },
     {
@@ -15754,55 +18842,97 @@
         "fileFormat": "WAV",
         "fileType": "WAV",
         "registDate": "2025-12-13 00:00:00",
-        "createdAt": "2026-07-17T17:05:50.204Z",
-        "lastFetchedAt": "2026-07-17T17:05:50.204Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T03:03:59.115Z",
+        "lastFetchedAt": "2026-07-25T03:03:59.115Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 10,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 10,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 114,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 384,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 3037,
+              "ratio": 85
+            }
+          ],
+          "count": 3555,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T17:05:50.204Z"
+            "lastFetched": "2026-07-25T03:03:59.115Z"
           }
         },
-        "updatedAt": "2026-07-17T17:05:50.204Z"
+        "updatedAt": "2026-07-25T03:03:59.115Z"
       }
     },
     {
@@ -15954,55 +19084,92 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-17T15:06:31.538Z",
-        "lastFetchedAt": "2026-07-17T15:06:31.538Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1155,
           "original": 1650,
-          "localeOfficialPrices": {
-            "it_IT": 8.88,
-            "sv_SE": 97.96,
-            "id_ID": 182846,
-            "pt_BR": 8.88,
-            "vi_VN": 266172,
-            "th_TH": 341.2,
-            "fr_FR": 8.88,
-            "de_DE": 8.88,
-            "zh_TW": 328,
-            "ko_KR": 15055,
-            "en_US": 10.16,
-            "es_ES": 8.88,
-            "zh_CN": 68.91,
-            "ar_AE": 10.16
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 6.21,
-            "sv_SE": 68.57,
-            "id_ID": 127992,
-            "pt_BR": 6.21,
-            "vi_VN": 186320,
-            "th_TH": 238.84,
-            "fr_FR": 6.21,
-            "de_DE": 6.21,
-            "zh_TW": 229,
-            "ko_KR": 10538,
-            "en_US": 7.12,
-            "es_ES": 6.21,
-            "zh_CN": 48.23,
-            "ar_AE": 7.12
+          "point": 52,
+          "localeOfficialPrices": {
+            "it_IT": 8.85,
+            "sv_SE": 98.26,
+            "id_ID": 180328,
+            "pt_BR": 8.85,
+            "vi_VN": 264678,
+            "th_TH": 340.99,
+            "fr_FR": 8.85,
+            "de_DE": 8.85,
+            "zh_TW": 326,
+            "ko_KR": 14865,
+            "en_US": 10.08,
+            "es_ES": 8.85,
+            "zh_CN": 68.37,
+            "ar_AE": 10.08
           },
-          "point": 52
+          "localePrices": {
+            "it_IT": 6.2,
+            "sv_SE": 68.78,
+            "id_ID": 126230,
+            "pt_BR": 6.2,
+            "vi_VN": 185274,
+            "th_TH": 238.69,
+            "fr_FR": 6.2,
+            "de_DE": 6.2,
+            "zh_TW": 228,
+            "ko_KR": 10405,
+            "en_US": 7.06,
+            "es_ES": 6.2,
+            "zh_CN": 47.86,
+            "ar_AE": 7.06
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.141Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.141Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 6,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 15,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 40,
+              "ratio": 7
+            },
+            {
+              "review_point": 5,
+              "count": 507,
+              "ratio": 89
+            }
+          ],
+          "count": 568,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:31.538Z"
+            "lastFetched": "2026-07-25T01:05:19.141Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:31.538Z"
+        "updatedAt": "2026-07-25T01:05:19.141Z"
       }
     },
     {
@@ -16135,53 +19302,95 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-06-23T17:05:14.633Z",
-        "lastFetchedAt": "2026-06-23T17:05:14.633Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:44.994Z",
+        "lastFetchedAt": "2026-07-25T17:03:44.994Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1320,
+          "point": 60,
           "localeOfficialPrices": {
-            "ko_KR": 12559,
-            "it_IT": 7.14,
-            "sv_SE": 78.53,
-            "id_ID": 145824,
-            "pt_BR": 7.14,
-            "vi_VN": 214251,
-            "th_TH": 268.97,
-            "fr_FR": 7.14,
-            "de_DE": 7.14,
-            "zh_TW": 259,
-            "en_US": 8.17,
-            "es_ES": 7.14,
-            "zh_CN": 55.43,
-            "ar_AE": 8.17
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
           "localePrices": {
-            "it_IT": 7.14,
-            "sv_SE": 78.53,
-            "id_ID": 145824,
-            "pt_BR": 7.14,
-            "vi_VN": 214251,
-            "th_TH": 268.97,
-            "fr_FR": 7.14,
-            "de_DE": 7.14,
-            "zh_TW": 259,
-            "ko_KR": 12559,
-            "en_US": 8.17,
-            "es_ES": 7.14,
-            "zh_CN": 55.43,
-            "ar_AE": 8.17
-          },
-          "point": 60
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 6,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 40,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 168,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 1760,
+              "ratio": 89
+            }
+          ],
+          "count": 1976,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-06-23T17:05:14.633Z"
+            "lastFetched": "2026-07-25T17:03:44.994Z"
           }
         },
-        "updatedAt": "2026-06-23T17:05:14.633Z"
+        "updatedAt": "2026-07-25T17:03:44.994Z"
       }
     },
     {
@@ -16302,55 +19511,92 @@
             "name": "フェラチオ"
           }
         ],
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "sv_SE": 65.51,
+            "id_ID": 120219,
+            "pt_BR": 5.9,
+            "vi_VN": 176452,
+            "th_TH": 227.32,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "ko_KR": 9910,
+            "en_US": 6.72,
+            "es_ES": 5.9,
+            "zh_CN": 45.58,
+            "ar_AE": 6.72
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "sv_SE": 32.75,
+            "id_ID": 60109,
+            "pt_BR": 2.95,
+            "vi_VN": 88226,
+            "th_TH": 113.66,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "ko_KR": 4955,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "zh_CN": 22.79,
+            "ar_AE": 3.36
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 17,
+              "ratio": 6
+            },
+            {
+              "review_point": 4,
+              "count": 30,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 215,
+              "ratio": 82
+            }
+          ],
+          "count": 263,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -16510,55 +19756,97 @@
             }
           ]
         },
-        "createdAt": "2026-07-17T15:06:33.777Z",
-        "lastFetchedAt": "2026-07-17T15:06:33.777Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 770,
           "original": 1540,
-          "localeOfficialPrices": {
-            "it_IT": 8.29,
-            "sv_SE": 91.43,
-            "id_ID": 170656,
-            "pt_BR": 8.29,
-            "vi_VN": 248427,
-            "th_TH": 318.45,
-            "fr_FR": 8.29,
-            "de_DE": 8.29,
-            "zh_TW": 306,
-            "ko_KR": 14051,
-            "en_US": 9.49,
-            "es_ES": 8.29,
-            "zh_CN": 64.31,
-            "ar_AE": 9.49
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 4.14,
-            "sv_SE": 45.71,
-            "id_ID": 85328,
-            "pt_BR": 4.14,
-            "vi_VN": 124214,
-            "th_TH": 159.23,
-            "fr_FR": 4.14,
-            "de_DE": 4.14,
-            "zh_TW": 153,
-            "ko_KR": 7026,
-            "en_US": 4.74,
-            "es_ES": 4.14,
-            "zh_CN": 32.16,
-            "ar_AE": 4.74
+          "point": 35,
+          "localeOfficialPrices": {
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "zh_TW": 304,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           },
-          "point": 35
+          "localePrices": {
+            "it_IT": 4.13,
+            "pt_BR": 4.13,
+            "fr_FR": 4.13,
+            "de_DE": 4.13,
+            "zh_TW": 152,
+            "en_US": 4.7,
+            "es_ES": 4.13,
+            "ar_AE": 4.7,
+            "sv_SE": 45.68,
+            "ko_KR": 6881,
+            "id_ID": 84125,
+            "vi_VN": 123576,
+            "zh_CN": 31.87,
+            "th_TH": 158.41
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 3,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 34,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 108,
+              "ratio": 9
+            },
+            {
+              "review_point": 5,
+              "count": 1001,
+              "ratio": 87
+            }
+          ],
+          "count": 1150,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:33.777Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:33.777Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -16674,55 +19962,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:06:32.121Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.121Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 550,
           "original": 1100,
-          "localeOfficialPrices": {
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "zh_TW": 218,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 2.96,
-            "sv_SE": 32.65,
-            "id_ID": 60949,
-            "pt_BR": 2.96,
-            "vi_VN": 88724,
-            "th_TH": 113.73,
-            "fr_FR": 2.96,
-            "de_DE": 2.96,
-            "zh_TW": 109,
-            "ko_KR": 5018,
-            "en_US": 3.39,
-            "es_ES": 2.96,
-            "zh_CN": 22.97,
-            "ar_AE": 3.39
+          "point": 25,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "sv_SE": 65.51,
+            "id_ID": 120219,
+            "pt_BR": 5.9,
+            "vi_VN": 176452,
+            "th_TH": 227.32,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "ko_KR": 9910,
+            "en_US": 6.72,
+            "es_ES": 5.9,
+            "zh_CN": 45.58,
+            "ar_AE": 6.72
           },
-          "point": 25
+          "localePrices": {
+            "zh_TW": 109,
+            "it_IT": 2.95,
+            "sv_SE": 32.75,
+            "id_ID": 60109,
+            "pt_BR": 2.95,
+            "vi_VN": 88226,
+            "th_TH": 113.66,
+            "fr_FR": 2.95,
+            "de_DE": 2.95,
+            "ko_KR": 4955,
+            "en_US": 3.36,
+            "es_ES": 2.95,
+            "zh_CN": 22.79,
+            "ar_AE": 3.36
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.142Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.142Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 2,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 12,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 30,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 194,
+              "ratio": 81
+            }
+          ],
+          "count": 239,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.121Z"
+            "lastFetched": "2026-07-25T01:05:19.142Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.121Z"
+        "updatedAt": "2026-07-25T01:05:19.142Z"
       }
     },
     {
@@ -16957,55 +20287,97 @@
             "name": "複数プレイ/乱交"
           }
         ],
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 55,
           "original": 110,
+          "discount": 50,
+          "point": 2,
           "localeOfficialPrices": {
             "zh_TW": 22,
-            "en_US": 0.68,
-            "ar_AE": 0.68,
             "it_IT": 0.59,
-            "sv_SE": 6.53,
             "pt_BR": 0.59,
             "es_ES": 0.59,
             "fr_FR": 0.59,
             "de_DE": 0.59,
-            "ko_KR": 1004,
-            "id_ID": 12190,
-            "vi_VN": 17745,
-            "zh_CN": 4.59,
-            "th_TH": 22.75
+            "en_US": 0.67,
+            "ar_AE": 0.67,
+            "sv_SE": 6.53,
+            "ko_KR": 983,
+            "id_ID": 12018,
+            "vi_VN": 17654,
+            "zh_CN": 4.55,
+            "th_TH": 22.63
           },
-          "discount": 50,
           "localePrices": {
             "it_IT": 0.3,
-            "sv_SE": 3.27,
-            "id_ID": 6095,
             "pt_BR": 0.3,
-            "vi_VN": 8872,
-            "th_TH": 11.37,
             "fr_FR": 0.3,
             "de_DE": 0.3,
             "zh_TW": 11,
-            "ko_KR": 502,
             "en_US": 0.34,
             "es_ES": 0.3,
-            "zh_CN": 2.3,
-            "ar_AE": 0.34
-          },
-          "point": 2
+            "ar_AE": 0.34,
+            "zh_CN": 2.28,
+            "sv_SE": 3.26,
+            "ko_KR": 492,
+            "id_ID": 6009,
+            "vi_VN": 8827,
+            "th_TH": 11.31
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 4,
+              "ratio": 1
+            },
+            {
+              "review_point": 2,
+              "count": 5,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 45,
+              "ratio": 7
+            },
+            {
+              "review_point": 4,
+              "count": 104,
+              "ratio": 15
+            },
+            {
+              "review_point": 5,
+              "count": 527,
+              "ratio": 77
+            }
+          ],
+          "count": 685,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -17129,55 +20501,97 @@
         "fileType": "AAC",
         "registDate": "2023-04-07 00:00:00",
         "releaseDateISO": "2023-04-07T00:00:00.000Z",
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 10,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 17,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 140,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 376,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 2849,
+              "ratio": 84
+            }
+          ],
+          "count": 3392,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -17352,55 +20766,97 @@
             "name": "妊娠/孕ませ"
           }
         ],
-        "createdAt": "2026-07-17T15:06:45.556Z",
-        "lastFetchedAt": "2026-07-17T15:06:45.556Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 786,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 35,
-          "localePrices": {
-            "it_IT": 4.23,
-            "sv_SE": 46.66,
-            "id_ID": 87101,
-            "pt_BR": 4.23,
-            "vi_VN": 126795,
-            "th_TH": 162.53,
-            "fr_FR": 4.23,
-            "de_DE": 4.23,
-            "zh_TW": 156,
-            "ko_KR": 7172,
-            "en_US": 4.84,
-            "es_ES": 4.23,
-            "zh_CN": 32.82,
-            "ar_AE": 4.84
+          "point": 35,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "sv_SE": 72.06,
+            "id_ID": 132240,
+            "pt_BR": 6.49,
+            "vi_VN": 194097,
+            "th_TH": 250.06,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "ko_KR": 10901,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "zh_CN": 50.14,
+            "ar_AE": 7.39
           },
-          "point": 35
+          "localePrices": {
+            "it_IT": 4.22,
+            "sv_SE": 46.81,
+            "id_ID": 85902,
+            "pt_BR": 4.22,
+            "vi_VN": 126083,
+            "th_TH": 162.43,
+            "fr_FR": 4.22,
+            "de_DE": 4.22,
+            "zh_TW": 155,
+            "ko_KR": 7081,
+            "en_US": 4.8,
+            "es_ES": 4.22,
+            "zh_CN": 32.57,
+            "ar_AE": 4.8
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:21.798Z",
+        "lastFetchedAt": "2026-07-25T01:05:21.798Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 18,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 32,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 247,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 746,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 5371,
+              "ratio": 84
+            }
+          ],
+          "count": 6414,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:45.556Z"
+            "lastFetched": "2026-07-25T01:05:21.798Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:45.556Z"
+        "updatedAt": "2026-07-25T01:05:21.798Z"
       }
     },
     {
@@ -17549,55 +21005,97 @@
         "fileType": "WAV",
         "registDate": "2023-06-22 00:00:00",
         "releaseDateISO": "2023-06-22T00:00:00.000Z",
-        "createdAt": "2026-07-17T15:06:54.073Z",
-        "lastFetchedAt": "2026-07-17T15:06:54.073Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:31.439Z",
+        "lastFetchedAt": "2026-07-25T01:05:31.439Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 605,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.26,
-            "sv_SE": 35.92,
-            "id_ID": 67043,
-            "pt_BR": 3.26,
-            "vi_VN": 97596,
-            "th_TH": 125.11,
-            "fr_FR": 3.26,
-            "de_DE": 3.26,
-            "zh_TW": 120,
-            "ko_KR": 5520,
-            "en_US": 3.73,
-            "es_ES": 3.26,
-            "zh_CN": 25.27,
-            "ar_AE": 3.73
+          "point": 27,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "pt_BR": 6.49,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "ar_AE": 7.39,
+            "sv_SE": 71.78,
+            "ko_KR": 10813,
+            "id_ID": 132197,
+            "vi_VN": 194190,
+            "zh_CN": 50.08,
+            "th_TH": 248.93
           },
-          "point": 27
+          "localePrices": {
+            "it_IT": 3.25,
+            "pt_BR": 3.25,
+            "fr_FR": 3.25,
+            "de_DE": 3.25,
+            "zh_TW": 119,
+            "es_ES": 3.25,
+            "sv_SE": 35.89,
+            "ko_KR": 5407,
+            "en_US": 3.69,
+            "id_ID": 66099,
+            "vi_VN": 97095,
+            "zh_CN": 25.04,
+            "th_TH": 124.46,
+            "ar_AE": 3.69
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 8,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 23,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 119,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 417,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 3042,
+              "ratio": 84
+            }
+          ],
+          "count": 3609,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:54.073Z"
+            "lastFetched": "2026-07-25T01:05:31.439Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:54.073Z"
+        "updatedAt": "2026-07-25T01:05:31.439Z"
       }
     },
     {
@@ -17756,55 +21254,97 @@
         "fileType": "WAV",
         "registDate": "2023-12-29 00:00:00",
         "releaseDateISO": "2023-12-29T00:00:00.000Z",
-        "createdAt": "2026-07-17T15:07:27.374Z",
-        "lastFetchedAt": "2026-07-17T15:07:27.374Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:03.385Z",
+        "lastFetchedAt": "2026-07-25T01:06:03.385Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 605,
           "original": 1210,
-          "localeOfficialPrices": {
-            "sv_SE": 71.83,
-            "zh_TW": 240,
-            "it_IT": 6.51,
-            "ko_KR": 11040,
-            "en_US": 7.45,
-            "id_ID": 134087,
-            "pt_BR": 6.51,
-            "vi_VN": 195193,
-            "es_ES": 6.51,
-            "zh_CN": 50.53,
-            "th_TH": 250.21,
-            "fr_FR": 6.51,
-            "ar_AE": 7.45,
-            "de_DE": 6.51
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.26,
-            "sv_SE": 35.92,
-            "id_ID": 67043,
-            "pt_BR": 3.26,
-            "vi_VN": 97596,
-            "th_TH": 125.11,
-            "fr_FR": 3.26,
-            "de_DE": 3.26,
-            "zh_TW": 120,
-            "ko_KR": 5520,
-            "en_US": 3.73,
-            "es_ES": 3.26,
-            "zh_CN": 25.27,
-            "ar_AE": 3.73
+          "point": 27,
+          "localeOfficialPrices": {
+            "it_IT": 6.49,
+            "pt_BR": 6.49,
+            "fr_FR": 6.49,
+            "de_DE": 6.49,
+            "zh_TW": 239,
+            "en_US": 7.39,
+            "es_ES": 6.49,
+            "ar_AE": 7.39,
+            "sv_SE": 71.78,
+            "ko_KR": 10813,
+            "id_ID": 132197,
+            "vi_VN": 194190,
+            "zh_CN": 50.08,
+            "th_TH": 248.93
           },
-          "point": 27
+          "localePrices": {
+            "it_IT": 3.25,
+            "pt_BR": 3.25,
+            "fr_FR": 3.25,
+            "de_DE": 3.25,
+            "zh_TW": 119,
+            "es_ES": 3.25,
+            "sv_SE": 35.89,
+            "ko_KR": 5407,
+            "en_US": 3.69,
+            "id_ID": 66099,
+            "vi_VN": 97095,
+            "zh_CN": 25.04,
+            "th_TH": 124.46,
+            "ar_AE": 3.69
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 7,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 15,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 85,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 258,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 2178,
+              "ratio": 86
+            }
+          ],
+          "count": 2543,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:27.374Z"
+            "lastFetched": "2026-07-25T01:06:03.385Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:27.374Z"
+        "updatedAt": "2026-07-25T01:06:03.385Z"
       }
     },
     {
@@ -17945,62 +21485,103 @@
             "name": "乳首/乳輪"
           }
         ],
-        "createdAt": "2026-07-17T15:07:14.163Z",
-        "lastFetchedAt": "2026-07-17T15:07:14.163Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:50.974Z",
+        "lastFetchedAt": "2026-07-25T01:05:50.974Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 643,
           "original": 1430,
-          "localeOfficialPrices": {
-            "zh_TW": 284,
-            "it_IT": 7.69,
-            "sv_SE": 84.9,
-            "id_ID": 158466,
-            "pt_BR": 7.69,
-            "vi_VN": 230682,
-            "th_TH": 295.71,
-            "fr_FR": 7.69,
-            "de_DE": 7.69,
-            "ko_KR": 13047,
-            "en_US": 8.81,
-            "es_ES": 7.69,
-            "zh_CN": 59.72,
-            "ar_AE": 8.81
-          },
           "discount": 55,
-          "localePrices": {
-            "it_IT": 3.46,
-            "sv_SE": 38.17,
-            "id_ID": 71254,
-            "pt_BR": 3.46,
-            "vi_VN": 103726,
-            "th_TH": 132.96,
-            "fr_FR": 3.46,
-            "de_DE": 3.46,
-            "zh_TW": 128,
-            "ko_KR": 5867,
-            "en_US": 3.96,
-            "es_ES": 3.46,
-            "zh_CN": 26.85,
-            "ar_AE": 3.96
+          "point": 29,
+          "localeOfficialPrices": {
+            "it_IT": 7.67,
+            "pt_BR": 7.67,
+            "fr_FR": 7.67,
+            "de_DE": 7.67,
+            "zh_TW": 282,
+            "es_ES": 7.67,
+            "sv_SE": 84.83,
+            "ko_KR": 12779,
+            "en_US": 8.73,
+            "id_ID": 156233,
+            "vi_VN": 229498,
+            "zh_CN": 59.18,
+            "th_TH": 294.18,
+            "ar_AE": 8.73
           },
-          "point": 29
+          "localePrices": {
+            "it_IT": 3.45,
+            "pt_BR": 3.45,
+            "fr_FR": 3.45,
+            "de_DE": 3.45,
+            "zh_TW": 127,
+            "es_ES": 3.45,
+            "sv_SE": 38.14,
+            "ko_KR": 5746,
+            "en_US": 3.92,
+            "id_ID": 70250,
+            "vi_VN": 103194,
+            "zh_CN": 26.61,
+            "th_TH": 132.28,
+            "ar_AE": 3.92
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 5,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 52,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 193,
+              "ratio": 13
+            },
+            {
+              "review_point": 5,
+              "count": 1241,
+              "ratio": 83
+            }
+          ],
+          "count": 1492,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:14.163Z"
+            "lastFetched": "2026-07-25T01:05:50.974Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:14.163Z"
+        "updatedAt": "2026-07-25T01:05:50.974Z"
       }
     },
     {
       "id": "RJ01041035",
       "data": {
         "workTypeString": "ロールプレイング",
-        "highResImageUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_main.jpg",
         "creators": {
           "others_by": [],
           "scenario_by": [],
@@ -18136,16 +21717,6 @@
         "titleMasked": "【AI번역 패치】신의 게임 세계 대전 ～행상 X 데스 게임～",
         "ageCategory": 3,
         "title": "【AI번역 패치】신의 게임 세계 대전 ～행상 X 데스 게임～",
-        "genres": [
-          "女主人公",
-          "人外娘/モンスター娘",
-          "売春/援交",
-          "レズ/女同士",
-          "陵辱",
-          "レイプ",
-          "異種姦",
-          "フタナリ"
-        ],
         "price": {
           "current": 0,
           "localeOfficialPrices": {
@@ -18186,46 +21757,11 @@
         },
         "id": "RJ01041035",
         "ageCategoryString": "adult",
-        "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_sam.jpg",
         "languageDownloads": [],
         "originalCategoryText": "ロールプレイング",
         "productId": "RJ01041035",
         "releaseDate": "2023-03-24 00:00:00",
         "ageRating": "R18",
-        "customGenres": [
-          {
-            "genre_key": "432",
-            "name": "女主人公"
-          },
-          {
-            "genre_key": "317",
-            "name": "人外娘/モンスター娘"
-          },
-          {
-            "genre_key": "446",
-            "name": "売春/援交"
-          },
-          {
-            "genre_key": "118",
-            "name": "レズ/女同士"
-          },
-          {
-            "genre_key": "134",
-            "name": "陵辱"
-          },
-          {
-            "genre_key": "113",
-            "name": "レイプ"
-          },
-          {
-            "genre_key": "324",
-            "name": "異種姦"
-          },
-          {
-            "genre_key": "190",
-            "name": "フタナリ"
-          }
-        ],
         "fileSize": null,
         "releaseDateDisplay": "2023年3月24日",
         "workType": "RPG",
@@ -18269,16 +21805,104 @@
         "fileFormat": "アプリケーション",
         "fileType": "EXE",
         "registDate": "2023-03-24 00:00:00",
-        "releaseDateISO": "2023-03-23T15:00:00.000Z",
-        "createdAt": "2025-07-30T15:13:27.343Z",
-        "lastFetchedAt": "2025-07-30T15:13:27.343Z",
+        "highResImageUrl": "https://www.dlsite.com/images/web/home/no_img_main.gif",
+        "genres": [
+          "女主人公",
+          "人外娘/モンスター娘",
+          "売春/援交",
+          "異種姦",
+          "陵辱",
+          "レイプ",
+          "レズ/女同士",
+          "フタナリ"
+        ],
+        "releaseDateISO": "2023-03-24T00:00:00.000Z",
+        "salesStatus": {
+          "isFree": true,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "customGenres": [
+          {
+            "genre_key": "432",
+            "name": "女主人公"
+          },
+          {
+            "genre_key": "317",
+            "name": "人外娘/モンスター娘"
+          },
+          {
+            "genre_key": "446",
+            "name": "売春/援交"
+          },
+          {
+            "genre_key": "324",
+            "name": "異種姦"
+          },
+          {
+            "genre_key": "134",
+            "name": "陵辱"
+          },
+          {
+            "genre_key": "113",
+            "name": "レイプ"
+          },
+          {
+            "genre_key": "118",
+            "name": "レズ/女同士"
+          },
+          {
+            "genre_key": "190",
+            "name": "フタナリ"
+          }
+        ],
+        "thumbnailUrl": "https://www.dlsite.com/images/web/home/no_img_sam.gif",
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 3
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 3
+            },
+            {
+              "review_point": 3,
+              "count": 3,
+              "ratio": 9
+            },
+            {
+              "review_point": 4,
+              "count": 5,
+              "ratio": 15
+            },
+            {
+              "review_point": 5,
+              "count": 24,
+              "ratio": 71
+            }
+          ],
+          "count": 34,
+          "stars": 4.5
+        },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2025-07-30T15:13:27.343Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2025-07-30T15:13:27.343Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -18411,55 +22035,92 @@
           }
         ],
         "thumbnailUrl": "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041971_img_sam@3x.jpg",
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 14,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 50,
+              "ratio": 8
+            },
+            {
+              "review_point": 5,
+              "count": 570,
+              "ratio": 90
+            }
+          ],
+          "count": 635,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -18574,55 +22235,92 @@
             "name": "レズ/女同士"
           }
         ],
-        "createdAt": "2026-07-17T15:06:45.557Z",
-        "lastFetchedAt": "2026-07-17T15:06:45.557Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 990,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 25,
-          "localePrices": {
-            "it_IT": 5.33,
-            "sv_SE": 58.77,
-            "id_ID": 109707,
-            "pt_BR": 5.33,
-            "vi_VN": 159703,
-            "th_TH": 204.72,
-            "fr_FR": 5.33,
-            "de_DE": 5.33,
-            "zh_TW": 197,
-            "ko_KR": 9033,
-            "en_US": 6.1,
-            "es_ES": 5.33,
-            "zh_CN": 41.34,
-            "ar_AE": 6.1
+          "point": 45,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 45
+          "localePrices": {
+            "it_IT": 5.31,
+            "sv_SE": 58.96,
+            "id_ID": 108197,
+            "pt_BR": 5.31,
+            "vi_VN": 158807,
+            "th_TH": 204.59,
+            "fr_FR": 5.31,
+            "de_DE": 5.31,
+            "zh_TW": 196,
+            "ko_KR": 8919,
+            "en_US": 6.05,
+            "es_ES": 5.31,
+            "zh_CN": 41.02,
+            "ar_AE": 6.05
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:21.798Z",
+        "lastFetchedAt": "2026-07-25T01:05:21.798Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 4,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 19,
+              "ratio": 3
+            },
+            {
+              "review_point": 4,
+              "count": 68,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 548,
+              "ratio": 86
+            }
+          ],
+          "count": 639,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:45.557Z"
+            "lastFetched": "2026-07-25T01:05:21.798Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:45.557Z"
+        "updatedAt": "2026-07-25T01:05:21.798Z"
       }
     },
     {
@@ -18810,53 +22508,95 @@
             "genre_key": "182"
           }
         ],
-        "createdAt": "2026-07-05T15:05:37.771Z",
-        "lastFetchedAt": "2026-07-05T15:05:37.771Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": false,
+          "onSale": 1,
+          "isDiscount": false,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T17:03:43.249Z",
+        "lastFetchedAt": "2026-07-25T17:03:43.249Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1540,
           "point": 70,
           "localeOfficialPrices": {
-            "it_IT": 8.35,
-            "sv_SE": 92.17,
-            "id_ID": 171626,
-            "pt_BR": 8.35,
-            "vi_VN": 250407,
-            "th_TH": 316.72,
-            "fr_FR": 8.35,
-            "de_DE": 8.35,
-            "zh_TW": 305,
-            "ko_KR": 14639,
-            "en_US": 9.55,
-            "es_ES": 8.35,
-            "zh_CN": 64.84,
-            "ar_AE": 9.55
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "zh_TW": 304,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           },
           "localePrices": {
-            "it_IT": 8.35,
-            "sv_SE": 92.17,
-            "id_ID": 171626,
-            "pt_BR": 8.35,
-            "vi_VN": 250407,
-            "th_TH": 316.72,
-            "fr_FR": 8.35,
-            "de_DE": 8.35,
-            "zh_TW": 305,
-            "ko_KR": 14639,
-            "en_US": 9.55,
-            "es_ES": 8.35,
-            "zh_CN": 64.84,
-            "ar_AE": 9.55
+            "it_IT": 8.26,
+            "pt_BR": 8.26,
+            "fr_FR": 8.26,
+            "de_DE": 8.26,
+            "zh_TW": 304,
+            "es_ES": 8.26,
+            "sv_SE": 91.36,
+            "ko_KR": 13762,
+            "en_US": 9.4,
+            "id_ID": 168251,
+            "vi_VN": 247151,
+            "zh_CN": 63.74,
+            "th_TH": 316.81,
+            "ar_AE": 9.4
           }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 6,
+              "ratio": 2
+            },
+            {
+              "review_point": 2,
+              "count": 5,
+              "ratio": 2
+            },
+            {
+              "review_point": 3,
+              "count": 26,
+              "ratio": 8
+            },
+            {
+              "review_point": 4,
+              "count": 51,
+              "ratio": 17
+            },
+            {
+              "review_point": 5,
+              "count": 220,
+              "ratio": 71
+            }
+          ],
+          "count": 308,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-05T15:05:37.771Z"
+            "lastFetched": "2026-07-25T17:03:43.249Z"
           }
         },
-        "updatedAt": "2026-07-05T15:05:37.771Z"
+        "updatedAt": "2026-07-25T17:03:43.249Z"
       }
     },
     {
@@ -19016,55 +22756,97 @@
             "genre_key": "128"
           }
         ],
-        "createdAt": "2026-07-17T15:06:55.519Z",
-        "lastFetchedAt": "2026-07-17T15:06:55.519Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": false,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:32.443Z",
+        "lastFetchedAt": "2026-07-25T01:05:32.443Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 1100,
           "original": 2200,
-          "localeOfficialPrices": {
-            "it_IT": 11.84,
-            "sv_SE": 130.61,
-            "id_ID": 243794,
-            "pt_BR": 11.84,
-            "vi_VN": 354896,
-            "th_TH": 454.93,
-            "fr_FR": 11.84,
-            "de_DE": 11.84,
-            "zh_TW": 437,
-            "ko_KR": 20073,
-            "en_US": 13.55,
-            "es_ES": 11.84,
-            "zh_CN": 91.87,
-            "ar_AE": 13.55
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "id_ID": 121897,
-            "pt_BR": 5.92,
-            "vi_VN": 177448,
-            "th_TH": 227.47,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "zh_TW": 218,
-            "ko_KR": 10036,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "zh_CN": 45.94,
-            "ar_AE": 6.78
+          "point": 50,
+          "localeOfficialPrices": {
+            "it_IT": 11.81,
+            "pt_BR": 11.81,
+            "fr_FR": 11.81,
+            "de_DE": 11.81,
+            "zh_TW": 434,
+            "es_ES": 11.81,
+            "sv_SE": 130.51,
+            "ko_KR": 19660,
+            "en_US": 13.43,
+            "id_ID": 240358,
+            "vi_VN": 353073,
+            "zh_CN": 91.05,
+            "th_TH": 452.59,
+            "ar_AE": 13.43
           },
-          "point": 50
+          "localePrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 93,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 91,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 503,
+              "ratio": 2
+            },
+            {
+              "review_point": 4,
+              "count": 1829,
+              "ratio": 7
+            },
+            {
+              "review_point": 5,
+              "count": 23317,
+              "ratio": 90
+            }
+          ],
+          "count": 25833,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:55.519Z"
+            "lastFetched": "2026-07-25T01:05:32.443Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:55.519Z"
+        "updatedAt": "2026-07-25T01:05:32.443Z"
       }
     },
     {
@@ -19200,55 +22982,97 @@
             "name": "耳舐め"
           }
         ],
-        "createdAt": "2026-07-17T15:07:26.571Z",
-        "lastFetchedAt": "2026-07-17T15:07:26.571Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:06:03.384Z",
+        "lastFetchedAt": "2026-07-25T01:06:03.384Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 770,
           "original": 1100,
-          "localeOfficialPrices": {
-            "zh_TW": 218,
-            "it_IT": 5.92,
-            "sv_SE": 65.3,
-            "pt_BR": 5.92,
-            "fr_FR": 5.92,
-            "de_DE": 5.92,
-            "en_US": 6.78,
-            "es_ES": 5.92,
-            "ar_AE": 6.78,
-            "ko_KR": 10036,
-            "id_ID": 121897,
-            "vi_VN": 177448,
-            "zh_CN": 45.94,
-            "th_TH": 227.47
-          },
           "discount": 30,
-          "localePrices": {
-            "it_IT": 4.14,
-            "sv_SE": 45.71,
-            "id_ID": 85328,
-            "pt_BR": 4.14,
-            "vi_VN": 124214,
-            "th_TH": 159.23,
-            "fr_FR": 4.14,
-            "de_DE": 4.14,
-            "zh_TW": 153,
-            "ko_KR": 7026,
-            "en_US": 4.74,
-            "es_ES": 4.14,
-            "zh_CN": 32.16,
-            "ar_AE": 4.74
+          "point": 35,
+          "localeOfficialPrices": {
+            "it_IT": 5.9,
+            "pt_BR": 5.9,
+            "fr_FR": 5.9,
+            "de_DE": 5.9,
+            "zh_TW": 217,
+            "es_ES": 5.9,
+            "sv_SE": 65.26,
+            "ko_KR": 9830,
+            "en_US": 6.71,
+            "id_ID": 120179,
+            "vi_VN": 176537,
+            "zh_CN": 45.53,
+            "th_TH": 226.3,
+            "ar_AE": 6.71
           },
-          "point": 35
+          "localePrices": {
+            "it_IT": 4.13,
+            "pt_BR": 4.13,
+            "fr_FR": 4.13,
+            "de_DE": 4.13,
+            "zh_TW": 152,
+            "en_US": 4.7,
+            "es_ES": 4.13,
+            "ar_AE": 4.7,
+            "sv_SE": 45.68,
+            "ko_KR": 6881,
+            "id_ID": 84125,
+            "vi_VN": 123576,
+            "zh_CN": 31.87,
+            "th_TH": 158.41
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 40,
+              "ratio": 1
+            },
+            {
+              "review_point": 2,
+              "count": 51,
+              "ratio": 2
+            },
+            {
+              "review_point": 3,
+              "count": 281,
+              "ratio": 10
+            },
+            {
+              "review_point": 4,
+              "count": 535,
+              "ratio": 19
+            },
+            {
+              "review_point": 5,
+              "count": 1922,
+              "ratio": 68
+            }
+          ],
+          "count": 2829,
+          "stars": 4.5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:07:26.571Z"
+            "lastFetched": "2026-07-25T01:06:03.384Z"
           }
         },
-        "updatedAt": "2026-07-17T15:07:26.571Z"
+        "updatedAt": "2026-07-25T01:06:03.384Z"
       }
     },
     {
@@ -19380,55 +23204,97 @@
             "name": "乳首/乳輪"
           }
         ],
-        "createdAt": "2026-07-17T15:06:33.777Z",
-        "lastFetchedAt": "2026-07-17T15:06:33.777Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "sv_SE": 78.61,
+            "id_ID": 144262,
+            "pt_BR": 7.08,
+            "vi_VN": 211742,
+            "th_TH": 272.79,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "ko_KR": 11892,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "zh_CN": 54.7,
+            "ar_AE": 8.06
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "sv_SE": 39.3,
+            "id_ID": 72131,
+            "pt_BR": 3.54,
+            "vi_VN": 105871,
+            "th_TH": 136.39,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "ko_KR": 5946,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "zh_CN": 27.35,
+            "ar_AE": 4.03
+          }
+        },
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 0,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:20.973Z",
+        "lastFetchedAt": "2026-07-25T01:05:20.973Z",
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 2,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 13,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 85,
+              "ratio": 5
+            },
+            {
+              "review_point": 4,
+              "count": 219,
+              "ratio": 12
+            },
+            {
+              "review_point": 5,
+              "count": 1466,
+              "ratio": 82
+            }
+          ],
+          "count": 1785,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:33.777Z"
+            "lastFetched": "2026-07-25T01:05:20.973Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:33.777Z"
+        "updatedAt": "2026-07-25T01:05:20.973Z"
       }
     },
     {
@@ -19580,55 +23446,92 @@
             "name": "巨乳/爆乳"
           }
         ],
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 1
+            },
+            {
+              "review_point": 3,
+              "count": 7,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 20,
+              "ratio": 11
+            },
+            {
+              "review_point": 5,
+              "count": 149,
+              "ratio": 84
+            }
+          ],
+          "count": 177,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     },
     {
@@ -19773,55 +23676,97 @@
           ]
         },
         "circle": "See you.",
-        "createdAt": "2026-07-17T15:06:32.122Z",
-        "lastFetchedAt": "2026-07-17T15:06:32.122Z",
+        "salesStatus": {
+          "isFree": false,
+          "isRental": false,
+          "isReserveWork": false,
+          "isSale": true,
+          "onSale": 1,
+          "isDiscount": true,
+          "dlsiteplayWork": true,
+          "isReservable": false,
+          "isTimesale": false
+        },
+        "createdAt": "2026-07-25T01:05:19.918Z",
+        "lastFetchedAt": "2026-07-25T01:05:19.918Z",
         "price": {
           "isFreeOrMissingPrice": false,
           "currency": "JPY",
           "current": 660,
           "original": 1320,
-          "localeOfficialPrices": {
-            "zh_TW": 262,
-            "it_IT": 7.1,
-            "sv_SE": 78.37,
-            "id_ID": 146277,
-            "pt_BR": 7.1,
-            "vi_VN": 212938,
-            "th_TH": 272.96,
-            "fr_FR": 7.1,
-            "de_DE": 7.1,
-            "ko_KR": 12044,
-            "en_US": 8.13,
-            "es_ES": 7.1,
-            "zh_CN": 55.12,
-            "ar_AE": 8.13
-          },
           "discount": 50,
-          "localePrices": {
-            "it_IT": 3.55,
-            "sv_SE": 39.18,
-            "id_ID": 73138,
-            "pt_BR": 3.55,
-            "vi_VN": 106469,
-            "th_TH": 136.48,
-            "fr_FR": 3.55,
-            "de_DE": 3.55,
-            "zh_TW": 131,
-            "ko_KR": 6022,
-            "en_US": 4.07,
-            "es_ES": 3.55,
-            "zh_CN": 27.56,
-            "ar_AE": 4.07
+          "point": 30,
+          "localeOfficialPrices": {
+            "it_IT": 7.08,
+            "pt_BR": 7.08,
+            "fr_FR": 7.08,
+            "de_DE": 7.08,
+            "zh_TW": 261,
+            "en_US": 8.06,
+            "es_ES": 7.08,
+            "ar_AE": 8.06,
+            "sv_SE": 78.31,
+            "ko_KR": 11796,
+            "id_ID": 144215,
+            "vi_VN": 211844,
+            "zh_CN": 54.63,
+            "th_TH": 271.55
           },
-          "point": 30
+          "localePrices": {
+            "it_IT": 3.54,
+            "pt_BR": 3.54,
+            "fr_FR": 3.54,
+            "de_DE": 3.54,
+            "zh_TW": 130,
+            "en_US": 4.03,
+            "es_ES": 3.54,
+            "ar_AE": 4.03,
+            "sv_SE": 39.15,
+            "ko_KR": 5898,
+            "id_ID": 72108,
+            "vi_VN": 105922,
+            "zh_CN": 27.32,
+            "th_TH": 135.78
+          }
+        },
+        "rating": {
+          "ratingDetail": [
+            {
+              "review_point": 1,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 2,
+              "count": 1,
+              "ratio": 0
+            },
+            {
+              "review_point": 3,
+              "count": 20,
+              "ratio": 4
+            },
+            {
+              "review_point": 4,
+              "count": 50,
+              "ratio": 10
+            },
+            {
+              "review_point": 5,
+              "count": 454,
+              "ratio": 86
+            }
+          ],
+          "count": 526,
+          "stars": 5
         },
         "dataSources": {
           "infoAPI": {
             "customGenres": [],
-            "lastFetched": "2026-07-17T15:06:32.122Z"
+            "lastFetched": "2026-07-25T01:05:19.918Z"
           }
         },
-        "updatedAt": "2026-07-17T15:06:32.122Z"
+        "updatedAt": "2026-07-25T01:05:19.918Z"
       }
     }
   ]

--- a/apps/web/src/app/works/[workId]/components/__tests__/star-rating.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/star-rating.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StarRating } from "../star-rating";
+
+/** 星ごとの塗り幅クラス（w-0 / w-1/2 / w-full）を左から順に取り出す */
+function fillWidths(container: HTMLElement): string[] {
+	return Array.from(container.querySelectorAll(".absolute")).map((el) => {
+		if (el.classList.contains("w-full")) return "full";
+		if (el.classList.contains("w-1/2")) return "half";
+		return "none";
+	});
+}
+
+describe("StarRating", () => {
+	it("満点は5つとも塗る（0-5 スケールをそのまま解釈する）", () => {
+		const { container } = render(<StarRating rating={5} />);
+
+		expect(fillWidths(container)).toEqual(["full", "full", "full", "full", "full"]);
+		expect(screen.getByRole("img")).toHaveAttribute("aria-label", "5段階評価で5.0");
+	});
+
+	it("読み上げは丸めない実値を伝える（表示の数値と一致させる）", () => {
+		render(<StarRating rating={4.3} />);
+
+		expect(screen.getByRole("img")).toHaveAttribute("aria-label", "5段階評価で4.3");
+	});
+
+	it("半端な評価は半分だけ塗った星で表す", () => {
+		const { container } = render(<StarRating rating={4.5} />);
+
+		expect(fillWidths(container)).toEqual(["full", "full", "full", "full", "half"]);
+	});
+
+	it("0.5 刻みに丸める", () => {
+		const { container: down } = render(<StarRating rating={4.1} />);
+		expect(fillWidths(down)).toEqual(["full", "full", "full", "full", "none"]);
+
+		const { container: up } = render(<StarRating rating={4.3} />);
+		expect(fillWidths(up)).toEqual(["full", "full", "full", "full", "half"]);
+	});
+
+	it("評価0は1つも塗らない", () => {
+		const { container } = render(<StarRating rating={0} />);
+
+		expect(fillWidths(container)).toEqual(["none", "none", "none", "none", "none"]);
+	});
+
+	it("範囲外の値は 0-5 にクランプする", () => {
+		const { container: over } = render(<StarRating rating={50} />);
+		expect(fillWidths(over)).toEqual(["full", "full", "full", "full", "full"]);
+
+		const { container: under } = render(<StarRating rating={-1} />);
+		expect(fillWidths(under)).toEqual(["none", "none", "none", "none", "none"]);
+	});
+});

--- a/apps/web/src/app/works/[workId]/components/__tests__/star-rating.test.tsx
+++ b/apps/web/src/app/works/[workId]/components/__tests__/star-rating.test.tsx
@@ -2,6 +2,11 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { StarRating } from "../star-rating";
 
+/** 読み上げ用ラベルを取り出す */
+function labelOf(container: HTMLElement): string | null | undefined {
+	return container.querySelector('[role="img"]')?.getAttribute("aria-label");
+}
+
 /** 星ごとの塗り幅クラス（w-0 / w-1/2 / w-full）を左から順に取り出す */
 function fillWidths(container: HTMLElement): string[] {
 	return Array.from(container.querySelectorAll(".absolute")).map((el) => {
@@ -45,11 +50,13 @@ describe("StarRating", () => {
 		expect(fillWidths(container)).toEqual(["none", "none", "none", "none", "none"]);
 	});
 
-	it("範囲外の値は 0-5 にクランプする", () => {
+	it("範囲外の値でも塗りは頭打ちにする（読み上げは値を歪めない）", () => {
 		const { container: over } = render(<StarRating rating={50} />);
 		expect(fillWidths(over)).toEqual(["full", "full", "full", "full", "full"]);
+		expect(labelOf(over)).toBe("5段階評価で50.0");
 
 		const { container: under } = render(<StarRating rating={-1} />);
 		expect(fillWidths(under)).toEqual(["none", "none", "none", "none", "none"]);
+		expect(labelOf(under)).toBe("5段階評価で-1.0");
 	});
 });

--- a/apps/web/src/app/works/[workId]/components/star-rating.tsx
+++ b/apps/web/src/app/works/[workId]/components/star-rating.tsx
@@ -22,12 +22,13 @@ function starFillWidth(rating: number, star: number): string {
  * 表示は 0.5 刻みに丸め、半端な値は半分だけ塗った星で表す。
  */
 export function StarRating({ rating }: { rating: number }) {
-	const value = Math.min(Math.max(rating, 0), 5);
-	// 塗り分けだけ 0.5 刻みに丸める（4.3 → 4.5 / 4.1 → 4.0）。読み上げは丸めない実値を使う
-	const rounded = Math.round(value * 2) / 2;
+	// 塗り分けだけ 0.5 刻みに丸める（4.3 → 4.5 / 4.1 → 4.0）。
+	// 星ごとの塗り幅は starFillWidth 側でクランプするため、ここで値を歪めない。
+	// 読み上げも生値のまま渡し、隣に並ぶ数値表示と必ず一致させる。
+	const rounded = Math.round(rating * 2) / 2;
 
 	return (
-		<div className="flex items-center" role="img" aria-label={`5段階評価で${value.toFixed(1)}`}>
+		<div className="flex items-center" role="img" aria-label={`5段階評価で${rating.toFixed(1)}`}>
 			{[1, 2, 3, 4, 5].map((star) => (
 				<div key={star} className="relative h-5 w-5">
 					<Star className="h-5 w-5 text-muted-foreground" />

--- a/apps/web/src/app/works/[workId]/components/star-rating.tsx
+++ b/apps/web/src/app/works/[workId]/components/star-rating.tsx
@@ -1,0 +1,43 @@
+import { Star } from "lucide-react";
+
+/**
+ * 星1つあたりの塗り幅クラスを返す。
+ *
+ * Tailwind は動的なクラス名生成（`w-${n}` 等）をスキャンできないため、静的な文字列で返す。
+ *
+ * @param rating 0.5 刻みに丸めた評価値（0-5）
+ * @param star 左から数えた星の位置（1-5）
+ */
+function starFillWidth(rating: number, star: number): string {
+	const fill = Math.min(Math.max(rating - (star - 1), 0), 1);
+	if (fill >= 1) return "w-full";
+	if (fill >= 0.5) return "w-1/2";
+	return "w-0";
+}
+
+/**
+ * 作品評価の星表示。
+ *
+ * 評価値の正本は `WorkPlainObject.rating.stars`（0-5 スケール。`work-schemas.ts` の zod で担保）。
+ * 表示は 0.5 刻みに丸め、半端な値は半分だけ塗った星で表す。
+ */
+export function StarRating({ rating }: { rating: number }) {
+	const value = Math.min(Math.max(rating, 0), 5);
+	// 塗り分けだけ 0.5 刻みに丸める（4.3 → 4.5 / 4.1 → 4.0）。読み上げは丸めない実値を使う
+	const rounded = Math.round(value * 2) / 2;
+
+	return (
+		<div className="flex items-center" role="img" aria-label={`5段階評価で${value.toFixed(1)}`}>
+			{[1, 2, 3, 4, 5].map((star) => (
+				<div key={star} className="relative h-5 w-5">
+					<Star className="h-5 w-5 text-muted-foreground" />
+					<div
+						className={`absolute inset-y-0 left-0 overflow-hidden ${starFillWidth(rounded, star)}`}
+					>
+						<Star className="h-5 w-5 text-foreground fill-current" />
+					</div>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/app/works/[workId]/components/work-detail.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-detail.tsx
@@ -23,7 +23,6 @@ import {
 	Share2,
 	Shield,
 	ShoppingCart,
-	Star,
 	Tag,
 	Users,
 } from "lucide-react";
@@ -35,28 +34,13 @@ import { formatJSTDateTime } from "@/utils/date-format";
 import { calculatePriceInfo } from "../../utils/price-info";
 import { AgeRatingBadge } from "./age-rating-badge";
 import SampleImageGallery from "./sample-image-gallery";
+import { StarRating } from "./star-rating";
 import { CreatorBadges, CreatorList } from "./work-creators";
 import WorkDescription from "./work-description";
 import { WorkEvaluation } from "./work-evaluation";
 
 interface WorkDetailProps {
 	work: WorkPlainObject;
-}
-
-// スターレーティングコンポーネント
-function StarRating({ rating }: { rating: number }) {
-	// Convert 0-50 scale to 0-5 scale for display
-	const displayRating = Math.round(rating / 10);
-	return (
-		<div className="flex items-center">
-			{[1, 2, 3, 4, 5].map((star) => (
-				<Star
-					key={star}
-					className={`h-5 w-5 ${star <= displayRating ? "text-foreground fill-current" : "text-muted-foreground"}`}
-				/>
-			))}
-		</div>
-	);
 }
 
 // シェア処理
@@ -186,7 +170,7 @@ export default function WorkDetail({ work }: WorkDetailProps) {
 							<div className="flex items-center gap-3">
 								<StarRating rating={work.rating.stars} />
 								<span className="text-xl font-semibold text-foreground">
-									{(work.rating.stars / 10).toFixed(1)}
+									{work.rating.stars.toFixed(1)}
 								</span>
 								<span className="text-base text-muted-foreground">
 									({work.rating.count}件の評価)


### PR DESCRIPTION
## 問題

作品詳細ページの評価表示が `rating.stars` を 0-50 スケールと誤認して 10 で割っていた。
満点の作品が「0.5・星1つ」に潰れ、**どんな評価値でも上限が 0.5 に張り付く**状態だった。

```tsx
// 修正前
const displayRating = Math.round(rating / 10);   // 5.0 → 星 1 つ
{(work.rating.stars / 10).toFixed(1)}            // 5.0 → "0.5"
```

## 原因

`stars` の正本は 0-5（`work-schemas.ts` の zod で `max(5)`）。
書き込み側は SPR-272 で `rate_average_star`(10-50) を 10 で割る形に正されているが、
読み出し側に鏡像の取り違えが残っていた。本番実データでも `stars` は 4.5 / 5.0 の
0-5 スケールで、想定どおり。

## 変更

- `/10` 換算を撤去（星の塗り・数値表示の 2 箇所）
- 星表示を半星対応に。元データが 0.5 刻みなので丸めずに部分塗りで表せる
- インライン定義だった `StarRating` を `star-rating.tsx` へ分離（単体テストのため）
- `role="img"` + `aria-label` を付与。ラベルは丸める前の実値を使い表示中の数値と一致させる
- ローカル fixtures を本番から再取得（`pnpm seed:dump`）。旧 fixtures は works 100 件
  すべてに `rating` が欠けており、Emulator では評価ブロックが描画されなかった

Tailwind は動的クラス生成をスキャンできないため、塗り幅は静的な文字列で持つ。

## 確認

- `pnpm verify` 通過（lint:docs / lint:tokens / lint / typecheck / test + カバレッジ閾値）
- `star-rating` 単体テスト 6 ケース追加（満点・半星・丸め・0・範囲外クランプ・読み上げ値）
- Emulator の実データで描画確認
  - `RJ01026771`（stars 4.5）: 塗り幅が `w-full` ×4 + `w-1/2` ×1 で半星が出る
  - `RJ01037463`（stars 5.0）: ★★★★★ 5.0（1976件の評価）

## 補足

ReUI に `@reui/rating`（無料・小数対応）があるが、ADR-012 の採用ゲート §4 で初期スコープが
Chart / Autocomplete / EmptyState / Filters の 4 点に限定されており Rating は列挙外のため、
本 PR では手組みのままとした。置換するなら ADR-012 の追補 +
`evaluation-radio-group.tsx` の星入力も含めて別 PR とするのが適切。

Two-Way Door（UI 表示の修正とローカル開発用 fixture の再取得のみ。Firestore スキーマ・
整合性 cron・認証・Terraform・CI・shared-types のいずれにも触れていない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
