### PR TITLE
feat(analytics): 動画一覧のビュー切替を GA4 で記録する (SPR-305)

### DIFF
--- a/apps/web/src/app/videos/components/__tests__/video-view-tabs.test.tsx
+++ b/apps/web/src/app/videos/components/__tests__/video-view-tabs.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveVideoViewTab, VideoViewTabs } from "../video-view-tabs";
+
+const mockTrackVideoTabSelect = vi.fn();
+vi.mock("@/lib/analytics/events", () => ({
+	trackVideoTabSelect: (tab: string) => mockTrackVideoTabSelect(tab),
+}));
 
 describe("resolveVideoViewTab（URL が状態の正本）", () => {
 	it("既定は新着", () => {
@@ -21,6 +27,10 @@ describe("resolveVideoViewTab（URL が状態の正本）", () => {
 });
 
 describe("VideoViewTabs", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	it("3タブがプリセット URL への Link で、アクティブに aria-current が付く", () => {
 		render(<VideoViewTabs active="pickable" />);
 
@@ -32,5 +42,18 @@ describe("VideoViewTabs", () => {
 			"href",
 			"/videos?videoType=live_upcoming",
 		);
+	});
+
+	it("タブのクリックで video_tab_select を送る（SPR-305）", async () => {
+		const user = userEvent.setup();
+		render(<VideoViewTabs active="newest" />);
+
+		await user.click(screen.getByRole("link", { name: "拾える配信" }));
+		expect(mockTrackVideoTabSelect).toHaveBeenCalledWith("pickable");
+	});
+
+	it("表示しただけでは送らない（リロード・戻るで増えない）", () => {
+		render(<VideoViewTabs active="pickable" />);
+		expect(mockTrackVideoTabSelect).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/app/videos/components/video-view-tab-link.tsx
+++ b/apps/web/src/app/videos/components/video-view-tab-link.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import Link from "next/link";
+import { trackVideoTabSelect } from "@/lib/analytics/events";
+
+interface VideoViewTabLinkProps {
+	href: string;
+	label: string;
+	/** GA4 に送るビュー識別子（VideoViewTab の値） */
+	tab: string;
+	isActive: boolean;
+}
+
+/**
+ * ビュータブ1つ分。計測（onClick）のためだけに client にしている（SPR-305）。
+ * 受け取るのは文字列と真偽値だけ＝server shell から関数 prop を渡さない
+ * （渡すと server 描画文脈で "Functions cannot be passed to Client Components" になる）。
+ */
+export function VideoViewTabLink({ href, label, tab, isActive }: VideoViewTabLinkProps) {
+	return (
+		<Link
+			href={href}
+			aria-current={isActive ? "page" : undefined}
+			onClick={() => trackVideoTabSelect(tab)}
+			className={
+				isActive
+					? "rounded-full bg-primary text-primary-foreground text-sm px-4 py-1.5 font-medium"
+					: "rounded-full border text-sm px-4 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+			}
+		>
+			{label}
+		</Link>
+	);
+}

--- a/apps/web/src/app/videos/components/video-view-tabs.tsx
+++ b/apps/web/src/app/videos/components/video-view-tabs.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { VideoViewTabLink } from "./video-view-tab-link";
 
 export type VideoViewTab = "newest" | "pickable" | "live_upcoming";
 
@@ -28,23 +28,19 @@ const TABS: Array<{ key: VideoViewTab; label: string; href: string }> = [
  * 動画一覧のビュー切り替えタブ（導線再設計 段3）。
  * 実体はフィルタ＋ソートのプリセットへの Link で、状態は URL に持たせる
  * （ConfigurableList も URL を正本にしているため二重管理にならない）。
+ * リンク自体は計測のため client（VideoViewTabLink）に切り出している（SPR-305）。
  */
 export function VideoViewTabs({ active }: { active: VideoViewTab }) {
 	return (
 		<nav aria-label="動画の見方" className="flex flex-wrap gap-2">
 			{TABS.map((tab) => (
-				<Link
+				<VideoViewTabLink
 					key={tab.key}
 					href={tab.href}
-					aria-current={active === tab.key ? "page" : undefined}
-					className={
-						active === tab.key
-							? "rounded-full bg-primary text-primary-foreground text-sm px-4 py-1.5 font-medium"
-							: "rounded-full border text-sm px-4 py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
-					}
-				>
-					{tab.label}
-				</Link>
+					label={tab.label}
+					tab={tab.key}
+					isActive={active === tab.key}
+				/>
 			))}
 		</nav>
 	);

--- a/apps/web/src/lib/analytics/__tests__/events.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/events.test.ts
@@ -12,6 +12,7 @@ import {
 	trackPlayButton,
 	trackSuggestionApply,
 	trackSuggestionGenerate,
+	trackVideoTabSelect,
 } from "../events";
 
 const gtag = vi.fn();
@@ -162,5 +163,12 @@ describe("GA4 カスタムイベント語彙 (SPR-149)", () => {
 			video_id: "vid00000001",
 			target: "tag",
 		});
+	});
+
+	it("video_tab_select (SPR-305): 切り替え先のビューを video_tab で送る", () => {
+		grantAnalyticsConsent();
+		trackVideoTabSelect("pickable");
+
+		expect(gtag).toHaveBeenCalledWith("event", "video_tab_select", { video_tab: "pickable" });
 	});
 });

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -94,6 +94,18 @@ export function trackSuggestionGenerate(input: {
 	});
 }
 
+/**
+ * 動画一覧のビュー切替タブのクリック（SPR-305）。
+ * 「拾える配信」(pickable) が S4「どの配信を拾うか決める」の入口として機能しているかを見る。
+ * tab の語彙の正本は app/videos/components/video-view-tabs.tsx の VideoViewTab
+ * （provider と同じく、語彙を持つ層が別にあるため型はここで縛らない）。
+ * クリックのみを数える＝リロードや戻るでは増えない（consent_update をクリック数と
+ * 読み違えた SPR-149 の反省）。アクティブなタブの再クリックは数に入る
+ */
+export function trackVideoTabSelect(tab: string): void {
+	sendGoogleAnalyticsEvent("video_tab_select", { video_tab: tab });
+}
+
 /** AI候補の採用（タイトルクリック or タグクリック）。target で内訳を分ける */
 export function trackSuggestionApply(videoId: string, target: "title" | "tag"): void {
 	sendGoogleAnalyticsEvent("suggestion_apply", { video_id: videoId, target });

--- a/apps/web/src/lib/analytics/ga4-custom-dimensions.json
+++ b/apps/web/src/lib/analytics/ga4-custom-dimensions.json
@@ -12,6 +12,12 @@
 		"description": "create_start / create_success。作成画面へ来た導線（watch_* / drafts_* / chip_now / detail_clip / queue_continue / unknown）。視聴起点への導線転換の当否判定に使う（SPR-296）"
 	},
 	{
+		"parameterName": "video_tab",
+		"displayName": "動画一覧のビュー",
+		"scope": "EVENT",
+		"description": "video_tab_select。切り替え先のビュー（newest / pickable / live_upcoming）。pickable が S4 の入口として機能しているかを見る（SPR-305）"
+	},
+	{
 		"parameterName": "reason",
 		"displayName": "失敗理由",
 		"scope": "EVENT",


### PR DESCRIPTION
## 何をしたか

「拾える配信」タブは `/videos` 内のフィルタ切替で作成画面へ遷移しないため、#908 で入れた `create_entry` には一切現れない。結果として **S4（まだボタンが少ない配信を拾いに行く）の入口が機能しているか**が測れず、「タブが使われていない」のか「使われているが視聴・マーク・作成へ進んでいない」のかを区別できなかった。

`video_tab_select`（パラメータ `video_tab`: `newest` / `pickable` / `live_upcoming`）を追加する。

## 設計上の判断

**クリックのみを数える。** 表示のたびに送る方式だと、`consent_update` をクリック数と読み違えた SPR-149 と同じ誤読を生む（あれはロード毎に再送される）。リロード・戻るでは増えないことをテストで固定した。トレードオフとして、ブックマークや共有 URL で直接そのビューに来た分は数えない。まず素の選択回数を見る、というチケットの方針どおり。

**リンクだけを client に切り出した。** 計測に `onClick` が要るため。`VideoViewTabLink` が受け取るのは文字列と真偽値だけで、server shell から関数 prop は渡さない（渡すと server 描画文脈で "Functions cannot be passed to Client Components" になる）。`VideoViewTabs` / `resolveVideoViewTab` は Server Component のまま。

**タブの語彙は増やさない。** 正本は `VideoViewTab`（`video-view-tabs.tsx`）のままにし、`events.ts` 側では型を縛らず `tab: string` で受ける。`lib` → `app` の逆依存を作らず、union を二重管理もしない（既存の `trackLoginStart(provider: string)` と同じ扱い）。

## 確認

- `pnpm verify` exit 0 / `pnpm build` exit 0（`/videos` は従来どおり PPR）
- `pnpm lint:ga4` green（`ga4-custom-dimensions.json` に `video_tab` を追加済み）
- ブラウザ（Emulator + dev）で実測:
  - タブ3つが従来どおりの `href` と `aria-current` で描画される（client 化でアンカーが落ちていない）
  - 「拾える配信」クリックで `gtag("event","video_tab_select",{video_tab:"pickable"})` が**1回**発火し、`/videos?videoType=live_archive&sort=least_buttons` へ遷移する
  - ページ表示だけでは発火しない

## 未了

`video_tab` の GA4 live 登録はまだ。カスタムディメンションは遡及適用されないので、**マージ＝配信より前に**登録する。

