### PR TITLE
fix(seo): 一覧のページ送りを実 URL のリンクにする (SPR-308)

### DIFF
--- a/packages/ui/src/components/custom/__tests__/configurable-list.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/configurable-list.test.tsx
@@ -6,6 +6,7 @@ import type { FilterConfig, StandardListParams } from "../configurable-list/type
 // Next.js のルーターをモック
 vi.mock("next/navigation", () => ({
 	useSearchParams: () => new URLSearchParams(),
+	usePathname: () => "/works",
 	useRouter: () => ({
 		push: vi.fn(),
 		replace: vi.fn(),

--- a/packages/ui/src/components/custom/configurable-list.tsx
+++ b/packages/ui/src/components/custom/configurable-list.tsx
@@ -306,6 +306,8 @@ export function ConfigurableList<T>({
 				hasPrev={pagination.hasPrev}
 				hasNext={pagination.hasNext}
 				onPageChange={handlePageChange}
+				// urlSync=false のときはページが URL に現れないため href を作らない
+				getPageHref={urlSync ? urlHook.getPageHref : undefined}
 				total={actualData.total}
 				startIndex={pagination.startIndex}
 				endIndex={pagination.endIndex}

--- a/packages/ui/src/components/custom/configurable-list/__tests__/configurable-list-pagination.test.tsx
+++ b/packages/ui/src/components/custom/configurable-list/__tests__/configurable-list-pagination.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConfigurableListPagination } from "../configurable-list-pagination";
+
+// ページ送りが実 URL の <a href> であることが要件（SPR-308）。
+// href が `#` だとクローラは2ページ目以降へ到達できず、詳細ページが発見されない。
+const getPageHref = (page: number) => (page === 1 ? "/works" : `/works?page=${page}`);
+
+const renderPagination = (props: Partial<Parameters<typeof ConfigurableListPagination>[0]> = {}) =>
+	render(
+		<ConfigurableListPagination
+			currentPage={3}
+			totalPages={10}
+			hasPrev={true}
+			hasNext={true}
+			onPageChange={vi.fn()}
+			getPageHref={getPageHref}
+			{...props}
+		/>,
+	);
+
+const hrefOf = (name: string | RegExp) => screen.getByRole("link", { name }).getAttribute("href");
+
+describe("ConfigurableListPagination: href", () => {
+	it("ページ番号リンクが実 URL を持つ", () => {
+		renderPagination();
+		expect(hrefOf("4")).toBe("/works?page=4");
+		expect(hrefOf("1")).toBe("/works");
+	});
+
+	it("前へ・次へが隣接ページを指す", () => {
+		renderPagination();
+		expect(hrefOf(/previous/i)).toBe("/works?page=2");
+		expect(hrefOf(/next/i)).toBe("/works?page=4");
+	});
+
+	it("先頭・末尾では無効側を page=0 や範囲外に向けない", () => {
+		renderPagination({ currentPage: 1, hasPrev: false });
+		expect(hrefOf(/previous/i)).toBe("#");
+	});
+
+	it("getPageHref 未指定（urlSync=false）では従来どおり # のまま", () => {
+		renderPagination({ getPageHref: undefined });
+		expect(hrefOf("4")).toBe("#");
+		expect(hrefOf(/next/i)).toBe("#");
+	});
+
+	it("クリックは href の遷移ではなく onPageChange で処理する", async () => {
+		const user = userEvent.setup();
+		const onPageChange = vi.fn();
+		renderPagination({ onPageChange });
+		await user.click(screen.getByRole("link", { name: "4" }));
+		expect(onPageChange).toHaveBeenCalledWith(4);
+	});
+});

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-footer.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-footer.tsx
@@ -10,6 +10,8 @@ interface ConfigurableListFooterProps {
 	hasPrev: boolean;
 	hasNext: boolean;
 	onPageChange: (page: number) => void;
+	/** ページ送りを実 URL のリンクにするための href 生成（未指定なら `#`）。SPR-308 */
+	getPageHref?: (page: number) => string;
 	total: number;
 	startIndex: number;
 	endIndex: number;
@@ -21,6 +23,7 @@ export function ConfigurableListFooter({
 	hasPrev,
 	hasNext,
 	onPageChange,
+	getPageHref,
 	total,
 	startIndex,
 	endIndex,
@@ -35,6 +38,7 @@ export function ConfigurableListFooter({
 				hasPrev={hasPrev}
 				hasNext={hasNext}
 				onPageChange={onPageChange}
+				getPageHref={getPageHref}
 			/>
 			<div className="mt-2 text-center text-sm text-muted-foreground">
 				{total}件中 {startIndex + 1}〜{Math.min(endIndex, total)}

--- a/packages/ui/src/components/custom/configurable-list/configurable-list-pagination.tsx
+++ b/packages/ui/src/components/custom/configurable-list/configurable-list-pagination.tsx
@@ -18,6 +18,12 @@ interface ConfigurableListPaginationProps {
 	hasPrev: boolean;
 	hasNext: boolean;
 	onPageChange: (page: number) => void;
+	/**
+	 * ページ番号から実 URL を作る。クローラが2ページ目以降を辿れるようにするため、
+	 * 与えられた場合は各リンクの href に使う（SPR-308）。
+	 * URL 同期していない一覧（urlSync=false）では URL に意味が無いため未指定＝`#` になる。
+	 */
+	getPageHref?: (page: number) => string;
 }
 
 export function ConfigurableListPagination({
@@ -26,7 +32,14 @@ export function ConfigurableListPagination({
 	hasPrev,
 	hasNext,
 	onPageChange,
+	getPageHref,
 }: ConfigurableListPaginationProps) {
+	// href はクローラの経路と、新しいタブで開く・戻る等のブラウザ標準動作のために置く。
+	// クリック時は onPageChange 側が preventDefault するため href の遷移は起きない
+	// （体感の挙動は変更前後で不変。use-list-url の pushState + popstate に App Router が
+	// ハード遷移で応答するため、クリックは元々フルリロードになっている）。
+	const hrefFor = (page: number) => getPageHref?.(page) ?? "#";
+
 	const maxVisiblePages = 5;
 	const halfVisible = Math.floor(maxVisiblePages / 2);
 
@@ -45,7 +58,7 @@ export function ConfigurableListPagination({
 				{/* Previous ボタン */}
 				<PaginationItem>
 					<PaginationPrevious
-						href="#"
+						href={hasPrev ? hrefFor(currentPage - 1) : "#"}
 						aria-disabled={!hasPrev}
 						onClick={(e) => {
 							e.preventDefault();
@@ -61,7 +74,7 @@ export function ConfigurableListPagination({
 				{startPage > 1 && (
 					<PaginationItem key="page-1">
 						<PaginationLink
-							href="#"
+							href={hrefFor(1)}
 							onClick={(e) => {
 								e.preventDefault();
 								onPageChange(1);
@@ -81,7 +94,7 @@ export function ConfigurableListPagination({
 				{Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i).map((page) => (
 					<PaginationItem key={`page-${page}`}>
 						<PaginationLink
-							href="#"
+							href={hrefFor(page)}
 							isActive={currentPage === page}
 							onClick={(e) => {
 								e.preventDefault();
@@ -103,7 +116,7 @@ export function ConfigurableListPagination({
 						)}
 						<PaginationItem key={`page-${totalPages}`}>
 							<PaginationLink
-								href="#"
+								href={hrefFor(totalPages)}
 								onClick={(e) => {
 									e.preventDefault();
 									onPageChange(totalPages);
@@ -118,7 +131,7 @@ export function ConfigurableListPagination({
 				{/* Next ボタン */}
 				<PaginationItem>
 					<PaginationNext
-						href="#"
+						href={hasNext ? hrefFor(currentPage + 1) : "#"}
 						aria-disabled={!hasNext}
 						onClick={(e) => {
 							e.preventDefault();

--- a/packages/ui/src/components/custom/configurable-list/hooks/__tests__/use-list-url.test.ts
+++ b/packages/ui/src/components/custom/configurable-list/hooks/__tests__/use-list-url.test.ts
@@ -7,6 +7,7 @@ import { useListUrl } from "../use-list-url";
 const h = vi.hoisted(() => ({ sp: new URLSearchParams() }));
 vi.mock("next/navigation", () => ({
 	useSearchParams: () => h.sp,
+	usePathname: () => "/works",
 }));
 
 const setSP = (qs: string) => {
@@ -128,5 +129,36 @@ describe("useListUrl: setter（pushState）", () => {
 		const p = lastPushedParams(pushSpy);
 		expect(p.get("tags")).toBeNull();
 		expect(p.get("flag")).toBeNull();
+	});
+});
+
+// クローラが2ページ目以降へ到達できることが要件（SPR-308）。
+describe("useListUrl: getPageHref", () => {
+	it("パス付きの実 URL を返す（相対クエリにしない）", () => {
+		const { result } = renderHook(() => useListUrl({ filters }));
+		expect(result.current.getPageHref(2)).toBe("/works?page=2");
+	});
+
+	it("1ページ目は page を落とし、クエリが空ならパスだけになる", () => {
+		setSP("page=3");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		expect(result.current.getPageHref(1)).toBe("/works");
+	});
+
+	it("フィルター・検索語・ソートを保持する", () => {
+		setSP("q=kw&sort=rating&tags=a|b&page=2");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		const p = new URLSearchParams(result.current.getPageHref(5).split("?")[1]);
+		expect(p.get("page")).toBe("5");
+		expect(p.get("q")).toBe("kw");
+		expect(p.get("sort")).toBe("rating");
+		expect(p.get("tags")).toBe("a|b");
+	});
+
+	it("setPage と同じ遷移先を指す", () => {
+		setSP("q=kw&tags=a|b");
+		const { result } = renderHook(() => useListUrl({ filters }));
+		act(() => result.current.setPage(4));
+		expect(result.current.getPageHref(4)).toBe(`/works?${lastPushedParams(pushSpy).toString()}`);
 	});
 });

--- a/packages/ui/src/components/custom/configurable-list/hooks/use-list-url.ts
+++ b/packages/ui/src/components/custom/configurable-list/hooks/use-list-url.ts
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { FilterConfig } from "../types";
 import { getDefaultFilterValues } from "../utils/filter-helpers";
@@ -161,6 +161,7 @@ function updateParam(
 export function useListUrl(options: UseListUrlOptions = {}) {
 	const { filters = {}, defaultPageSize = 12, defaultSort } = options;
 	const searchParams = useSearchParams();
+	const pathname = usePathname();
 
 	// URLの更新フラグを管理
 	const isUpdatingUrl = useRef(false);
@@ -282,6 +283,23 @@ export function useListUrl(options: UseListUrlOptions = {}) {
 		[updateUrl],
 	);
 
+	/**
+	 * setPage(page) が遷移する先の URL を、遷移せずに返す。
+	 *
+	 * ページ送りを `<a href>` として描画するために使う。href が無い（`#`）と
+	 * クローラは一覧の2ページ目以降へ到達できず、詳細ページが発見されない（SPR-308）。
+	 * 直列化は updateParam を updateUrl と共有するため、page=1 はクエリから落ちる。
+	 */
+	const getPageHref = useCallback(
+		(page: number) => {
+			const params = new URLSearchParams(searchParams.toString());
+			updateParam(params, "page", page, 1);
+			const query = params.toString();
+			return query ? `${pathname}?${query}` : pathname;
+		},
+		[searchParams, pathname],
+	);
+
 	const setItemsPerPage = useCallback(
 		(itemsPerPage: number) => {
 			updateUrl({ itemsPerPage, page: 1 }); // ページサイズ変更時は1ページ目へ
@@ -347,6 +365,7 @@ export function useListUrl(options: UseListUrlOptions = {}) {
 	return {
 		params: stableParams,
 		setPage,
+		getPageHref,
 		setItemsPerPage,
 		setSort,
 		setSearch,


### PR DESCRIPTION
## 背景

[SPR-308](https://linear.app/nothink/issue/SPR-308) の①。ページ送りが `href="#"` + `onClick` だったため、**クローラは一覧の2ページ目以降へ到達できない**状態だった。

本番 `/works` の初期 HTML 実測:

| 項目 | 実測 |
|---|---|
| works 詳細へのリンク | 12 件のみ |
| `page=` を含むリンク | 0 件 |
| `href="#"` のアンカー | 6 件（ページ送りの全リンク） |

sitemap も 7/22 の取得失敗以降読まれておらず（管理画面で「サイトマップを読み込めませんでした」／検出ページ数 0）、発見経路が二重に塞がっていた。結果、sitemap の works 2,164 URL のうちサンプル21件中 **16件（76%）が「URL が Google に認識されていません」**。

`/works?page=2` はサーバー側で正しく動くので、**足りないのはリンクだけ**だった。

## 変更

`useListUrl` に `getPageHref` を追加し、`setPage` と同じ直列化（`page=1` は落とす・フィルタ/検索/ソートは保持）で実 URL を作って各リンクの href に渡す。共通コンポーネントなので **works / videos / circles / creators / buttons に一括で効く**。

- `urlSync=false` の一覧はページが URL に現れないため `getPageHref` を渡さず、従来どおり `href="#"` にフォールバック
- 無効な「前へ/次へ」は `#` のまま（`page=0` や範囲外の URL を作らない）

## 挙動は変えていない

クリックは従来どおり `onPageChange` が `preventDefault` して処理する（テストで `defaultPrevented` を固定）。

なお**ページ送りは変更前からフルリロードしている**（本番で計測: `navigation.type === "reload"`・JS コンテキスト破棄）。`use-list-url` の `pushState({}, "", url)` + 手動 popstate に App Router がハード遷移で応答するためで、本 PR の前後で不変。ソフト遷移化は検索・ソート・フィルタも同じ経路を通るため別スコープ。

副次的に **ctrl+クリック・中クリック・「新しいタブで開く」が動くようになる**（従来は `#` なので不可能だった）。

## 検証

`pnpm verify` 通過。Firestore Emulator で `/videos?page=5&sort=oldest` の初期 HTML を実測:

| 項目 | 修正前（本番） | 修正後 |
|---|---|---|
| `href="#"` | 6 | **0** |
| `page=` リンク | 0 | **7**（前へ・1・3・4・5・6・7・最終9・次へ） |
| ソート保持 | — | 全リンクで `sort=oldest` を維持 |
| 1ページ目の href | — | `/videos?sort=oldest`（`page=1` は落ちる） |

テストは `getPageHref` 4件・pagination の href 5件を追加。

## 効果測定

インデックス登録数（現在 1,060）と works サンプル21件の未認識率（現在 76%）で判定する。impressions は SPR-302 の施策と混ざるため使わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
