### PR TITLE
perf(web): creator/circle 一覧の全件取得をキャッシュ境界に畳む (SPR-311)

### DIFF
--- a/apps/web/src/app/circles/[circleId]/__tests__/actions-cache-safety.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions-cache-safety.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `getCircleWorksList` がキャッシュ済みの配列を破壊しないことの回帰テスト（SPR-311）。
+ * 理由と再現条件は creator 側の同名テストと同じ。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
+vi.mock("@suzumina.click/shared-types", () => ({
+	isValidCircleId: (id: string) => /^RG\d{5}$/.test(id),
+}));
+
+const loadCircleWorks = vi.fn();
+vi.mock("../circle-works-source", () => ({
+	loadCircleInfo: vi.fn(),
+	loadCircleWorks: (circleId: string) => loadCircleWorks(circleId),
+}));
+
+import { getCircleWorksList } from "../actions";
+
+const work = (productId: string, releaseDateISO: string) =>
+	({ id: productId, productId, title: productId, releaseDateISO }) as never;
+
+describe("getCircleWorksList のキャッシュ安全性", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("ソートしてもキャッシュ側の配列順を書き換えない", async () => {
+		const cached = [work("RJ111111", "2025-01-01"), work("RJ222222", "2025-06-01")];
+		const snapshot = [...cached];
+		loadCircleWorks.mockResolvedValue(cached);
+
+		const result = await getCircleWorksList({ circleId: "RG12345", sort: "newest" });
+
+		expect(result.works.map((w) => w.productId)).toEqual(["RJ222222", "RJ111111"]);
+		expect(cached).toEqual(snapshot);
+	});
+
+	it("存在しないサークル（null）と作品0件を区別して空結果を返す", async () => {
+		loadCircleWorks.mockResolvedValue(null);
+		expect(await getCircleWorksList({ circleId: "RG99999" })).toEqual({
+			works: [],
+			totalCount: 0,
+		});
+
+		loadCircleWorks.mockResolvedValue([]);
+		expect(await getCircleWorksList({ circleId: "RG12345" })).toEqual({
+			works: [],
+			totalCount: 0,
+		});
+	});
+
+	it("ページ送り・ソートの違いで Firestore を引き直さない", async () => {
+		loadCircleWorks.mockResolvedValue([work("RJ111111", "2025-01-01")]);
+
+		await getCircleWorksList({ circleId: "RG12345", page: 1 });
+		await getCircleWorksList({ circleId: "RG12345", page: 2, sort: "oldest" });
+
+		expect(loadCircleWorks).toHaveBeenNthCalledWith(1, "RG12345");
+		expect(loadCircleWorks).toHaveBeenNthCalledWith(2, "RG12345");
+	});
+});

--- a/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/[circleId]/__tests__/actions.test.ts
@@ -4,6 +4,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
+// vitest では "use cache" ディレクティブは no-op になり cacheLife が cache スコープ外呼び出しになるためモックする
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
 // Mock conversion helper function
 
 // workTransformers, convertToCirclePlainObject のモック

--- a/apps/web/src/app/circles/[circleId]/actions.ts
+++ b/apps/web/src/app/circles/[circleId]/actions.ts
@@ -1,15 +1,9 @@
 "use server";
 
-import type {
-	CircleDocument,
-	CirclePlainObject,
-	WorkPlainObject,
-} from "@suzumina.click/shared-types";
-import { convertToCirclePlainObject, isValidCircleId } from "@suzumina.click/shared-types";
+import type { CirclePlainObject, WorkPlainObject } from "@suzumina.click/shared-types";
+import { isValidCircleId } from "@suzumina.click/shared-types";
 import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
-import { getFirestore } from "@/lib/firestore";
-import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
-import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
+import { loadCircleInfo, loadCircleWorks } from "./circle-works-source";
 
 /**
  * サークル情報を取得
@@ -23,15 +17,7 @@ export async function getCircleInfo(circleId: string): Promise<CirclePlainObject
 	}
 
 	try {
-		const firestore = getFirestore();
-		const circleDoc = await firestore.collection("circles").doc(circleId).get();
-
-		if (!circleDoc.exists) {
-			return null;
-		}
-
-		const data = circleDoc.data() as CircleDocument;
-		return convertToCirclePlainObject(data);
+		return await loadCircleInfo(circleId);
 	} catch (_error) {
 		// エラー発生時はnullを返す
 		return null;
@@ -40,6 +26,9 @@ export async function getCircleInfo(circleId: string): Promise<CirclePlainObject
 
 /**
  * サークル作品リストを取得（ConfigurableList用）
+ *
+ * ページ送り・ソート・検索は `loadCircleSource` が返す全作品に対する純粋な導出。
+ * Firestore へは行かない（キャッシュ境界の内側で 1 日 1 回）。
  * @param params パラメータ
  * @returns 作品一覧と総件数
  */
@@ -58,44 +47,26 @@ export async function getCircleWorksList(params: {
 	}
 
 	try {
-		const firestore = getFirestore();
-
-		const circleDoc = await firestore.collection("circles").doc(circleId).get();
-		if (!circleDoc.exists) {
+		const allWorks = await loadCircleWorks(circleId);
+		if (!allWorks) {
 			return { works: [], totalCount: 0 };
 		}
 
-		const circleData = circleDoc.data() as CircleDocument;
-
-		// サークル所属作品の正本は circles/{id}.workIds。
-		// 書き手は DLsite 取り込み（2h毎に arrayUnion・circle-firestore.ts）で、
-		// checkDataIntegrity（週次）が重複除去と欠落補填を事後修復する。
-		// 読み取り側はこの配列を引き当てるだけにし、所属条件を read 時に再計算しない。
-		//
-		// 旧実装は works を全件取得して `circleId 一致 || サークル名一致` で再導出していたため、
-		// 1 リクエストあたり works 全件（実測 2,156件）を読んでいた。
-		// ヘッダーの「作品数」は元から workIds.length 由来（circle-conversions.ts）で、
-		// 同一ページ内で所属の正本が二重化していた状態を解消する。
-		const workIds = circleData.workIds ?? [];
-		const matchingWorks = await fetchWorksByIds(firestore, workIds);
-
-		// WorkPlainObjectに変換（work-converters の正本を共用）
-		const convertedWorks = convertWorksToPlainObjects(matchingWorks);
-
 		// 検索フィルタリング（circle/creator 共通）
-		const { filtered: filteredWorks, count: filteredCount } = searchWorks(convertedWorks, search);
+		const { filtered: filteredWorks, count: filteredCount } = searchWorks(allWorks, search);
 
-		// ソート処理
-		filteredWorks.sort((a, b) => compareWorks(a, b, sort));
+		// ソート処理。`searchWorks` は検索語が無いと入力配列をそのまま返すため、
+		// ここで複製しないと **キャッシュ済みの配列を破壊的に並べ替える**（以降の全リクエストに漏れる）。
+		const sortedWorks = [...filteredWorks].sort((a, b) => compareWorks(a, b, sort));
 
 		// ページネーション適用
 		const startIndex = (page - 1) * limit;
 		const endIndex = startIndex + limit;
-		const paginatedWorks = filteredWorks.slice(startIndex, endIndex);
+		const paginatedWorks = sortedWorks.slice(startIndex, endIndex);
 
 		return {
 			works: paginatedWorks,
-			totalCount: convertedWorks.length,
+			totalCount: allWorks.length,
 			filteredCount,
 		};
 	} catch (_error) {

--- a/apps/web/src/app/circles/[circleId]/actions.ts
+++ b/apps/web/src/app/circles/[circleId]/actions.ts
@@ -27,7 +27,7 @@ export async function getCircleInfo(circleId: string): Promise<CirclePlainObject
 /**
  * サークル作品リストを取得（ConfigurableList用）
  *
- * ページ送り・ソート・検索は `loadCircleSource` が返す全作品に対する純粋な導出。
+ * ページ送り・ソート・検索は `loadCircleWorks` が返す全作品に対する純粋な導出。
  * Firestore へは行かない（キャッシュ境界の内側で 1 日 1 回）。
  * @param params パラメータ
  * @returns 作品一覧と総件数

--- a/apps/web/src/app/circles/[circleId]/circle-works-source.ts
+++ b/apps/web/src/app/circles/[circleId]/circle-works-source.ts
@@ -1,0 +1,66 @@
+import type {
+	CircleDocument,
+	CirclePlainObject,
+	WorkPlainObject,
+} from "@suzumina.click/shared-types";
+import { convertToCirclePlainObject } from "@suzumina.click/shared-types";
+import { cacheLife } from "next/cache";
+import { getFirestore } from "@/lib/firestore";
+import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
+import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
+
+/**
+ * サークルページの読み取り正本（SPR-311）。
+ *
+ * ページ送り・ソート・検索はいずれも作品本体のフィールド（releaseDateISO / price / rating /
+ * title / genres / 声優名）を見るため Firestore 側では絞り込めず、所属作品が全件要る。
+ * 素直に書くと「1 ページ表示するたびに所属作品を全件読む」になり、最大サークル（789作品）で
+ * 789 read / ページ表示だった。`use cache` をサークル単位に括り、ページ番号・ソート・検索語を
+ * **キャッシュキーに入れない**ことで、全ページ・全ソートが 1 日 1 回の取得を共有する。
+ *
+ * #917 が潰したのは「works コレクションの全件スキャン」であって、
+ * 「所属作品を全件引いて in-memory で slice する」構造はここまで残っていた。
+ *
+ * **ヘッダー情報と作品でキャッシュ境界を分けてある**。`loadCircleInfo` は OG 画像ルート
+ * （`opengraph-image.tsx`）が単独で呼ぶ経路で、そこは元から circles/{id} の 1 read で済む。
+ * 1 つの境界に畳むと OG 生成が所属作品まで引くことになり、クローラの OG 巡回で悪化する。
+ * creator 側を 1 つに畳んであるのは、あちらのヘッダー情報（types / workCount）が
+ * サブコレクション全件を必要とし、分けても安くならないため。
+ *
+ * 取得失敗は throw して伝播させる（キャッシュに載せない）。
+ * null は「そのサークルが存在しない」という、キャッシュしてよい結果だけに使う。
+ */
+export async function loadCircleInfo(circleId: string): Promise<CirclePlainObject | null> {
+	"use cache";
+	cacheLife("days");
+
+	const circleData = await fetchCircleDocument(circleId);
+	return circleData ? convertToCirclePlainObject(circleData) : null;
+}
+
+/**
+ * サークルの所属作品を全件取得する。存在しないサークルは null（空配列と区別する）。
+ */
+export async function loadCircleWorks(circleId: string): Promise<WorkPlainObject[] | null> {
+	"use cache";
+	cacheLife("days");
+
+	const circleData = await fetchCircleDocument(circleId);
+	if (!circleData) {
+		return null;
+	}
+
+	// サークル所属作品の正本は circles/{id}.workIds。
+	// 書き手は DLsite 取り込み（2h毎に arrayUnion・circle-firestore.ts）で、
+	// checkDataIntegrity（週次）が重複除去と欠落補填を事後修復する。
+	// 読み取り側はこの配列を引き当てるだけにし、所属条件を read 時に再計算しない。
+	const workIds = circleData.workIds ?? [];
+	const firestore = getFirestore();
+	return convertWorksToPlainObjects(await fetchWorksByIds(firestore, workIds));
+}
+
+async function fetchCircleDocument(circleId: string): Promise<CircleDocument | null> {
+	const firestore = getFirestore();
+	const circleDoc = await firestore.collection("circles").doc(circleId).get();
+	return circleDoc.exists ? (circleDoc.data() as CircleDocument) : null;
+}

--- a/apps/web/src/app/circles/[circleId]/circle-works-source.ts
+++ b/apps/web/src/app/circles/[circleId]/circle-works-source.ts
@@ -24,8 +24,9 @@ import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
  * **ヘッダー情報と作品でキャッシュ境界を分けてある**。`loadCircleInfo` は OG 画像ルート
  * （`opengraph-image.tsx`）が単独で呼ぶ経路で、そこは元から circles/{id} の 1 read で済む。
  * 1 つの境界に畳むと OG 生成が所属作品まで引くことになり、クローラの OG 巡回で悪化する。
- * creator 側を 1 つに畳んであるのは、あちらのヘッダー情報（types / workCount）が
- * サブコレクション全件を必要とし、分けても安くならないため。
+ * creator 側も同じ理由・同じ構造で `loadCreatorInfo` / `loadCreatorWorks` に分割済み（SPR-311）。
+ * 代償として、ページ表示（info と works の両方を使う経路）では circles/{id} を境界ごとに
+ * 1 回ずつ＝計 2 read 引く。分割で削れる量に対して無視できるので畳んでいない。
  *
  * 取得失敗は throw して伝播させる（キャッシュに載せない）。
  * null は「そのサークルが存在しない」という、キャッシュしてよい結果だけに使う。

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions-cache-safety.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions-cache-safety.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `getCreatorWorksList` がキャッシュ済みの配列を破壊しないことの回帰テスト（SPR-311）。
+ *
+ * `loadCreatorSource` の戻り値は `use cache` 越しに**複数リクエストで共有される**。
+ * `searchWorks` は検索語が無いと入力配列をそのまま返すため、その結果を `.sort()` すると
+ * 共有されている配列そのものを並べ替えてしまい、以降の全リクエストのページ送りが
+ * 直前の誰かのソート順に引きずられる。本番でしか起きず、再現条件も掴みにくい類の壊れ方。
+ *
+ * 実 Firestore 経路のテストでは `use cache` が no-op になり配列が毎回作り直されるため
+ * この不具合は再現しない。ここでは source をモックして不変条件だけを直接固定する。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
+vi.mock("@suzumina.click/shared-types", () => ({
+	isValidCreatorId: (id: string) => /^[A-Z]{2}\d{5,7}$/.test(id),
+}));
+
+const loadCreatorSource = vi.fn();
+vi.mock("../creator-works-source", () => ({
+	loadCreatorSource: (creatorId: string) => loadCreatorSource(creatorId),
+}));
+
+import { getCreatorWorksList } from "../actions";
+
+const work = (productId: string, releaseDateISO: string) =>
+	({ id: productId, productId, title: productId, releaseDateISO }) as never;
+
+describe("getCreatorWorksList のキャッシュ安全性", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("ソートしてもキャッシュ側の配列順を書き換えない", async () => {
+		const cached = [work("RJ111111", "2025-01-01"), work("RJ222222", "2025-06-01")];
+		const snapshot = [...cached];
+		loadCreatorSource.mockResolvedValue({
+			info: { id: "VA12345", name: "C", types: [], workCount: 2 },
+			works: cached,
+		});
+
+		const result = await getCreatorWorksList({ creatorId: "VA12345", sort: "newest" });
+
+		// 返り値は新しい順に並ぶが…
+		expect(result.works.map((w) => w.productId)).toEqual(["RJ222222", "RJ111111"]);
+		// …キャッシュ側は元の順のまま
+		expect(cached).toEqual(snapshot);
+	});
+
+	it("検索語ありでもキャッシュ側の配列順を書き換えない", async () => {
+		const cached = [work("RJ111111", "2025-01-01"), work("RJ222222", "2025-06-01")];
+		const snapshot = [...cached];
+		loadCreatorSource.mockResolvedValue({
+			info: { id: "VA12345", name: "C", types: [], workCount: 2 },
+			works: cached,
+		});
+
+		await getCreatorWorksList({ creatorId: "VA12345", sort: "newest", search: "RJ" });
+
+		expect(cached).toEqual(snapshot);
+	});
+
+	it("ページ送り・ソートの違いで Firestore を引き直さない", async () => {
+		loadCreatorSource.mockResolvedValue({
+			info: { id: "VA12345", name: "C", types: [], workCount: 1 },
+			works: [work("RJ111111", "2025-01-01")],
+		});
+
+		await getCreatorWorksList({ creatorId: "VA12345", page: 1 });
+		await getCreatorWorksList({ creatorId: "VA12345", page: 2, sort: "oldest" });
+
+		// ページ番号・ソート・検索語はキャッシュキーに入らない＝同じ引数で呼ばれる
+		expect(loadCreatorSource).toHaveBeenCalledTimes(2);
+		expect(loadCreatorSource).toHaveBeenNthCalledWith(1, "VA12345");
+		expect(loadCreatorSource).toHaveBeenNthCalledWith(2, "VA12345");
+	});
+});

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions-cache-safety.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions-cache-safety.test.ts
@@ -1,7 +1,7 @@
 /**
  * `getCreatorWorksList` がキャッシュ済みの配列を破壊しないことの回帰テスト（SPR-311）。
  *
- * `loadCreatorSource` の戻り値は `use cache` 越しに**複数リクエストで共有される**。
+ * `loadCreatorWorks` の戻り値は `use cache` 越しに**複数リクエストで共有される**。
  * `searchWorks` は検索語が無いと入力配列をそのまま返すため、その結果を `.sort()` すると
  * 共有されている配列そのものを並べ替えてしまい、以降の全リクエストのページ送りが
  * 直前の誰かのソート順に引きずられる。本番でしか起きず、再現条件も掴みにくい類の壊れ方。
@@ -18,9 +18,10 @@ vi.mock("@suzumina.click/shared-types", () => ({
 	isValidCreatorId: (id: string) => /^[A-Z]{2}\d{5,7}$/.test(id),
 }));
 
-const loadCreatorSource = vi.fn();
+const loadCreatorWorks = vi.fn();
 vi.mock("../creator-works-source", () => ({
-	loadCreatorSource: (creatorId: string) => loadCreatorSource(creatorId),
+	loadCreatorInfo: vi.fn(),
+	loadCreatorWorks: (creatorId: string) => loadCreatorWorks(creatorId),
 }));
 
 import { getCreatorWorksList } from "../actions";
@@ -36,10 +37,7 @@ describe("getCreatorWorksList のキャッシュ安全性", () => {
 	it("ソートしてもキャッシュ側の配列順を書き換えない", async () => {
 		const cached = [work("RJ111111", "2025-01-01"), work("RJ222222", "2025-06-01")];
 		const snapshot = [...cached];
-		loadCreatorSource.mockResolvedValue({
-			info: { id: "VA12345", name: "C", types: [], workCount: 2 },
-			works: cached,
-		});
+		loadCreatorWorks.mockResolvedValue(cached);
 
 		const result = await getCreatorWorksList({ creatorId: "VA12345", sort: "newest" });
 
@@ -52,28 +50,36 @@ describe("getCreatorWorksList のキャッシュ安全性", () => {
 	it("検索語ありでもキャッシュ側の配列順を書き換えない", async () => {
 		const cached = [work("RJ111111", "2025-01-01"), work("RJ222222", "2025-06-01")];
 		const snapshot = [...cached];
-		loadCreatorSource.mockResolvedValue({
-			info: { id: "VA12345", name: "C", types: [], workCount: 2 },
-			works: cached,
-		});
+		loadCreatorWorks.mockResolvedValue(cached);
 
 		await getCreatorWorksList({ creatorId: "VA12345", sort: "newest", search: "RJ" });
 
 		expect(cached).toEqual(snapshot);
 	});
 
-	it("ページ送り・ソートの違いで Firestore を引き直さない", async () => {
-		loadCreatorSource.mockResolvedValue({
-			info: { id: "VA12345", name: "C", types: [], workCount: 1 },
-			works: [work("RJ111111", "2025-01-01")],
+	it("存在しないクリエイター（null）と作品0件を区別して空結果を返す", async () => {
+		loadCreatorWorks.mockResolvedValue(null);
+		expect(await getCreatorWorksList({ creatorId: "VA99999" })).toEqual({
+			works: [],
+			totalCount: 0,
 		});
+
+		loadCreatorWorks.mockResolvedValue([]);
+		expect(await getCreatorWorksList({ creatorId: "VA12345" })).toEqual({
+			works: [],
+			totalCount: 0,
+		});
+	});
+
+	it("ページ送り・ソートの違いで Firestore を引き直さない", async () => {
+		loadCreatorWorks.mockResolvedValue([work("RJ111111", "2025-01-01")]);
 
 		await getCreatorWorksList({ creatorId: "VA12345", page: 1 });
 		await getCreatorWorksList({ creatorId: "VA12345", page: 2, sort: "oldest" });
 
 		// ページ番号・ソート・検索語はキャッシュキーに入らない＝同じ引数で呼ばれる
-		expect(loadCreatorSource).toHaveBeenCalledTimes(2);
-		expect(loadCreatorSource).toHaveBeenNthCalledWith(1, "VA12345");
-		expect(loadCreatorSource).toHaveBeenNthCalledWith(2, "VA12345");
+		expect(loadCreatorWorks).toHaveBeenCalledTimes(2);
+		expect(loadCreatorWorks).toHaveBeenNthCalledWith(1, "VA12345");
+		expect(loadCreatorWorks).toHaveBeenNthCalledWith(2, "VA12345");
 	});
 });

--- a/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/actions.test.ts
@@ -4,6 +4,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// vitest では "use cache" ディレクティブは no-op になり cacheLife が cache スコープ外呼び出しになるためモックする
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
 // workTransformers のモック
 vi.mock("@suzumina.click/shared-types", () => ({
 	// parseWorkDocument 用の pass-through（検証は素通し）
@@ -86,14 +89,16 @@ import { getCreatorInfo, getCreatorWorksList } from "../actions";
 describe("Creator page server actions", () => {
 	// テスト用のヘルパー関数
 	const setupCreatorMocks = (creatorData: any, worksSnapshot: any) => {
-		// mockDocの設定
+		// mockDocの設定。Firestore の QuerySnapshot は size === docs.length なので、
+		// 呼び出し側が size を読んでも実物と食い違わないよう補完する。
+		const snapshot = { size: worksSnapshot.docs?.length ?? 0, ...worksSnapshot };
 		mockDoc.mockReturnValue({
 			get: vi.fn().mockResolvedValue({
 				exists: true,
 				data: () => creatorData,
 				ref: {
 					collection: vi.fn().mockReturnValue({
-						get: vi.fn().mockResolvedValue(worksSnapshot),
+						get: vi.fn().mockResolvedValue(snapshot),
 					}),
 				},
 			}),

--- a/apps/web/src/app/creators/[creatorId]/__tests__/creator-works-source.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/creator-works-source.test.ts
@@ -1,0 +1,114 @@
+/**
+ * クリエイターページの読み取り正本（SPR-311）のテスト。
+ *
+ * ここで守りたいのは「何を返すか」より **Firestore を何回叩くか** と
+ * **失敗をキャッシュに載せないか**。どちらも壊れても表示は正しいままで、
+ * 課金と障害の持続時間だけが静かに悪化する。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vitest では "use cache" ディレクティブは no-op になり cacheLife が cache スコープ外呼び出しになるためモックする
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
+vi.mock("@suzumina.click/shared-types", () => ({
+	WorkDocumentSchema: { safeParse: (data: unknown) => ({ success: true, data }) },
+	workTransformers: {
+		fromFirestore: vi.fn((data: { id: string; productId: string }) => ({ ...data })),
+	},
+}));
+
+const worksSubcollectionGet = vi.fn();
+const creatorDocGet = vi.fn();
+const mockDoc = vi.fn(() => ({ get: creatorDocGet }));
+const mockGetAll = vi.fn();
+const mockCollection = vi.fn((name: string) => ({
+	doc: name === "works" ? vi.fn((id: string) => ({ id })) : mockDoc,
+}));
+
+vi.mock("@/lib/firestore", () => ({
+	getFirestore: () => ({ collection: mockCollection, getAll: mockGetAll }),
+}));
+
+import { loadCreatorSource } from "../creator-works-source";
+
+/** 関連付け 3 件・実在する works 3 件のクリエイターを組み立てる */
+function setupCreator(relationDocs: Array<{ id: string; roles?: string[] }>) {
+	worksSubcollectionGet.mockResolvedValue({
+		size: relationDocs.length,
+		docs: relationDocs.map((r) => ({ id: r.id, data: () => ({ roles: r.roles }) })),
+	});
+	creatorDocGet.mockResolvedValue({
+		exists: true,
+		data: () => ({ name: "テストクリエイター", primaryRole: "voiceActor" }),
+		ref: { collection: vi.fn(() => ({ get: worksSubcollectionGet })) },
+	});
+	mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
+		Promise.resolve(refs.map((ref) => ({ exists: true, id: ref.id, data: () => ({}) }))),
+	);
+}
+
+describe("loadCreatorSource", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("creator doc と works サブコレクションをそれぞれ 1 回だけ読む", async () => {
+		setupCreator([
+			{ id: "RJ111111", roles: ["voiceActor", "scenario"] },
+			{ id: "RJ222222", roles: ["illustration"] },
+		]);
+
+		await loadCreatorSource("VA12345");
+
+		// 旧実装は getCreatorInfo と fetchWorkIds が同じものを二重に引いており、
+		// 1 ページ表示あたり 3N + 2 read になっていた（SPR-311 の主因）。
+		expect(creatorDocGet).toHaveBeenCalledTimes(1);
+		expect(worksSubcollectionGet).toHaveBeenCalledTimes(1);
+	});
+
+	it("ヘッダー情報と作品を 1 回の取得から組み立てる", async () => {
+		setupCreator([
+			{ id: "RJ111111", roles: ["scenario"] },
+			{ id: "RJ222222", roles: ["illustration"] },
+		]);
+
+		const source = await loadCreatorSource("VA12345");
+
+		expect(source?.info).toEqual({
+			id: "VA12345",
+			name: "テストクリエイター",
+			// primaryRole は roles に含まれないので先頭に足される
+			types: ["voiceActor", "scenario", "illustration"],
+			workCount: 2,
+		});
+		expect(source?.works.map((w) => w.id)).toEqual(["RJ111111", "RJ222222"]);
+	});
+
+	it("workCount は関連付けの件数で、実在しない作品が欠けても減らない", async () => {
+		setupCreator([{ id: "RJ111111" }, { id: "RJ222222" }]);
+		mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
+			Promise.resolve(
+				refs.map((ref) => ({ exists: ref.id === "RJ111111", id: ref.id, data: () => ({}) })),
+			),
+		);
+
+		const source = await loadCreatorSource("VA12345");
+
+		// 欠けは整合性 cron の担当で、ヘッダーの総作品数は関連付け基準のまま（既存挙動）
+		expect(source?.info.workCount).toBe(2);
+		expect(source?.works).toHaveLength(1);
+	});
+
+	it("存在しないクリエイターは null を返す（キャッシュしてよい結果）", async () => {
+		creatorDocGet.mockResolvedValue({ exists: false });
+
+		await expect(loadCreatorSource("VA99999")).resolves.toBeNull();
+	});
+
+	it("取得失敗は throw する（null に畳むとエラーが 1 日キャッシュに居座る）", async () => {
+		creatorDocGet.mockRejectedValue(new Error("Firestore error"));
+
+		await expect(loadCreatorSource("VA12345")).rejects.toThrow("Firestore error");
+	});
+});

--- a/apps/web/src/app/creators/[creatorId]/__tests__/creator-works-source.test.ts
+++ b/apps/web/src/app/creators/[creatorId]/__tests__/creator-works-source.test.ts
@@ -30,17 +30,23 @@ vi.mock("@/lib/firestore", () => ({
 	getFirestore: () => ({ collection: mockCollection, getAll: mockGetAll }),
 }));
 
-import { loadCreatorSource } from "../creator-works-source";
+import { loadCreatorInfo, loadCreatorWorks } from "../creator-works-source";
 
-/** 関連付け 3 件・実在する works 3 件のクリエイターを組み立てる */
-function setupCreator(relationDocs: Array<{ id: string; roles?: string[] }>) {
+/**
+ * @param creatorData creators/{id} の中身。workCount/types を渡すと非正規化ありの経路になる
+ * @param relationDocs works サブコレクションの中身
+ */
+function setupCreator(
+	creatorData: Record<string, unknown>,
+	relationDocs: Array<{ id: string; roles?: string[] }>,
+) {
 	worksSubcollectionGet.mockResolvedValue({
 		size: relationDocs.length,
 		docs: relationDocs.map((r) => ({ id: r.id, data: () => ({ roles: r.roles }) })),
 	});
 	creatorDocGet.mockResolvedValue({
 		exists: true,
-		data: () => ({ name: "テストクリエイター", primaryRole: "voiceActor" }),
+		data: () => creatorData,
 		ref: { collection: vi.fn(() => ({ get: worksSubcollectionGet })) },
 	});
 	mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
@@ -48,67 +54,107 @@ function setupCreator(relationDocs: Array<{ id: string; roles?: string[] }>) {
 	);
 }
 
-describe("loadCreatorSource", () => {
+const RELATIONS = [
+	{ id: "RJ111111", roles: ["scenario"] },
+	{ id: "RJ222222", roles: ["illustration"] },
+];
+
+describe("loadCreatorInfo", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("creator doc と works サブコレクションをそれぞれ 1 回だけ読む", async () => {
-		setupCreator([
-			{ id: "RJ111111", roles: ["voiceActor", "scenario"] },
-			{ id: "RJ222222", roles: ["illustration"] },
-		]);
+	it("非正規化された workCount/types があればサブコレクションを読まない", async () => {
+		setupCreator(
+			{ name: "テストクリエイター", primaryRole: "voiceActor", workCount: 2, types: ["scenario"] },
+			RELATIONS,
+		);
 
-		await loadCreatorSource("VA12345");
+		const info = await loadCreatorInfo("VA12345");
 
-		// 旧実装は getCreatorInfo と fetchWorkIds が同じものを二重に引いており、
-		// 1 ページ表示あたり 3N + 2 read になっていた（SPR-311 の主因）。
+		// OG 画像ルートはこの経路しか通らない。ここでサブコレクションを読むと、
+		// 作品 2,178 件のクリエイターが OG 巡回のたびに数千 read を払う（SPR-311）。
 		expect(creatorDocGet).toHaveBeenCalledTimes(1);
-		expect(worksSubcollectionGet).toHaveBeenCalledTimes(1);
-	});
-
-	it("ヘッダー情報と作品を 1 回の取得から組み立てる", async () => {
-		setupCreator([
-			{ id: "RJ111111", roles: ["scenario"] },
-			{ id: "RJ222222", roles: ["illustration"] },
-		]);
-
-		const source = await loadCreatorSource("VA12345");
-
-		expect(source?.info).toEqual({
+		expect(worksSubcollectionGet).not.toHaveBeenCalled();
+		expect(info).toEqual({
 			id: "VA12345",
 			name: "テストクリエイター",
-			// primaryRole は roles に含まれないので先頭に足される
+			// primaryRole は types に含まれないので先頭に足される
+			types: ["voiceActor", "scenario"],
+			workCount: 2,
+		});
+	});
+
+	it("非正規化が無い旧データはサブコレクションから数え直す", async () => {
+		setupCreator({ name: "テストクリエイター", primaryRole: "voiceActor" }, RELATIONS);
+
+		const info = await loadCreatorInfo("VA12345");
+
+		expect(worksSubcollectionGet).toHaveBeenCalledTimes(1);
+		expect(info).toEqual({
+			id: "VA12345",
+			name: "テストクリエイター",
 			types: ["voiceActor", "scenario", "illustration"],
 			workCount: 2,
 		});
-		expect(source?.works.map((w) => w.id)).toEqual(["RJ111111", "RJ222222"]);
 	});
 
-	it("workCount は関連付けの件数で、実在しない作品が欠けても減らない", async () => {
-		setupCreator([{ id: "RJ111111" }, { id: "RJ222222" }]);
+	it("workCount だけ・types だけの半端な非正規化は fallback 扱いにする", async () => {
+		setupCreator({ name: "C", workCount: 2 }, RELATIONS);
+		await loadCreatorInfo("VA12345");
+		expect(worksSubcollectionGet).toHaveBeenCalledTimes(1);
+	});
+
+	it("存在しないクリエイターは null を返す（キャッシュしてよい結果）", async () => {
+		creatorDocGet.mockResolvedValue({ exists: false });
+
+		await expect(loadCreatorInfo("VA99999")).resolves.toBeNull();
+	});
+
+	it("取得失敗は throw する（null に畳むとエラーが 1 日キャッシュに居座る）", async () => {
+		creatorDocGet.mockRejectedValue(new Error("Firestore error"));
+
+		await expect(loadCreatorInfo("VA12345")).rejects.toThrow("Firestore error");
+	});
+});
+
+describe("loadCreatorWorks", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("サブコレクションを 1 回だけ読んで作品本体を引く", async () => {
+		setupCreator({ name: "C", workCount: 2, types: ["scenario"] }, RELATIONS);
+
+		const works = await loadCreatorWorks("VA12345");
+
+		// 旧実装は getCreatorInfo と fetchWorkIds が同じものを二重に引いており、
+		// 1 ページ表示あたり 3N + 2 read になっていた（SPR-311 の主因）。
+		expect(worksSubcollectionGet).toHaveBeenCalledTimes(1);
+		expect(works?.map((w) => w.id)).toEqual(["RJ111111", "RJ222222"]);
+	});
+
+	it("実在しない作品は黙って除外する（workCount とは一致しなくてよい）", async () => {
+		setupCreator({ name: "C" }, RELATIONS);
 		mockGetAll.mockImplementation((...refs: Array<{ id: string }>) =>
 			Promise.resolve(
 				refs.map((ref) => ({ exists: ref.id === "RJ111111", id: ref.id, data: () => ({}) })),
 			),
 		);
 
-		const source = await loadCreatorSource("VA12345");
-
-		// 欠けは整合性 cron の担当で、ヘッダーの総作品数は関連付け基準のまま（既存挙動）
-		expect(source?.info.workCount).toBe(2);
-		expect(source?.works).toHaveLength(1);
+		// 欠けは整合性 cron の担当。ヘッダーの総作品数（workCount）は関連付け基準のまま
+		await expect(loadCreatorWorks("VA12345")).resolves.toHaveLength(1);
 	});
 
-	it("存在しないクリエイターは null を返す（キャッシュしてよい結果）", async () => {
+	it("存在しないクリエイターは null を返す（作品0件と区別する）", async () => {
 		creatorDocGet.mockResolvedValue({ exists: false });
 
-		await expect(loadCreatorSource("VA99999")).resolves.toBeNull();
+		await expect(loadCreatorWorks("VA99999")).resolves.toBeNull();
 	});
 
-	it("取得失敗は throw する（null に畳むとエラーが 1 日キャッシュに居座る）", async () => {
+	it("取得失敗は throw する", async () => {
 		creatorDocGet.mockRejectedValue(new Error("Firestore error"));
 
-		await expect(loadCreatorSource("VA12345")).rejects.toThrow("Firestore error");
+		await expect(loadCreatorWorks("VA12345")).rejects.toThrow("Firestore error");
 	});
 });

--- a/apps/web/src/app/creators/[creatorId]/actions.ts
+++ b/apps/web/src/app/creators/[creatorId]/actions.ts
@@ -3,7 +3,7 @@
 import type { CreatorPageInfo, WorkPlainObject } from "@suzumina.click/shared-types";
 import { isValidCreatorId } from "@suzumina.click/shared-types";
 import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
-import { loadCreatorSource } from "./creator-works-source";
+import { loadCreatorInfo, loadCreatorWorks } from "./creator-works-source";
 
 /**
  * クリエイター情報を取得
@@ -17,8 +17,7 @@ export async function getCreatorInfo(creatorId: string): Promise<CreatorPageInfo
 	}
 
 	try {
-		const source = await loadCreatorSource(creatorId);
-		return source?.info ?? null;
+		return await loadCreatorInfo(creatorId);
 	} catch (_error) {
 		// エラー発生時はnullを返す
 		return null;
@@ -28,7 +27,7 @@ export async function getCreatorInfo(creatorId: string): Promise<CreatorPageInfo
 /**
  * クリエイター作品リストを取得（ConfigurableList用）
  *
- * ページ送り・ソート・検索は `loadCreatorSource` が返す全作品に対する純粋な導出。
+ * ページ送り・ソート・検索は `loadCreatorWorks` が返す全作品に対する純粋な導出。
  * Firestore へは行かない（キャッシュ境界の内側で 1 日 1 回）。
  * @param params パラメータ
  * @returns 作品一覧と総件数
@@ -48,13 +47,13 @@ export async function getCreatorWorksList(params: {
 	}
 
 	try {
-		const source = await loadCreatorSource(creatorId);
-		if (!source) {
+		const allWorks = await loadCreatorWorks(creatorId);
+		if (!allWorks) {
 			return { works: [], totalCount: 0 };
 		}
 
 		// 検索フィルター適用
-		const { filtered: filteredWorks, count: filteredCount } = searchWorks(source.works, search);
+		const { filtered: filteredWorks, count: filteredCount } = searchWorks(allWorks, search);
 
 		// ソート処理。`searchWorks` は検索語が無いと入力配列をそのまま返すため、
 		// ここで複製しないと **キャッシュ済みの配列を破壊的に並べ替える**（以降の全リクエストに漏れる）。
@@ -65,7 +64,7 @@ export async function getCreatorWorksList(params: {
 		const endIndex = startIndex + limit;
 		const paginatedWorks = sortedWorks.slice(startIndex, endIndex);
 
-		return { works: paginatedWorks, totalCount: source.works.length, filteredCount };
+		return { works: paginatedWorks, totalCount: allWorks.length, filteredCount };
 	} catch (_error) {
 		// エラー発生時は空配列を返す
 		return { works: [], totalCount: 0 };

--- a/apps/web/src/app/creators/[creatorId]/actions.ts
+++ b/apps/web/src/app/creators/[creatorId]/actions.ts
@@ -1,16 +1,9 @@
 "use server";
 
-import type {
-	CreatorDocument,
-	CreatorPageInfo,
-	CreatorWorkRelation,
-	WorkPlainObject,
-} from "@suzumina.click/shared-types";
+import type { CreatorPageInfo, WorkPlainObject } from "@suzumina.click/shared-types";
 import { isValidCreatorId } from "@suzumina.click/shared-types";
 import { compareWorks, searchWorks } from "@/lib/circle-creator-works";
-import { getFirestore } from "@/lib/firestore";
-import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
-import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
+import { loadCreatorSource } from "./creator-works-source";
 
 /**
  * クリエイター情報を取得
@@ -24,41 +17,8 @@ export async function getCreatorInfo(creatorId: string): Promise<CreatorPageInfo
 	}
 
 	try {
-		// 新しいcreatorsコレクションから情報を取得
-		const firestore = getFirestore();
-		const creatorDoc = await firestore.collection("creators").doc(creatorId).get();
-
-		if (!creatorDoc.exists) {
-			return null;
-		}
-
-		const creatorData = creatorDoc.data() as CreatorDocument;
-
-		// worksサブコレクションから作品数と役割を取得
-		const worksSnapshot = await creatorDoc.ref.collection("works").get();
-
-		const allTypes = new Set<string>();
-		worksSnapshot.docs.forEach((doc) => {
-			const workRelation = doc.data() as CreatorWorkRelation;
-			workRelation.roles?.forEach((role) => {
-				allTypes.add(role);
-			});
-		});
-
-		// クリエイター情報の集約
-		const creatorInfo: CreatorPageInfo = {
-			id: creatorId,
-			name: creatorData.name,
-			types: Array.from(allTypes),
-			workCount: worksSnapshot.size,
-		};
-
-		// primaryRoleが設定されていて、typesに含まれていない場合は追加
-		if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
-			creatorInfo.types.unshift(creatorData.primaryRole);
-		}
-
-		return creatorInfo;
+		const source = await loadCreatorSource(creatorId);
+		return source?.info ?? null;
 	} catch (_error) {
 		// エラー発生時はnullを返す
 		return null;
@@ -66,29 +26,10 @@ export async function getCreatorInfo(creatorId: string): Promise<CreatorPageInfo
 }
 
 /**
- * 作品IDを取得
- */
-async function fetchWorkIds(
-	firestore: FirebaseFirestore.Firestore,
-	creatorId: string,
-): Promise<string[] | null> {
-	const creatorDoc = await firestore.collection("creators").doc(creatorId).get();
-
-	if (!creatorDoc.exists) {
-		return null;
-	}
-
-	const worksSnapshot = await creatorDoc.ref.collection("works").get();
-
-	if (worksSnapshot.empty) {
-		return [];
-	}
-
-	return worksSnapshot.docs.map((doc) => doc.id);
-}
-
-/**
  * クリエイター作品リストを取得（ConfigurableList用）
+ *
+ * ページ送り・ソート・検索は `loadCreatorSource` が返す全作品に対する純粋な導出。
+ * Firestore へは行かない（キャッシュ境界の内側で 1 日 1 回）。
  * @param params パラメータ
  * @returns 作品一覧と総件数
  */
@@ -107,35 +48,24 @@ export async function getCreatorWorksList(params: {
 	}
 
 	try {
-		const firestore = getFirestore();
-
-		// 作品IDを取得
-		const workIds = await fetchWorkIds(firestore, creatorId);
-		if (workIds === null) {
+		const source = await loadCreatorSource(creatorId);
+		if (!source) {
 			return { works: [], totalCount: 0 };
 		}
-		if (workIds.length === 0) {
-			return { works: [], totalCount: 0 };
-		}
-
-		// 作品詳細を取得
-		const allWorks = await fetchWorksByIds(firestore, workIds);
-
-		// WorkPlainObjectに変換
-		const convertedWorks = convertWorksToPlainObjects(allWorks);
 
 		// 検索フィルター適用
-		const { filtered: filteredWorks, count: filteredCount } = searchWorks(convertedWorks, search);
+		const { filtered: filteredWorks, count: filteredCount } = searchWorks(source.works, search);
 
-		// ソート処理
-		filteredWorks.sort((a, b) => compareWorks(a, b, sort));
+		// ソート処理。`searchWorks` は検索語が無いと入力配列をそのまま返すため、
+		// ここで複製しないと **キャッシュ済みの配列を破壊的に並べ替える**（以降の全リクエストに漏れる）。
+		const sortedWorks = [...filteredWorks].sort((a, b) => compareWorks(a, b, sort));
 
 		// ページネーション適用
 		const startIndex = (page - 1) * limit;
 		const endIndex = startIndex + limit;
-		const paginatedWorks = filteredWorks.slice(startIndex, endIndex);
+		const paginatedWorks = sortedWorks.slice(startIndex, endIndex);
 
-		return { works: paginatedWorks, totalCount: convertedWorks.length, filteredCount };
+		return { works: paginatedWorks, totalCount: source.works.length, filteredCount };
 	} catch (_error) {
 		// エラー発生時は空配列を返す
 		return { works: [], totalCount: 0 };

--- a/apps/web/src/app/creators/[creatorId]/creator-works-source.ts
+++ b/apps/web/src/app/creators/[creatorId]/creator-works-source.ts
@@ -1,0 +1,82 @@
+import type {
+	CreatorDocument,
+	CreatorPageInfo,
+	CreatorWorkRelation,
+	WorkPlainObject,
+} from "@suzumina.click/shared-types";
+import { cacheLife } from "next/cache";
+import { getFirestore } from "@/lib/firestore";
+import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
+import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
+
+/**
+ * クリエイターページの読み取り正本。ヘッダー情報と参加作品を **1 回の取得に畳む**（SPR-311）。
+ *
+ * ページ送り・ソート・検索はいずれも作品本体のフィールド（releaseDateISO / price / rating /
+ * title / genres / 声優名）を見るため、Firestore 側では絞り込めず全作品が要る。
+ * 素直に書くと「1 ページ表示するたびに全作品を読む」になり、`creators/{id}/works` を
+ * ヘッダー用と一覧用で二重に引いていたこともあって **3N + 2 read / ページ表示** だった。
+ * 作品 2,178 件のクリエイターで 1 ページ 6,536 read・全 182 ページ巡回で約 119 万 read に達し、
+ * これ単独で月額予算を使い切っていた。
+ *
+ * 対策は 2 つ:
+ * 1. サブコレクションの二重取得をやめて 1 回に畳む（3N + 2 → 2N + 1）
+ * 2. `use cache` でクリエイター単位に括る。ページ番号・ソート・検索語は**キャッシュキーに入れない**ので、
+ *    同じクリエイターの全ページ・全ソートが 1 日 1 回の取得を共有する
+ *
+ * `cacheLife("days")` は works 詳細の関連作品・価格推移（SPR-302）と揃えた。
+ * 元データの更新は DLsite 取り込みパイプライン側で、一覧の鮮度は日次で足りる。
+ *
+ * 取得失敗は **throw して伝播させる**（キャッシュに載せない）。null を返すとエラーが 1 日居座る。
+ * null は「そのクリエイターが存在しない」という、キャッシュしてよい結果だけに使う。
+ */
+export interface CreatorSource {
+	info: CreatorPageInfo;
+	/** 実在する参加作品のみ（サブコレクションの関連付けに対して欠けがありうる） */
+	works: WorkPlainObject[];
+}
+
+export async function loadCreatorSource(creatorId: string): Promise<CreatorSource | null> {
+	"use cache";
+	cacheLife("days");
+
+	const firestore = getFirestore();
+	const creatorDoc = await firestore.collection("creators").doc(creatorId).get();
+
+	if (!creatorDoc.exists) {
+		return null;
+	}
+
+	const creatorData = creatorDoc.data() as CreatorDocument;
+	const worksSnapshot = await creatorDoc.ref.collection("works").get();
+
+	const types = new Set<string>();
+	for (const doc of worksSnapshot.docs) {
+		const relation = doc.data() as CreatorWorkRelation;
+		for (const role of relation.roles ?? []) {
+			types.add(role);
+		}
+	}
+
+	const info: CreatorPageInfo = {
+		id: creatorId,
+		name: creatorData.name,
+		types: Array.from(types),
+		// 関連付けの件数。実在する作品数（works.length）とは意図的に別物で、
+		// ヘッダーの「総作品数」は元から関連付け基準（欠けは整合性 cron の担当）。
+		workCount: worksSnapshot.size,
+	};
+
+	if (creatorData.primaryRole && !types.has(creatorData.primaryRole)) {
+		info.types.unshift(creatorData.primaryRole);
+	}
+
+	const works = convertWorksToPlainObjects(
+		await fetchWorksByIds(
+			firestore,
+			worksSnapshot.docs.map((doc) => doc.id),
+		),
+	);
+
+	return { info, works };
+}

--- a/apps/web/src/app/creators/[creatorId]/creator-works-source.ts
+++ b/apps/web/src/app/creators/[creatorId]/creator-works-source.ts
@@ -10,73 +10,111 @@ import { fetchWorksByIds } from "../../works/utils/fetch-works-by-ids";
 import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
 
 /**
- * クリエイターページの読み取り正本。ヘッダー情報と参加作品を **1 回の取得に畳む**（SPR-311）。
+ * クリエイターページの読み取り正本（SPR-311）。
  *
  * ページ送り・ソート・検索はいずれも作品本体のフィールド（releaseDateISO / price / rating /
- * title / genres / 声優名）を見るため、Firestore 側では絞り込めず全作品が要る。
+ * title / genres / 声優名）を見るため Firestore 側では絞り込めず、全作品が要る。
  * 素直に書くと「1 ページ表示するたびに全作品を読む」になり、`creators/{id}/works` を
  * ヘッダー用と一覧用で二重に引いていたこともあって **3N + 2 read / ページ表示** だった。
  * 作品 2,178 件のクリエイターで 1 ページ 6,536 read・全 182 ページ巡回で約 119 万 read に達し、
  * これ単独で月額予算を使い切っていた。
  *
- * 対策は 2 つ:
- * 1. サブコレクションの二重取得をやめて 1 回に畳む（3N + 2 → 2N + 1）
- * 2. `use cache` でクリエイター単位に括る。ページ番号・ソート・検索語は**キャッシュキーに入れない**ので、
- *    同じクリエイターの全ページ・全ソートが 1 日 1 回の取得を共有する
+ * `use cache` をクリエイター単位に括り、ページ番号・ソート・検索語を**キャッシュキーに入れない**
+ * ことで、全ページ・全ソートが取得を共有する。`cacheLife("days")` は works 詳細の
+ * 関連作品・価格推移（SPR-302）と揃えた。元データの更新は DLsite 取り込みパイプライン側で、
+ * 一覧の鮮度は日次で足りる。
  *
- * `cacheLife("days")` は works 詳細の関連作品・価格推移（SPR-302）と揃えた。
- * 元データの更新は DLsite 取り込みパイプライン側で、一覧の鮮度は日次で足りる。
+ * **ヘッダー情報と作品でキャッシュ境界を分けてある**（circle 側と同じ構造）。
+ * `getCreatorInfo` は OG 画像ルート（`opengraph-image.tsx`）が単独で呼ぶ経路で、そこは
+ * name / types / workCount しか使わない。1 つの境界に畳むと OG 生成が全作品まで引くことになり、
+ * クローラの OG 巡回で `28165` のような大口が数千 read を払い続ける。
  *
  * 取得失敗は **throw して伝播させる**（キャッシュに載せない）。null を返すとエラーが 1 日居座る。
  * null は「そのクリエイターが存在しない」という、キャッシュしてよい結果だけに使う。
  */
-export interface CreatorSource {
-	info: CreatorPageInfo;
-	/** 実在する参加作品のみ（サブコレクションの関連付けに対して欠けがありうる） */
-	works: WorkPlainObject[];
-}
-
-export async function loadCreatorSource(creatorId: string): Promise<CreatorSource | null> {
+export async function loadCreatorInfo(creatorId: string): Promise<CreatorPageInfo | null> {
 	"use cache";
 	cacheLife("days");
 
-	const firestore = getFirestore();
-	const creatorDoc = await firestore.collection("creators").doc(creatorId).get();
+	const creator = await fetchCreatorDocument(creatorId);
+	if (!creator) {
+		return null;
+	}
+	const { data, ref } = creator;
 
-	if (!creatorDoc.exists) {
+	// SPR-74 Phase B の非正規化フィールドがあればサブコレクションを読まない（1 read で済む）。
+	// 判定は `/creators` 一覧（`creators/actions.ts`）と同じにしてある。本番実測で 1,193 件中
+	// 1,177 件（98.7%）が該当し、欠損 16 件はいずれも作品 100 件未満＝fallback でも安い。
+	// なお一覧は元からこの非正規化値を使っており、詳細だけがサブコレクションを数え直していたため、
+	// 同期が 1 件遅れている 29 件で一覧と詳細の「参加作品数」が食い違っていた。ここを揃えると解消する。
+	if (typeof data.workCount === "number" && Array.isArray(data.types)) {
+		return buildCreatorInfo(creatorId, data, new Set<string>(data.types), data.workCount);
+	}
+
+	const worksSnapshot = await ref.collection("works").get();
+	return buildCreatorInfo(creatorId, data, collectRoles(worksSnapshot.docs), worksSnapshot.size);
+}
+
+/**
+ * クリエイターの参加作品を全件取得する。存在しないクリエイターは null（空配列と区別する）。
+ */
+export async function loadCreatorWorks(creatorId: string): Promise<WorkPlainObject[] | null> {
+	"use cache";
+	cacheLife("days");
+
+	const creator = await fetchCreatorDocument(creatorId);
+	if (!creator) {
 		return null;
 	}
 
-	const creatorData = creatorDoc.data() as CreatorDocument;
-	const worksSnapshot = await creatorDoc.ref.collection("works").get();
-
-	const types = new Set<string>();
-	for (const doc of worksSnapshot.docs) {
-		const relation = doc.data() as CreatorWorkRelation;
-		for (const role of relation.roles ?? []) {
-			types.add(role);
-		}
-	}
-
-	const info: CreatorPageInfo = {
-		id: creatorId,
-		name: creatorData.name,
-		types: Array.from(types),
-		// 関連付けの件数。実在する作品数（works.length）とは意図的に別物で、
-		// ヘッダーの「総作品数」は元から関連付け基準（欠けは整合性 cron の担当）。
-		workCount: worksSnapshot.size,
-	};
-
-	if (creatorData.primaryRole && !types.has(creatorData.primaryRole)) {
-		info.types.unshift(creatorData.primaryRole);
-	}
-
-	const works = convertWorksToPlainObjects(
+	const worksSnapshot = await creator.ref.collection("works").get();
+	const firestore = getFirestore();
+	return convertWorksToPlainObjects(
 		await fetchWorksByIds(
 			firestore,
 			worksSnapshot.docs.map((doc) => doc.id),
 		),
 	);
+}
 
-	return { info, works };
+async function fetchCreatorDocument(creatorId: string) {
+	const firestore = getFirestore();
+	const creatorDoc = await firestore.collection("creators").doc(creatorId).get();
+	if (!creatorDoc.exists) {
+		return null;
+	}
+	return { data: creatorDoc.data() as CreatorDocument, ref: creatorDoc.ref };
+}
+
+function collectRoles(docs: FirebaseFirestore.QueryDocumentSnapshot[]): Set<string> {
+	const roles = new Set<string>();
+	for (const doc of docs) {
+		const relation = doc.data() as CreatorWorkRelation;
+		for (const role of relation.roles ?? []) {
+			roles.add(role);
+		}
+	}
+	return roles;
+}
+
+function buildCreatorInfo(
+	creatorId: string,
+	data: CreatorDocument,
+	types: Set<string>,
+	// 関連付けの件数。実在する作品数（loadCreatorWorks の length）とは意図的に別物で、
+	// ヘッダーの「総作品数」は元から関連付け基準（欠けは整合性 cron の担当）。
+	workCount: number,
+): CreatorPageInfo {
+	const info: CreatorPageInfo = {
+		id: creatorId,
+		name: data.name,
+		types: Array.from(types),
+		workCount,
+	};
+
+	if (data.primaryRole && !types.has(data.primaryRole)) {
+		info.types.unshift(data.primaryRole);
+	}
+
+	return info;
 }

--- a/apps/web/src/app/creators/[creatorId]/creator-works-source.ts
+++ b/apps/web/src/app/creators/[creatorId]/creator-works-source.ts
@@ -28,6 +28,8 @@ import { convertWorksToPlainObjects } from "../../works/utils/work-converters";
  * `getCreatorInfo` は OG 画像ルート（`opengraph-image.tsx`）が単独で呼ぶ経路で、そこは
  * name / types / workCount しか使わない。1 つの境界に畳むと OG 生成が全作品まで引くことになり、
  * クローラの OG 巡回で `28165` のような大口が数千 read を払い続ける。
+ * 代償として、ページ表示（info と works の両方を使う経路）では creators/{id} を境界ごとに
+ * 1 回ずつ＝計 2 read 引く。分割で削れる量に対して無視できるので畳んでいない。
  *
  * 取得失敗は **throw して伝播させる**（キャッシュに載せない）。null を返すとエラーが 1 日居座る。
  * null は「そのクリエイターが存在しない」という、キャッシュしてよい結果だけに使う。


### PR DESCRIPTION
Linear: [SPR-311](https://linear.app/nothink/issue/SPR-311/予算100percent到達2026-08-18-firestore-reads-が単独で予算を使い切っている)

8/18 に GCP 予算 100% 到達のメールが届いた件の対応。**8/1-8/18 の Firestore reads は 51,453,279 回（無料枠控除後 50,553,279 回・¥3,145）で、read 単独で月額予算 ¥3,000 を超えていた**（単価は Billing Catalog の `Cloud Firestore Read Ops Tokyo` = ¥0.00006222/read。BigQuery 課金エクスポートが無いため Monitoring の実測 usage と突き合わせて算出）。

## 原因

`/creators/[creatorId]` が **ページ番号に関係なく全作品を読んでいた**。一覧のソート・検索・ページ送りはいずれも作品本体のフィールド（releaseDateISO / price / rating / title / genres / 声優名）を見るため Firestore 側では絞り込めない。加えて `creators/{id}/works` サブコレクションを `getCreatorInfo` と `fetchWorkIds` で二重に引いており **3N + 2 read / ページ表示** だった。

Firestore の count 集計で全 1,193 creators を走査した実測:

| creator | 作品数 | 1ページ表示 | 全ページ巡回(limit=12) |
|---|---|---|---|
| `28165` | 2,178 | **6,536 read** | 182p → 1,189,552 read |
| `17385` | 236 | 710 | 20p → 14,200 |
| 中央値 | 2 | 8 | — |

8/17 は `28165` だけで 989 リクエスト × 6,536 = **6,464,104 read＝その日の 88%**。

引き金は 8/14 の #926 / #928（SPR-308）で深いページ送りが実 URL 化され到達深度が O(log n) になったこと。**Cloud Run のリクエスト数は増えていない**（8/12 15,350 → 8/17 9,973）。増えたのは 1 リクエストあたりの read（約 100 → 約 400）で、トラフィック増ではなくコード起因。

`/circles/[circleId]` も同型。#917 が潰したのは「works コレクションの全件スキャン」であって、「所属作品を全件引いて in-memory で slice する」構造は残っていた（最大サークル 798 作品）。

## 方針

ページングを Firestore に降ろすには関連付け側にソートキーを非正規化する必要があり、整合性 cron の負債を増やす One-Way Door なので取らなかった。

代わりに **`use cache` の境界をエンティティ単位に置き、ページ番号・ソート・検索語をキャッシュキーに入れない**。同じクリエイター／サークルの全ページ・全ソートが取得を共有する。`cacheLife("days")` は works 詳細の関連作品・価格推移（SPR-302）と揃えた。

creator / circle とも **ヘッダー情報（info）と作品（works）で境界を 2 つに分けてある**。`getCreatorInfo` / `getCircleInfo` は OG 画像ルート（`opengraph-image.tsx`）が単独で呼ぶ経路で、name / types / workCount しか使わない。1 つに畳むと OG 生成が全作品まで引くことになり、クローラの OG 巡回で大口が数千 read を払い続ける。

| | 変更前 | ミス時 | ヒット時 |
|---|---|---|---|
| `/creators/[id]` ページ表示 | 3N + 2 | 2N + 2 | 0 |
| `/creators/[id]` info のみ（OG） | 2N + 1 | **1** | 0 |
| `/circles/[id]` ページ表示 | N + 2 | N + 2 | 0 |
| `/circles/[id]` info のみ（OG） | 1 | 1 | 0 |

creator の info が 1 read で済むのは、`CreatorDocument` に SPR-74 Phase B の非正規化フィールド `workCount` / `types` があるため（`/creators` 一覧が既に使っている判定に揃えた）。本番実測で 1,193 件中 **1,177 件（98.7%）**が該当し、欠損 16 件はいずれも作品 100 件未満＝fallback でも安い（作品 100 件以上の欠損は 0 件）。read 急増の主犯 `28165` は非正規化ありなので、OG 巡回が **4,357 read → 1 read** になる。

副次的に既存の不整合も消える。一覧は元から非正規化値を使い、詳細だけがサブコレクションを数え直していたため、同期が 1 件遅れている 29 件で一覧と詳細の「参加作品数」が食い違っていた（例: `17386` は denorm=34 / 実際=35）。

## 埋めた地雷

`searchWorks` は検索語が無いと**入力配列をそのまま返す**。その結果を `.sort()` すると、`use cache` 越しに共有されている配列そのものを並べ替えてしまい、以降の全リクエストのページ送りが直前の誰かのソート順に引きずられる。本番でしか起きず再現条件も掴みにくい類なので、`[...filtered].sort()` に直したうえで回帰テストを置いた（in-place に戻すと落ちることを確認済み）。

取得失敗は throw して伝播させる。null に畳むとエラーがキャッシュに 1 日居座るため、null は「エンティティが存在しない」というキャッシュしてよい結果だけに使う。

## 効果の見積もり（実測ベース）

推計モデル（creator = 3N+2 / circle = N+2）は 8/17 の実測 read を 98% 再現した。8/12 との突き合わせで約 10% の過大評価が判明したので補正済み。

| | 8/12（平常日） | 8/17（スパイク日） |
|---|---|---|
| 実測 reads | 1,140,000 | 7,315,613 |
| creators+circles 起因 | 254,530 (22%) | 約 6,430,000 (88%) |
| それ以外の定常分 | 約 885,000 | 約 885,000 |
| **修正後の creators+circles** | **75,361** | **457,025** |

**月額 ¥5,200〜7,100 → ¥1,700〜2,400 の見込み。**

`next.config.mjs` にカスタム `cacheHandler` は無く `use cache` はインスタンスローカルなので、削減率はインスタンス世代数に依存する（8/17 は 1 日 58 世代・8/12 は 11 世代。`max_instances=2` なので同時数ではなく再生成の回数）。世代数 11 なら 98.2%、58 なら 93.6% 削減。ただし 8/17 に世代数が膨らんだのは 1 リクエストが数千 read を叩いて応答が遅くスケールアウトを繰り返したためで、修正後は世代数自体が減ってキャッシュ局所性が上がる方向に働く。

副次的にメモリも下がるはず。修正前は同時リクエストが**それぞれ**全作品を実体化していた（`concurrency=50`・作品 1 件約 8KB なので `28165` で 1 リクエスト 17MB 超）が、修正後は 1 世代につき 1 部を共有する。

## テスト

- `creator-works-source.test.ts`（新規）— creator doc とサブコレクションを**それぞれ 1 回だけ**読む／workCount は関連付け基準のまま／存在しない creator は null／**取得失敗は throw**
- `actions-cache-safety.test.ts`（creators / circles 各新規）— ソートがキャッシュ側配列を破壊しない／ページ送り・ソートの違いで引き直さない
- 既存テストに `next/cache` のモックを追加（vitest では `use cache` が no-op になり `cacheLife` がスコープ外呼び出しになる。リポジトリの既存パターンに合わせた）

`pnpm verify` 通過、`pnpm --filter web build` 通過。ローカル（emulator + 手動投入した creator 100作品 / circle 100作品）でページ送り・ソート・検索の描画を確認済み。

**read 削減の実測はデプロイ後**。emulator は per-read のログを持たず、`NODE_ENV=production` + `FIRESTORE_EMULATOR_HOST` は安全弁で接続拒否されるためローカルでは測れない。本番 Monitoring で #917 と同じ制御実験（相異なる N ページを叩いて 5 分バケットの増分を見る）で確認する。

## このPRに入れていないもの

- 約 885,000 read/日の定常分。web のリクエスト構成では説明できず、Cloud Functions が日によらず一定（12回/日 + 120回/日）なことから取り込みパイプライン側と見ている。**修正後は残額の約 7 割がこれになる**ので別途調査が要る
- `/works` の `.limit(startOffset).get()` オフセット走査（page=N が (N-1)×12 read）
- クローラ抑制の是非・予算の見直し・Firestore read の監視アラート（`docs/operations/monitoring.md:194` の `Monthly budget: $150` が実際の ¥3,000 と乖離している件を含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

