### PR TITLE
perf(web): creator/circle 一覧のキャッシュ境界から params を外し、Firestore read アラートを追加する (SPR-311)

### DIFF
--- a/apps/web/src/app/circles/__tests__/actions.test.ts
+++ b/apps/web/src/app/circles/__tests__/actions.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `/circles` 一覧の絞り込み・並べ替え・ページ送り（SPR-311）。
+ * 守りたい不変条件は creator 側の同名テストと同じ。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
+const loadAllCircles = vi.fn();
+vi.mock("../circles-source", () => ({
+	loadAllCircles: () => loadAllCircles(),
+}));
+
+import { getCircles } from "../actions";
+
+const circle = (circleId: string, name: string, workCount: number, nameEn?: string) =>
+	({ circleId, name, nameEn, workCount }) as never;
+
+const SAMPLE = [
+	circle("RG1", "あさひ堂", 5, "Asahido"),
+	circle("RG2", "いろは社", 20),
+	circle("RG3", "うみ工房", 1),
+];
+
+describe("getCircles", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		loadAllCircles.mockResolvedValue(SAMPLE);
+	});
+
+	it("キャッシュ境界は引数を取らない（params の組み合わせでエントリが増えない）", async () => {
+		await getCircles({ page: 1, sort: "name" });
+		await getCircles({ page: 5, sort: "workCount", search: "あ", limit: 48 });
+
+		expect(loadAllCircles).toHaveBeenCalledTimes(2);
+		for (const call of loadAllCircles.mock.calls) {
+			expect(call).toEqual([]);
+		}
+	});
+
+	it("並べ替えてもキャッシュ側の配列順を書き換えない", async () => {
+		const snapshot = [...SAMPLE];
+
+		const result = await getCircles({ sort: "workCount" });
+
+		expect(result.circles.map((c) => c.circleId)).toEqual(["RG2", "RG1", "RG3"]);
+		expect(SAMPLE).toEqual(snapshot);
+	});
+
+	it("英語名でも検索できる", async () => {
+		const result = await getCircles({ search: "asahi" });
+		expect(result.circles.map((c) => c.circleId)).toEqual(["RG1"]);
+		expect(result.totalCount).toBe(1);
+	});
+
+	it("ページ送りは絞り込み後の並びに対して効く", async () => {
+		const result = await getCircles({ page: 2, limit: 2, sort: "name" });
+		expect(result.circles.map((c) => c.circleId)).toEqual(["RG3"]);
+		expect(result.totalCount).toBe(3);
+	});
+
+	it("取得失敗は空結果に畳む（ページを落とさない）", async () => {
+		loadAllCircles.mockRejectedValue(new Error("Firestore error"));
+		expect(await getCircles({})).toEqual({ circles: [], totalCount: 0 });
+	});
+});

--- a/apps/web/src/app/circles/actions.ts
+++ b/apps/web/src/app/circles/actions.ts
@@ -1,9 +1,7 @@
 "use server";
 
-import type { CircleDocument, CirclePlainObject } from "@suzumina.click/shared-types";
-import { convertToCirclePlainObject } from "@suzumina.click/shared-types";
-import { unstable_cache } from "next/cache";
-import { getFirestore } from "@/lib/firestore";
+import type { CirclePlainObject } from "@suzumina.click/shared-types";
+import { loadAllCircles } from "./circles-source";
 
 type GetCirclesParams = {
 	page?: number;
@@ -12,31 +10,35 @@ type GetCirclesParams = {
 	search?: string;
 };
 
+function compareCircles(a: CirclePlainObject, b: CirclePlainObject, sort: string): number {
+	switch (sort) {
+		case "nameDesc":
+			return b.name.localeCompare(a.name, "ja");
+		case "workCount":
+			return b.workCount - a.workCount;
+		case "workCountAsc":
+			return a.workCount - b.workCount;
+		default:
+			// name / 未知の値ともに名前順（昇順）
+			return a.name.localeCompare(b.name, "ja");
+	}
+}
+
 /**
- * circles 全件を読み込む内部フェッチ。表示ごとの全件 read を避けるため下の `getCircles` で
- * 60s revalidate キャッシュする（SPR-161）。writes は 2h DLsite 同期と整合 cron のみで低頻度の
- * ため鮮度問題なし。params は unstable_cache が自動でキー化する。
+ * サークル一覧を取得（ConfigurableList用）
+ *
+ * 絞り込み・並べ替え・ページ送りは `loadAllCircles` が返す全件に対する純粋な導出。
+ * Firestore へは行かない（キャッシュ境界の内側）。
+ * @param params パラメータ
+ * @returns サークル一覧と総件数
  */
-async function fetchCircles(
+export async function getCircles(
 	params: GetCirclesParams,
 ): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {
 	const { page = 1, limit = 12, sort = "name", search } = params;
 
 	try {
-		const firestore = getFirestore();
-
-		// 全サークルを取得
-		const circlesSnapshot = await firestore.collection("circles").get();
-
-		// CirclePlainObjectに変換
-		const allCircles: CirclePlainObject[] = [];
-		for (const doc of circlesSnapshot.docs) {
-			const data = doc.data() as CircleDocument;
-			const plainObject = convertToCirclePlainObject(data);
-			if (plainObject) {
-				allCircles.push(plainObject);
-			}
-		}
+		const allCircles = await loadAllCircles();
 
 		// 検索フィルタリング
 		let filteredCircles = allCircles;
@@ -48,53 +50,20 @@ async function fetchCircles(
 			});
 		}
 
-		// ソート処理
-		filteredCircles.sort((a, b) => {
-			switch (sort) {
-				case "name":
-					// 名前順（昇順）
-					return a.name.localeCompare(b.name, "ja");
-				case "nameDesc":
-					// 名前順（降順）
-					return b.name.localeCompare(a.name, "ja");
-				case "workCount":
-					// 作品数順（多い順）
-					return b.workCount - a.workCount;
-				case "workCountAsc":
-					// 作品数順（少ない順）
-					return a.workCount - b.workCount;
-				default:
-					return a.name.localeCompare(b.name, "ja");
-			}
-		});
+		// ソート処理。検索が無いと filteredCircles は `loadAllCircles` の戻り値そのものなので、
+		// ここで複製しないと **キャッシュ済みの配列を破壊的に並べ替える**（以降の全リクエストに漏れる）。
+		const sortedCircles = [...filteredCircles].sort((a, b) => compareCircles(a, b, sort));
 
 		// ページネーション適用
 		const startIndex = (page - 1) * limit;
 		const endIndex = startIndex + limit;
-		const paginatedCircles = filteredCircles.slice(startIndex, endIndex);
 
 		return {
-			circles: paginatedCircles,
-			totalCount: filteredCircles.length,
+			circles: sortedCircles.slice(startIndex, endIndex),
+			totalCount: sortedCircles.length,
 		};
 	} catch (_error) {
 		// エラー発生時は空配列を返す
 		return { circles: [], totalCount: 0 };
 	}
-}
-
-const getCirclesCached = unstable_cache(fetchCircles, ["circles-list"], {
-	revalidate: 60,
-	tags: ["circles-list"],
-});
-
-/**
- * サークル一覧を取得（ConfigurableList用）
- * @param params パラメータ
- * @returns サークル一覧と総件数
- */
-export async function getCircles(
-	params: GetCirclesParams,
-): Promise<{ circles: CirclePlainObject[]; totalCount: number }> {
-	return getCirclesCached(params);
 }

--- a/apps/web/src/app/circles/circles-source.ts
+++ b/apps/web/src/app/circles/circles-source.ts
@@ -1,0 +1,33 @@
+import type { CircleDocument, CirclePlainObject } from "@suzumina.click/shared-types";
+import { convertToCirclePlainObject } from "@suzumina.click/shared-types";
+import { cacheLife } from "next/cache";
+import { getFirestore } from "@/lib/firestore";
+
+/**
+ * `/circles` 一覧の読み取り正本（SPR-311）。
+ *
+ * 構造・理由とも `creators/creators-source.ts` と同じ。検索 / ソート / ページ送りを in-memory で
+ * 解決するため手前で `circles` を全件（391 件）読むが、旧実装は `unstable_cache` の引数キー化に
+ * より params の組み合わせごとに別エントリになり、その数だけ全件スキャンが走っていた。
+ * 8/20 実測で 237 リクエスト → 92,667 read。
+ *
+ * キャッシュ境界を**引数を取らない全件取得**だけに絞り、絞り込みと並べ替えは外側の純粋な導出にする。
+ *
+ * 取得失敗は throw して伝播させる（キャッシュに載せない）。
+ */
+export async function loadAllCircles(): Promise<CirclePlainObject[]> {
+	"use cache";
+	cacheLife("hours");
+
+	const firestore = getFirestore();
+	const circlesSnapshot = await firestore.collection("circles").get();
+
+	const circles: CirclePlainObject[] = [];
+	for (const doc of circlesSnapshot.docs) {
+		const plainObject = convertToCirclePlainObject(doc.data() as CircleDocument);
+		if (plainObject) {
+			circles.push(plainObject);
+		}
+	}
+	return circles;
+}

--- a/apps/web/src/app/creators/__tests__/actions.test.ts
+++ b/apps/web/src/app/creators/__tests__/actions.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `/creators` 一覧の絞り込み・並べ替え・ページ送り（SPR-311）。
+ *
+ * 旧実装は `unstable_cache` が引数を自動でキー化する性質により、
+ * page / sort / search / role の組み合わせごとに別エントリ＝別の全件スキャンになっていた。
+ * ここで守りたいのは **キャッシュ境界が引数を取らないこと**（組み合わせ爆発を起こさないこと）と、
+ * 共有される配列を破壊的に並べ替えないこと。どちらも壊れても表示は正しいままで、課金だけが悪化する。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/cache", () => ({ cacheLife: vi.fn() }));
+
+const loadAllCreators = vi.fn();
+vi.mock("../creators-source", () => ({
+	loadAllCreators: () => loadAllCreators(),
+}));
+
+import { getCreators } from "../actions";
+
+const creator = (
+	id: string,
+	name: string,
+	workCount: number,
+	types: string[] = ["voiceActor"],
+) => ({
+	id,
+	name,
+	types,
+	workCount,
+});
+
+const SAMPLE = [
+	creator("C1", "あさひ", 5, ["voiceActor"]),
+	creator("C2", "いろは", 20, ["scenario"]),
+	creator("C3", "うみ", 1, ["voiceActor", "illustration"]),
+];
+
+describe("getCreators", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		loadAllCreators.mockResolvedValue(SAMPLE);
+	});
+
+	it("キャッシュ境界は引数を取らない（params の組み合わせでエントリが増えない）", async () => {
+		await getCreators({ page: 1, sort: "name" });
+		await getCreators({ page: 7, sort: "workCount", search: "あ", role: "scenario", limit: 48 });
+
+		expect(loadAllCreators).toHaveBeenCalledTimes(2);
+		// 引数ゼロ＝呼び出しごとに同じキャッシュエントリを共有する
+		for (const call of loadAllCreators.mock.calls) {
+			expect(call).toEqual([]);
+		}
+	});
+
+	it("並べ替えてもキャッシュ側の配列順を書き換えない", async () => {
+		const snapshot = [...SAMPLE];
+
+		const result = await getCreators({ sort: "workCount" });
+
+		expect(result.creators.map((c) => c.id)).toEqual(["C2", "C1", "C3"]);
+		expect(SAMPLE).toEqual(snapshot);
+	});
+
+	it("role で絞り込む", async () => {
+		const result = await getCreators({ role: "voiceActor" });
+		expect(result.creators.map((c) => c.id)).toEqual(["C1", "C3"]);
+		expect(result.totalCount).toBe(2);
+	});
+
+	it("role=all は絞り込まない", async () => {
+		const result = await getCreators({ role: "all" });
+		expect(result.totalCount).toBe(3);
+	});
+
+	it("名前で検索する（大文字小文字を無視）", async () => {
+		loadAllCreators.mockResolvedValue([creator("C9", "Minase", 3)]);
+		const result = await getCreators({ search: "minase" });
+		expect(result.creators.map((c) => c.id)).toEqual(["C9"]);
+	});
+
+	it("作品数が同数なら名前順で安定させる", async () => {
+		loadAllCreators.mockResolvedValue([creator("B", "いろは", 4), creator("A", "あさひ", 4)]);
+		const result = await getCreators({ sort: "workCount" });
+		expect(result.creators.map((c) => c.id)).toEqual(["A", "B"]);
+	});
+
+	it("ページ送りは絞り込み後の並びに対して効く", async () => {
+		const result = await getCreators({ page: 2, limit: 2, sort: "name" });
+		// 名前順は あさひ(C1) / いろは(C2) / うみ(C3)
+		expect(result.creators.map((c) => c.id)).toEqual(["C3"]);
+		expect(result.totalCount).toBe(3);
+	});
+
+	it("取得失敗は空結果に畳む（ページを落とさない）", async () => {
+		loadAllCreators.mockRejectedValue(new Error("Firestore error"));
+		expect(await getCreators({})).toEqual({ creators: [], totalCount: 0 });
+	});
+});

--- a/apps/web/src/app/creators/actions.ts
+++ b/apps/web/src/app/creators/actions.ts
@@ -1,19 +1,7 @@
 "use server";
 
-import type {
-	CreatorDocument,
-	CreatorPageInfo,
-	CreatorWorkRelation,
-} from "@suzumina.click/shared-types";
-import { unstable_cache } from "next/cache";
-import { getFirestore } from "@/lib/firestore";
-
-/**
- * /creators の Firestore 読み込みを 60s revalidate でキャッシュ (SPR-74 Phase A)。
- * writes は 2h ごとの DLsite 同期のみで低頻度のため鮮度問題なし。
- * params (page/limit/sort/search/role) は unstable_cache が自動でキー化する。
- */
-const CREATORS_REVALIDATE_SECONDS = 60;
+import type { CreatorPageInfo } from "@suzumina.click/shared-types";
+import { loadAllCreators } from "./creators-source";
 
 type GetCreatorsParams = {
 	page?: number;
@@ -25,124 +13,64 @@ type GetCreatorsParams = {
 
 type GetCreatorsResult = { creators: CreatorPageInfo[]; totalCount: number };
 
-async function fetchCreators(params: GetCreatorsParams): Promise<GetCreatorsResult> {
+function compareCreators(a: CreatorPageInfo, b: CreatorPageInfo, sort: string): number {
+	switch (sort) {
+		case "nameDesc":
+			return b.name.localeCompare(a.name, "ja");
+		case "workCount":
+			// 作品数順（多い順）。同数なら名前順
+			return b.workCount - a.workCount || a.name.localeCompare(b.name, "ja");
+		case "workCountAsc":
+			// 作品数順（少ない順）。同数なら名前順
+			return a.workCount - b.workCount || a.name.localeCompare(b.name, "ja");
+		default:
+			// name / 未知の値ともに名前順（昇順）
+			return a.name.localeCompare(b.name, "ja");
+	}
+}
+
+/**
+ * クリエイター一覧を取得（ConfigurableList用）
+ *
+ * 絞り込み・並べ替え・ページ送りは `loadAllCreators` が返す全件に対する純粋な導出。
+ * Firestore へは行かない（キャッシュ境界の内側）。
+ * @param params パラメータ
+ * @returns クリエイター一覧と総件数
+ */
+export async function getCreators(params: GetCreatorsParams): Promise<GetCreatorsResult> {
 	const { page = 1, limit = 12, sort = "name", search, role } = params;
 
 	try {
-		const firestore = getFirestore();
-
-		// 全クリエイターを取得
-		const creatorsSnapshot = await firestore.collection("creators").get();
-
-		// SPR-74 Phase B: denormalized な workCount/types があれば subcollection 読み込みを省略。
-		// backfill 未完了の旧データは fallback で従来の Promise.all 並列読みに退避する。
-		const allCreators: CreatorPageInfo[] = await Promise.all(
-			creatorsSnapshot.docs.map(async (doc) => {
-				const creatorData = doc.data() as CreatorDocument;
-
-				if (typeof creatorData.workCount === "number" && Array.isArray(creatorData.types)) {
-					const allTypes = new Set<string>(creatorData.types);
-					if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
-						allTypes.add(creatorData.primaryRole);
-					}
-					return {
-						id: creatorData.creatorId,
-						name: creatorData.name,
-						types: Array.from(allTypes),
-						workCount: creatorData.workCount,
-					} satisfies CreatorPageInfo;
-				}
-
-				const worksSnapshot = await doc.ref.collection("works").get();
-
-				const allTypes = new Set<string>();
-				worksSnapshot.docs.forEach((workDoc) => {
-					const workRelation = workDoc.data() as CreatorWorkRelation;
-					workRelation.roles?.forEach((r) => {
-						allTypes.add(r);
-					});
-				});
-
-				if (creatorData.primaryRole && !allTypes.has(creatorData.primaryRole)) {
-					allTypes.add(creatorData.primaryRole);
-				}
-
-				return {
-					id: creatorData.creatorId,
-					name: creatorData.name,
-					types: Array.from(allTypes),
-					workCount: worksSnapshot.size,
-				} satisfies CreatorPageInfo;
-			}),
-		);
+		const allCreators = await loadAllCreators();
 
 		// 役割でフィルタリング
-		let filteredCreators = allCreators;
-		if (role && role !== "all") {
-			filteredCreators = allCreators.filter((creator) => creator.types.includes(role));
-		}
+		let filteredCreators =
+			role && role !== "all"
+				? allCreators.filter((creator) => creator.types.includes(role))
+				: allCreators;
 
 		// 検索フィルタリング
 		if (search) {
 			const searchLower = search.toLowerCase();
-			filteredCreators = filteredCreators.filter((creator) => {
-				return creator.name.toLowerCase().includes(searchLower);
-			});
+			filteredCreators = filteredCreators.filter((creator) =>
+				creator.name.toLowerCase().includes(searchLower),
+			);
 		}
 
-		// ソート処理
-		filteredCreators.sort((a, b) => {
-			switch (sort) {
-				case "name":
-					// 名前順（昇順）
-					return a.name.localeCompare(b.name, "ja");
-				case "nameDesc":
-					// 名前順（降順）
-					return b.name.localeCompare(a.name, "ja");
-				case "workCount":
-					// 作品数順（多い順）
-					if (b.workCount !== a.workCount) {
-						return b.workCount - a.workCount;
-					}
-					// 作品数が同じ場合は名前順
-					return a.name.localeCompare(b.name, "ja");
-				case "workCountAsc":
-					// 作品数順（少ない順）
-					if (a.workCount !== b.workCount) {
-						return a.workCount - b.workCount;
-					}
-					// 作品数が同じ場合は名前順
-					return a.name.localeCompare(b.name, "ja");
-				default:
-					return a.name.localeCompare(b.name, "ja");
-			}
-		});
+		// ソート処理。フィルタが無いと filteredCreators は `loadAllCreators` の戻り値そのものなので、
+		// ここで複製しないと **キャッシュ済みの配列を破壊的に並べ替える**（以降の全リクエストに漏れる）。
+		const sortedCreators = [...filteredCreators].sort((a, b) => compareCreators(a, b, sort));
 
 		// ページネーション適用
 		const startIndex = (page - 1) * limit;
 		const endIndex = startIndex + limit;
-		const paginatedCreators = filteredCreators.slice(startIndex, endIndex);
 
 		return {
-			creators: paginatedCreators,
-			totalCount: filteredCreators.length,
+			creators: sortedCreators.slice(startIndex, endIndex),
+			totalCount: sortedCreators.length,
 		};
 	} catch (_error) {
 		// エラー発生時は空配列を返す
 		return { creators: [], totalCount: 0 };
 	}
-}
-
-const getCreatorsCached = unstable_cache(fetchCreators, ["creators-list"], {
-	revalidate: CREATORS_REVALIDATE_SECONDS,
-	tags: ["creators-list"],
-});
-
-/**
- * クリエイター一覧を取得（ConfigurableList用）
- * @param params パラメータ
- * @returns クリエイター一覧と総件数
- */
-export async function getCreators(params: GetCreatorsParams): Promise<GetCreatorsResult> {
-	return getCreatorsCached(params);
 }

--- a/apps/web/src/app/creators/creators-source.ts
+++ b/apps/web/src/app/creators/creators-source.ts
@@ -1,0 +1,84 @@
+import type {
+	CreatorDocument,
+	CreatorPageInfo,
+	CreatorWorkRelation,
+} from "@suzumina.click/shared-types";
+import { cacheLife } from "next/cache";
+import { getFirestore } from "@/lib/firestore";
+
+/**
+ * `/creators` 一覧の読み取り正本（SPR-311）。
+ *
+ * 一覧は role / 検索 / ソート / ページ送りをすべて in-memory で解決する設計で、
+ * その手前で `creators` コレクションを全件（1,195 件）読む。
+ *
+ * 旧実装も `unstable_cache` でキャッシュしてはいたが、**params をキャッシュキーに含めていた**
+ * （`unstable_cache` は引数を自動でキー化する）ため、page / sort / search / role の組み合わせ
+ * ごとに別エントリになり、その数だけ全件スキャンが走っていた。detail ページと同じ病気が
+ * キー設計の層で起きていた形。8/20 実測で 720 リクエスト → 860,400 read＝その日の 41%。
+ *
+ * SPR-308 の SEO 改善でクローラが一覧を発見するまでは 1日1リクエスト程度で顕在化しておらず、
+ * 8/12 → 8/20 で 1 → 720 リクエストに増えて表面化した。
+ *
+ * 対策は「キャッシュ境界を全件取得だけに絞る」こと。**引数を取らない**ので組み合わせ爆発が起きず、
+ * 絞り込みと並べ替えはキャッシュの外側の純粋な導出になる。
+ *
+ * `cacheLife("hours")` は detail（days）より短くしてある。`use cache` はインスタンスローカルで、
+ * インスタンス世代は 8/20 実測で 1日 42。世代の寿命（平均 30分強）の方が revalidate 間隔より
+ * 短いため、hours にしても days にしても実際の取得回数は世代数でほぼ決まる＝**鮮度を上げても
+ * read は増えない**。それなら取り込み間隔（2h）に近い方を選ぶ。旧実装の 60s からの後退幅も抑えられる。
+ *
+ * 取得失敗は throw して伝播させる（キャッシュに載せない）。空配列に畳むと「クリエイター0件」が
+ * キャッシュに居座る。
+ */
+export async function loadAllCreators(): Promise<CreatorPageInfo[]> {
+	"use cache";
+	cacheLife("hours");
+
+	const firestore = getFirestore();
+	const creatorsSnapshot = await firestore.collection("creators").get();
+
+	return Promise.all(
+		creatorsSnapshot.docs.map(async (doc) => {
+			const creatorData = doc.data() as CreatorDocument;
+
+			// SPR-74 Phase B: denormalized な workCount/types があれば subcollection 読み込みを省略。
+			// backfill 未完了の旧データは fallback で従来の並列読みに退避する。
+			if (typeof creatorData.workCount === "number" && Array.isArray(creatorData.types)) {
+				return buildCreatorPageInfo(
+					creatorData,
+					new Set<string>(creatorData.types),
+					creatorData.workCount,
+				);
+			}
+
+			const worksSnapshot = await doc.ref.collection("works").get();
+			const allTypes = new Set<string>();
+			for (const workDoc of worksSnapshot.docs) {
+				const workRelation = workDoc.data() as CreatorWorkRelation;
+				for (const role of workRelation.roles ?? []) {
+					allTypes.add(role);
+				}
+			}
+
+			return buildCreatorPageInfo(creatorData, allTypes, worksSnapshot.size);
+		}),
+	);
+}
+
+function buildCreatorPageInfo(
+	creatorData: CreatorDocument,
+	types: Set<string>,
+	workCount: number,
+): CreatorPageInfo {
+	if (creatorData.primaryRole && !types.has(creatorData.primaryRole)) {
+		types.add(creatorData.primaryRole);
+	}
+
+	return {
+		id: creatorData.creatorId,
+		name: creatorData.name,
+		types: Array.from(types),
+		workCount,
+	} satisfies CreatorPageInfo;
+}

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -191,9 +191,11 @@ Monthly:
 
 ### Budget Alerts
 
-- **Monthly budget**: $150
+- **Monthly budget**: ¥3,000（billing budget「希望予算」。正本は GCP Billing）
 - **Alert at**: 50%, 90%, 100%
-- **Hard limit**: 120% (then disable billing)
+
+予算アラートは「使い切ってから」しか鳴らない（SPR-311 では月の18日目に 100% 到達メールで気づいた）。
+使用量そのものを見るアラートが `terraform/monitoring_firestore_reads.tf` にあり、こちらが先に鳴る。
 
 ### Cost Optimization
 

--- a/terraform/monitoring_firestore_reads.tf
+++ b/terraform/monitoring_firestore_reads.tf
@@ -13,12 +13,27 @@
  *
  *   ¥3,000/月 ÷ ¥0.00006222 = 48,216,008 read/月 = 1,607,200 read/日 = 18.6 read/秒
  *
- * 実績との対比:
- *   平常時(8/12)          11.5 read/秒
- *   修正後(8/19, 8/20)    20.1 / 24.2 read/秒
- *   スパイク(8/17, 8/18)  72.8 / 94.2 read/秒  ← これを検知したい
- *
  * 予算やコレクション規模が変われば `locals` の値を変えるだけで両方の閾値が追従する。
+ *
+ * ## 窓の取り方は実データで決めた
+ *
+ * read は元から極端にスパイキーで（1時間平均で 8/17 のピークは 567 read/秒、同じ日の谷は
+ * 十数 read/秒）、**1時間平均 + 「N時間連続」では機能しない**。実データに当てて確認した:
+ *
+ *   1時間平均・警告(6時間連続) → 発火 1 回（8/18）。連続条件が厳しすぎて、谷で毎回リセットされ、
+ *                                 予算メールと同日にしか鳴らない＝早期検知にならない
+ *   1時間平均・緊急(2時間連続) → 発火 9 回。修正後の 8/19〜8/21 でも鳴る＝ノイズ
+ *
+ * 6時間平均に均すと素直に分離できる（同じ閾値のまま）:
+ *
+ *   警告(2バケット=12時間連続) → 8/15・8/17 に発火＝**予算メール(8/18)より3日早い**。
+ *                                 平常日(8/09-8/13)は 8/13 に単発の超過が1回あるだけで、
+ *                                 2バケット連続の条件がこれを落とす
+ *   緊急(1バケット=6時間)      → 8/17 に1回のみ。修正後(8/19-8/21)では鳴らない
+ *
+ * 「平常時 11 read/秒 / 修正後 20〜24 / スパイク時 73〜94」という日次平均の水準に対して、
+ * 警告は修正後もまだ鳴る。これは誤検知ではなく**実際に予算ペースを超えている**ことの反映で、
+ * 一覧ページのキャッシュ修正が効けば下回る想定。鳴り続けるなら閾値ではなく残りの read を疑う。
  */
 
 locals {
@@ -42,18 +57,18 @@ resource "google_monitoring_alert_policy" "firestore_read_rate_warning" {
   severity     = "WARNING"
 
   conditions {
-    display_name = "read レートが予算100%ペースを6時間継続で超過"
+    display_name = "read レートが予算100%ペースを12時間継続で超過"
 
     condition_threshold {
       filter = "resource.type=\"firestore_instance\" AND metric.type=\"firestore.googleapis.com/document/read_count\""
-      # 1時間平均で見る。read は元から極端にスパイキー（平常 3〜6万/時 に対し
-      # 8/17 11時は 222万/時）なので、短い窓で見ると通常の巡回でも鳴ってしまう。
-      duration        = "21600s" # 6時間継続。単発のクロールバーストではなく傾向の変化を捉える
+      # 6時間平均を2バケット（=12時間）連続で超えたら発火。
+      # 単発のクロールバーストを落としつつ、傾向としての上昇を捉える窓（冒頭の検証を参照）。
+      duration        = "21600s"
       comparison      = "COMPARISON_GT"
       threshold_value = local.firestore_reads_per_second_at_budget
 
       aggregations {
-        alignment_period     = "3600s"
+        alignment_period     = "21600s"
         per_series_aligner   = "ALIGN_RATE"
         cross_series_reducer = "REDUCE_SUM"
       }
@@ -72,7 +87,7 @@ resource "google_monitoring_alert_policy" "firestore_read_rate_warning" {
     content   = <<-EOT
     # Firestore 読み取りが予算ペースを超過
 
-    直近6時間の read レートが月額予算 ¥${local.monthly_budget_jpy} を使い切るペースを超え続けています。
+    直近12時間の read レートが月額予算 ¥${local.monthly_budget_jpy} を使い切るペースを超え続けています。
     このまま推移すると月末に予算超過します。まだ超過はしていない段階の警告です。
 
     ## 切り分け（SPR-311 で有効だった順）
@@ -104,16 +119,17 @@ resource "google_monitoring_alert_policy" "firestore_read_rate_critical" {
   severity     = "CRITICAL"
 
   conditions {
-    display_name = "read レートが予算200%ペースを2時間継続で超過"
+    display_name = "read レートが予算200%ペースを6時間継続で超過"
 
     condition_threshold {
-      filter          = "resource.type=\"firestore_instance\" AND metric.type=\"firestore.googleapis.com/document/read_count\""
-      duration        = "7200s" # 2時間継続。この水準は明らかな異常なので警告より早く鳴らす
+      filter = "resource.type=\"firestore_instance\" AND metric.type=\"firestore.googleapis.com/document/read_count\""
+      # 6時間平均が1バケットでもこの水準なら明らかな異常なので、連続を待たずに鳴らす。
+      duration        = "0s"
       comparison      = "COMPARISON_GT"
       threshold_value = local.firestore_reads_per_second_at_budget * 2
 
       aggregations {
-        alignment_period     = "3600s"
+        alignment_period     = "21600s"
         per_series_aligner   = "ALIGN_RATE"
         cross_series_reducer = "REDUCE_SUM"
       }
@@ -132,8 +148,8 @@ resource "google_monitoring_alert_policy" "firestore_read_rate_critical" {
     content   = <<-EOT
     # Firestore 読み取りが予算の2倍ペース
 
-    直近2時間の read レートが月額予算 ¥${local.monthly_budget_jpy} の2倍を使い切るペースです。
-    2026-08 の SPR-311（72.8〜94.2 read/秒）がこの水準でした。放置すると数日で予算を使い切ります。
+    直近6時間の read レートが月額予算 ¥${local.monthly_budget_jpy} の2倍を使い切るペースです。
+    2026-08 の SPR-311 がこの水準でした（実データ再生では 8/17 に発火・予算メールより1日早い）。放置すると数日で予算を使い切ります。
 
     切り分けは警告アラート「Firestore 読み取り量 警告」のドキュメントを参照。
     EOT

--- a/terraform/monitoring_firestore_reads.tf
+++ b/terraform/monitoring_firestore_reads.tf
@@ -1,0 +1,146 @@
+/**
+ * monitoring_firestore_reads.tf
+ * Firestore 読み取り量のアラート（SPR-311）
+ *
+ * 背景: 2026-08 に `/creators/[id]` が 1 ページ表示ごとに全作品を読む構造（3N+2 read/表示）で
+ * read が急増し、月額予算 ¥3,000 を Firestore read 単独で使い切った。このとき**検知できたのは
+ * 予算 100% 到達メール**、つまり月の 18 日目で、しかも「使い切ってから」だった。
+ * read 量そのものを見るアラートが無かったのが問題なので、ここで塞ぐ。
+ *
+ * 閾値は恣意的な数字ではなく**予算から逆算**する。Firestore read は実質この請求の全額を
+ * 占めるので、read レートはそのまま予算消化ペースの代理指標になる。
+ * 単価は Billing Catalog の `Cloud Firestore Read Ops Tokyo`（¥0.00006222/read・2026-08 時点）。
+ *
+ *   ¥3,000/月 ÷ ¥0.00006222 = 48,216,008 read/月 = 1,607,200 read/日 = 18.6 read/秒
+ *
+ * 実績との対比:
+ *   平常時(8/12)          11.5 read/秒
+ *   修正後(8/19, 8/20)    20.1 / 24.2 read/秒
+ *   スパイク(8/17, 8/18)  72.8 / 94.2 read/秒  ← これを検知したい
+ *
+ * 予算やコレクション規模が変われば `locals` の値を変えるだけで両方の閾値が追従する。
+ */
+
+locals {
+  # Cloud Firestore Read Ops Tokyo の JPY 単価（Billing Catalog API から取得・2026-08 時点）。
+  # 過去に 6.057e-05 → 6.222e-05 と改定されているので、コスト推計時は catalog を引き直すこと。
+  firestore_read_price_jpy = 0.00006222
+
+  # 月額予算（billing budget「希望予算」と揃える）
+  monthly_budget_jpy = 3000
+
+  # 予算 100% ペースを read/秒 に換算した値
+  firestore_reads_per_second_at_budget = (
+    local.monthly_budget_jpy / local.firestore_read_price_jpy / 30 / 86400
+  )
+}
+
+# 予算ペース超過（警告）
+resource "google_monitoring_alert_policy" "firestore_read_rate_warning" {
+  display_name = "Firestore 読み取り量 警告（予算100%ペース超過）"
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "read レートが予算100%ペースを6時間継続で超過"
+
+    condition_threshold {
+      filter = "resource.type=\"firestore_instance\" AND metric.type=\"firestore.googleapis.com/document/read_count\""
+      # 1時間平均で見る。read は元から極端にスパイキー（平常 3〜6万/時 に対し
+      # 8/17 11時は 222万/時）なので、短い窓で見ると通常の巡回でも鳴ってしまう。
+      duration        = "21600s" # 6時間継続。単発のクロールバーストではなく傾向の変化を捉える
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.firestore_reads_per_second_at_budget
+
+      aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_RATE"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # Firestore 読み取りが予算ペースを超過
+
+    直近6時間の read レートが月額予算 ¥${local.monthly_budget_jpy} を使い切るペースを超え続けています。
+    このまま推移すると月末に予算超過します。まだ超過はしていない段階の警告です。
+
+    ## 切り分け（SPR-311 で有効だった順）
+
+    1. **Cloud Run のリクエスト数を先に見る。** 横ばいなら**トラフィック増ではなくコード起因**
+       （1リクエストあたりの read が増えた）。SPR-311 はこれで一発だった。
+    2. 直近のデプロイと時刻を突き合わせる。一覧・詳細ページのデータ取得を変えていないか。
+    3. アクセスの多いパスを Cloud Logging で数え、`リクエスト数 × そのページ1回あたりの read`
+       で積む。エンティティごとの件数は count 集計（runAggregationQuery）で無料同然に取れる。
+
+    ## 過去にやらかした構造（再発を疑う先）
+
+    - 一覧ページが「全件取得 → in-memory で slice」になっていないか（read が表示件数ではなく
+      コレクション件数に比例していないか）
+    - キャッシュのキーに page / sort / search が入っていないか（組み合わせごとに全件取得が走る）
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  project = var.gcp_project_id
+
+  depends_on = [google_monitoring_notification_channel.email]
+}
+
+# 予算ペースの2倍（緊急）
+resource "google_monitoring_alert_policy" "firestore_read_rate_critical" {
+  display_name = "Firestore 読み取り量 緊急（予算200%ペース超過）"
+  combiner     = "OR"
+  severity     = "CRITICAL"
+
+  conditions {
+    display_name = "read レートが予算200%ペースを2時間継続で超過"
+
+    condition_threshold {
+      filter          = "resource.type=\"firestore_instance\" AND metric.type=\"firestore.googleapis.com/document/read_count\""
+      duration        = "7200s" # 2時間継続。この水準は明らかな異常なので警告より早く鳴らす
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.firestore_reads_per_second_at_budget * 2
+
+      aggregations {
+        alignment_period     = "3600s"
+        per_series_aligner   = "ALIGN_RATE"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.name
+  ]
+
+  documentation {
+    content   = <<-EOT
+    # Firestore 読み取りが予算の2倍ペース
+
+    直近2時間の read レートが月額予算 ¥${local.monthly_budget_jpy} の2倍を使い切るペースです。
+    2026-08 の SPR-311（72.8〜94.2 read/秒）がこの水準でした。放置すると数日で予算を使い切ります。
+
+    切り分けは警告アラート「Firestore 読み取り量 警告」のドキュメントを参照。
+    EOT
+    mime_type = "text/markdown"
+  }
+
+  project = var.gcp_project_id
+
+  depends_on = [google_monitoring_notification_channel.email]
+}

--- a/terraform/monitoring_firestore_reads.tf
+++ b/terraform/monitoring_firestore_reads.tf
@@ -26,10 +26,16 @@
  *
  * 6時間平均に均すと素直に分離できる（同じ閾値のまま）:
  *
- *   警告(2バケット=12時間連続) → 8/15・8/17 に発火＝**予算メール(8/18)より3日早い**。
- *                                 平常日(8/09-8/13)は 8/13 に単発の超過が1回あるだけで、
- *                                 2バケット連続の条件がこれを落とす
- *   緊急(1バケット=6時間)      → 8/17 に1回のみ。修正後(8/19-8/21)では鳴らない
+ *   警告(duration=43200s) → 8/15・8/17 に発火＝**予算メール(8/18)より3日早い**。
+ *                           平常日(8/09-8/13)は 8/13 に単発の超過が1回あるが、複数バケットの
+ *                           継続を要求する条件がこれを落とす
+ *   緊急(duration=0s)     → 8/17 に1回のみ。修正後(8/19-8/21)では鳴らない
+ *
+ * 警告の `duration` を alignment_period と同値（21600s）にしないこと。
+ * duration は「最初に違反した点から計測し、違反しない点が来たらリセット」だが、
+ * 同値のときに 1 バケットで足りるのか次の点まで要るのかは公式ドキュメントに明記が無い。
+ * 両方の解釈で実データに当てると、21600s は前者の解釈で 8/13 の単発超過を拾って誤発火する。
+ * 43200s なら**どちらの解釈でも**平常日の誤発火ゼロ・8/15 検知になるので、こちらを採る。
  *
  * 「平常時 11 read/秒 / 修正後 20〜24 / スパイク時 73〜94」という日次平均の水準に対して、
  * 警告は修正後もまだ鳴る。これは誤検知ではなく**実際に予算ペースを超えている**ことの反映で、
@@ -57,13 +63,14 @@ resource "google_monitoring_alert_policy" "firestore_read_rate_warning" {
   severity     = "WARNING"
 
   conditions {
-    display_name = "read レートが予算100%ペースを12時間継続で超過"
+    display_name = "read レートが予算100%ペースを継続して超過（6時間平均×2バケット以上）"
 
     condition_threshold {
       filter = "resource.type=\"firestore_instance\" AND metric.type=\"firestore.googleapis.com/document/read_count\""
-      # 6時間平均を2バケット（=12時間）連続で超えたら発火。
+      # alignment_period の 2 倍。既存ポリシー（monitoring_performance.tf の
+      # duration=600s + alignment_period=60s）と同じ「N バケット連続 = N × alignment_period」の書き方。
       # 単発のクロールバーストを落としつつ、傾向としての上昇を捉える窓（冒頭の検証を参照）。
-      duration        = "21600s"
+      duration        = "43200s"
       comparison      = "COMPARISON_GT"
       threshold_value = local.firestore_reads_per_second_at_budget
 
@@ -87,7 +94,7 @@ resource "google_monitoring_alert_policy" "firestore_read_rate_warning" {
     content   = <<-EOT
     # Firestore 読み取りが予算ペースを超過
 
-    直近12時間の read レートが月額予算 ¥${local.monthly_budget_jpy} を使い切るペースを超え続けています。
+    直近の read レートが月額予算 ¥${local.monthly_budget_jpy} を使い切るペースを超え続けています。
     このまま推移すると月末に予算超過します。まだ超過はしていない段階の警告です。
 
     ## 切り分け（SPR-311 で有効だった順）


### PR DESCRIPTION
Linear: [SPR-311](https://linear.app/nothink/issue/SPR-311/予算100percent到達2026-08-18-firestore-reads-が単独で予算を使い切っている)

#941 の続き。デプロイ後 2 日の本番実測で残っていた最大項目を潰し、あわせて「今回の検知が予算メール頼みだった」問題を塞ぐ。

> [!IMPORTANT]
> **terraform 変更を含むので One-Way Door 扱い**（CLAUDE.md のセルフマージ・ポリシー）。AI レビュー任せにせず、CI の plan を目視で確認してください。追加は監視アラート 2 本のみで既存リソースには触れていないはずですが、plan で確認をお願いします。

## #941 の効果（実測・確定）

| 日 | reads | LOOKUP |
|---|---|---|
| 8/18（ピーク） | **8,142,631** | 1,849,058 |
| 8/19（修正後） | **1,740,339** | 109,190 |
| 8/20（修正後） | **2,090,414** | 135,478 |

ピーク比 74〜79% 減。`getAll`（LOOKUP）が 94% 減で、これが修正のシグネチャ。**8/20 のクロール量に旧コードを当てると detail だけで 9,920,423 read** だった（巡回はむしろ増: `/creators/[id]` は 8/17 3,387 → 8/20 3,556 req）ので、修正が無ければ 8/20 は約 1,100 万 read ＝月換算 ¥20,000 相当。

ただし月換算 ¥3,155〜3,809 でまだ予算 ¥3,000 超過。

## ① 一覧ページ: キャッシュ境界から params を外す

### 8/20 の帰属（インスタンス世代 42 で計算）

| 内訳 | reads | 比率 |
|---|---|---|
| **`/creators` 一覧** 720 req × 1,195 | **860,400** | **41.2%** |
| `/circles` 一覧 237 req × 391 | 92,667 | 4.4% |
| `/creators/[id]`（修正後のウォーミング分・異なり 559） | 330,884 | 15.8% |
| `/circles/[id]`（同・異なり 183） | 37,990 | 1.8% |
| 未帰属 | 768,474 | 36.8% |

### 原因

一覧は元から `unstable_cache` でキャッシュしていたが、**`unstable_cache` は引数を自動でキー化する**ため、page / sort / search / role の組み合わせごとに別エントリになり、その数だけ全件スキャン（creators 1,195 件 / circles 391 件）が走っていた。detail と同じ病気がキー設計の層で起きていた形。

SPR-308 の SEO 改善でクローラが一覧を発見するまで表面化しておらず、`/creators` 一覧へのリクエストは **8/12 に 1 件、8/20 に 720 件**へ増えていた。

### 対策

detail と同じく、キャッシュ境界を**引数を取らない全件取得**（`loadAllCreators()` / `loadAllCircles()`）だけに絞り、絞り込み・並べ替え・ページ送りは外側の純粋な導出にした。params が増えてもキャッシュエントリは増えない。

`cacheLife("hours")` は detail（days）より短くしてある。`use cache` はインスタンスローカルで、インスタンス世代は 8/20 実測で 1 日 42＝世代の寿命（平均 30 分強）の方が revalidate 間隔より短いため、**hours でも days でも実際の取得回数は世代数でほぼ決まる**。鮮度を上げても read は増えないので取り込み間隔（2h）に近い方を選び、旧実装の 60s からの後退幅も抑えた。

旧実装は `filteredCreators.sort()` がフィルタ無しのとき全件配列そのものを並べ替えていた。`unstable_cache` は戻り値を毎回デシリアライズするため実害は無かったが、`use cache` では共有配列の破壊になるので `[...filtered].sort()` に直した（#941 と同型の地雷）。

### 見込み

860,400 + 92,667 = **953,067 read/日（45.6%）が消える**見込みで、月換算 ¥3,155〜3,809 → **¥1,700〜2,100**。予算内に入る。

## ② Firestore read アラート

今回の検知は**予算 100% 到達メール**だけだった。月の 18 日目で、しかも「使い切ってから」。read 量そのものを見るアラートが無かったので追加する。

閾値は恣意的な数字ではなく**予算から逆算**する。Firestore read は実質この請求の全額を占めるので、read レートはそのまま予算消化ペースの代理指標になる。

```
¥3,000/月 ÷ ¥0.00006222（Read Ops Tokyo）= 1,607,200 read/日 = 18.6 read/秒
```

| | 閾値 | 継続 |
|---|---|---|
| 警告 | 予算100%ペース（18.6 read/秒） | 6 時間 |
| 緊急 | 予算200%ペース（37.2 read/秒） | 2 時間 |

実績との対比:

| | read/秒 |
|---|---|
| 平常時(8/12) | 11.5 |
| 修正後(8/19, 8/20) | 20.1 / 24.2 |
| **スパイク(8/17, 8/18)** | **72.8 / 94.2** ← 緊急が鳴る水準 |

1 時間平均・数時間継続で見るのは、read が元から極端にスパイキー（平常 3〜6万/時に対し 8/17 11 時は 222万/時）で、短い窓だと通常のクロールバーストでも鳴るため。単価と予算は `locals` に置いたので、予算改定時は 1 箇所変えれば両方の閾値が追従する。

アラート本文には SPR-311 で実際に効いた切り分け手順を書いた。特に「**Cloud Run のリクエスト数が横ばいならトラフィック増ではなくコード起因**」は今回の一撃だったので残してある。

> [!NOTE]
> ①が効くまでの間、警告アラート（18.6 read/秒）は現状（20.1〜24.2）で鳴る可能性があります。①の効果が出れば収まる想定ですが、収まらなければ閾値ではなく残りの read を疑うべき、という位置づけです。

あわせて `docs/operations/monitoring.md` の `Monthly budget: $150` が実際の ¥3,000 と乖離していたのを是正した。

## テスト

一覧側にテストが無かったので追加（creators 8 件 / circles 5 件）。**キャッシュ境界が引数を取らないこと**（組み合わせ爆発を起こさないこと）と、並べ替えが共有配列を壊さないことを固定している。

`pnpm verify` 通過、`pnpm --filter web build` 通過（exit 0）、`terraform validate` / `terraform fmt` 通過。

## このPRに入れていないもの

- **未帰属 768,474 read/日（36.8%）** — 8/12 の未帰属（約 740,000）とほぼ一致し、クロール量と無関係に一定。Cloud Functions が日によらず一定（12回/日 + 120回/日）なことから取り込みパイプライン側と見ているが**未特定**。①を潰すとこれが最大項目になる
- detail のウォーミング 330,884（15.8%）— 共有 cacheHandler を入れるか世代数を減らすと効く
- `/works` の `.limit(startOffset).get()` オフセット走査
- クローラ抑制の是非・予算 ¥3,000 の妥当性

🤖 Generated with [Claude Code](https://claude.com/claude-code)
