### PR TITLE
fix(deps): nanoid override を 3.3.18 へ引き上げ audit の赤を解消する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   postcss: '>=8.5.23'
   kysely: 0.28.17
   fast-uri: '>=4.1.2'
-  nanoid: '>=3.3.17 <3.3.18'
+  nanoid: '>=3.3.18 <4'
   sharp: '>=0.35.0'
 
 importers:
@@ -3905,8 +3905,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8127,7 +8127,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanostores@1.4.2: {}
 
@@ -8345,13 +8345,13 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,18 +39,16 @@ overrides:
   # >=4.0.0 <4.1.2: 同じくバックスラッシュを authority 区切りと誤読するホスト混同（GHSA-7p8r-x3mc-p8w7）。
   # 旧 floor（>=3.1.4）が 4.1.1 を掴んで新 advisory の範囲に入っていたため 4.1.2 へ引き上げ。
   fast-uri: ">=4.1.2"
-  # nanoid < 3.3.17: custom generator に size=0 を渡すと無限ループする DoS（GHSA-2v37-7h3g-55p8）。
+  # nanoid < 3.3.18: custom generator に size=0 を渡すと無限ループする DoS（GHSA-2v37-7h3g-55p8）。
   # 唯一の依存元 postcss は `^3.3.16` を要求し自然解決が 3.3.16 に留まるため引き上げる。
-  # 他の override と違い上限が要る。しかも `<4` では足りず `<3.3.18` まで絞る。理由は別々の2つ:
-  # - `<4` が要る理由: nanoid 4 以降は main を持たない ESM 専用。上限なしだと `>=3.3.17` が
-  #   6.x を掴み、CJS require している postcss（Tailwind/Next/Vite/Storybook の土台）が壊れる。
-  # - さらに `<3.3.18` まで絞る理由: 3.x 最新の 3.3.18 は公開が新しく pnpm 既定の
-  #   minimumReleaseAge に掛かるため、minimumReleaseAgeExclude への自動追加を誘発する。
-  #   これは公開直後パッケージの待機という供給網対策をこの版だけ外すもので、3.3.18 が
-  #   十分古くなった後は不要な残骸として残る。3.3.17 は advisory の patched 版そのもので
-  #   脆弱性は解消し、待機ゲートを自然に通る。
-  # 将来 3.3.18 以降へ動かすときは floor と上限の両方を上げる（上限だけ残すと audit が赤くなって気づける）。
-  nanoid: ">=3.3.17 <3.3.18"
+  # 当初この advisory の patched は 3.3.17 で、3.3.18 が公開直後（minimumReleaseAge に掛かる）
+  # だったため floor 3.3.17 / 上限 `<3.3.18` で運用していた。その後 advisory の脆弱範囲が
+  # `<3.3.18` へ広がり、上限に張り付いていた解決値が範囲内に入って audit が赤くなったため
+  # 両方を引き上げた（＝上限を残しておいたことで気づけた設計どおりの動作）。
+  # `<4` は維持する: nanoid 4 以降は main を持たない ESM 専用で、上限なしだと 6.x を掴み
+  # CJS require している postcss（Tailwind/Next/Vite/Storybook の土台）が壊れる。
+  # 将来また動かすときも floor と上限の両方を上げる（上限だけ残すと audit が赤くなって気づける）。
+  nanoid: ">=3.3.18 <4"
   # sharp < 0.35.0: 継承する libvips の脆弱性群（CVE-2026-33327/33328/35590/35591）。next の依存範囲が
   # ^0.34.5（0.35.0 未満に固定）のため override なしでは追従しない。
   sharp: ">=0.35.0"


### PR DESCRIPTION
## 背景

今週の Dependabot PR（#932 / #933 / #934）が3件とも `Security Check` だけ落ちていた。原因は3件のどれでもなく、既存の override の上限に張り付いた解決値が新しい advisory 範囲に入ったこと。

- `GHSA-2v37-7h3g-55p8`（nanoid の custom generator に `size=0` を渡すと無限ループする DoS）の脆弱範囲が `<3.3.17` から **`<3.3.18` へ広がった**
- pnpm-workspace.yaml の override は `">=3.3.17 <3.3.18"` で、解決値 3.3.17 がそのまま新しい範囲に入った
- 唯一の依存元は postcss（`^3.3.16`）で、Tailwind / Next / Vite / Storybook の土台として全ワークスペースに伝播している

## 変更

override を `">=3.3.18 <4"` へ引き上げ、コメントを現在の advisory 範囲に合わせて更新した。

- 上限 `<4` は維持。nanoid 4 以降は `main` を持たない ESM 専用で、上限を外すと 6.x を掴んで CJS require している postcss が壊れる
- 上限を 3.3.18 未満に絞っていた理由（3.3.18 が公開直後で pnpm の minimumReleaseAge に掛かる）は、公開 2026-08-07 から十分経過したため解消。`minimumReleaseAgeExclude` への追加は不要

元のコメントに書いてあった「上限だけ残すと audit が赤くなって気づける」がそのまま働いたケースなので、その運用方針は据え置いている。

## 確認

- `pnpm audit --audit-level high` → `No known vulnerabilities found`
- `pnpm verify` → exit 0
- lockfile の差分は nanoid 3.3.17 → 3.3.18 と postcss 2エントリの参照更新のみ

## 後続

これをマージしてから #932 → #933 → #934 の順に rebase して進める（3件とも pnpm-lock.yaml を触るため連続 squash は避ける）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)