### PR TITLE
fix(deps): nanoid の脆弱性 override を追加 (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   postcss: '>=8.5.23'
   kysely: 0.28.17
   fast-uri: '>=4.1.2'
+  nanoid: '>=3.3.17 <3.3.18'
   sharp: '>=0.35.0'
 
 importers:
@@ -3778,8 +3779,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7866,7 +7867,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nanostores@1.4.1: {}
 
@@ -8084,7 +8085,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,8 +41,15 @@ overrides:
   fast-uri: ">=4.1.2"
   # nanoid < 3.3.17: custom generator に size=0 を渡すと無限ループする DoS（GHSA-2v37-7h3g-55p8）。
   # 唯一の依存元 postcss は `^3.3.16` を要求し自然解決が 3.3.16 に留まるため引き上げる。
-  # 他の override と違い上限 `<4` が必須: nanoid 4 以降は main を持たない ESM 専用で、
-  # 上限なしだと 6.x を掴んで postcss(CJS require) が壊れる。3.x 最新は 3.3.18。
+  # 他の override と違い上限が要る。しかも `<4` では足りず `<3.3.18` まで絞る。理由は別々の2つ:
+  # - `<4` が要る理由: nanoid 4 以降は main を持たない ESM 専用。上限なしだと `>=3.3.17` が
+  #   6.x を掴み、CJS require している postcss（Tailwind/Next/Vite/Storybook の土台）が壊れる。
+  # - さらに `<3.3.18` まで絞る理由: 3.x 最新の 3.3.18 は公開が新しく pnpm 既定の
+  #   minimumReleaseAge に掛かるため、minimumReleaseAgeExclude への自動追加を誘発する。
+  #   これは公開直後パッケージの待機という供給網対策をこの版だけ外すもので、3.3.18 が
+  #   十分古くなった後は不要な残骸として残る。3.3.17 は advisory の patched 版そのもので
+  #   脆弱性は解消し、待機ゲートを自然に通る。
+  # 将来 3.3.18 以降へ動かすときは floor と上限の両方を上げる（上限だけ残すと audit が赤くなって気づける）。
   nanoid: ">=3.3.17 <3.3.18"
   # sharp < 0.35.0: 継承する libvips の脆弱性群（CVE-2026-33327/33328/35590/35591）。next の依存範囲が
   # ^0.34.5（0.35.0 未満に固定）のため override なしでは追従しない。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,11 @@ overrides:
   # >=4.0.0 <4.1.2: 同じくバックスラッシュを authority 区切りと誤読するホスト混同（GHSA-7p8r-x3mc-p8w7）。
   # 旧 floor（>=3.1.4）が 4.1.1 を掴んで新 advisory の範囲に入っていたため 4.1.2 へ引き上げ。
   fast-uri: ">=4.1.2"
+  # nanoid < 3.3.17: custom generator に size=0 を渡すと無限ループする DoS（GHSA-2v37-7h3g-55p8）。
+  # 唯一の依存元 postcss は `^3.3.16` を要求し自然解決が 3.3.16 に留まるため引き上げる。
+  # 他の override と違い上限 `<4` が必須: nanoid 4 以降は main を持たない ESM 専用で、
+  # 上限なしだと 6.x を掴んで postcss(CJS require) が壊れる。3.x 最新は 3.3.18。
+  nanoid: ">=3.3.17 <3.3.18"
   # sharp < 0.35.0: 継承する libvips の脆弱性群（CVE-2026-33327/33328/35590/35591）。next の依存範囲が
   # ^0.34.5（0.35.0 未満に固定）のため override なしでは追従しない。
   sharp: ">=0.35.0"


### PR DESCRIPTION
**main が現在赤いのを直します。** #918 の Security Check 失敗を調べて見つけたもので、Node/pnpm 更新とは無関係です。

## 原因

nanoid の [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)（custom generator に `size=0` を渡すと無限ループする DoS / high）の **対象範囲が 2026-08-07 20:50Z に更新**されました。main の Security Check が最後に成功したのは 08-05 なので、コードを一切変えていないのに既存 lockfile の `nanoid@3.3.16` が該当して赤くなった形です。

`pnpm-lock.yaml` を触っていない全PRが同じく赤くなります。

## 修正

```yaml
nanoid: ">=3.3.17 <3.3.18"
```

唯一の依存元 postcss が `^3.3.16` を要求し自然解決が 3.3.16 に留まるため、override で floor を引き上げます。

## 上限 `<3.3.18` が必須な理由

他の override（`postcss: ">=8.5.23"` など）と違い、この項目は上限が要ります。

**1. 上限なしだとビルドが壊れる**

`>=3.3.17` と書くと最新の `6.0.1` を掴みます。nanoid 4 以降は `main` フィールドを持たない **ESM 専用**で、CJS で `require("nanoid")` している postcss（= Tailwind / Next / Vite / Storybook の土台）が動かなくなります。

| version | `main` | 形式 |
|---|---|---|
| 3.3.18 | `index.cjs` | CJS 可 |
| 4.0.0 | なし | ESM 専用 |
| 6.0.1 | なし | ESM 専用 |

**2. 3.3.18 ではなく 3.3.17 を選ぶ理由**

3.x 最新は 3.3.18 ですが、公開が **2026-08-07 16:41Z**（約15時間前）と新しく、pnpm 既定の `minimumReleaseAge` に引っかかって `minimumReleaseAgeExclude` へ `nanoid@3.3.18` が自動追加されます。これは公開直後のパッケージを待機させる供給網対策をこの版だけ外すもので、しかも 3.3.18 が十分古くなった後は不要な残骸として残ります（消し忘れても気づけない）。

3.3.17（2026-08-03 公開・5日経過）はアドバイザリの patched 版そのもので脆弱性は解消し、待機ゲートを自然に通ります。取りこぼしが起きた場合も audit が赤くなって気づける fail-safe 側です。

## 検証

- `pnpm audit --audit-level moderate` → `No known vulnerabilities found`
- `pnpm why nanoid` → `nanoid@3.3.17`、`minimumReleaseAgeExclude` への追加なし
- `pnpm install --frozen-lockfile` / `pnpm verify` 通過
- main の toolchain（Node 24.18.0 / pnpm 11.15.1）で検証しており、#918 の Node/pnpm 更新には依存しません

lockfile の差分は nanoid の解決のみです。

## 関連

これがマージされたら #918 に main を取り込んで再実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)