### PR TITLE
feat(analytics): GA4 の実測をまとめて読むレポートと月次実行を足す (SPR-306)

### DIFF
--- a/.github/workflows/ga4-report.yml
+++ b/.github/workflows/ga4-report.yml
@@ -1,0 +1,99 @@
+name: GA4 Report
+
+# GA4 に入れた計器の**値そのもの**を月次で読む（SPR-306）。
+# ga4-dimension-drift.yml（宣言と live の一致を見る drift 検出）とは別物で、
+# こちらは作成の入口・ビュー選択・ログインファネルの実測値を出す。
+#
+# 月次にしている理由: 2026-08 時点で母数が 1日数セッションしかなく（SPR-137）、
+# 週次で回してもほぼ同じゼロが並ぶだけで、通知が「いつもの沈黙」になる。
+#
+# 読ませ方: 毎回 Summary を見に行くのは続かないので、スクリプトが出す
+# `[signal] action_events=N` を見て **操作が記録された月だけ** warning を出す。
+# 沈黙＝まだ何も起きていない、と読める設計にしてある（人が来ただけでは通知しない）。
+#
+# 認証: ga4-dimension-drift.yml と同じ。WIF で terraform-plan-sa を assume し、
+# スクリプトが GA4 閲覧者の ga4-ci-reader を impersonate する。
+# GA4 編集者の ga4-reader は CI からは使わない（実体は terraform/analytics_ga4.tf）。
+
+on:
+  schedule:
+    - cron: '0 1 1 * *' # 毎月1日 01:00 UTC（10:00 JST）。週次 drift 系とは別枠
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'scripts/report-ga4.mjs'
+      - '.github/workflows/ga4-report.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  report:
+    name: GA4 report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # スクリプトの既定は GA4 編集者の ga4-reader。CI では読み取り専用の SA に差し替える
+      GA4_READER_SA: ga4-ci-reader@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'terraform-plan-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24.18.0'
+
+      # スクリプトは npm 依存ゼロなので install 不要。
+      # continue-on-error は使わない（conclusion まで success に塗られ「緑だが壊れている」を作る＝SPR-282）。
+      - name: Run GA4 report (capture exit code)
+        id: report
+        run: |
+          set +e
+          node scripts/report-ga4.mjs 31 2>&1 | tee /tmp/ga4-report.txt
+          code=${PIPESTATUS[0]}
+          {
+            echo "### GA4 Report (exit ${code})"
+            echo '```'
+            cat /tmp/ga4-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
+          # 表示ではなく機械可読行を契約にする（Summary の文言を変えても壊れない）
+          actions=$(grep -o '\[signal\] action_events=[0-9]*' /tmp/ga4-report.txt | grep -o '[0-9]*$')
+          echo "action_events=${actions:-0}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # 実測が動いた月だけ warning を出す＝沈黙は「まだ何も起きていない」を意味する。
+      # 取得そのものが失敗した場合は run を赤にする（気づかないまま計測が止まるのを防ぐ・SPR-282）。
+      - name: Report result
+        env:
+          REPORT_EXIT: ${{ steps.report.outputs.exit_code }}
+          ACTION_EVENTS: ${{ steps.report.outputs.action_events }}
+        run: |
+          if [ "$REPORT_EXIT" != "0" ]; then
+            echo "::error::GA4 レポートを取得できませんでした（exit ${REPORT_EXIT}）。計測の読み取りが停止しています"
+            exit 1
+          fi
+          if [ "${ACTION_EVENTS:-0}" -gt 0 ]; then
+            echo "::warning::操作イベントが ${ACTION_EVENTS} 件記録されています。Summary を読んで判断してください（SPR-306）"
+          else
+            echo "::notice::操作イベントは0件。まだ読むものはありません（計器ではなく母数の問題）"
+          fi

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"lint:ga4": "node scripts/lint-ga4-params.mjs",
 		"check:index-drift": "node scripts/check-firestore-index-drift.mjs",
 		"check:ga4-drift": "node scripts/check-ga4-drift.mjs",
+		"report:ga4": "node scripts/report-ga4.mjs",
 		"report:search-console": "node scripts/search-console-report.mjs",
 		"format": "pnpm -r format",
 		"check": "pnpm -r check",

--- a/scripts/report-ga4.mjs
+++ b/scripts/report-ga4.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// scripts/report-ga4.mjs
+//
+// GA4 に入れた計器を1回の実行でまとめて読む（SPR-306）。
+// check-ga4-drift.mjs / search-console-report.mjs と同じ認証方式
+// （ADC → SA を impersonate・npm 依存なし）。
+//
+// 何のためにあるか:
+//   計器を足すたびに「数日後に読む」チケットを立てると、同じ認証と同じクエリ骨格を
+//   毎回書き直すことになる。読むこと自体はチケットにせず、判断だけをチケットに残す。
+//   drift 検出（宣言と live が一致しているか）とは別物で、こちらは**値そのもの**を見る。
+//
+// 使い方:
+//   node scripts/report-ga4.mjs              # 直近28日
+//   node scripts/report-ga4.mjs 28           # 直近28日
+//   node scripts/report-ga4.mjs 2026-08-01 2026-08-31
+//
+// 読むときの前提:
+//   **母数を最初に出す**。suzumina.click は 2026-08 時点で 1日あたり数セッションしかなく、
+//   ゼロは「そういう結果」ではなく「まだ判断できない」を意味することが多い（SPR-137）。
+//   件数だけ見て導線の優劣を結論しないための並べ順にしてある。
+//
+// 前提（どれか欠けると止まる）:
+//   1. ADC が有効で、ga4-reader@（CI では ga4-ci-reader@）を impersonate できる
+//   2. 対象 SA が GA4 プロパティのアクセス権を持つ（**GA4 管理画面で手動付与**・terraform 不可）
+// 終了コード: 0=成功 / 2=実行エラー
+
+import { execFileSync } from "node:child_process";
+
+const PROPERTY = `properties/${process.env.GA4_PROPERTY_ID ?? "496464197"}`;
+const TARGET_SA = process.env.GA4_READER_SA ?? "ga4-reader@suzumina-click.iam.gserviceaccount.com";
+const SCOPE = "https://www.googleapis.com/auth/analytics.readonly";
+const API_BASE = "https://analyticsdata.googleapis.com/v1beta";
+
+/** 母数がこれ未満の期間は、内訳の比較に意味が無いと明示する */
+const MIN_SESSIONS_FOR_COMPARISON = 100;
+
+function abort(message) {
+	console.error(`✗ ${message}`);
+	process.exit(2);
+}
+
+/** ADC から SA を impersonate してトークンを取る（トークンは一切出力しない） */
+function accessToken() {
+	try {
+		return execFileSync(
+			"gcloud",
+			[
+				"auth",
+				"print-access-token",
+				`--impersonate-service-account=${TARGET_SA}`,
+				`--scopes=${SCOPE}`,
+			],
+			{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+		).trim();
+	} catch (e) {
+		const detail = String(e.stderr || e.message)
+			.trim()
+			.split("\n")
+			.at(-1);
+		return abort(
+			`アクセストークンを取得できませんでした（ADC 未設定 or ${TARGET_SA} の impersonate 権限なし）: ${detail}`,
+		);
+	}
+}
+
+async function runReport(token, path, body) {
+	const res = await fetch(`${API_BASE}/${PROPERTY}:${path}`, {
+		method: "POST",
+		headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+		body: JSON.stringify(body),
+	});
+	const json = await res.json().catch(() => ({}));
+	if (!res.ok) {
+		const reason = json?.error?.message ?? `HTTP ${res.status}`;
+		return abort(`${path} が失敗しました: ${reason}`);
+	}
+	return json;
+}
+
+/** 行を [次元値..., 指標値...] の素の配列にする */
+function rows(report) {
+	return (report.rows ?? []).map((row) => [
+		...(row.dimensionValues ?? []).map((d) => d.value),
+		...(row.metricValues ?? []).map((m) => Number(m.value)),
+	]);
+}
+
+function daysAgo(n) {
+	const d = new Date();
+	d.setUTCDate(d.getUTCDate() - n);
+	return d.toISOString().slice(0, 10);
+}
+
+function section(title) {
+	console.log(`\n── ${title} ${"─".repeat(Math.max(0, 56 - title.length))}`);
+}
+
+/** 件数の内訳。母数が薄いときは比較するなと明示する */
+function printBreakdown(pairs, { empty = "（0件）", note } = {}) {
+	if (pairs.length === 0) {
+		console.log(`  ${empty}`);
+		return;
+	}
+	const width = Math.max(...pairs.map(([label]) => label.length));
+	const total = pairs.reduce((sum, [, count]) => sum + count, 0);
+	for (const [label, count] of [...pairs].sort((a, b) => b[1] - a[1])) {
+		const share = total > 0 ? ` (${Math.round((count / total) * 100)}%)` : "";
+		console.log(`  ${label.padEnd(width)}  ${String(count).padStart(6)}${share}`);
+	}
+	console.log(`  ${"計".padEnd(width)}  ${String(total).padStart(6)}`);
+	if (note) console.log(`  → ${note}`);
+}
+
+async function main() {
+	const [a, b] = process.argv.slice(2);
+	const startDate = a && a.includes("-") ? a : daysAgo(Number.parseInt(a ?? "28", 10) || 28);
+	const endDate = b && b.includes("-") ? b : "today";
+
+	const token = accessToken();
+	console.log(`GA4 report (${PROPERTY})  ${startDate} 〜 ${endDate}`);
+	const dateRanges = [{ startDate, endDate }];
+
+	// 1) 母数。ここが薄いと以降の内訳は全て「まだ判断できない」になる
+	section("母数");
+	const totals = await runReport(token, "runReport", {
+		dateRanges,
+		metrics: [{ name: "sessions" }, { name: "activeUsers" }, { name: "eventCount" }],
+	});
+	const [sessions = 0, users = 0, events = 0] = rows(totals)[0] ?? [];
+	console.log(`  セッション ${sessions} / アクティブユーザー ${users} / 総イベント ${events}`);
+	const thin = sessions < MIN_SESSIONS_FOR_COMPARISON;
+	if (thin) {
+		console.log(
+			`  ⚠ セッションが ${MIN_SESSIONS_FOR_COMPARISON} 未満。以降の内訳は傾向であって結論ではない`,
+		);
+	}
+
+	// 2) 計器の生存。0件が「起きていない」なのか「送れていない」なのかの一次切り分け
+	section("計器の生存（カスタムイベント件数）");
+	const byEvent = await runReport(token, "runReport", {
+		dateRanges,
+		dimensions: [{ name: "eventName" }],
+		metrics: [{ name: "eventCount" }],
+		limit: 200,
+	});
+	const CUSTOM_EVENTS = [
+		"play_button",
+		"create_start",
+		"create_success",
+		"create_error",
+		"add_to_favorite",
+		"remove_from_favorite",
+		"mark_draft",
+		"suggestion_generate",
+		"suggestion_apply",
+		"login_start",
+		"login_success",
+		"login_error",
+		"consent_update",
+		"web_vitals",
+		"video_tab_select",
+	];
+	const eventCounts = new Map(rows(byEvent).map(([name, count]) => [name, count]));
+	printBreakdown(
+		CUSTOM_EVENTS.filter((name) => eventCounts.has(name)).map((name) => [
+			name,
+			eventCounts.get(name),
+		]),
+		{
+			empty: "（カスタムイベント 0件。送信経路の故障か、単に操作が起きていないかを切り分けること）",
+			note: "web_vitals だけが出ている＝送信経路は生きているが操作が起きていない",
+		},
+	);
+
+	// 3) 作成の入口（SPR-296 / SPR-297）。導線転換の賭けが当たったかの本体
+	section("作成の入口 create_entry（SPR-296 / SPR-297）");
+	for (const eventName of ["create_start", "create_success"]) {
+		const report = await runReport(token, "runReport", {
+			dateRanges,
+			dimensions: [{ name: "customEvent:create_entry" }],
+			metrics: [{ name: "eventCount" }],
+			dimensionFilter: {
+				filter: { fieldName: "eventName", stringFilter: { value: eventName } },
+			},
+			limit: 50,
+		});
+		console.log(`  [${eventName}]`);
+		printBreakdown(rows(report).map(([entry, count]) => [`  ${entry}`, count]));
+	}
+	console.log("  → 仮説: S1/S2（視聴起点）が主なら queue_continue と watch_*/drafts_* が厚い");
+	console.log("  → 反証: detail_clip ばかりなら、S3 を +1 クリック重くしただけの改悪");
+
+	// 4) S4 の入口（SPR-305）
+	section("動画一覧のビュー選択 video_tab（SPR-305）");
+	const tabs = await runReport(token, "runReport", {
+		dateRanges,
+		dimensions: [{ name: "customEvent:video_tab" }],
+		metrics: [{ name: "eventCount" }],
+		dimensionFilter: {
+			filter: { fieldName: "eventName", stringFilter: { value: "video_tab_select" } },
+		},
+		limit: 50,
+	});
+	printBreakdown(
+		rows(tabs).map(([tab, count]) => [tab, count]),
+		{
+			empty: "（0件。タブが見つかっていないか、そもそも /videos に人が来ていない）",
+		},
+	);
+
+	// 5) ログインファネル（SPR-267 → SPR-108 の着手要否）
+	section("ログインファネル（SPR-108 の判断材料）");
+	printBreakdown(
+		["login_start", "login_success", "login_error"]
+			.filter((name) => eventCounts.has(name))
+			.map((name) => [name, eventCounts.get(name)]),
+		{ empty: "（0件。Discord ログイン自体が試されていない）" },
+	);
+
+	// 6) landingPage の (not set) 率（SPR-299 → SPR-284 のブロック解除判断）
+	section("landingPage の (not set) 率（SPR-284 のブロック解除判断）");
+	const landing = await runReport(token, "runReport", {
+		dateRanges,
+		dimensions: [{ name: "landingPage" }],
+		metrics: [{ name: "sessions" }],
+		limit: 500,
+	});
+	const landingRows = rows(landing);
+	const landingTotal = landingRows.reduce((sum, [, count]) => sum + count, 0);
+	const notSet = landingRows.find(([page]) => page === "(not set)")?.[1] ?? 0;
+	if (landingTotal === 0) {
+		console.log("  （セッション 0件）");
+	} else {
+		const rate = Math.round((notSet / landingTotal) * 100);
+		console.log(`  (not set) ${notSet}/${landingTotal} = ${rate}%`);
+		console.log(
+			rate > 50
+				? "  → 着地ページが特定できない。SPR-284 は引き続きブロック"
+				: "  → 着地ページが取れている。SPR-284 のブロック解除を検討できる",
+		);
+	}
+
+	// 定期実行から「読む価値が出た」を検出するための機械可読行。
+	// Summary を grep させると表示を変えるたびに壊れるので、ここを契約にする（英語キー固定）。
+	// 母数ではなく**操作**の件数で判定する: 人が来ただけでは読む必要がない
+	section("signal");
+	const actionEvents = [
+		"create_start",
+		"create_success",
+		"video_tab_select",
+		"login_start",
+		"play_button",
+		"mark_draft",
+	];
+	const actionCount = actionEvents.reduce((sum, name) => sum + (eventCounts.get(name) ?? 0), 0);
+	console.log(`[signal] action_events=${actionCount} sessions=${sessions}`);
+	console.log(
+		actionCount > 0
+			? "  → 操作が記録されている。読んで判断する価値がある"
+			: "  → 操作は0件。まだ読むものが無い（計器ではなく母数の問題）",
+	);
+
+	console.log("");
+}
+
+await main();

--- a/scripts/report-ga4.mjs
+++ b/scripts/report-ga4.mjs
@@ -35,6 +35,38 @@ const API_BASE = "https://analyticsdata.googleapis.com/v1beta";
 /** 母数がこれ未満の期間は、内訳の比較に意味が無いと明示する */
 const MIN_SESSIONS_FOR_COMPARISON = 100;
 
+/**
+ * GA4 が自動収集するイベント（拡張計測を含む）。自作イベントの一覧はこれの補集合として出す。
+ *
+ * 自作イベント側を列挙しない理由: events.ts に新しいイベントを足したときに
+ * このリストの更新を忘れると、**操作は起きているのにレポートからも signal からも消える**。
+ * 「読むものが無い」と「読むべきものを落とした」が見分けられなくなり、
+ * 月次通知が沈黙したまま実測を取り逃す＝このスクリプトが防ごうとしている失敗そのものになる。
+ * 除外側だけを持てば、未知のイベントは**出る方向**に倒れる（#910 のレビュー所見）。
+ */
+const AUTO_EVENTS = new Set([
+	"session_start",
+	"first_visit",
+	"first_open",
+	"page_view",
+	"user_engagement",
+	"scroll",
+	"click",
+	"file_download",
+	"form_start",
+	"form_submit",
+	"view_search_results",
+	"video_start",
+	"video_progress",
+	"video_complete",
+]);
+
+/**
+ * 自作イベントのうち「操作ではない」もの。signal（読む価値の判定）から除く。
+ * ここも除外側で持つ＝新しい操作イベントは既定で signal に入り、通知が出る方向に倒れる
+ */
+const PASSIVE_EVENTS = new Set(["web_vitals", "consent_update"]);
+
 function abort(message) {
 	console.error(`✗ ${message}`);
 	process.exit(2);
@@ -144,32 +176,13 @@ async function main() {
 		metrics: [{ name: "eventCount" }],
 		limit: 200,
 	});
-	const CUSTOM_EVENTS = [
-		"play_button",
-		"create_start",
-		"create_success",
-		"create_error",
-		"add_to_favorite",
-		"remove_from_favorite",
-		"mark_draft",
-		"suggestion_generate",
-		"suggestion_apply",
-		"login_start",
-		"login_success",
-		"login_error",
-		"consent_update",
-		"web_vitals",
-		"video_tab_select",
-	];
 	const eventCounts = new Map(rows(byEvent).map(([name, count]) => [name, count]));
+	const customEvents = [...eventCounts.keys()].filter((name) => !AUTO_EVENTS.has(name));
 	printBreakdown(
-		CUSTOM_EVENTS.filter((name) => eventCounts.has(name)).map((name) => [
-			name,
-			eventCounts.get(name),
-		]),
+		customEvents.map((name) => [name, eventCounts.get(name)]),
 		{
 			empty: "（カスタムイベント 0件。送信経路の故障か、単に操作が起きていないかを切り分けること）",
-			note: "web_vitals だけが出ている＝送信経路は生きているが操作が起きていない",
+			note: "web_vitals / consent_update しか無い＝送信経路は生きているが操作が起きていない",
 		},
 	);
 
@@ -245,15 +258,9 @@ async function main() {
 	// Summary を grep させると表示を変えるたびに壊れるので、ここを契約にする（英語キー固定）。
 	// 母数ではなく**操作**の件数で判定する: 人が来ただけでは読む必要がない
 	section("signal");
-	const actionEvents = [
-		"create_start",
-		"create_success",
-		"video_tab_select",
-		"login_start",
-		"play_button",
-		"mark_draft",
-	];
-	const actionCount = actionEvents.reduce((sum, name) => sum + (eventCounts.get(name) ?? 0), 0);
+	const actionCount = customEvents
+		.filter((name) => !PASSIVE_EVENTS.has(name))
+		.reduce((sum, name) => sum + (eventCounts.get(name) ?? 0), 0);
 	console.log(`[signal] action_events=${actionCount} sessions=${sessions}`);
 	console.log(
 		actionCount > 0


### PR DESCRIPTION
## なぜ

計器を足すたびに「数日後に読む」チケットを立てると、同じ認証と同じクエリ骨格を毎回書き直すことになる。#908 / #909 で足した `create_entry` / `video_tab` に加え、SPR-108（ログインファネル）・SPR-284（landingPage の `(not set)` 率）・SPR-299（計器の生存）も読む先は同じ Data API で、形が揃っている。

**読むこと自体はチケットにせず、判断だけをチケットに残す**方針に変える。

## 何をしたか

**`pnpm report:ga4`** — `check:ga4-drift`（宣言と live の一致を見る）とは別物で、値そのものを出す。`report:search-console` と同じ「ローカル実行の読み取り専用レポート」型。

**母数を最初に印字する。** セッションが 100 未満なら「傾向であって結論ではない」と明示する。実測では 1日数セッションしかなく（SPR-137）、0件を「そういう結果」と読み違える余地を消す必要があった。実際このセッションで、`create_entry` が0件なのは計器の不具合ではなく作成行為が起きていないためだと切り分けている。

**イベント一覧は除外リスト側で持つ。** GA4 自動収集イベントと「自作だが操作ではないもの」だけを列挙し、自作イベント一覧はその補集合として出す。自作イベント側を列挙すると、`events.ts` に足したときに更新を忘れて**操作が起きているのにレポートからも signal からも消える**。未知のイベントは出る方向・signal に入る方向へ倒れる（レビュー所見で修正）。

**月次 CI**（毎月1日 10:00 JST）。週次にしてもほぼ同じゼロが並び、通知が「いつもの沈黙」になるため。

**操作が記録された月だけ通知する。** 毎回 Summary を見に行く運用は続かない。スクリプトが出す `[signal] action_events=N` を workflow が読み、N>0 のときだけ `::warning::` を出す。沈黙＝まだ何も起きていない、と読める。Summary の文言を変えても壊れないよう、表示ではなくこの行を契約にしている。

取得そのものが失敗したら run を赤にする（SPR-282 の「緑だが壊れている」を作らない）。

## 実行結果（live GA4・2026-07-02〜2026-08-02）

```
── 母数 ──
  セッション 119 / アクティブユーザー 113 / 総イベント 762

── 計器の生存（カスタムイベント件数） ──
  web_vitals         117 (84%)
  consent_update      23 (16%)
  計                  140
  → web_vitals / consent_update しか無い＝送信経路は生きているが操作が起きていない

── 作成の入口 create_entry ──（create_start / create_success ともに 0件）
── 動画一覧のビュー選択 video_tab ──（0件）
── ログインファネル ──（0件）
── landingPage の (not set) 率 ── 91/120 = 76% → SPR-284 は引き続きブロック

[signal] action_events=0 sessions=119
```

## 確認

- `pnpm verify` exit 0
- live GA4 に対して実行し、全セクションが値を返すことを確認
- workflow と同じ式で `[signal]` 行を抽出できることを確認（`0` が取れる）

## レビューのお願い

**`.github/workflows/ga4-report.yml` を足しているので One-Way Door です。** CLAUDE.md のセルフマージ・ポリシーにより、AI レビュー任せにせず人がレビューしてからマージしてください。認証は `ga4-dimension-drift.yml` と同一（WIF → terraform-plan-sa → `ga4-ci-reader@` を impersonate）で、新しい連携先は増やしていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
