### PR TITLE
docs(ci): chromatic.yml の SPR-263 誤参照を PR #776 に直す

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -3,7 +3,7 @@ name: Chromatic
 # packages/ui の Storybook を Chromatic にアップロードし視覚回帰(visual regression)を検出する（SPR-130）。
 # コスト設計: ui 変更時のみ実行 + TurboSnap(--only-changed) で変更 story だけスナップショットし無料枠を節約。
 # - pull_request: マージ前に視覚差分をレビュー（exitZeroOnChanges で GH チェックはブロックしない＝段階的導入）。
-# - push(main): **TurboSnap のベースラインを作るために必須**。SPR-263 で一度廃止したが、それが
+# - push(main): **TurboSnap のベースラインを作るために必須**。#776 で一度廃止したが、それが
 #   「全ビルドがフルビルドになる」真因だった＝squash merge + ブランチ削除で PR ビルドの commit は
 #   GitHub から消えるため、main 上にビルドが無いと Chromatic は直近ビルドの commit を見つけられず
 #   （`we couldn't find the commit (…) for the most recent build`）、commit が生きている最後のビルド


### PR DESCRIPTION
## 背景

#929 の取りこぼし。機能面は全てマージ済みで、**残っていたのはコメント 1 行の誤参照だけ**。

`chromatic.yml` の「push(main) トリガーは廃止（SPR-263）」という記述は誤り。#929 で該当行を書き直した際、削除前のコメントにあった SPR 番号をそのまま引き継いでしまっていた。

Linear で確認したところ **SPR-263 の実体は「YouTube 未取込動画5件のバックフィル（search.list 時代の取り込み漏れ）」** で、Chromatic とは無関係。[PR #776](https://github.com/nothink-jp/suzumina.click/pull/776) の本文にも SPR 参照は無く、対応する Linear issue はそもそも存在しない。

## 変更

根拠として実際に辿れる PR 番号（#776）に置き換える。1 行のみ。

```diff
-# - push(main): **TurboSnap のベースラインを作るために必須**。SPR-263 で一度廃止したが、それが
+# - push(main): **TurboSnap のベースラインを作るために必須**。#776 で一度廃止したが、それが
```

## なぜ直すか

この workflow を後から読む人（ステートレスな LLM 含む）を確実に誤誘導する。CLAUDE.md 軸3（意図と理解の一致）で最優先の「名前・型の約束と実際のズレ」に当たる。誤った SPR 番号は、辿った先が無関係な issue なので気づきにくく、`lint:docs` でも検出できない。

## Door 判定

**Two-Way Door**（コメント 1 行の変更・実行される設定に一切影響しない）。`.github/workflows` 配下ではあるが、YAML のキーも値も変えていない。

## 注意

`chromatic.yml` は paths-filter の対象なので、この PR でも Chromatic が発火する。9/3 の枠リセットまでは quota 制限で `Running 47 tests (skipping 310 tests)` となり、結果は不完全（想定内）。関連: SPR-309

🤖 Generated with [Claude Code](https://claude.com/claude-code)