### PR TITLE
fix(deps): 脆弱性 override の floor を引き上げる (fast-uri / brace-expansion / postcss)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,12 @@ settings:
 overrides:
   js-yaml: '>=5.2.2'
   protobufjs: '>=8.6.6'
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   uuid: '>=11.1.1'
   ws: '>=8.21.0'
-  postcss: '>=8.5.10'
+  postcss: '>=8.5.23'
   kysely: 0.28.17
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   sharp: '>=0.35.0'
 
 importers:
@@ -2600,8 +2600,8 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3037,8 +3037,8 @@ packages:
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -3953,10 +3953,6 @@ packages:
 
   postal-mime@2.7.5:
     resolution: {integrity: sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==}
-
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -5979,7 +5975,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.19
+      postcss: 8.5.23
       tailwindcss: 4.3.3
 
   '@testing-library/dom@10.4.1':
@@ -6434,7 +6430,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6553,7 +6549,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6956,7 +6952,7 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fd-package-json@2.0.0:
     dependencies:
@@ -7850,11 +7846,11 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -8079,12 +8075,6 @@ snapshots:
   possible-typed-array-names@1.1.0: {}
 
   postal-mime@2.7.5: {}
-
-  postcss@8.5.19:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,21 +20,25 @@ overrides:
   # patch）に加え、5.x系のみの別advisory「非制限な展開長によるOOM DoS」（GHSA-mh99-v99m-4gvg、5.0.8で修正）がある。
   # pnpm の override はセレクタが違っても同一パッケージ名では最後の1件のみが解決全体に効く（実測・複数セレクタ
   # 併記は無意味）ため、単一ルールで最新パッチ済みの5.x系に寄せる。
-  brace-expansion: ">=5.0.8"
+  # >=4.0.0 <5.0.9: 中間展開結果が非制限に膨らむ DoS（GHSA-rgw5-rvv9-x895、CVE-2026-14257 の修正漏れ）。5.0.9 で修正。
+  brace-expansion: ">=5.0.9"
   # uuid: override を外すと transitive が 8.3.2（deprecated）に落ちる。11.x に統一して維持。
   uuid: ">=11.1.1"
   # ws < 8.21.0: 小さな fragment/data chunk によるメモリ枯渇 DoS（GHSA-96hv-2xvq-fx4p）。8.21.0 で修正。
   # override を外すと 7.5.11 が混在するため維持。
   ws: ">=8.21.0"
-  # postcss: override を外すと 8.4.31 が混在する。8.5.10 以上に揃えて維持。
-  postcss: ">=8.5.10"
+  # postcss: override を外すと 8.4.31 が混在する。加えて <=8.5.22 は `from` 未指定時に攻撃者が仕込んだ
+  # sourceMappingURL から任意の .map を読む（GHSA-fxqj-rqcc-2cmp、GHSA-6g55-p6wh-862q の修正漏れ）。8.5.23 で修正。
+  postcss: ">=8.5.23"
   # better-auth(@better-auth/kysely-adapter) は kysely 0.28 系の DEFAULT_MIGRATION_LOCK_TABLE を要求するが
   # 0.29.x で削除されており、0.29.2 が解決されると認証ルートが ESM import で 500 になる。0.28 系にピン（SPR-156）。
   kysely: "0.28.17"
   # fast-uri < 3.1.4: IDN canonicalization 失敗によるホスト混同 / バックスラッシュを authority
   # delimiter として誤解釈するホスト混同（GHSA-4c8g-83qw-93j6・GHSA-v2hh-gcrm-f6hx）。ajv(secretlint 経由)
   # は ^3.0.1 を要求するため override なしでも解決範囲内だが、自然解決が 3.1.2 に留まるため明示的に引き上げ。
-  fast-uri: ">=3.1.4"
+  # >=4.0.0 <4.1.2: 同じくバックスラッシュを authority 区切りと誤読するホスト混同（GHSA-7p8r-x3mc-p8w7）。
+  # 旧 floor（>=3.1.4）が 4.1.1 を掴んで新 advisory の範囲に入っていたため 4.1.2 へ引き上げ。
+  fast-uri: ">=4.1.2"
   # sharp < 0.35.0: 継承する libvips の脆弱性群（CVE-2026-33327/33328/35590/35591）。next の依存範囲が
   # ^0.34.5（0.35.0 未満に固定）のため override なしでは追従しない。
   sharp: ">=0.35.0"


### PR DESCRIPTION
## 概要

`pnpm audit --audit-level moderate` が main で 3 件（high 2 / moderate 1）検出しており、PR の Security Check も落ちていた。いずれも **既に override 済みだが floor が新しい advisory の範囲を下回っていた** ため、floor を引き上げる。

| package | before | after | advisory |
| --- | --- | --- | --- |
| fast-uri | `>=3.1.4` | `>=4.1.2` | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (high) |
| brace-expansion | `>=5.0.8` | `>=5.0.9` | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (high) |
| postcss | `>=8.5.10` | `>=8.5.23` | [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (moderate) |

- **fast-uri**: Dependabot alert #104。旧 floor が 4.1.1 を掴んでおり、バックスラッシュを authority 区切りと誤読するホスト混同の範囲（`>=4.0.0 <4.1.2`）に入っていた。経路は secretlint → ajv。
- **brace-expansion**: 中間展開結果が非制限に膨らむ DoS（CVE-2026-14257 の修正漏れ）。経路は rimraf/glob/minimatch ほか 13 経路。
- **postcss**: `from` 未指定時に攻撃者が仕込んだ sourceMappingURL から任意の `.map` を読む。経路は `@tailwindcss/postcss`。

3 件とも transitive で override 管理のため、Dependabot は PR を出せない（＝手動対応が必要）。

## 確認

- `pnpm audit --audit-level moderate` → `No known vulnerabilities found`
- `pnpm verify` → exit 0（lint:docs / lint:tokens / lint / typecheck / test すべて通過）
- 解決版: fast-uri 4.1.2 / brace-expansion 5.0.9 / postcss 8.5.23

🤖 Generated with [Claude Code](https://claude.com/claude-code)