### PR TITLE
fix(ci): Chromatic の TurboSnap ベースラインを復旧し無料枠の空振りを止める

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,9 +3,13 @@ name: Chromatic
 # packages/ui の Storybook を Chromatic にアップロードし視覚回帰(visual regression)を検出する（SPR-130）。
 # コスト設計: ui 変更時のみ実行 + TurboSnap(--only-changed) で変更 story だけスナップショットし無料枠を節約。
 # - pull_request: マージ前に視覚差分をレビュー（exitZeroOnChanges で GH チェックはブロックしない＝段階的導入）。
-# - push(main) トリガーは廃止（SPR-263）。globals.css 等グローバルファイル変更のたびに TurboSnap が
-#   無効化されフルビルド(678 snapshots)になり無料枠を圧迫したため、main のベースライン確立は
-#   workflow_dispatch の手動実行に切替（autoAcceptChanges: main は手動実行時のみ効く）。
+# - push(main): **TurboSnap のベースラインを作るために必須**。SPR-263 で一度廃止したが、それが
+#   「全ビルドがフルビルドになる」真因だった＝squash merge + ブランチ削除で PR ビルドの commit は
+#   GitHub から消えるため、main 上にビルドが無いと Chromatic は直近ビルドの commit を見つけられず
+#   （`we couldn't find the commit (…) for the most recent build`）、commit が生きている最後のビルド
+#   （廃止直前の #188 / 2026-07-11）まで遡る。差分が1か月ぶんに膨らみ globals.css が毎回入る
+#   → preview.ts が import している → TurboSnap 無効 → 毎回フル 357 snapshots。
+#   実測: 2026-08-03〜13 の 14 ビルドが全てフル ＝ 4,998 snapshots で無料枠 5,000 を消費。
 # - draft PR 中は実行しない（開発中の連続 push でフルビルドを繰り返さないため）。
 # play/a11y は storybook-test.yml、本番ビルド回帰は e2e-smoke.yml が担い、本 workflow は見た目の差分のみ担保する。
 
@@ -14,11 +18,16 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # main の run は打ち切らない。途中で切るとその commit のビルドが残らず、次回また
+  # 「直近ビルドの commit が見つからない」状態に戻ってフルビルドを誘発するため。
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -36,11 +45,13 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: changes
         with:
+          # pnpm-lock.yaml は対象外。dependabot 以外の依存更新 PR（Node 更新・脆弱性 override 等）が
+          # UI 無関係のままフルビルドを起こしていた（2026-08 期間で 14 本中 3 本 ≒ 1,070 snapshots）。
+          # 依存起因の見た目の変化は packages/ui を触る PR か workflow_dispatch のフルビルドで拾う。
           filters: |
             ui:
               - 'packages/ui/**'
               - 'packages/shared-types/**'
-              - 'pnpm-lock.yaml'
               - '.github/workflows/chromatic.yml'
 
   chromatic:
@@ -52,6 +63,8 @@ jobs:
     # draft PR は対象外（ready_for_review か workflow_dispatch で改めて実行される）。
     # workflow_dispatch は paths-filter の差分検出（既定 base は直近コミットのみ比較）に関わらず常に実行し、
     # 手動でのベースライン更新が静かに no-op になることを防ぐ。
+    # push(main) は paths-filter で ui 変更のみに絞る（＝ベースラインは ui を触った commit 上にだけ立つ。
+    # 無関係な commit まで撮ると枠を食うだけで、TurboSnap の遡り先としては ui 変更 commit で十分）。
     if: >
       (needs.changes.outputs.ui == 'true' || github.event_name == 'workflow_dispatch') &&
       github.actor != 'dependabot[bot]' &&
@@ -106,7 +119,10 @@ jobs:
           buildScriptName: build-storybook
           # TurboSnap: 変更に関係する story のみスナップショット
           onlyChanged: true
+          # lock の変更は依存トレースの起点にしない。packages/ui と同時に依存を足す PR で
+          # 「lock が変わった → 依存グラフ全体が変更 → TurboSnap 無効」になるのを防ぐ。
+          untraced: pnpm-lock.yaml
           # 視覚差分があっても GH チェックは成功させる（差分は Chromatic 上でレビュー＝段階的導入）
           exitZeroOnChanges: true
-          # main では差分を新ベースラインとして自動採用（push トリガー廃止済みのため workflow_dispatch 時のみ効く）
+          # main では差分を新ベースラインとして自動採用（push(main) と workflow_dispatch で効く）
           autoAcceptChanges: main

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -42,6 +42,15 @@ jobs:
       ui: ${{ steps.changes.outputs.ui }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          # push(main) では paths-filter が github.event.before とのローカル diff で判定する
+          # （pull_request は GitHub API 経由なので git 履歴に依存しない）。main ruleset は
+          # squash-only ＝ push は常に 1 コミットなので、depth 2 あれば before が手元に揃い
+          # ネットワーク取得なしで確定する。取れなかった場合 paths-filter は自力で
+          # `git fetch --depth=1 origin <sha>` するが、そこが失敗すると changes ジョブごと落ちて
+          # chromatic が静かに skip され、ベースラインが立たない（＝この修正が直した状態に逆戻り）。
+          # 黙って自己修復しない失敗なので、ほぼ無料な保険として depth を明示する。
+          fetch-depth: 2
       - uses: dorny/paths-filter@v4
         id: changes
         with:


### PR DESCRIPTION
## 背景

Chromatic の無料枠（月 5,000 snapshots）が 8/13 に上限到達した。調べたところ、**TurboSnap が一度も効いておらず全ビルドがフルビルドになっていた**。

課金期間 2026-08-03〜13 に Chromatic ジョブが実際に走ったのは 14 本（他は paths-filter / dependabot 除外で skip）。全ビルドのログに `TurboSnap disabled due to file change` があり、ストーリー数は 357（`Running 47 tests (skipping 310 tests)`）。

**14 × 357 = 4,998 ≒ 無料枠 5,000**。

## 真因

```
When detecting git changes for TurboSnap, we couldn't find the commit (7fc3e45) for the most recent build (#244).
To avoid re-snapshotting stories we know haven't changed, we copied from the most recent build (#188) that did have a commit (7ee5423) instead.
⚠ TurboSnap disabled due to file change
   Found a Storybook config change in packages/ui/.storybook/preview.ts
   This was triggered by a change to packages/ui/src/styles/globals.css
```

1. #776（SPR-263, 2026-07-11）で `push: main` を廃止 → 以降 main コミット上のビルドが 1 本も無い
2. PR は squash merge + ブランチ削除なので、**PR ビルドの commit は GitHub から消える**（#242〜#244 が全滅）
3. フォールバック先が build #188 = commit `7ee5423` = **廃止直前の #775 / 2026-07-11** で固定
4. 差分が「7/11 以降の全変更」になり、7/23 に変更された `globals.css` が毎回入る → `preview.ts` が import → TurboSnap 無効 → 毎回 357 枚

`globals.css` は 7/23 以降まったく変更されていないのに、毎ビルド full 判定になっていた。SPR-263 の対策がフルビルドを減らすどころか**全ビルドをフルにしていた**。

## 変更

- **`push: main` を復活**（paths-filter で ui 変更のみ）。commit が生き残るベースラインを作り直す唯一の方法。main の run は `cancel-in-progress` の対象外にする（途中で切るとその commit のビルドが残らず同じ穴に戻るため）
- **paths-filter から `pnpm-lock.yaml` を除外**。dependabot 以外の依存更新 PR（Node 更新・nanoid override）が UI 無関係のままフルビルドを起こしていた＝同期間 14 本中 3 本 ≒ 1,070 snapshots（21%）
- **`untraced: pnpm-lock.yaml`** を追加。ui と依存を同時に触る PR で lock 経由の依存グラフ全体変更が TurboSnap を無効化するのを防ぐ

## 効果の見積り

追加される main ビルドは月 24 本程度（直近30日で packages/ui を触った main commit 数）だが、いずれも前回 main ビルド基準の増分になる。概算で月 1,500〜3,600 枚（対 5,000 枠）。

## 注意

**枠は 9/3 まで枯渇したままなので、このマージ直後の main ビルドは quota 制限で不完全**（`Running 47 tests (skipping 310 tests)` になる）。クリーンなベースラインは **9/3 の枠リセット後に `workflow_dispatch` でフルビルドを 1 回**回して確立するのが確実。

## レビュー観点

`.github/workflows` 変更 = One-Way Door（CLAUDE.md §1）なので AI レビュー任せにせず自分で確認する。特に:
- `concurrency.cancel-in-progress` の式（workflow レベルで `github.event_name` は参照可）
- push イベント時の paths-filter の base（既定 base = デフォルトブランチ = push 先が同一 → `github.event.before` と比較）

🤖 Generated with [Claude Code](https://claude.com/claude-code)