### PR TITLE
fix(web): works の Offer に seller を明示し product snippet 側の意図を固定する

### DIFF
--- a/apps/web/src/app/works/[workId]/__tests__/structured-data.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/structured-data.test.ts
@@ -70,6 +70,14 @@ describe("buildWorkStructuredData", () => {
 		expect(data.offers?.url).toContain("dlsite.com");
 	});
 
+	// 当サイトは販売者ではない（merchant listing ではなく product snippet を狙う）
+	it("Offer の seller は DLsite", () => {
+		expect(buildWorkStructuredData(createWork(), PAGE_URL).offers?.seller).toEqual({
+			"@type": "Organization",
+			name: "DLsite",
+		});
+	});
+
 	it("無料作品は Offer を出さない", () => {
 		const work = createWork({
 			price: {
@@ -103,6 +111,15 @@ describe("buildWorkStructuredData", () => {
 		});
 
 		expect(buildWorkStructuredData(createWork(), PAGE_URL).aggregateRating).toBeUndefined();
+	});
+
+	// offers を落とすと review / aggregateRating / offers すべてを欠き、
+	// product snippet の適格性ごと失う（助言レベルの警告 → 必須項目エラーに悪化）
+	it("評価がなくても Offer は落とさない", () => {
+		const data = buildWorkStructuredData(createWork(), PAGE_URL);
+
+		expect(data.aggregateRating).toBeUndefined();
+		expect(data.offers?.price).toBe(1760);
 	});
 
 	it("制作陣を role 横断で平坦化し重複を除く", () => {

--- a/apps/web/src/app/works/[workId]/__tests__/structured-data.test.ts
+++ b/apps/web/src/app/works/[workId]/__tests__/structured-data.test.ts
@@ -116,9 +116,8 @@ describe("buildWorkStructuredData", () => {
 	// offers を落とすと review / aggregateRating / offers すべてを欠き、
 	// product snippet の適格性ごと失う（助言レベルの警告 → 必須項目エラーに悪化）
 	it("評価がなくても Offer は落とさない", () => {
-		const data = buildWorkStructuredData(createWork(), PAGE_URL);
+		const data = buildWorkStructuredData(createWork({ rating: undefined }), PAGE_URL);
 
-		expect(data.aggregateRating).toBeUndefined();
 		expect(data.offers?.price).toBe(1760);
 	});
 

--- a/apps/web/src/app/works/[workId]/structured-data.ts
+++ b/apps/web/src/app/works/[workId]/structured-data.ts
@@ -13,6 +13,15 @@ import type { WorkPlainObject } from "@suzumina.click/shared-types";
  * 入れると Google 側で「無効な値」として警告になるため。
  *
  * 表示文言と同じくロジックを純関数に置くのは、テスト対象を JSX でなくデータにするため。
+ *
+ * 狙う Google の枠は **product snippet**（購入できないページ向け）であって
+ * merchant listing ではない。販売は DLsite 側で行われ、当サイトは購入できないため
+ * merchant listing の適格性はそもそも無い（Google: 購入できるページのみが対象で、
+ * 他サイトへのリンクを持つページは対象外）。Search Console が「販売者のリスティング」
+ * レポートで `shippingDetails` / `hasMerchantReturnPolicy` の欠落を報告するのは、
+ * Offer を含む Product を merchant listing 側でも検査するためで、**埋めても得るものはない**。
+ * ダウンロード販売の配送条件・返品規定を当サイトが宣言する形になり不実記載になるので、
+ * この2項目は意図的に出さない。`seller` を明示するのはその境界を機械可読にするため。
  */
 export interface WorkStructuredData {
 	"@context": "https://schema.org";
@@ -32,6 +41,7 @@ export interface WorkStructuredData {
 		priceCurrency: string;
 		availability: "https://schema.org/InStock";
 		url: string;
+		seller: { "@type": "Organization"; name: "DLsite" };
 	};
 	aggregateRating?: {
 		"@type": "AggregateRating";
@@ -43,7 +53,18 @@ export interface WorkStructuredData {
 	contributor?: { "@type": "Person"; name: string }[];
 }
 
-/** 評価は件数がある場合のみ出す（0件で ratingCount:0 を出すと無効な構造化データになる） */
+/** 購入先は常に DLsite。当サイトは販売者ではない（上の doc コメント参照） */
+const SELLER = { "@type": "Organization", name: "DLsite" } as const;
+
+/**
+ * 評価は件数がある場合のみ出す（0件で ratingCount:0 を出すと無効な構造化データになる）。
+ *
+ * 結果として評価なし作品は `offers` 単独の Product になり、Rich Results Test の
+ * product snippet セクションが「review / aggregateRating を伴わない offers」を
+ * 警告することがある。**それでも `offers` は落とさない**：product snippet の必須は
+ * review / aggregateRating / offers のいずれか1つで、offers を落とすと評価なし作品は
+ * 3つすべてを欠いて適格性ごと失う＝助言レベルの警告が必須項目エラーに悪化する。
+ */
 function buildAggregateRating(work: WorkPlainObject): WorkStructuredData["aggregateRating"] {
 	const rating = work.rating;
 	if (!rating?.hasRatings || rating.count <= 0) return undefined;
@@ -107,6 +128,7 @@ export function buildWorkStructuredData(
 					priceCurrency: work.price.currency,
 					availability: "https://schema.org/InStock",
 					url: work.workUrl,
+					seller: SELLER,
 				},
 		aggregateRating: buildAggregateRating(work),
 		contributor: buildContributors(work),


### PR DESCRIPTION
## 背景

Search Console から「販売者のリスティング（merchant listing）の構造化データに 2 件の非重大な問題」というメールが届いた。

- 項目「shippingDetails」がありません（「offers」に含まれる）
- 項目「hasMerchantReturnPolicy」がありません（「offers」に含まれる）

調査したところ、SPR-302 で works 詳細に Product JSON-LD を入れた時点で構造的に確定していた表示で、新しい不具合ではなかった。Google の merchant listing ドキュメントは「Merchant listings レポートは **Offer 構造化データを含む product snippet も検査対象に含む**」と明言しており、購入できないページでも `offers` があればこのレポートに出る。

## 判断: この 2 項目は埋めない

Google の merchant listing 適格性は「購入できるページのみが対象で、**その商品を販売する他サイトへのリンクを持つページは対象外**」と定義されている。`offers.url` が `dlsite.com` を指しているとおり、当サイトは販売者ではなくアグリゲーター側なので:

- 2 項目を埋めても merchant listing のリッチリザルトは出ない（適格性がそもそも無い）
- ダウンロード販売の配送条件・返品規定を当サイトが宣言する形になり不実記載になる＝得るものゼロでポリシー違反リスクだけ
- メールにある「今後重大な問題に再分類される可能性」も効くのは merchant listing 適格性に対してだけで、SPR-302 で狙った価格・評価の表示は **product snippet 側の別判定**なので影響しない

この判断を doc コメントに残し、将来「GSC の警告を消そう」で蒸し返されないようにした。

## 変更

- `Offer.seller` に DLsite を明示。販売者が当サイトでないことを機械可読にする（警告は消えないが、意図と表現を一致させる）
- 狙う枠は product snippet であって merchant listing ではないこと、上記 2 項目を意図的に出さないことを doc コメントに記録
- **評価なし作品でも `offers` は落とさない**方針を doc コメント＋回帰テストで固定。product snippet の必須は `review` / `aggregateRating` / `offers` のいずれか 1 つで、`offers` を落とすと評価なし作品は 3 つすべてを欠いて適格性ごと失う＝助言レベルの警告が必須項目エラーに悪化する

## 検証

- `pnpm verify` 通過
- Emulator + シードで本番と同じ経路の HTML を取得し、`seller` が出力されることを確認済み

```json
"offers": {
  "@type": "Offer", "price": 1188, "priceCurrency": "JPY",
  "availability": "https://schema.org/InStock",
  "url": "https://www.dlsite.com/maniax/work/=/product_id/RJ01000639.html",
  "seller": { "@type": "Organization", "name": "DLsite" }
}
```

評価なし側の分岐は fixtures の works 100 件すべてが評価ありのためブラウザでは再現できず、ユニットテストでの確認に留まる（純関数なので分岐は網羅済み）。

## Two-Way Door

JSON-LD の出力内容のみで、スキーマ・認証・インフラに触れない。revert で完全に戻せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
