### PR TITLE
fix(web): standalone に @swc/helpers の esm を含め Cloud Run 起動失敗を直す

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -15,10 +15,16 @@ const nextConfig = {
 	serverExternalPackages: ["@google-cloud/firestore", "@google-cloud/storage", "resend"],
 
 	// standalone の file tracing が @swc/helpers の esm/ を取りこぼすため明示的に含める。
-	// next 16.3.1 が同梱する @swc/helpers 0.5.23 は exports がワイルドカード subpath（"./esm/*"）
-	// になっており静的解析でたどれない。一方 next の require-hook は esm/_interop_require_default.js を
-	// 実行時に解決するため、欠落すると Cloud Run で MODULE_NOT_FOUND となり起動プローブが落ちる
-	// （standalone 出力に cjs/ と package.json しか入らない状態を実ビルドで確認済み）。
+	// 上流バグ: vercel/next.js#97358（pnpm + standalone + Docker で 16.3.1 のみ起動失敗）。
+	// Turbopack の ResolveResult::with_replaced_request_key が条件（conditions）を上書きし、
+	// 同一 subpath の module-sync と require の解決結果が同じキーに潰れて片方が捨てられる。
+	// pnpm は仮想ストアで候補ディレクトリが2つになるため顕在化する。
+	// @swc/helpers 0.5.23（next 16.3.1 が同梱）は module-sync を先頭に持ち、Node >= 22.12 の
+	// require は esm/_interop_require_default.js に解決するため、cjs/ しか含まれない standalone は
+	// MODULE_NOT_FOUND で exit(1)＝Cloud Run の起動プローブが落ちる。
+	// 修正 PR vercel/next.js#97372 は 16.3.1-canary.20 以降にのみ入っており stable 未リリース。
+	// **stable に取り込まれたらこの include は不要**（判定: 修正コミット 904a4185 が対象タグに
+	// 含まれるかを `gh api repos/vercel/next.js/compare/904a4185...v<version>` の status で確認）。
 	// パスは next.config からの相対＝monorepo ルートの node_modules を指す。
 	outputFileTracingIncludes: {
 		"**/*": ["../../node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**"],

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,6 +14,16 @@ const nextConfig = {
 	// Server ComponentsでのみGoogle Cloud SDKを使用するための設定
 	serverExternalPackages: ["@google-cloud/firestore", "@google-cloud/storage", "resend"],
 
+	// standalone の file tracing が @swc/helpers の esm/ を取りこぼすため明示的に含める。
+	// next 16.3.1 が同梱する @swc/helpers 0.5.23 は exports がワイルドカード subpath（"./esm/*"）
+	// になっており静的解析でたどれない。一方 next の require-hook は esm/_interop_require_default.js を
+	// 実行時に解決するため、欠落すると Cloud Run で MODULE_NOT_FOUND となり起動プローブが落ちる
+	// （standalone 出力に cjs/ と package.json しか入らない状態を実ビルドで確認済み）。
+	// パスは next.config からの相対＝monorepo ルートの node_modules を指す。
+	outputFileTracingIncludes: {
+		"**/*": ["../../node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**"],
+	},
+
 	// コンパイラー最適化
 	compiler: {
 		// 本番環境でのコンソール除去


### PR DESCRIPTION
## 事象

next 16.3.1 が入った #933 以降、**Cloud Run の Deploy Web が起動プローブで落ち続けている**（`efdf9a51` / `36b1e6e7` の2回）。production は直前の正常 revision（#932 相当）を維持しているためサイトは稼働しているが、#933・#934 の内容が web に届いていない。

失敗した revision のログ:

```
Error: Cannot find module '/app/node_modules/.pnpm/next@16.3.1_.../node_modules/@swc/helpers/esm/_interop_require_default.js'
  code: 'MODULE_NOT_FOUND'
Container called exit(1).
```

## 原因

next 16.3.1 は同梱する `@swc/helpers` を 0.5.15 → **0.5.23** に上げている。0.5.23 は exports がワイルドカード subpath（`"./esm/*"` / `"./_/*"`）になり、standalone の file tracing が静的解析でたどれない。一方 next の require-hook は実行時に `esm/_interop_require_default.js` を解決するため、欠落するとコンテナ起動時に落ちる。

実ビルドでの確認:

- 修正前の `.next/standalone` 配下の `@swc/helpers` は **`cjs/` と `package.json` のみ**（`esm/` が丸ごと欠落）
- その状態で standalone を起動すると、本番と同一の `Cannot find module '.../@swc/helpers/esm/_interop_require_default.js'` を再現

CI をすり抜けた理由: `Docker Build Check` はイメージのビルドのみで起動しない。`Smoke (prod build x emulator)` は `next build` + `next start` で standalone 出力を使わないため、tracing の欠落が現れない。

## 変更

`outputFileTracingIncludes` で `@swc/helpers/esm/**` を明示的に含める。バージョン部分はワイルドカード（`@swc+helpers@*`）にして、次回 next が helpers を上げても追従が要らないようにした。

## 確認

- 修正後の standalone 出力に `esm/` の 108 ファイルが含まれる
- standalone を起動 → `/api/health` が 200（`✓ Ready`、Next.js 16.3.1）
- `pnpm verify` → exit 0

## 後続

マージ後の Deploy Web の成否を確認し、本番の応答まで見る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)