### PR TITLE
test(ui): getComputedStyle スタブに max/min サイズを補う

### DIFF
--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -64,6 +64,9 @@ Object.defineProperty(window, "matchMedia", {
 });
 
 // Mock for getComputedStyle
+// 未定義プロパティは undefined になるため、参照する側が文字列前提だとクラッシュする
+// （base-ui の Select popup が maxHeight.endsWith("px") を読む）。
+// 実ブラウザの初期計算値と同じ値を返す。
 Object.defineProperty(window, "getComputedStyle", {
 	writable: true,
 	value: (element: Element) => ({
@@ -75,6 +78,10 @@ Object.defineProperty(window, "getComputedStyle", {
 		bottom: "auto",
 		width: "auto",
 		height: "auto",
+		maxWidth: "none",
+		maxHeight: "none",
+		minWidth: "auto",
+		minHeight: "auto",
 		transform: "none",
 		transformOrigin: "50% 50% 0px",
 		display: "block",


### PR DESCRIPTION
## 背景

Dependabot PR #922（production-minor グループ）で `packages/ui` のテストが 6 件失敗していた。切り分けの結果、原因は **`@base-ui/react` 1.6.0 → 1.7.0 単独**。

`packages/ui/vitest.setup.ts` の `getComputedStyle` スタブは手書きの固定プロパティ集合で、そこに無いプロパティは `undefined` を返す。base-ui 1.7.0 の `SelectPopup` が `getMaxPopupHeight()` で `popupStyles.maxHeight.endsWith("px")` を読むようになったため、

```
TypeError: Cannot read properties of undefined (reading 'endsWith')
  at getMaxPopupHeight (@base-ui/react/select/popup/SelectPopup.mjs:377)
```

でレイアウトエフェクト中に落ち、React ツリーごと消える（テストの `<body>` が `<div />` だけになる）。

## 実 UX への影響

なし。実ブラウザの `getComputedStyle().maxHeight` は未指定でも `"none"` を返すので、この経路は本番では踏まない。実際 #922 の「Story play tests (browser)」（実 Chromium）は 1.7.0 でもパスしている。**テストスタブの不足**であって、依存側の退行ではない。

## 変更

スタブに実ブラウザの初期計算値（`max-*: none` / `min-*: auto`）を追加。

## 検証

- base-ui **1.7.0** をローカルで入れた状態: `packages/ui` 31 files / 399 tests パス（修正前は 6 失敗）
- base-ui **1.6.0**（= 現 main）: 31 files / 399 tests パス（無害）
- `pnpm verify` exit 0

このPRをマージ後、#922 を rebase すれば CI が緑になる想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)