### PR TITLE
feat(seo): works 詳細に構造化データと関連作品をサーバー描画する (SPR-302)

### DIFF
--- a/apps/web/src/app/works/[workId]/__tests__/related-works.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/related-works.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { pickRelatedWorks, RELATED_WORKS_LIMIT } from "../related-works";
+
+describe("pickRelatedWorks", () => {
+	const ids = (n: number) => Array.from({ length: n }, (_, i) => `RJ${i + 1}`);
+
+	it("自分自身を除外する", () => {
+		expect(pickRelatedWorks(["RJ1", "RJ2", "RJ3"], "RJ2")).not.toContain("RJ2");
+	});
+
+	// 上限は表示件数であると同時に読み取りコストの上限（#917 の全件スキャン再発防止）
+	it("上限を超えて返さない", () => {
+		expect(pickRelatedWorks(ids(100), "RJ1")).toHaveLength(RELATED_WORKS_LIMIT);
+	});
+
+	it("末尾（新しい側）から新しい順に返す", () => {
+		expect(pickRelatedWorks(ids(8), "RJ1")).toEqual(["RJ8", "RJ7", "RJ6", "RJ5", "RJ4", "RJ3"]);
+	});
+
+	it("自分以外が無ければ空（セクションごと出さないため）", () => {
+		expect(pickRelatedWorks(["RJ1"], "RJ1")).toEqual([]);
+		expect(pickRelatedWorks([], "RJ1")).toEqual([]);
+	});
+});

--- a/apps/web/src/app/works/[workId]/__tests__/structured-data.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/structured-data.test.ts
@@ -1,0 +1,149 @@
+import type { WorkCreatorsPlain, WorkPlainObject } from "@suzumina.click/shared-types";
+import { describe, expect, it } from "vitest";
+import { buildWorkStructuredData, serializeStructuredData } from "../structured-data";
+
+const PAGE_URL = "https://suzumina.click/works/RJ01616204";
+
+// 構造化データの組み立てに必要なフィールドだけを持つ最小の work。
+// 全フィールドを埋めると型の変更ごとにテストが壊れ、何を検証しているかも見えなくなる。
+const createCreators = (
+	roles: Partial<Pick<WorkCreatorsPlain, "voiceActors" | "scenario" | "illustration" | "music">>,
+): WorkCreatorsPlain => ({
+	voiceActors: [],
+	scenario: [],
+	illustration: [],
+	music: [],
+	others: [],
+	voiceActorNames: [],
+	scenarioNames: [],
+	illustrationNames: [],
+	musicNames: [],
+	otherNames: [],
+	...roles,
+});
+
+const createWork = (overrides: Partial<WorkPlainObject> = {}): WorkPlainObject =>
+	({
+		productId: "RJ01616204",
+		title: "テスト作品",
+		description: "作品の説明",
+		circle: "テストサークル",
+		workUrl: "https://www.dlsite.com/maniax/work/=/product_id/RJ01616204.html",
+		thumbnailUrl: "https://img.dlsite.jp/thumb.jpg",
+		genres: ["耳舐め", "バイノーラル"],
+		ageRating: "R18",
+		releaseDateISO: "2026-07-02",
+		price: {
+			current: 1760,
+			currency: "JPY",
+			isFree: false,
+			isDiscounted: false,
+			formattedPrice: "¥1,760",
+		},
+		creators: createCreators({
+			voiceActors: [{ id: "1", name: "涼花みなせ" }],
+			scenario: [{ id: "2", name: "シナリオ担当" }],
+		}),
+		...overrides,
+	}) as WorkPlainObject;
+
+describe("buildWorkStructuredData", () => {
+	it("Product として基本情報を出す", () => {
+		const data = buildWorkStructuredData(createWork(), PAGE_URL);
+
+		expect(data["@type"]).toBe("Product");
+		expect(data.name).toBe("テスト作品");
+		expect(data.url).toBe(PAGE_URL);
+		expect(data.productID).toBe("RJ01616204");
+		expect(data.brand).toEqual({ "@type": "Brand", name: "テストサークル" });
+		expect(data.contentRating).toBe("R18");
+	});
+
+	it("価格は Offer として出し、購入先は DLsite を指す", () => {
+		const data = buildWorkStructuredData(createWork(), PAGE_URL);
+
+		expect(data.offers).toMatchObject({
+			price: 1760,
+			priceCurrency: "JPY",
+			availability: "https://schema.org/InStock",
+		});
+		expect(data.offers?.url).toContain("dlsite.com");
+	});
+
+	it("無料作品は Offer を出さない", () => {
+		const work = createWork({
+			price: {
+				current: 0,
+				currency: "JPY",
+				isFree: true,
+				isDiscounted: false,
+				formattedPrice: "無料",
+			},
+		});
+
+		expect(buildWorkStructuredData(work, PAGE_URL).offers).toBeUndefined();
+	});
+
+	// 評価0件で ratingCount:0 を出すと Google 側で無効な構造化データになる
+	it("評価は件数があるときだけ出す", () => {
+		const withRatings = createWork({
+			rating: {
+				stars: 4.5,
+				count: 170,
+				average: 4.5,
+				hasRatings: true,
+				isHighlyRated: true,
+				reliability: "high",
+				formattedRating: "4.5",
+			},
+		});
+		expect(buildWorkStructuredData(withRatings, PAGE_URL).aggregateRating).toMatchObject({
+			ratingValue: 4.5,
+			ratingCount: 170,
+		});
+
+		expect(buildWorkStructuredData(createWork(), PAGE_URL).aggregateRating).toBeUndefined();
+	});
+
+	it("制作陣を role 横断で平坦化し重複を除く", () => {
+		const work = createWork({
+			creators: createCreators({
+				voiceActors: [{ id: "1", name: "涼花みなせ" }],
+				scenario: [{ id: "1", name: "涼花みなせ" }],
+				illustration: [{ id: "3", name: "イラスト担当" }],
+			}),
+		});
+
+		expect(buildWorkStructuredData(work, PAGE_URL).contributor).toEqual([
+			{ "@type": "Person", name: "涼花みなせ" },
+			{ "@type": "Person", name: "イラスト担当" },
+		]);
+	});
+
+	// title / description は DLsite 由来の外部データなので script 要素から脱出できてはいけない
+	it("script 要素から脱出できないようエスケープする", () => {
+		const work = createWork({
+			title: '</script><script>alert("xss")</script>',
+			description: "<img src=x onerror=alert(1)>",
+		});
+
+		const serialized = serializeStructuredData(buildWorkStructuredData(work, PAGE_URL));
+
+		expect(serialized).not.toContain("</script>");
+		expect(serialized).not.toContain("<img");
+		// エスケープしても JSON としての値は変わらない
+		expect(JSON.parse(serialized).title ?? JSON.parse(serialized).name).toBe(
+			'</script><script>alert("xss")</script>',
+		);
+	});
+
+	// 空値を出すと Google 側で警告になるため、キーごと落とす
+	it("値が無い項目はキーごと出さない", () => {
+		const work = createWork({ description: "", genres: [], ageRating: undefined });
+		const json = JSON.parse(JSON.stringify(buildWorkStructuredData(work, PAGE_URL)));
+
+		expect(json).not.toHaveProperty("description");
+		expect(json).not.toHaveProperty("genre");
+		expect(json).not.toHaveProperty("contentRating");
+	});
+});

--- a/apps/web/src/app/works/[workId]/components/work-related-works.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-related-works.tsx
@@ -1,0 +1,81 @@
+import type { CircleDocument } from "@suzumina.click/shared-types";
+import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
+import { cacheLife } from "next/cache";
+import Link from "next/link";
+import { getFirestore } from "@/lib/firestore";
+import { fetchWorksByIds } from "../../utils/fetch-works-by-ids";
+import { convertWorksToPlainObjects } from "../../utils/work-converters";
+import { pickRelatedWorks, type RelatedWork } from "../related-works";
+
+/**
+ * 同じサークルの他の作品（SPR-302 第2弾）。**Server Component であることが要件**。
+ *
+ * 目的は2つ:
+ * 1. works 詳細に DLsite の写しではない情報を増やす（第1弾の価格推移と同じ狙い）
+ * 2. works 詳細どうしを内部リンクで結ぶ。一覧のページ送りしか経路が無いと
+ *    クローラは深さ181ページを順に辿るしかないが、作品間リンクがあれば
+ *    サークル単位の塊として辿れる（SPR-308）
+ *
+ * 読み取りコスト: circles/{id} が 1 read ＋ 表示分の works が最大 RELATED_WORKS_LIMIT read。
+ * Firestore reads は課金上位のため `use cache` + `cacheLife("days")` で 1 作品 1 日 1 回に抑える。
+ * **workIds 全件を引かない**ことが重要（789作品のサークルが存在し、全件取得は #917 で
+ * 潰したのと同じ全件スキャンになる）。
+ */
+async function loadRelatedWorks(circleId: string, currentWorkId: string): Promise<RelatedWork[]> {
+	"use cache";
+	cacheLife("days");
+
+	const firestore = getFirestore();
+	const circleDoc = await firestore.collection("circles").doc(circleId).get();
+	if (!circleDoc.exists) return [];
+
+	const circleData = circleDoc.data() as CircleDocument;
+	const targetIds = pickRelatedWorks(circleData.workIds ?? [], currentWorkId);
+	if (targetIds.length === 0) return [];
+
+	const works = await fetchWorksByIds(firestore, targetIds);
+	return convertWorksToPlainObjects(works).map((work) => ({
+		productId: work.productId,
+		title: work.title,
+		formattedPrice: work.price.formattedPrice,
+	}));
+}
+
+export default async function WorkRelatedWorks({
+	circleId,
+	circleName,
+	currentWorkId,
+}: {
+	circleId: string;
+	circleName: string;
+	currentWorkId: string;
+}) {
+	const relatedWorks = await loadRelatedWorks(circleId, currentWorkId);
+	if (relatedWorks.length === 0) return null;
+
+	return (
+		<Card className="mt-6">
+			<CardHeader>
+				<CardTitle className="text-lg">{circleName}の他の作品</CardTitle>
+				<p className="text-sm text-muted-foreground">
+					同じサークルの作品を{relatedWorks.length}件表示しています。
+				</p>
+			</CardHeader>
+			<CardContent>
+				<ul className="space-y-2">
+					{relatedWorks.map((work) => (
+						<li key={work.productId} className="text-sm">
+							<Link
+								href={`/works/${work.productId}`}
+								className="text-foreground underline-offset-4 hover:underline"
+							>
+								{work.title}
+							</Link>
+							<span className="ml-2 text-muted-foreground">{work.formattedPrice}</span>
+						</li>
+					))}
+				</ul>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/web/src/app/works/[workId]/components/work-related-works.tsx
+++ b/apps/web/src/app/works/[workId]/components/work-related-works.tsx
@@ -1,11 +1,8 @@
-import type { CircleDocument } from "@suzumina.click/shared-types";
 import { Card, CardContent, CardHeader, CardTitle } from "@suzumina.click/ui/components/ui/card";
 import { cacheLife } from "next/cache";
 import Link from "next/link";
-import { getFirestore } from "@/lib/firestore";
-import { fetchWorksByIds } from "../../utils/fetch-works-by-ids";
-import { convertWorksToPlainObjects } from "../../utils/work-converters";
-import { pickRelatedWorks, type RelatedWork } from "../related-works";
+import type { RelatedWork } from "../related-works";
+import { getCircleRelatedWorks } from "../related-works-actions";
 
 /**
  * 同じサークルの他の作品（SPR-302 第2弾）。**Server Component であることが要件**。
@@ -18,27 +15,14 @@ import { pickRelatedWorks, type RelatedWork } from "../related-works";
  *
  * 読み取りコスト: circles/{id} が 1 read ＋ 表示分の works が最大 RELATED_WORKS_LIMIT read。
  * Firestore reads は課金上位のため `use cache` + `cacheLife("days")` で 1 作品 1 日 1 回に抑える。
- * **workIds 全件を引かない**ことが重要（789作品のサークルが存在し、全件取得は #917 で
- * 潰したのと同じ全件スキャンになる）。
+ * Firestore アクセス自体は `related-works-actions.ts` に置く（第1弾の `work-price-summary.tsx`
+ * と同じく、コンポーネントはキャッシュ境界と JSX の組み立てだけを持つ）。
  */
 async function loadRelatedWorks(circleId: string, currentWorkId: string): Promise<RelatedWork[]> {
 	"use cache";
 	cacheLife("days");
 
-	const firestore = getFirestore();
-	const circleDoc = await firestore.collection("circles").doc(circleId).get();
-	if (!circleDoc.exists) return [];
-
-	const circleData = circleDoc.data() as CircleDocument;
-	const targetIds = pickRelatedWorks(circleData.workIds ?? [], currentWorkId);
-	if (targetIds.length === 0) return [];
-
-	const works = await fetchWorksByIds(firestore, targetIds);
-	return convertWorksToPlainObjects(works).map((work) => ({
-		productId: work.productId,
-		title: work.title,
-		formattedPrice: work.price.formattedPrice,
-	}));
+	return getCircleRelatedWorks(circleId, currentWorkId);
 }
 
 export default async function WorkRelatedWorks({

--- a/apps/web/src/app/works/[workId]/page.tsx
+++ b/apps/web/src/app/works/[workId]/page.tsx
@@ -3,6 +3,8 @@ import { Suspense } from "react";
 import { getWorkById } from "../actions";
 import WorkDetail from "./components/work-detail";
 import WorkPriceSummary from "./components/work-price-summary";
+import WorkRelatedWorks from "./components/work-related-works";
+import { buildWorkStructuredData, serializeStructuredData } from "./structured-data";
 
 interface WorkDetailPageProps {
 	params: Promise<{
@@ -22,15 +24,33 @@ export default async function WorkDetailPage({ params }: WorkDetailPageProps) {
 
 	// per-user の評価はここで取得しない（session を読まない純公開 shell）。
 	// WorkEvaluation（client island）が認証時に自分の評価を self-fetch する（SPR-226）。
+	const structuredData = buildWorkStructuredData(work, `https://suzumina.click/works/${workId}`);
+
 	return (
 		<div className="min-h-screen bg-muted">
+			{/* 構造化データ。価格・評価をリッチリザルトの対象にして CTR を上げる狙い
+				（順位6〜8位に対し CTR 1.5〜3.0% と低いことが降格の引き金だった・SPR-302） */}
+			<script
+				type="application/ld+json"
+				// biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD は script 要素の中身として埋める必要がある。< は serializeStructuredData でエスケープ済み
+				dangerouslySetInnerHTML={{ __html: serializeStructuredData(structuredData) }}
+			/>
 			<main className="max-w-7xl mx-auto px-4 py-8">
 				<WorkDetail work={work} />
-				{/* 価格推移は WorkDetail（client・タブ内）ではなくここで**サーバー描画**する。
+				{/* 価格推移・関連作品は WorkDetail（client・タブ内）ではなくここで**サーバー描画**する。
 					タブ内の client fetch では初期 HTML に出ずクローラから見えないため（SPR-302） */}
 				<Suspense fallback={null}>
 					<WorkPriceSummary workId={work.productId} title={work.title} />
 				</Suspense>
+				{work.circleId && (
+					<Suspense fallback={null}>
+						<WorkRelatedWorks
+							circleId={work.circleId}
+							circleName={work.circle}
+							currentWorkId={work.productId}
+						/>
+					</Suspense>
+				)}
 			</main>
 		</div>
 	);

--- a/apps/web/src/app/works/[workId]/related-works-actions.ts
+++ b/apps/web/src/app/works/[workId]/related-works-actions.ts
@@ -1,0 +1,38 @@
+"use server";
+
+import type { CircleDocument } from "@suzumina.click/shared-types";
+import { getFirestore } from "@/lib/firestore";
+import { fetchWorksByIds } from "../utils/fetch-works-by-ids";
+import { convertWorksToPlainObjects } from "../utils/work-converters";
+import { pickRelatedWorks, type RelatedWork } from "./related-works";
+
+/**
+ * 同じサークルの他の作品を引く（SPR-302 第2弾）。
+ *
+ * 共有層（`src/actions/`）ではなく route 同居にしているのは、`fetchWorksByIds` と
+ * `pickRelatedWorks` が works route 配下にあり、**共有層から route 層への逆依存が
+ * 禁止されている**ため（同ディレクトリの `evaluation-actions.ts` と同じ置き方）。
+ *
+ * 読み取りは circles/{id} の 1 read ＋ 表示分の最大 RELATED_WORKS_LIMIT read に固定する。
+ * **workIds 全件は引かない**（789作品のサークルが存在し、全件取得は #917 で潰した
+ * 全件スキャンの再発になる）。キャッシュは呼び出し側の Server Component が持つ。
+ */
+export async function getCircleRelatedWorks(
+	circleId: string,
+	currentWorkId: string,
+): Promise<RelatedWork[]> {
+	const firestore = getFirestore();
+	const circleDoc = await firestore.collection("circles").doc(circleId).get();
+	if (!circleDoc.exists) return [];
+
+	const circleData = circleDoc.data() as CircleDocument;
+	const targetIds = pickRelatedWorks(circleData.workIds ?? [], currentWorkId);
+	if (targetIds.length === 0) return [];
+
+	const works = await fetchWorksByIds(firestore, targetIds);
+	return convertWorksToPlainObjects(works).map((work) => ({
+		productId: work.productId,
+		title: work.title,
+		formattedPrice: work.price.formattedPrice,
+	}));
+}

--- a/apps/web/src/app/works/[workId]/related-works.ts
+++ b/apps/web/src/app/works/[workId]/related-works.ts
@@ -1,0 +1,29 @@
+/**
+ * 同じサークルの他の作品を選ぶ純関数（SPR-302 第2弾）。
+ *
+ * 表示件数の上限をここに置くのは、これが**読み取りコストの上限そのもの**だから。
+ * サークルには最大 789 作品あり、workIds を全件引くと #917 で潰した全件スキャンが
+ * 別経路で復活する。ID を絞ってから `fetchWorksByIds` に渡すこと。
+ */
+export interface RelatedWork {
+	productId: string;
+	title: string;
+	formattedPrice: string;
+}
+
+/** 1 作品あたりの追加読み取り数の上限（circles/{id} の 1 read は別途） */
+export const RELATED_WORKS_LIMIT = 6;
+
+/**
+ * 表示対象の作品 ID を選ぶ。
+ *
+ * 並びは workIds の**末尾から**取る。DLsite 取り込みが arrayUnion で追記するため
+ * 末尾ほど新しく、新しい作品の方が検索需要があるという想定（順序が保証された
+ * フィールドではないので、これは best-effort であって仕様ではない）。
+ */
+export function pickRelatedWorks(workIds: string[], currentWorkId: string): string[] {
+	const others = workIds.filter((id) => id !== currentWorkId);
+	if (others.length === 0) return [];
+
+	return others.slice(-RELATED_WORKS_LIMIT).reverse();
+}

--- a/apps/web/src/app/works/[workId]/structured-data.ts
+++ b/apps/web/src/app/works/[workId]/structured-data.ts
@@ -1,0 +1,114 @@
+import type { WorkPlainObject } from "@suzumina.click/shared-types";
+
+/**
+ * works 詳細の JSON-LD（schema.org Product）を組み立てる（SPR-302 第2弾）。
+ *
+ * SPR-302 の診断では、順位6〜8位に対して CTR が 1.5〜3.0%（期待値 3〜10%）と低く、
+ * それが降格の引き金になっていた。構造化データは価格・評価をリッチリザルトの
+ * 対象にする＝**順位を上げずに CTR を上げられる**数少ない手段なので、
+ * 順位回復（コンテンツ改善）とは別軸の打ち手として入れる。
+ *
+ * 出力は Product 単体（ItemList や BreadcrumbList は別途）。値が無い項目は
+ * **キーごと出さない**（`undefined` を JSON.stringify が落とす）。空文字や 0 を
+ * 入れると Google 側で「無効な値」として警告になるため。
+ *
+ * 表示文言と同じくロジックを純関数に置くのは、テスト対象を JSX でなくデータにするため。
+ */
+export interface WorkStructuredData {
+	"@context": "https://schema.org";
+	"@type": "Product";
+	name: string;
+	url: string;
+	productID: string;
+	description?: string;
+	image?: string;
+	brand?: { "@type": "Brand"; name: string };
+	genre?: string[];
+	contentRating?: string;
+	releaseDate?: string;
+	offers?: {
+		"@type": "Offer";
+		price: number;
+		priceCurrency: string;
+		availability: "https://schema.org/InStock";
+		url: string;
+	};
+	aggregateRating?: {
+		"@type": "AggregateRating";
+		ratingValue: number;
+		ratingCount: number;
+		bestRating: 5;
+		worstRating: 1;
+	};
+	contributor?: { "@type": "Person"; name: string }[];
+}
+
+/** 評価は件数がある場合のみ出す（0件で ratingCount:0 を出すと無効な構造化データになる） */
+function buildAggregateRating(work: WorkPlainObject): WorkStructuredData["aggregateRating"] {
+	const rating = work.rating;
+	if (!rating?.hasRatings || rating.count <= 0) return undefined;
+
+	return {
+		"@type": "AggregateRating",
+		ratingValue: rating.stars,
+		ratingCount: rating.count,
+		bestRating: 5,
+		worstRating: 1,
+	};
+}
+
+/** 制作陣は role ごとに分かれているが、Product では contributor に平坦化する */
+function buildContributors(work: WorkPlainObject): WorkStructuredData["contributor"] {
+	const names = [
+		...work.creators.voiceActors,
+		...work.creators.scenario,
+		...work.creators.illustration,
+		...work.creators.music,
+	]
+		.map((creator) => creator.name)
+		.filter((name) => name.length > 0);
+
+	const unique = [...new Set(names)];
+	return unique.length > 0 ? unique.map((name) => ({ "@type": "Person", name })) : undefined;
+}
+
+/**
+ * JSON-LD を `<script>` の中身として安全に埋められる文字列にする。
+ *
+ * title / description は DLsite 由来の**外部データ**で、`</script>` を含んでいれば
+ * そのまま script 要素から脱出できてしまう（XSS）。`<` を Unicode エスケープすれば
+ * JSON としての意味は変わらないまま脱出を塞げる。
+ */
+export function serializeStructuredData(data: WorkStructuredData): string {
+	return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+export function buildWorkStructuredData(
+	work: WorkPlainObject,
+	pageUrl: string,
+): WorkStructuredData {
+	return {
+		"@context": "https://schema.org",
+		"@type": "Product",
+		name: work.title,
+		url: pageUrl,
+		productID: work.productId,
+		description: work.description || undefined,
+		image: work.highResImageUrl || work.thumbnailUrl || undefined,
+		brand: work.circle ? { "@type": "Brand", name: work.circle } : undefined,
+		genre: work.genres.length > 0 ? work.genres : undefined,
+		contentRating: work.ageRating || undefined,
+		releaseDate: work.releaseDateISO || undefined,
+		offers: work.price.isFree
+			? undefined
+			: {
+					"@type": "Offer",
+					price: work.price.current,
+					priceCurrency: work.price.currency,
+					availability: "https://schema.org/InStock",
+					url: work.workUrl,
+				},
+		aggregateRating: buildAggregateRating(work),
+		contributor: buildContributors(work),
+	};
+}


### PR DESCRIPTION
## 背景

[SPR-302](https://linear.app/nothink/issue/SPR-302) の第2弾。第1弾（価格推移のサーバー描画・[#899](https://github.com/nothink-jp/suzumina.click/pull/899)）に続いて、works 詳細が DLsite の薄い重複ページになっている状態への手当てを2つ足す。

## 1. 構造化データ（JSON-LD / schema.org Product）

**リポジトリに JSON-LD は1つも無かった**（`application/ld+json` の grep が 0 件）。

SPR-302 の診断では、掲載順位6〜8位に対して **CTR が 1.5〜3.0%（期待値 3〜10%）** と低いことが降格の引き金だった。構造化データは価格・評価をリッチリザルトの対象にする＝**順位を上げずに CTR を上げられる**数少ない手段なので、コンテンツ改善とは別軸の打ち手として入れる。

- 追加の Firestore 読み取りは**なし**（work オブジェクトの範囲で組み立てる）
- 値が無い項目はキーごと落とす（空文字や `ratingCount: 0` は Google 側で無効な値になるため）
- **`title` / `description` は DLsite 由来の外部データ**なので、`</script>` で script 要素から脱出できないよう `<` を Unicode エスケープする

## 2. 関連作品（同じサークルの他の作品）

works 詳細から**他の works へのリンクが0件**で、クローラは一覧のページ送りしか経路が無かった（[SPR-308](https://linear.app/nothink/issue/SPR-308)）。作品間リンクがあればサークル単位の塊として辿れる。

読み取りコストを固定するのが設計上の要点:

- `circles/{id}` の **1 read** ＋ 表示分の **最大6 read** に固定
- `use cache` + `cacheLife("days")` で 1 作品 1 日 1 回に抑える
- **`workIds` 全件は引かない**（789作品のサークルが存在し、全件取得は [#917](https://github.com/nothink-jp/suzumina.click/pull/917) で潰した全件スキャンの再発になる）。件数上限を純関数側に置いたのは、それが読み取りコストの上限そのものだから

## 見送ったもの

**サンプル画像のサーバー描画**（SPR-302 本文の候補）は入れていない。画像のホストが `img.dlsite.jp` で**自ドメインの資産にならず**、画像検索を含めて SEO 上の価値がほぼ無いため。

## 検証

`pnpm verify` 通過。Firestore Emulator の works 詳細で初期 HTML を実測:

| 項目 | 変更前 | 変更後 |
|---|---|---|
| JSON-LD | 0 | **1（Product / Offer / AggregateRating / contributor 4名）** |
| 他 works へのリンク | 0 | **4**（サークルの作品数に依存・最大6） |
| JSON-LD 内の生の `<` | — | **0**（エスケープ済み・`JSON.parse` は通る） |

テストは構造化データ7件・関連作品4件を追加。XSS エスケープと「評価0件では `aggregateRating` を出さない」を含む。

dev ログの `uncached data during prerendering` 警告は本 PR の前後で同じ（`getWorkById` と第1弾の `WorkPriceSummary` 由来・stash して A/B 済み）。

## 効果測定への影響（重要）

本 PR は[第1弾の効果判定（8/20〜8/23 予定）](https://linear.app/nothink/issue/SPR-302#comment-c8843a9a-9279-4a73-ad99-4e81a3f824db)の**測定期間に入る**ため、以後の impressions は第1弾と第2弾の混合効果になる。両者を事後に分離することはできない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
