### PR TITLE
feat(analytics): 作成の入口を GA4 で記録する (SPR-296)

### DIFF
--- a/apps/web/src/app/buttons/create/page.tsx
+++ b/apps/web/src/app/buttons/create/page.tsx
@@ -13,6 +13,7 @@ import { getAudioButtonsList } from "@/app/buttons/actions";
 import { getVideoById } from "@/app/videos/actions";
 import { AudioButtonCreator } from "@/components/audio/audio-button-creator";
 import ProtectedRoute from "@/components/system/protected-route";
+import { CREATE_ENTRY, CREATE_ENTRY_PARAM, parseCreateEntry } from "@/lib/analytics/create-entry";
 
 interface CreateAudioButtonPageProps {
 	searchParams: Promise<{
@@ -20,6 +21,8 @@ interface CreateAudioButtonPageProps {
 		start_time?: string;
 		/** /watch の下書きから開いた場合に付与。作成成功時にその下書きを消化する（SPR-146） */
 		draft_id?: string;
+		/** どの導線から来たか。GA4 の create_entry として送る（SPR-296） */
+		entry?: string;
 	}>;
 }
 
@@ -187,12 +190,15 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 	// 常に渡すと通常作成でも成功時にキューへ進んでしまい遷移挙動が変わる（一般化は SPR-290）
 	const videoDrafts = resolvedSearchParams.draft_id ? myVideoDrafts : undefined;
 
+	// 入口はログイン往復（callbackPath）でも保つ。未知の値は unknown に畳まれるので運ばない
+	const createEntry = parseCreateEntry(resolvedSearchParams.entry);
 	const callbackQuery = new URLSearchParams(
 		Object.entries({
 			video_id: videoId,
 			start_time: resolvedSearchParams.start_time,
 			draft_id: resolvedSearchParams.draft_id,
-		}).filter((entry): entry is [string, string] => entry[1] !== undefined),
+			[CREATE_ENTRY_PARAM]: createEntry === CREATE_ENTRY.unknown ? undefined : createEntry,
+		}).filter((param): param is [string, string] => param[1] !== undefined),
 	).toString();
 	const callbackPath = `/buttons/create?${callbackQuery}`;
 
@@ -209,6 +215,7 @@ export default async function CreateAudioButtonPage({ searchParams }: CreateAudi
 				videoDuration={videoDuration}
 				initialStartTime={startTime}
 				draftId={resolvedSearchParams.draft_id}
+				entry={createEntry}
 				videoDrafts={videoDrafts}
 				madeMarks={madeMarks}
 				draftMarks={draftMarks}

--- a/apps/web/src/app/videos/[videoId]/components/__tests__/video-detail.test.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/__tests__/video-detail.test.tsx
@@ -386,7 +386,7 @@ describe("VideoDetail", () => {
 			const markLink = screen.getByText("マークして見る").closest("a");
 			expect(markLink).toHaveAttribute("href", "/watch?v=abc123");
 			const clipLink = screen.getByText("ここを切り抜く").closest("a");
-			expect(clipLink).toHaveAttribute("href", "/buttons/create?video_id=abc123");
+			expect(clipLink).toHaveAttribute("href", "/buttons/create?video_id=abc123&entry=detail_clip");
 			// 意図の分岐点の1行説明
 			expect(screen.getByText(/見ながら複数拾うなら/)).toBeInTheDocument();
 			// サイドバーの「新規作成」は削除済み（作成導線は本文の1組に集約）

--- a/apps/web/src/app/videos/[videoId]/components/video-detail.tsx
+++ b/apps/web/src/app/videos/[videoId]/components/video-detail.tsx
@@ -26,6 +26,7 @@ import React, { type ReactNode, useMemo } from "react";
 import { resolveCaptureVideoMode } from "@/components/capture/video-mode";
 import { ThumbnailImage } from "@/components/ui";
 import { getVideoBadgeInfo } from "@/components/video/video-badge";
+import { CREATE_ENTRY, CREATE_ENTRY_PARAM } from "@/lib/analytics/create-entry";
 import { formatDescriptionText } from "@/lib/text-utils";
 
 interface VideoDetailProps {
@@ -362,7 +363,7 @@ export default function VideoDetail({
 											variant="outline"
 											render={
 												<Link
-													href={`/buttons/create?video_id=${video.videoId}`}
+													href={`/buttons/create?video_id=${video.videoId}&${CREATE_ENTRY_PARAM}=${CREATE_ENTRY.detailClip}`}
 													className="flex items-center whitespace-nowrap"
 												>
 													<Scissors className="h-4 w-4 mr-2" />

--- a/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
+++ b/apps/web/src/components/audio/__tests__/audio-button-creator.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CREATE_ENTRY } from "@/lib/analytics/create-entry";
 import { mockUseSession } from "@/test-utils/auth";
 import { AudioButtonCreator } from "../audio-button-creator";
 
@@ -17,6 +18,15 @@ vi.mock("@/app/buttons/actions", () => ({
 const mockDeleteButtonDraft = vi.fn().mockResolvedValue({ success: true });
 vi.mock("@/actions/button-drafts", () => ({
 	deleteButtonDraft: (draftId: string) => mockDeleteButtonDraft(draftId),
+}));
+
+// GA4 の作成ファネルだけ差し替える（AI候補パネルも同じモジュールを使うため他は実体のまま）
+const mockTrackCreateStart = vi.fn();
+const mockTrackCreateSuccess = vi.fn();
+vi.mock("@/lib/analytics/events", async (importOriginal) => ({
+	...(await importOriginal<typeof import("@/lib/analytics/events")>()),
+	trackCreateStart: (input: unknown) => mockTrackCreateStart(input),
+	trackCreateSuccess: (input: unknown) => mockTrackCreateSuccess(input),
 }));
 
 const mockGetVideoTranscriptChunk = vi.fn();
@@ -94,6 +104,7 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 		videoTitle: "テスト動画タイトル",
 		videoDuration: 300,
 		initialStartTime: 0,
+		entry: CREATE_ENTRY.detailClip,
 	};
 
 	beforeEach(() => {
@@ -732,6 +743,51 @@ describe("AudioButtonCreator - Refactored Architecture", () => {
 				"href",
 				"/buttons/new-audio-button-id",
 			);
+		});
+
+		it("create_entry は1本目が入口・2本目以降は queue_continue になる（SPR-296）", async () => {
+			const user = userEvent.setup();
+			render(
+				<AudioButtonCreator
+					{...defaultProps}
+					entry={CREATE_ENTRY.watchBulk}
+					initialStartTime={30}
+					draftId="draft-1"
+					videoDrafts={[makeDraft("draft-1", 30), makeDraft("draft-2", 120)]}
+				/>,
+			);
+
+			await user.type(screen.getByPlaceholderText("例: おはようございます"), "1個目のボタン");
+			const continueButton = screen.getByRole("button", {
+				name: "作成して次の下書きへ（残り1）",
+			});
+			await waitFor(() => expect(continueButton).toBeEnabled());
+			await user.click(continueButton);
+
+			// 1本目は URL 由来の入口のまま
+			expect(mockTrackCreateStart).toHaveBeenLastCalledWith({
+				videoId: "test-video-id",
+				fromDraft: true,
+				entry: "watch_bulk",
+			});
+			await waitFor(() => {
+				expect(mockTrackCreateSuccess).toHaveBeenLastCalledWith(
+					expect.objectContaining({ entry: "watch_bulk" }),
+				);
+			});
+
+			// 2本目は遷移していない＝URL は変わらないので、実行時に queue_continue へ切り替わる
+			await createWithTitle(user, "2個目のボタン");
+			expect(mockTrackCreateStart).toHaveBeenLastCalledWith({
+				videoId: "test-video-id",
+				fromDraft: true,
+				entry: "queue_continue",
+			});
+			await waitFor(() => {
+				expect(mockTrackCreateSuccess).toHaveBeenLastCalledWith(
+					expect.objectContaining({ entry: "queue_continue" }),
+				);
+			});
 		});
 
 		it("主ボタン「音声ボタンを作成」はキューが残っていても詳細ページへフルロード遷移する（続行は毎回選ぶ・段4）", async () => {

--- a/apps/web/src/components/audio/audio-button-creator.tsx
+++ b/apps/web/src/components/audio/audio-button-creator.tsx
@@ -10,6 +10,7 @@ import { createAudioButton } from "@/app/buttons/actions";
 import { useAudioButtonEditor } from "@/hooks/use-audio-button-editor";
 import { refreshDraftCount } from "@/hooks/use-draft-count";
 import { useVideoTranscript } from "@/hooks/use-video-transcript";
+import { CREATE_ENTRY, type CreateEntry } from "@/lib/analytics/create-entry";
 import { trackCreateError, trackCreateStart, trackCreateSuccess } from "@/lib/analytics/events";
 import { useSession } from "@/lib/auth/client";
 import { snapRangeForUtterance, type TranscriptUtterance } from "@/lib/gemini/transcription-core";
@@ -39,6 +40,8 @@ interface AudioButtonCreatorProps {
 	madeMarks?: number[];
 	/** 自分の下書きの開始時刻（探索レーンの目印・SPR-289）。キューとは独立に常時渡る */
 	draftMarks?: number[];
+	/** この画面へ来た導線。GA4 の create_entry として送る（SPR-296） */
+	entry: CreateEntry;
 }
 
 /** 同値が複数あっても1件分だけ取り除く（下書きマークは同時刻が並存しうる） */
@@ -66,6 +69,7 @@ export function AudioButtonCreator({
 	videoDrafts,
 	madeMarks: initialMadeMarks,
 	draftMarks,
+	entry,
 }: AudioButtonCreatorProps) {
 	const router = useRouter();
 	const user = useSession();
@@ -97,6 +101,11 @@ export function AudioButtonCreator({
 		(videoDrafts ?? []).filter((draft) => draft.id !== draftId),
 	);
 	const [lastCreated, setLastCreated] = useState<{ id: string; buttonText: string } | null>(null);
+
+	// 2本目以降は遷移せず URL も変わらないため、入口は prop ではなくここで queue_continue に切り替える
+	// （SPR-296。連続して作られたかどうかが「1回で5〜20本」仮説の検証そのもの）
+	const [hasContinued, setHasContinued] = useState(false);
+	const createEntry = hasContinued ? CREATE_ENTRY.queueContinue : entry;
 
 	// 探索レーンのマーク。作成成功時にその場で加減する（再取得はしない・SPR-289）。
 	// 下書きマークも state 化しないと、連続仕上げ（遷移なし）で消化した下書きが残って見える
@@ -198,6 +207,8 @@ export function AudioButtonCreator({
 	const finishAfterCreate = useCallback(
 		(createdId: string, createdText: string, continueAfter: boolean) => {
 			if (continueAfter) {
+				// 以降の作成はキュー内の2本目以降として記録する（SPR-296）
+				setHasContinued(true);
 				const [next, ...rest] = remainingDrafts;
 				if (next) {
 					setLastCreated({ id: createdId, buttonText: createdText });
@@ -230,7 +241,7 @@ export function AudioButtonCreator({
 
 			setIsCreating(true);
 			setError("");
-			trackCreateStart(videoId, Boolean(activeDraftId));
+			trackCreateStart({ videoId, fromDraft: Boolean(activeDraftId), entry: createEntry });
 
 			try {
 				const input: CreateAudioButtonInput = {
@@ -250,6 +261,7 @@ export function AudioButtonCreator({
 						audioButtonId: result.data.id,
 						videoId,
 						fromDraft: Boolean(activeDraftId),
+						entry: createEntry,
 					});
 					// 探索レーンへ即時反映（連続作成時に同じ箇所の二重作成を防ぐ）
 					setMadeMarks((prev) => [...prev, input.startTime]);
@@ -279,6 +291,7 @@ export function AudioButtonCreator({
 			setError,
 			videoTitle,
 			activeDraftId,
+			createEntry,
 			consumeActiveDraft,
 			finishAfterCreate,
 		],

--- a/apps/web/src/components/capture/__tests__/capture-view.test.tsx
+++ b/apps/web/src/components/capture/__tests__/capture-view.test.tsx
@@ -88,7 +88,7 @@ describe("CaptureView の今回のマーク（集中モード・導線再設計 
 		const bulkLink = screen.getByRole("link", { name: /まとめて仕上げる/ });
 		expect(bulkLink).toHaveAttribute(
 			"href",
-			"/buttons/create?video_id=video-curr111&start_time=100&draft_id=a1",
+			"/buttons/create?video_id=video-curr111&start_time=100&draft_id=a1&entry=watch_bulk",
 		);
 	});
 

--- a/apps/web/src/components/capture/capture-view.tsx
+++ b/apps/web/src/components/capture/capture-view.tsx
@@ -5,6 +5,7 @@ import type { YTPlayer } from "@suzumina.click/ui/components/custom/youtube-type
 import Link from "next/link";
 import { useCallback, useEffect, useRef } from "react";
 import { useCaptureDrafts } from "@/hooks/use-capture-drafts";
+import { CREATE_ENTRY, CREATE_ENTRY_PARAM } from "@/lib/analytics/create-entry";
 import { matchShortcutKey } from "@/lib/keyboard-shortcut";
 import { CaptureActionBar } from "./capture-action-bar";
 import { CaptureHeader } from "./capture-header";
@@ -37,7 +38,7 @@ function buildBulkHref(drafts: AudioButtonDraft[]): string | null {
 	const first = drafts.reduce((min, draft) =>
 		draft.suggestedStartTime < min.suggestedStartTime ? draft : min,
 	);
-	return `/buttons/create?video_id=${first.videoId}&start_time=${first.suggestedStartTime}&draft_id=${first.id}`;
+	return `/buttons/create?video_id=${first.videoId}&start_time=${first.suggestedStartTime}&draft_id=${first.id}&${CREATE_ENTRY_PARAM}=${CREATE_ENTRY.watchBulk}`;
 }
 
 /**

--- a/apps/web/src/components/capture/draft-queue.tsx
+++ b/apps/web/src/components/capture/draft-queue.tsx
@@ -4,6 +4,7 @@ import type { AudioButtonDraft } from "@suzumina.click/shared-types";
 import { Badge } from "@suzumina.click/ui/components/ui/badge";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { ExternalLink, Trash2 } from "lucide-react";
+import { CREATE_ENTRY, CREATE_ENTRY_PARAM } from "@/lib/analytics/create-entry";
 import { formatSeconds } from "@/utils/format-seconds";
 
 interface DraftQueueProps {
@@ -81,7 +82,7 @@ export function DraftQueue({ drafts, sessionMarkedIds, isLocked, onDelete }: Dra
 									render={
 										// この1件だけを仕上げたいときの個別導線（フルロード・SPR-252）
 										<a
-											href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
+											href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}&${CREATE_ENTRY_PARAM}=${CREATE_ENTRY.watchSingle}`}
 										>
 											<ExternalLink className="h-3.5 w-3.5 mr-1" />
 											仕上げる

--- a/apps/web/src/components/capture/mark-chip.tsx
+++ b/apps/web/src/components/capture/mark-chip.tsx
@@ -4,6 +4,7 @@ import type { AudioButtonDraft } from "@suzumina.click/shared-types";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { ExternalLink, Minus, Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { CREATE_ENTRY, CREATE_ENTRY_PARAM } from "@/lib/analytics/create-entry";
 import { formatSeconds } from "@/utils/format-seconds";
 
 /** 微調整の1回あたりの秒数（/drafts の行調整と共通） */
@@ -96,7 +97,7 @@ export function MarkChip({ draft, showFinishNow, isAdjusting, onAdjust }: MarkCh
 					render={
 						// フルロード遷移（intercepting route 回避・SPR-252）
 						<a
-							href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
+							href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}&${CREATE_ENTRY_PARAM}=${CREATE_ENTRY.chipNow}`}
 						>
 							<ExternalLink className="h-3.5 w-3.5 mr-1" />
 							すぐ仕上げる

--- a/apps/web/src/components/drafts/__tests__/drafts-shelf-view.test.tsx
+++ b/apps/web/src/components/drafts/__tests__/drafts-shelf-view.test.tsx
@@ -51,7 +51,7 @@ describe("DraftsShelfView（マーク棚・導線再設計 段2）", () => {
 		const bulkLinks = screen.getAllByRole("link", { name: /まとめて仕上げる/ });
 		expect(bulkLinks[0]).toHaveAttribute(
 			"href",
-			"/buttons/create?video_id=video-older11&start_time=50&draft_id=old1",
+			"/buttons/create?video_id=video-older11&start_time=50&draft_id=old1&entry=drafts_bulk",
 		);
 		expect(bulkLinks[0]).toHaveTextContent("まとめて仕上げる（2）");
 

--- a/apps/web/src/components/drafts/drafts-shelf-view.tsx
+++ b/apps/web/src/components/drafts/drafts-shelf-view.tsx
@@ -10,6 +10,7 @@ import { deleteButtonDraft, updateButtonDraftPlayerTime } from "@/actions/button
 import { type DraftVideoGroup, groupDraftsByVideo } from "@/components/capture/draft-groups";
 import { MARK_ADJUST_STEP_SECONDS } from "@/components/capture/mark-chip";
 import { refreshDraftCount } from "@/hooks/use-draft-count";
+import { CREATE_ENTRY, CREATE_ENTRY_PARAM } from "@/lib/analytics/create-entry";
 import { formatSeconds } from "@/utils/format-seconds";
 
 /** グループ表示に使う動画の現在状態（page 側で videos から算出して渡す） */
@@ -106,7 +107,7 @@ function DraftShelfRow({
 					render={
 						// /buttons ツリーへの遷移はフルロード（intercepting route 回避・SPR-252）
 						<a
-							href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}`}
+							href={`/buttons/create?video_id=${draft.videoId}&start_time=${draft.suggestedStartTime}&draft_id=${draft.id}&${CREATE_ENTRY_PARAM}=${CREATE_ENTRY.draftsSingle}`}
 						>
 							<ExternalLink className="h-3.5 w-3.5 mr-1" />
 							この1件を仕上げる
@@ -187,7 +188,7 @@ function DraftShelfGroup({
 									// 先頭（推奨開始秒が最小）から開けば同一動画のキューは create 側が読み込み、
 									// 連続仕上げ（SPR-266 第2段）につながる。フルロード遷移（SPR-252）
 									<a
-										href={`/buttons/create?video_id=${group.videoId}&start_time=${firstDraft.suggestedStartTime}&draft_id=${firstDraft.id}`}
+										href={`/buttons/create?video_id=${group.videoId}&start_time=${firstDraft.suggestedStartTime}&draft_id=${firstDraft.id}&${CREATE_ENTRY_PARAM}=${CREATE_ENTRY.draftsBulk}`}
 									>
 										<ExternalLink className="h-3.5 w-3.5 mr-1" />
 										まとめて仕上げる（{group.drafts.length}）

--- a/apps/web/src/lib/analytics/__tests__/create-entry.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/create-entry.test.ts
@@ -14,6 +14,11 @@ describe("作成の入口（SPR-296）", () => {
 		expect(parseCreateEntry(undefined)).toBe(CREATE_ENTRY.unknown);
 	});
 
+	it("queue_continue は URL から受け付けない（実行時にのみ立つ値）", () => {
+		// 通すと手書き URL の1本目が連続作成として記録され、連続性の検証そのものが汚れる
+		expect(parseCreateEntry("queue_continue")).toBe(CREATE_ENTRY.unknown);
+	});
+
 	it("create_entry が GA4 カスタムディメンションに宣言されている", () => {
 		// 宣言漏れは lint:ga4 でも弾かれるが、遡及適用されない＝取り返せないので二重に守る
 		expect(dimensions.map((dimension) => dimension.parameterName)).toContain("create_entry");

--- a/apps/web/src/lib/analytics/__tests__/create-entry.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/create-entry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { CREATE_ENTRY, parseCreateEntry } from "../create-entry";
+import dimensions from "../ga4-custom-dimensions.json";
+
+describe("作成の入口（SPR-296）", () => {
+	it("既知の入口はそのまま通す", () => {
+		expect(parseCreateEntry("watch_bulk")).toBe(CREATE_ENTRY.watchBulk);
+		expect(parseCreateEntry("detail_clip")).toBe(CREATE_ENTRY.detailClip);
+	});
+
+	it("未知・未指定は unknown に畳む（GA4 ディメンションのカーディナリティ汚染を防ぐ）", () => {
+		expect(parseCreateEntry("../../etc/passwd")).toBe(CREATE_ENTRY.unknown);
+		expect(parseCreateEntry("")).toBe(CREATE_ENTRY.unknown);
+		expect(parseCreateEntry(undefined)).toBe(CREATE_ENTRY.unknown);
+	});
+
+	it("create_entry が GA4 カスタムディメンションに宣言されている", () => {
+		// 宣言漏れは lint:ga4 でも弾かれるが、遡及適用されない＝取り返せないので二重に守る
+		expect(dimensions.map((dimension) => dimension.parameterName)).toContain("create_entry");
+	});
+});

--- a/apps/web/src/lib/analytics/__tests__/events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/events.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CREATE_ENTRY } from "../create-entry";
 import {
 	trackCreateError,
 	trackCreateStart,
@@ -34,11 +35,12 @@ describe("GA4 カスタムイベント語彙 (SPR-149)", () => {
 	// Cookie/識別子の可否だけが GA4 の consent mode 側で切り替わる。
 	it("consent 未取得でもイベントを送る（ゲートは撤廃済み）", () => {
 		trackPlayButton("ab1");
-		trackCreateStart("vid00000001", false);
+		trackCreateStart({ videoId: "vid00000001", fromDraft: false, entry: CREATE_ENTRY.detailClip });
 		expect(gtag).toHaveBeenCalledWith("event", "play_button", { audio_button_id: "ab1" });
 		expect(gtag).toHaveBeenCalledWith("event", "create_start", {
 			video_id: "vid00000001",
 			from_draft: false,
+			create_entry: "detail_clip",
 		});
 	});
 
@@ -48,20 +50,27 @@ describe("GA4 カスタムイベント語彙 (SPR-149)", () => {
 		expect(gtag).toHaveBeenCalledWith("event", "play_button", { audio_button_id: "ab1" });
 	});
 
-	it("create ファネル: start / success（from_draft 付き） / error を送る", () => {
+	it("create ファネル: start / success（from_draft・create_entry 付き） / error を送る", () => {
 		grantAnalyticsConsent();
-		trackCreateStart("vid00000001", true);
-		trackCreateSuccess({ audioButtonId: "ab1", videoId: "vid00000001", fromDraft: true });
+		trackCreateStart({ videoId: "vid00000001", fromDraft: true, entry: CREATE_ENTRY.watchBulk });
+		trackCreateSuccess({
+			audioButtonId: "ab1",
+			videoId: "vid00000001",
+			fromDraft: true,
+			entry: CREATE_ENTRY.watchBulk,
+		});
 		trackCreateError("vid00000001", "認証エラー");
 
 		expect(gtag).toHaveBeenCalledWith("event", "create_start", {
 			video_id: "vid00000001",
 			from_draft: true,
+			create_entry: "watch_bulk",
 		});
 		expect(gtag).toHaveBeenCalledWith("event", "create_success", {
 			audio_button_id: "ab1",
 			video_id: "vid00000001",
 			from_draft: true,
+			create_entry: "watch_bulk",
 		});
 		expect(gtag).toHaveBeenCalledWith("event", "create_error", {
 			video_id: "vid00000001",

--- a/apps/web/src/lib/analytics/create-entry.ts
+++ b/apps/web/src/lib/analytics/create-entry.ts
@@ -1,0 +1,49 @@
+/**
+ * 音声ボタン作成画面（/buttons/create）へ来た入口の語彙（SPR-296）。
+ *
+ * PR #892 で作成の本線を「作る起点」から「視聴起点」へ反転した。動画カードから作成を降ろし
+ * 狙い撃ちを詳細ページ経由（+1クリック）にした交換が損だったかを判定するには、作成が
+ * どの入口から来たかを分けて数える必要がある。既存の from_draft は「draft_id クエリが
+ * 付いていたか」に等価で、/watch・マーク棚・動画詳細を区別できない。
+ *
+ * 値は URL クエリ（?entry=）で運ぶ＝ユーザーが任意に書ける。GA4 のカスタムディメンションは
+ * 値のカーディナリティを制限せず、一度入った値は消せないため、parseCreateEntry で
+ * 既知の値だけを通す（未知は unknown へ畳む）。
+ */
+
+export const CREATE_ENTRY = {
+	/** /watch 固定バーの「まとめて仕上げる」 */
+	watchBulk: "watch_bulk",
+	/** /watch キュー内の個別「仕上げる」 */
+	watchSingle: "watch_single",
+	/** マーク棚（/drafts）の「まとめて仕上げる」 */
+	draftsBulk: "drafts_bulk",
+	/** マーク棚（/drafts）の「この1件を仕上げる」 */
+	draftsSingle: "drafts_single",
+	/** マーク直後チップの「すぐ仕上げる」 */
+	chipNow: "chip_now",
+	/** 動画詳細の「ここを切り抜く」＝狙い撃ち（S3）。導線転換で +1 クリックになった側 */
+	detailClip: "detail_clip",
+	/**
+	 * 作成画面に留まったままの2本目以降。遷移を伴わないため URL には現れず、実行時に立てる。
+	 * 下書きキューを進む場合と素の連続作成の区別は from_draft が持つ
+	 * （後者は下書きを消化済みで from_draft=false になる）
+	 */
+	queueContinue: "queue_continue",
+	/** 直リンク・ブックマーク・未知の値。(not set) は本計器の導入前を意味する */
+	unknown: "unknown",
+} as const;
+
+export type CreateEntry = (typeof CREATE_ENTRY)[keyof typeof CREATE_ENTRY];
+
+/** 入口を作成画面へ運ぶクエリキー */
+export const CREATE_ENTRY_PARAM = "entry";
+
+const KNOWN_ENTRIES: readonly string[] = Object.values(CREATE_ENTRY);
+
+/** クエリ由来の入口を既知の値へ畳む（未知・未指定は unknown） */
+export function parseCreateEntry(value: string | undefined): CreateEntry {
+	return value !== undefined && KNOWN_ENTRIES.includes(value)
+		? (value as CreateEntry)
+		: CREATE_ENTRY.unknown;
+}

--- a/apps/web/src/lib/analytics/create-entry.ts
+++ b/apps/web/src/lib/analytics/create-entry.ts
@@ -25,7 +25,8 @@ export const CREATE_ENTRY = {
 	/** 動画詳細の「ここを切り抜く」＝狙い撃ち（S3）。導線転換で +1 クリックになった側 */
 	detailClip: "detail_clip",
 	/**
-	 * 作成画面に留まったままの2本目以降。遷移を伴わないため URL には現れず、実行時に立てる。
+	 * 作成画面に留まったままの2本目以降。遷移を伴わないため URL には現れず、実行時に立てる
+	 * （URL から受け付けないことは URL_ENTRIES で担保する）。
 	 * 下書きキューを進む場合と素の連続作成の区別は from_draft が持つ
 	 * （後者は下書きを消化済みで from_draft=false になる）
 	 */
@@ -39,11 +40,16 @@ export type CreateEntry = (typeof CREATE_ENTRY)[keyof typeof CREATE_ENTRY];
 /** 入口を作成画面へ運ぶクエリキー */
 export const CREATE_ENTRY_PARAM = "entry";
 
-const KNOWN_ENTRIES: readonly string[] = Object.values(CREATE_ENTRY);
+// URL クエリで受け付ける入口。queue_continue だけは実行時にしか立たない値なので除く。
+// 通してしまうと `?entry=queue_continue` を手で付けた1本目が連続作成として記録され、
+// 「1回で5〜20本」仮説の検証そのものを汚す（GA4 に入った値は後から消せない）
+const URL_ENTRIES: readonly string[] = Object.values(CREATE_ENTRY).filter(
+	(entry) => entry !== CREATE_ENTRY.queueContinue,
+);
 
-/** クエリ由来の入口を既知の値へ畳む（未知・未指定は unknown） */
+/** クエリ由来の入口を既知の値へ畳む（未知・未指定・queue_continue は unknown） */
 export function parseCreateEntry(value: string | undefined): CreateEntry {
-	return value !== undefined && KNOWN_ENTRIES.includes(value)
+	return value !== undefined && URL_ENTRIES.includes(value)
 		? (value as CreateEntry)
 		: CREATE_ENTRY.unknown;
 }

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -11,6 +11,7 @@
  */
 
 import { sendGoogleAnalyticsEvent } from "@/lib/consent/google-consent-mode";
+import type { CreateEntry } from "./create-entry";
 
 /** GA4 のイベントパラメータ値上限（100文字）に収める */
 const MAX_PARAM_LENGTH = 100;
@@ -24,20 +25,33 @@ export function trackPlayButton(audioButtonId: string): void {
 }
 
 /** 作成ファネル: 送信開始（バリデーション通過後） */
-export function trackCreateStart(videoId: string, fromDraft: boolean): void {
-	sendGoogleAnalyticsEvent("create_start", { video_id: videoId, from_draft: fromDraft });
+export function trackCreateStart(input: {
+	videoId: string;
+	fromDraft: boolean;
+	entry: CreateEntry;
+}): void {
+	sendGoogleAnalyticsEvent("create_start", {
+		video_id: input.videoId,
+		from_draft: input.fromDraft,
+		create_entry: input.entry,
+	});
 }
 
-/** 作成ファネル: 成功。from_draft は SPR-146 下書きフローの効果測定に使う */
+/**
+ * 作成ファネル: 成功。from_draft は SPR-146 下書きフローの効果測定に、
+ * create_entry は視聴起点への導線転換（PR #892）の当否判定に使う（SPR-296）
+ */
 export function trackCreateSuccess(input: {
 	audioButtonId: string;
 	videoId: string;
 	fromDraft: boolean;
+	entry: CreateEntry;
 }): void {
 	sendGoogleAnalyticsEvent("create_success", {
 		audio_button_id: input.audioButtonId,
 		video_id: input.videoId,
 		from_draft: input.fromDraft,
+		create_entry: input.entry,
 	});
 }
 

--- a/apps/web/src/lib/analytics/ga4-custom-dimensions.json
+++ b/apps/web/src/lib/analytics/ga4-custom-dimensions.json
@@ -6,6 +6,12 @@
 		"description": "create_start / create_success。配信中マーキングの下書き(SPR-146)からの作成かどうか"
 	},
 	{
+		"parameterName": "create_entry",
+		"displayName": "作成の入口",
+		"scope": "EVENT",
+		"description": "create_start / create_success。作成画面へ来た導線（watch_* / drafts_* / chip_now / detail_clip / queue_continue / unknown）。視聴起点への導線転換の当否判定に使う（SPR-296）"
+	},
+	{
 		"parameterName": "reason",
 		"displayName": "失敗理由",
 		"scope": "EVENT",

--- a/scripts/lint-ga4-params.mjs
+++ b/scripts/lint-ga4-params.mjs
@@ -204,6 +204,23 @@ const declared = new Map(
 	JSON.parse(readFileSync(MANIFEST, "utf8")).map((d) => [d.parameterName, d]),
 );
 
+// Admin API の description 上限。超えると登録が HTTP 400 で落ちるが、それが分かるのは
+// `pnpm check:ga4-drift --apply`（GA4 認証が要る＝verify に入っていない）を叩いた時点で、
+// PR が通った後になる。宣言と同じ場所で弾く（SPR-296 で実際に踏んだ）
+const DESCRIPTION_MAX_LENGTH = 150;
+const tooLongDescriptions = [...declared.values()].filter(
+	(d) => (d.description ?? "").length > DESCRIPTION_MAX_LENGTH,
+);
+if (tooLongDescriptions.length > 0) {
+	console.error(
+		`[lint-ga4-params] ✗ description が ${DESCRIPTION_MAX_LENGTH} 文字を超えている（Admin API が受け付けない）:`,
+	);
+	for (const d of tooLongDescriptions) {
+		console.error(`  ${d.parameterName}  (${d.description.length} 文字)`);
+	}
+	process.exit(1);
+}
+
 const used = new Map(); // param -> 最初に見つけた場所
 const unresolved = []; // { id, where }
 let callSites = 0;


### PR DESCRIPTION
## 何をしたか

視聴起点への導線転換（#892）で、動画カードから作成を降ろし狙い撃ちを詳細ページ経由（+1クリック）にした。この交換が損だったかを判定するには作成がどの入口から来たかを分けて数える必要があるが、既存の `from_draft` は「`draft_id` クエリが付いていたか」に等価で、/watch・マーク棚・動画詳細を区別できなかった。

`create_start` / `create_success` に `create_entry` を追加し、作成画面へ至る6導線にクエリで入口を持たせる。

| 入口 | 導線 |
| -- | -- |
| `detail_clip` | 動画詳細「ここを切り抜く」＝S3 狙い撃ち |
| `chip_now` | マーク直後チップ「すぐ仕上げる」 |
| `watch_single` / `watch_bulk` | /watch のキュー個別 / 固定バー |
| `drafts_single` / `drafts_bulk` | マーク棚の個別 / まとめて |
| `queue_continue` | 作成画面に留まったままの2本目以降 |
| `unknown` | 直リンク・ブックマーク・未知の値 |

## 設計上の判断

**`queue_continue` は URL に現れない。** 連続作成は遷移せず state を進めるだけなので、2本目以降を実行時に立てている。下書きキューを進む連続と素の連続作成の区別は既存の `from_draft` が持つ（後者は下書き消化済みで false）ため、語彙を増やさずに済んだ。

**クエリ由来の値は既知の値のみ通す。** `parseCreateEntry` で未知は `unknown` に畳む。GA4 のカスタムディメンションは入った値を消せないため、URL 経由のカーディナリティ汚染は恒久化する。

**ログイン往復で入口を落とさない。** `callbackPath` は3キー固定で再構成していたので `entry` も運ぶ。落とすと未ログインユーザーの入口が全て `unknown` になる。

## live 反映済み

`create_entry`（EVENT scope）は GA4（properties/496464197）に**登録済み**。`pnpm check:ga4-drift` で live 15件 = 宣言 15件、drift なし。カスタムディメンションは遡及適用されないため、デプロイ前に登録してある＝本番に出た時点から漏れなく取れる。

登録は一度 HTTP 400 で失敗した（description 185文字 > Admin API の150文字上限）。宣言を139文字に縮めて通したうえで、同じ失敗を `verify` で弾けるよう `lint:ga4` に長さチェックを足している（2つ目のコミット）。上限超過が分かるのは GA4 認証が要る `check:ga4-drift --apply` の時点＝PR が通った後になるため。

## 確認

- `pnpm verify` exit 0
- `pnpm build` exit 0（`/buttons/create` は従来どおり PPR）
- `pnpm check:ga4-drift` drift なし
- 長さチェックは151文字で落ち150文字以下で通ることを実測

ブラウザ確認は省いた。観測面は href のクエリと gtag への送信値で、どちらも単体テストで押さえてある（`queue_continue` への切り替わり、6導線の href、`parseCreateEntry`）。

## スコープ外

「拾える配信」タブ（S4 の入口）は作成画面へ遷移せず `create_entry` に現れないため、別イベントの新設として SPR-305 に切り出した。

Two-Way Door（クライアント計器とクエリ文字列のみ。Firestore スキーマ・認証・Terraform・shared-types のいずれにも触れていない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
