### PR TITLE
fix(circles): サークル作品一覧の works 全件スキャンを workIds 起点に置換

### DIFF
--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -81,6 +81,7 @@ const mockWhere = vi.fn();
 const mockOrderBy = vi.fn();
 const mockLimit = vi.fn();
 const mockGet = vi.fn();
+const mockGetAll = vi.fn();
 
 const mockCollection = vi.fn((_collectionName) => ({
 	doc: mockDoc,
@@ -109,12 +110,61 @@ mockLimit.mockReturnValue(mockQuery);
 vi.mock("@/lib/firestore", () => ({
 	getFirestore: () => ({
 		collection: mockCollection,
+		getAll: mockGetAll,
 	}),
 }));
 
 // テスト対象のインポート（モック設定後）
 
 import { getCircleInfo, getCircleWorksList } from "../actions";
+
+/**
+ * サークル作品一覧の Firestore モック。
+ *
+ * 実装は `circles/{id}.workIds` を所属の正本として引き、その ID を `getAll` で取得する
+ * （works の全件スキャンはしない）。モックも同じ経路だけを満たすようにし、
+ * 全件スキャンへ戻ったら `works` コレクションに `get` が無くて落ちるようにしてある。
+ *
+ * `workIds` と `works` を別々に渡せるのは、非正規化配列に実在しない ID が残る状態
+ * （作品削除と整合性cron の間のラグ）を表現するため。
+ */
+function setupCircleWorksMock({
+	circle,
+	workIds,
+	works,
+}: {
+	circle: Record<string, unknown>;
+	workIds: string[];
+	works: { id: string }[];
+}) {
+	const worksById = new Map(works.map((work) => [work.id, work]));
+
+	mockCollection.mockImplementation((collectionName) => {
+		if (collectionName === "circles") {
+			return {
+				doc: vi.fn().mockReturnValue({
+					get: vi.fn().mockResolvedValue({
+						exists: true,
+						data: () => ({ ...circle, workIds }),
+					}),
+				}),
+			};
+		}
+		if (collectionName === "works") {
+			return { doc: (id: string) => ({ id }) };
+		}
+		return {};
+	});
+
+	mockGetAll.mockImplementation((...refs: { id: string }[]) =>
+		Promise.resolve(
+			refs.map((ref) => {
+				const work = worksById.get(ref.id);
+				return { exists: work !== undefined, id: ref.id, data: () => work };
+			}),
+		),
+	);
+}
 
 describe("Circle page server actions", () => {
 	beforeEach(() => {
@@ -311,29 +361,10 @@ describe("Circle page server actions", () => {
 				},
 			];
 
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: false,
-							docs: mockWorks.map((work) => ({
-								id: work.id,
-								data: () => work,
-							})),
-						}),
-					};
-				}
-				return {};
+			setupCircleWorksMock({
+				circle: mockCircleData,
+				workIds: mockWorks.map((work) => work.id),
+				works: mockWorks,
 			});
 
 			// "魔法"で検索
@@ -422,29 +453,10 @@ describe("Circle page server actions", () => {
 				},
 			];
 
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: false,
-							docs: mockWorks.map((work) => ({
-								id: work.id,
-								data: () => work,
-							})),
-						}),
-					};
-				}
-				return {};
+			setupCircleWorksMock({
+				circle: mockCircleData,
+				workIds: mockWorks.map((work) => work.id),
+				works: mockWorks,
 			});
 
 			// 声優名で検索
@@ -499,29 +511,10 @@ describe("Circle page server actions", () => {
 				lastFetchedAt: `2025-01-${15 - i}T00:00:00.000Z`,
 			}));
 
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: false,
-							docs: mockWorks.map((work) => ({
-								id: work.id,
-								data: () => work,
-							})),
-						}),
-					};
-				}
-				return {};
+			setupCircleWorksMock({
+				circle: mockCircleData,
+				workIds: mockWorks.map((work) => work.id),
+				works: mockWorks,
 			});
 
 			// "冒険"で検索、ページ2を取得（limit=2）
@@ -580,29 +573,10 @@ describe("Circle page server actions", () => {
 				},
 			];
 
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: false,
-							docs: mockWorks.map((work) => ({
-								id: work.id,
-								data: () => work,
-							})),
-						}),
-					};
-				}
-				return {};
+			setupCircleWorksMock({
+				circle: mockCircleData,
+				workIds: mockWorks.map((work) => work.id),
+				works: mockWorks,
 			});
 
 			const result = await getCircleWorksList({
@@ -657,29 +631,10 @@ describe("Circle page server actions", () => {
 				},
 			];
 
-			mockCollection.mockImplementation((collectionName) => {
-				if (collectionName === "circles") {
-					return {
-						doc: vi.fn().mockReturnValue({
-							get: vi.fn().mockResolvedValue({
-								exists: true,
-								data: () => mockCircleData,
-							}),
-						}),
-					};
-				}
-				if (collectionName === "works") {
-					return {
-						get: vi.fn().mockResolvedValue({
-							empty: false,
-							docs: mockWorks.map((work) => ({
-								id: work.id,
-								data: () => work,
-							})),
-						}),
-					};
-				}
-				return {};
+			setupCircleWorksMock({
+				circle: mockCircleData,
+				workIds: mockWorks.map((work) => work.id),
+				works: mockWorks,
 			});
 
 			const result = await getCircleWorksList({
@@ -730,6 +685,107 @@ describe("Circle page server actions", () => {
 			});
 
 			expect(result).toEqual({ works: [], totalCount: 0 });
+		});
+
+		describe("所属判定の正本（workIds）", () => {
+			const buildWork = (id: string, overrides: Record<string, unknown> = {}) => ({
+				id,
+				productId: id,
+				title: `作品${id}`,
+				circle: "テストサークル",
+				circleId: "RG12345",
+				price: { current: 1100, currency: "JPY" },
+				category: "SOU",
+				workType: "SOU",
+				thumbnailUrl: "https://example.com/thumb.jpg",
+				workUrl: "https://example.com/work.html",
+				registDate: "2025-01-15",
+				releaseDateISO: "2025-01-15",
+				releaseDateDisplay: "2025年01月15日",
+				description: "",
+				genres: [],
+				customGenres: [],
+				creators: {
+					voiceActors: [],
+					scenario: [],
+					illustration: [],
+					music: [],
+					others: [],
+				},
+				salesStatus: {},
+				sampleImages: [],
+				ageRating: "general",
+				updateDate: "2025-01-15",
+				createdAt: "2025-01-15T00:00:00.000Z",
+				updatedAt: "2025-01-15T00:00:00.000Z",
+				lastFetchedAt: "2025-01-15T00:00:00.000Z",
+				...overrides,
+			});
+
+			it("workIds に無い作品は circleId が一致していても含めない", async () => {
+				// 旧実装は works 全件から `circleId 一致 || サークル名一致` で再導出していたため、
+				// workIds に未登録の作品も拾えていた。所属の正本を workIds に一本化した回帰テスト。
+				const listed = buildWork("RJ111111");
+				const unlisted = buildWork("RJ999999");
+
+				setupCircleWorksMock({
+					circle: { circleId: "RG12345", name: "テストサークル" },
+					workIds: [listed.id],
+					works: [listed, unlisted],
+				});
+
+				const result = await getCircleWorksList({ circleId: "RG12345" });
+
+				expect(result.totalCount).toBe(1);
+				expect(result.works.map((work) => work.productId)).toEqual(["RJ111111"]);
+			});
+
+			it("同名の別サークルの作品は workIds に載っていれば含める", async () => {
+				// DLsite の maker_id 振り直しで同名サークルが 2 件並ぶ実データがある
+				// （RG56747 / RG01076099「桃色アルカディア」）。旧実装のサークル名フォールバックを
+				// 外しても、整合性cron が workIds に載せている限り表示は変わらないことを固定する。
+				const renumbered = buildWork("RJ01443068", { circleId: "RG01076099" });
+
+				setupCircleWorksMock({
+					circle: { circleId: "RG56747", name: "桃色アルカディア" },
+					workIds: [renumbered.id],
+					works: [renumbered],
+				});
+
+				const result = await getCircleWorksList({ circleId: "RG56747" });
+
+				expect(result.totalCount).toBe(1);
+				expect(result.works[0]!.productId).toBe("RJ01443068");
+			});
+
+			it("workIds に実在しない作品IDが混ざっていても残りを返す", async () => {
+				// 作品削除と整合性cron の間には必ずラグがあり、欠けている ID は異常ではない。
+				const existing = buildWork("RJ111111");
+
+				setupCircleWorksMock({
+					circle: { circleId: "RG12345", name: "テストサークル" },
+					workIds: ["RJ000000", existing.id, "RJ777777"],
+					works: [existing],
+				});
+
+				const result = await getCircleWorksList({ circleId: "RG12345" });
+
+				expect(result.totalCount).toBe(1);
+				expect(result.works[0]!.productId).toBe("RJ111111");
+			});
+
+			it("workIds が空なら works を一切読まない", async () => {
+				setupCircleWorksMock({
+					circle: { circleId: "RG12345", name: "テストサークル" },
+					workIds: [],
+					works: [],
+				});
+
+				const result = await getCircleWorksList({ circleId: "RG12345" });
+
+				expect(result).toEqual({ works: [], totalCount: 0, filteredCount: undefined });
+				expect(mockGetAll).not.toHaveBeenCalled();
+			});
 		});
 	});
 

--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -774,6 +774,24 @@ describe("Circle page server actions", () => {
 				expect(result.works[0]!.productId).toBe("RJ111111");
 			});
 
+			it("workIds が重複していても totalCount を水増ししない", async () => {
+				// 重複は checkDataIntegrity が事後修復する対象＝週次 cron までは残りうる。
+				// 全件スキャンだった旧実装はクエリ結果が doc 単位で一意になるため免疫があった。
+				const duplicated = buildWork("RJ111111");
+				const other = buildWork("RJ222222");
+
+				setupCircleWorksMock({
+					circle: { circleId: "RG12345", name: "テストサークル" },
+					workIds: [duplicated.id, other.id, duplicated.id],
+					works: [duplicated, other],
+				});
+
+				const result = await getCircleWorksList({ circleId: "RG12345" });
+
+				expect(result.totalCount).toBe(2);
+				expect(result.works.map((work) => work.productId)).toEqual(["RJ222222", "RJ111111"]);
+			});
+
 			it("workIds が空なら works を一切読まない", async () => {
 				setupCircleWorksMock({
 					circle: { circleId: "RG12345", name: "テストサークル" },

--- a/apps/web/src/app/circles/[circleId]/actions.ts
+++ b/apps/web/src/app/circles/[circleId]/actions.ts
@@ -3,12 +3,12 @@
 import type {
 	CircleDocument,
 	CirclePlainObject,
-	WorkDocument,
 	WorkPlainObject,
 } from "@suzumina.click/shared-types";
 import { convertToCirclePlainObject, isValidCircleId } from "@suzumina.click/shared-types";
 import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
 import { getFirestore } from "@/lib/firestore";
+import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
 import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
 
 /**
@@ -60,33 +60,27 @@ export async function getCircleWorksList(params: {
 	try {
 		const firestore = getFirestore();
 
-		// まずサークル情報を取得してサークル名を確認
 		const circleDoc = await firestore.collection("circles").doc(circleId).get();
 		if (!circleDoc.exists) {
 			return { works: [], totalCount: 0 };
 		}
 
 		const circleData = circleDoc.data() as CircleDocument;
-		const circleName = circleData.name;
 
-		// 全作品を取得してクライアント側でフィルタリング
-		const allWorksSnapshot = await firestore.collection("works").get();
-
-		const allMatchingWorks = allWorksSnapshot.docs
-			.map((doc) => {
-				const data = doc.data();
-				return {
-					...data,
-					id: doc.id,
-				} as WorkDocument;
-			})
-			.filter((work) => {
-				// circleId が一致するか、circleId がない場合はサークル名で一致判定
-				return work.circleId === circleId || work.circle === circleName;
-			});
+		// サークル所属作品の正本は circles/{id}.workIds。
+		// 書き手は DLsite 取り込み（2h毎に arrayUnion・circle-firestore.ts）で、
+		// checkDataIntegrity（週次）が重複除去と欠落補填を事後修復する。
+		// 読み取り側はこの配列を引き当てるだけにし、所属条件を read 時に再計算しない。
+		//
+		// 旧実装は works を全件取得して `circleId 一致 || サークル名一致` で再導出していたため、
+		// 1 リクエストあたり works 全件（実測 2,156件）を読んでいた。
+		// ヘッダーの「作品数」は元から workIds.length 由来（circle-conversions.ts）で、
+		// 同一ページ内で所属の正本が二重化していた状態を解消する。
+		const workIds = circleData.workIds ?? [];
+		const matchingWorks = await fetchWorksByIds(firestore, workIds);
 
 		// WorkPlainObjectに変換（work-converters の正本を共用）
-		const convertedWorks = convertWorksToPlainObjects(allMatchingWorks);
+		const convertedWorks = convertWorksToPlainObjects(matchingWorks);
 
 		// 検索フィルタリング（circle/creator 共通）
 		const { filtered: filteredWorks, count: filteredCount } = searchWorks(convertedWorks, search);

--- a/apps/web/src/app/creators/[creatorId]/actions.ts
+++ b/apps/web/src/app/creators/[creatorId]/actions.ts
@@ -4,12 +4,12 @@ import type {
 	CreatorDocument,
 	CreatorPageInfo,
 	CreatorWorkRelation,
-	WorkDocument,
 	WorkPlainObject,
 } from "@suzumina.click/shared-types";
 import { isValidCreatorId } from "@suzumina.click/shared-types";
 import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
 import { getFirestore } from "@/lib/firestore";
+import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
 import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
 
 /**
@@ -88,35 +88,6 @@ async function fetchWorkIds(
 }
 
 /**
- * 作品詳細を取得
- */
-async function fetchWorkDocuments(
-	firestore: FirebaseFirestore.Firestore,
-	workIds: string[],
-): Promise<WorkDocument[]> {
-	const allWorks: WorkDocument[] = [];
-
-	// Firestoreの whereIn 制限により、一度に10件まで
-	for (let i = 0; i < workIds.length; i += 10) {
-		const batch = workIds.slice(i, i + 10);
-		const workRefs = batch.map((id) => firestore.collection("works").doc(id));
-		const workDocs = await firestore.getAll(...workRefs);
-
-		for (const doc of workDocs) {
-			if (doc.exists) {
-				const data = doc.data();
-				allWorks.push({
-					...data,
-					id: doc.id,
-				} as WorkDocument);
-			}
-		}
-	}
-
-	return allWorks;
-}
-
-/**
  * クリエイター作品リストを取得（ConfigurableList用）
  * @param params パラメータ
  * @returns 作品一覧と総件数
@@ -148,7 +119,7 @@ export async function getCreatorWorksList(params: {
 		}
 
 		// 作品詳細を取得
-		const allWorks = await fetchWorkDocuments(firestore, workIds);
+		const allWorks = await fetchWorksByIds(firestore, workIds);
 
 		// WorkPlainObjectに変換
 		const convertedWorks = convertWorksToPlainObjects(allWorks);

--- a/apps/web/src/app/works/utils/__tests__/fetch-works-by-ids.test.ts
+++ b/apps/web/src/app/works/utils/__tests__/fetch-works-by-ids.test.ts
@@ -54,6 +54,23 @@ describe("fetchWorksByIds", () => {
 		expect(works.map((work) => work.id)).toEqual(["RJ111111"]);
 	});
 
+	it("重複 ID は 1 件に畳む（件数の水増しと二重描画を防ぐ）", async () => {
+		// circles/{id}.workIds の重複は checkDataIntegrity が事後修復する対象で、
+		// 週次 cron が走るまでは重複したままになりうる。
+		const { firestore, batchSizes } = createFirestoreMock(["RJ111111", "RJ222222"]);
+
+		const works = await fetchWorksByIds(firestore, [
+			"RJ111111",
+			"RJ222222",
+			"RJ111111",
+			"RJ111111",
+		]);
+
+		expect(works.map((work) => work.id)).toEqual(["RJ111111", "RJ222222"]);
+		// 重複分の ref を Firestore に投げていない（read も無駄に増やさない）
+		expect(batchSizes).toEqual([2]);
+	});
+
 	it("空配列なら Firestore に触らない", async () => {
 		const { firestore, getAll } = createFirestoreMock([]);
 

--- a/apps/web/src/app/works/utils/__tests__/fetch-works-by-ids.test.ts
+++ b/apps/web/src/app/works/utils/__tests__/fetch-works-by-ids.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchWorksByIds } from "../fetch-works-by-ids";
+
+/**
+ * `firestore.getAll(...refs)` を、存在する ID だけスナップショットを返すように模したモック。
+ * 呼び出しごとの ref 数を記録し、バッチ分割の検証に使う。
+ */
+function createFirestoreMock(existingIds: string[]) {
+	const existing = new Set(existingIds);
+	const batchSizes: number[] = [];
+
+	const getAll = vi.fn((...refs: { id: string }[]) => {
+		batchSizes.push(refs.length);
+		return Promise.resolve(
+			refs.map((ref) => ({
+				exists: existing.has(ref.id),
+				id: ref.id,
+				data: () => ({ productId: ref.id, title: `作品${ref.id}` }),
+			})),
+		);
+	});
+
+	const firestore = {
+		collection: vi.fn(() => ({ doc: (id: string) => ({ id }) })),
+		getAll,
+	} as unknown as FirebaseFirestore.Firestore;
+
+	return { firestore, getAll, batchSizes };
+}
+
+describe("fetchWorksByIds", () => {
+	it("ID を渡すと WorkDocument を入力順で返す", async () => {
+		const { firestore } = createFirestoreMock(["RJ111111", "RJ222222", "RJ333333"]);
+
+		const works = await fetchWorksByIds(firestore, ["RJ333333", "RJ111111", "RJ222222"]);
+
+		expect(works.map((work) => work.id)).toEqual(["RJ333333", "RJ111111", "RJ222222"]);
+		expect(works[0]?.productId).toBe("RJ333333");
+	});
+
+	it("doc.id を id として埋める（サブコレクション由来の ID をそのまま使えるように）", async () => {
+		const { firestore } = createFirestoreMock(["RJ111111"]);
+
+		const works = await fetchWorksByIds(firestore, ["RJ111111"]);
+
+		expect(works[0]?.id).toBe("RJ111111");
+	});
+
+	it("存在しない ID は黙って除外する", async () => {
+		const { firestore } = createFirestoreMock(["RJ111111"]);
+
+		const works = await fetchWorksByIds(firestore, ["RJ000000", "RJ111111", "RJ999999"]);
+
+		expect(works.map((work) => work.id)).toEqual(["RJ111111"]);
+	});
+
+	it("空配列なら Firestore に触らない", async () => {
+		const { firestore, getAll } = createFirestoreMock([]);
+
+		const works = await fetchWorksByIds(firestore, []);
+
+		expect(works).toEqual([]);
+		expect(getAll).not.toHaveBeenCalled();
+	});
+
+	it("300件までは 1 回の getAll で取る", async () => {
+		const ids = Array.from({ length: 300 }, (_, i) => `RJ${i}`);
+		const { firestore, getAll, batchSizes } = createFirestoreMock(ids);
+
+		const works = await fetchWorksByIds(firestore, ids);
+
+		expect(works).toHaveLength(300);
+		expect(getAll).toHaveBeenCalledTimes(1);
+		expect(batchSizes).toEqual([300]);
+	});
+
+	it("300件を超えたら分割し、全件を取り切る", async () => {
+		// 最大サークルの実測は 789 作品。旧実装の 10 件刻みなら 79 往復だった。
+		const ids = Array.from({ length: 789 }, (_, i) => `RJ${i}`);
+		const { firestore, getAll, batchSizes } = createFirestoreMock(ids);
+
+		const works = await fetchWorksByIds(firestore, ids);
+
+		expect(works).toHaveLength(789);
+		expect(getAll).toHaveBeenCalledTimes(3);
+		expect(batchSizes).toEqual([300, 300, 189]);
+		expect(works.map((work) => work.id)).toEqual(ids);
+	});
+});

--- a/apps/web/src/app/works/utils/fetch-works-by-ids.ts
+++ b/apps/web/src/app/works/utils/fetch-works-by-ids.ts
@@ -1,0 +1,58 @@
+import type { WorkDocument } from "@suzumina.click/shared-types";
+
+/**
+ * 1 回の getAll で引く作品数。
+ *
+ * 旧実装は「Firestoreの whereIn 制限により、一度に10件まで」として 10 件ずつ逐次取得していたが、
+ * これは制約の取り違え。10 件上限は `where(..., "in", [...])` のものであって、
+ * ここで使う `getAll`（BatchGetDocuments）には掛からない。
+ * 最大サークル（789作品）で 79 往復していたのを 3 往復に畳む。
+ */
+const BATCH_SIZE = 300;
+
+/**
+ * 作品IDの配列から WorkDocument を引く（circle / creator の作品一覧の共通土台）。
+ *
+ * circle も creator も「所属する作品IDは書き込み側が正本を持つ」構造で、
+ * 読み取り側は ID を引き当てるだけでよい（所属条件を read 時に再計算しない）。
+ * - circle: `circles/{id}.workIds`（DLsite 取り込みが arrayUnion / 整合性cron が修復）
+ * - creator: `creators/{id}/works` サブコレクション
+ *
+ * 存在しない ID は黙って除外する。ID の出所は非正規化された配列/サブコレクションで、
+ * 作品削除との間に必ずラグがあるため「欠けている」は異常ではない（整合性cron の担当）。
+ *
+ * @param firestore Firestore インスタンス
+ * @param workIds 取得する作品IDの配列
+ * @returns 実在した作品のみの WorkDocument 配列（入力順を保つ）
+ */
+export async function fetchWorksByIds(
+	firestore: FirebaseFirestore.Firestore,
+	workIds: string[],
+): Promise<WorkDocument[]> {
+	if (workIds.length === 0) {
+		return [];
+	}
+
+	const batches: string[][] = [];
+	for (let i = 0; i < workIds.length; i += BATCH_SIZE) {
+		batches.push(workIds.slice(i, i + BATCH_SIZE));
+	}
+
+	const snapshots = await Promise.all(
+		batches.map((batch) =>
+			firestore.getAll(...batch.map((id) => firestore.collection("works").doc(id))),
+		),
+	);
+
+	const works: WorkDocument[] = [];
+	for (const docs of snapshots) {
+		for (const doc of docs) {
+			if (!doc.exists) {
+				continue;
+			}
+			works.push({ ...doc.data(), id: doc.id } as WorkDocument);
+		}
+	}
+
+	return works;
+}

--- a/apps/web/src/app/works/utils/fetch-works-by-ids.ts
+++ b/apps/web/src/app/works/utils/fetch-works-by-ids.ts
@@ -21,21 +21,27 @@ const BATCH_SIZE = 300;
  * 存在しない ID は黙って除外する。ID の出所は非正規化された配列/サブコレクションで、
  * 作品削除との間に必ずラグがあるため「欠けている」は異常ではない（整合性cron の担当）。
  *
+ * 重複 ID は 1 件に畳む。`circles/{id}.workIds` の重複は checkDataIntegrity が
+ * 事後修復する対象＝週次 cron が走るまでは重複したままになりうる不変条件で、
+ * 読み取り側がそれに依存すると cron 未実行の窓で件数の水増しと同一作品の二重描画になる。
+ * 全件スキャンだった旧実装はクエリ結果が doc 単位で一意になるため構造的に免疫があった。
+ *
  * @param firestore Firestore インスタンス
  * @param workIds 取得する作品IDの配列
- * @returns 実在した作品のみの WorkDocument 配列（入力順を保つ）
+ * @returns 実在した作品のみの WorkDocument 配列（ID ごとに1件・初出順を保つ）
  */
 export async function fetchWorksByIds(
 	firestore: FirebaseFirestore.Firestore,
 	workIds: string[],
 ): Promise<WorkDocument[]> {
-	if (workIds.length === 0) {
+	const uniqueWorkIds = Array.from(new Set(workIds));
+	if (uniqueWorkIds.length === 0) {
 		return [];
 	}
 
 	const batches: string[][] = [];
-	for (let i = 0; i < workIds.length; i += BATCH_SIZE) {
-		batches.push(workIds.slice(i, i + BATCH_SIZE));
+	for (let i = 0; i < uniqueWorkIds.length; i += BATCH_SIZE) {
+		batches.push(uniqueWorkIds.slice(i, i + BATCH_SIZE));
 	}
 
 	const snapshots = await Promise.all(


### PR DESCRIPTION
## なぜ

GCP 予算アラート（¥3,000/月）が 8/7（月の7日目）に 50% で発火した。gcloud + Cloud Monitoring の実測で、Firestore reads の 1 経路にほぼ全額が帰属することが分かった。

**8/5（UTC日）の突合**

| | |
|---|---|
| `/circles/[id]` ページリクエスト | 1,693 件 |
| `works` コレクション | 2,156 ドキュメント |
| 1,693 × 2,156 | **3,650,108 reads** |
| 同日の実測 Firestore reads | 3,686,977 |
| **一致率** | **99%** |

`/circles/[id]` はリクエストの 8.6% にすぎないが reads の 99% を出していた。

**コスト**（Billing Catalog の Tokyo 実単価 ¥0.000062223/read、無料枠 5万/日）

- 8/1〜8/6 実績: 25,066,351 reads → ¥1,541（予算の 51%。アラート発火と一致）
- 同ペースの月額換算: 約 1.3億 reads → **約 ¥7,960**（予算の 2.7倍）

Cloud Run（2.9インスタンス時間/日）・Firestore writes（4,137/日で無料枠内）・Artifact Registry（340MB）はいずれも誤差だった。

トラフィックは横ばい（1.6〜2.9万 req/日）で、7/27 以降に Cloudflare 経由・Chrome を騙る UA の分散スクレイパーが `/circles/` を巡回し始めたことが引き金。コード側が前から高コストで、そこに巡回が当たった。

## 本当の欠陥

コストは症状で、欠陥は**正本の二重化**。circle→works の所属は書き込み側が正本を持っている。

| 層 | 責務 |
|---|---|
| DLsite 取り込み（2h毎） | `workIds` を `arrayUnion` で追加（`circle-firestore.ts`） |
| `checkDataIntegrity`（週次） | 重複除去・欠落補填の事後修復 |

ところが読み取り側は `workIds` を無視し、works 全件から `circleId 一致 || サークル名一致` で再導出していた。結果、**同一ページ内で所属の正本が 2 つに割れていた**:

- ヘッダーの「作品数」→ `data.workIds?.length ?? 0`（`circle-conversions.ts`）
- その下のリスト → 全件スキャン＋名前フォールバック

CLAUDE.md 軸3「正本が曖昧な箇所はそれ自体を欠陥として扱う」に該当する。

## 何をしたか

読み取り側を `workIds` 一本に寄せ、**creator 側と同じ形**に揃えた。

```
creator: fetchWorkIds → fetchWorksByIds → convertWorksToPlainObjects → searchWorks → compareWorks → slice
circle:  workIds      → fetchWorksByIds → ───────────────── 以下同じ ─────────────────
```

違っていたのは第1段だけなので、**新しい変換層・抽象は足していない**。`searchWorks` / `compareWorks` は既存の `lib/circle-creator-works.ts` をそのまま共用。

creator のローカル関数 `fetchWorkDocuments` を `app/works/utils/fetch-works-by-ids.ts` へ共有化した（circle/creator とも既に `app/works/utils/work-converters` を import しており、逆依存にならない）。

併せて**バッチ根拠の誤りを修正**した。旧コメントの「Firestoreの whereIn 制限により、一度に10件まで」は制約の取り違えで、10件上限は `where(..., "in", [...])` のものであって `getAll`（BatchGetDocuments）には掛からない。300件刻みにして最大サークル（789作品）を 79 往復から 3 往復に畳んだ。

## 挙動が変わらないことの確認（本番データ実測）

| 検査 | 結果 |
|---|---|
| `circleId` が欠損した works | **0 / 2,156** |
| `circleId` が指す circle doc が無い孤児 | **0** |
| 388 サークル全部で `workIds` の集合 == 現行ロジックの集合 | **差分ゼロ** |
| 名前フォールバックが効いていた件数 | **1 件のみ** |

その 1 件は `RG56747` と `RG01076099` が同名「桃色アルカディア」（DLsite の maker_id 振り直し）。当該作品 `RJ01443068` は `RG56747.workIds` にも入っているため表示は変わらない。

この実測が方式選択を決めている。`where("circleId","==")` だと `/circles/RG56747` が空ページになる（＝挙動変更）ため採らず、`workIds` + `getAll` を採った。Firestore 複合インデックスの追加も不要。

`workIds` の鮮度も問題ない（週次 cron 待ちではなく取り込み時に `arrayUnion` される）。

## 想定効果

`workIds` は中央値 2 / 平均 5.6 / 最大 789（1サークルのみ、次点 63）。1,693 req/日 × 平均 ≈ **1.3万 reads/日** で無料枠 5万/日 の内側に収まる見込み。

## テスト

追加した回帰テスト（`circles/[circleId]/__tests__/actions.test.ts`）:

- `workIds` に無い作品は `circleId` が一致していても含めない ← フォールバック削除の固定
- 同名の別サークルの作品も `workIds` に載っていれば含める ← RG56747 の実データケース
- `workIds` に実在しない作品IDが混ざっても残りを返す ← 作品削除と整合性cron のラグ
- `workIds` が空なら works を一切読まない

モックは `works` コレクションに `get` を生やしていないので、全件スキャンに戻すとテストが落ちる。

新規 `works/utils/__tests__/fetch-works-by-ids.test.ts`: バッチ分割（300/789件）・欠損ID除外・入力順保持・空配列。

## 検証

- `pnpm verify` exit=0（lint:docs / lint:tokens / lint / typecheck / test 一括、カバレッジ閾値込み）
- Firestore Emulator で実表示確認: `/circles/RG26596`・`/circles/RG15563` とも 200、作品カード描画・検索絞り込み・ソート・件数表示すべて正常。`/creators/10006` も 200、サーバーログにエラーなし

## レビュー時の注意

- **本番での read 削減はまだ未測定**。削減の根拠は上記の本番データ突合であって、デプロイ後の実測ではない。マージ後に Cloud Monitoring で再測定が要る
- Two-Way Door 判定（読み取りパスのクエリ変更のみ。スキーマ変更なし・index 追加なし・Cloud Function 挙動変更なし）
- Linear の起票はしていない（MCP 未接続のため。CLAUDE.md の方針に従い `gh issue create` にも流していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
