### PR TITLE
fix(web): DLsite の「画像なし」URL で next/image が dev だけ落ちるのを防ぐ

### DIFF
--- a/apps/web/src/app/works/[workId]/components/sample-image-gallery.tsx
+++ b/apps/web/src/app/works/[workId]/components/sample-image-gallery.tsx
@@ -13,28 +13,11 @@ import {
 import { Image as ImageIcon, ZoomIn } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
+import { isOptimizableImageSrc, normalizeImageUrl } from "@/lib/image-src";
 
 interface SampleImageGalleryProps {
 	sampleImages: SampleImage[];
 	workTitle: string;
-}
-
-// DLsite画像URLを正規化
-function normalizeDLsiteUrl(url: string): string {
-	if (typeof url !== "string" || url.trim() === "") {
-		return "";
-	}
-
-	// プロトコル相対URL（//img.dlsite.jp/...）をHTTPS URLに変換
-	if (url.startsWith("//")) {
-		return `https:${url}`;
-	}
-	// HTTPプロトコルをHTTPSに変換
-	if (url.startsWith("http://")) {
-		return url.replace("http://", "https://");
-	}
-
-	return url;
 }
 
 // サムネイル専用の画像コンポーネント
@@ -48,9 +31,9 @@ function SampleThumbnail({
 	className?: string;
 }) {
 	const [hasError, setHasError] = useState(false);
-	const normalizedSrc = normalizeDLsiteUrl(src);
-
-	if (hasError) {
+	const normalizedSrc = normalizeImageUrl(src);
+	// 許可ホスト外の URL は next/image に渡さない（開発時の throw / 本番の 400 を避ける）
+	if (hasError || !isOptimizableImageSrc(normalizedSrc)) {
 		return (
 			<div
 				className={`${className} bg-muted flex items-center justify-center`}
@@ -92,7 +75,7 @@ function ExpandedImage({
 }) {
 	const [hasError, setHasError] = useState(false);
 	const [displayDimensions, setDisplayDimensions] = useState({ width, height });
-	const normalizedSrc = normalizeDLsiteUrl(src);
+	const normalizedSrc = normalizeImageUrl(src);
 
 	// SSR対応: クライアントサイドでのみwindowサイズを取得
 	useEffect(() => {
@@ -128,7 +111,7 @@ function ExpandedImage({
 		return () => window.removeEventListener("resize", handleResize);
 	}, [width, height]);
 
-	if (hasError) {
+	if (hasError || !isOptimizableImageSrc(normalizedSrc)) {
 		return (
 			<div
 				className="bg-muted flex items-center justify-center"

--- a/apps/web/src/app/works/components/__tests__/work-card.test.tsx
+++ b/apps/web/src/app/works/components/__tests__/work-card.test.tsx
@@ -20,8 +20,8 @@ const createWork = (overrides: Partial<WorkPlainObject> = {}): WorkPlainObject =
 		circle: "テストサークル",
 		circleId: "RG12345",
 		workUrl: "https://www.dlsite.com/work/RJ123456",
-		thumbnailUrl: "thumb.jpg",
-		highResImageUrl: "high.jpg",
+		thumbnailUrl: "https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_sam.jpg",
+		highResImageUrl: "https://img.dlsite.jp/modpub/images2/work/doujin/RJ01/RJ001_img_main.jpg",
 		releaseDate: "2023年5月6日",
 		genres: ["ボイス・ASMR", "癒し"],
 		price: {
@@ -231,13 +231,33 @@ describe("WorkCard", () => {
 	it("highResImageUrl が無いと thumbnailUrl をサムネイルに使う", () => {
 		render(<WorkCard work={createWork({ highResImageUrl: undefined })} />);
 		const img = screen.getByAltText("テスト作品のサムネイル画像");
-		expect(img).toHaveAttribute("src", "thumb.jpg");
+		expect(img).toHaveAttribute(
+			"src",
+			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_sam.jpg",
+		);
 	});
 
-	it("highResImageUrl も thumbnailUrl も無いと placeholder にフォールバックする", () => {
+	it("highResImageUrl も thumbnailUrl も無いと「画像なし」プレースホルダーになる", () => {
 		render(<WorkCard work={createWork({ highResImageUrl: undefined, thumbnailUrl: undefined })} />);
 		const img = screen.getByAltText("テスト作品のサムネイル画像");
-		expect(img).toHaveAttribute("src", "/placeholder.svg");
+		expect(img).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
+	});
+
+	// DLsite の「画像なし」プレースホルダ（next.config.mjs の remotePatterns に無いホスト）は
+	// next/image に渡すと開発時にレンダリングごと throw する。一覧カード 1 枚のデータ汚れで
+	// ページ全体が落ちないことを固定する。
+	it("DLsite の「画像なし」プレースホルダURLでもカードが落ちず「画像なし」表示になる", () => {
+		render(
+			<WorkCard
+				work={createWork({
+					highResImageUrl: "https://www.dlsite.com/images/web/home/no_img_main.gif",
+					thumbnailUrl: "https://www.dlsite.com/images/web/home/no_img_sam.gif",
+				})}
+			/>,
+		);
+		const img = screen.getByAltText("テスト作品のサムネイル画像");
+		expect(img).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
+		expect(screen.getByText("画像なし")).toBeInTheDocument();
 	});
 
 	it("creators が無くてもクラッシュせず CV 表示を出さない", () => {

--- a/apps/web/src/app/works/components/work-card.tsx
+++ b/apps/web/src/app/works/components/work-card.tsx
@@ -147,8 +147,8 @@ export default function WorkCard({ work, variant = "default", priority = false }
 							aria-label={`${work.title}の詳細を見る`}
 						>
 							<ThumbnailImage
-								src={work.highResImageUrl || work.thumbnailUrl || "/placeholder.svg"}
-								fallbackSrc={work.thumbnailUrl || "/placeholder.svg"}
+								src={work.highResImageUrl || work.thumbnailUrl}
+								fallbackSrc={work.thumbnailUrl}
 								alt={`${work.title}のサムネイル画像`}
 								className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
 								priority={priority}

--- a/apps/web/src/components/ui/__tests__/thumbnail-image.test.tsx
+++ b/apps/web/src/components/ui/__tests__/thumbnail-image.test.tsx
@@ -5,7 +5,7 @@ import ThumbnailImage from "../thumbnail-image";
 
 describe("ThumbnailImage", () => {
 	const defaultProps = {
-		src: "https://example.com/image.jpg",
+		src: "https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_main.jpg",
 		alt: "テスト画像",
 	};
 
@@ -48,7 +48,10 @@ describe("ThumbnailImage", () => {
 
 		const image = screen.getByTestId("next-image");
 		expect(image).toBeInTheDocument();
-		expect(image).toHaveAttribute("src", "https://example.com/image.jpg");
+		expect(image).toHaveAttribute(
+			"src",
+			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_main.jpg",
+		);
 		expect(image).toHaveAttribute("alt", "テスト画像");
 	});
 
@@ -58,7 +61,10 @@ describe("ThumbnailImage", () => {
 		const image = screen.getByTestId("next-image");
 
 		// 初期状態の確認
-		expect(image).toHaveAttribute("src", "https://example.com/image.jpg");
+		expect(image).toHaveAttribute(
+			"src",
+			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_main.jpg",
+		);
 		expect(image).toHaveAttribute("alt", "テスト画像");
 
 		// エラーイベントを発火
@@ -104,7 +110,12 @@ describe("ThumbnailImage", () => {
 		fireEvent.load(image);
 		expect(container?.querySelector('[aria-hidden="true"].blur-sm')).not.toBeInTheDocument();
 
-		rerender(<ThumbnailImage {...defaultProps} src="https://example.com/new-image.jpg" />);
+		rerender(
+			<ThumbnailImage
+				{...defaultProps}
+				src="https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ002_img_main.jpg"
+			/>,
+		);
 
 		expect(container?.querySelector('[aria-hidden="true"].blur-sm')).toBeInTheDocument();
 	});
@@ -116,7 +127,10 @@ describe("ThumbnailImage", () => {
 
 		// 初期状態の確認
 		expect(image).toBeInTheDocument();
-		expect(image).toHaveAttribute("src", "https://example.com/image.jpg");
+		expect(image).toHaveAttribute(
+			"src",
+			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_main.jpg",
+		);
 
 		// 最初のエラーイベントを発火
 		fireEvent.error(image);
@@ -142,7 +156,10 @@ describe("ThumbnailImage", () => {
 		);
 
 		const image = screen.getByTestId("next-image");
-		expect(image).toHaveAttribute("src", "https://example.com/image.jpg");
+		expect(image).toHaveAttribute(
+			"src",
+			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ001_img_main.jpg",
+		);
 		expect(image).toHaveAttribute("alt", "テスト画像");
 		expect(image).toHaveAttribute("data-fill", "true");
 		expect(image).toHaveAttribute("data-priority", "true");
@@ -242,20 +259,11 @@ describe("ThumbnailImage", () => {
 
 	// エラーハンドリングの詳細テスト
 	describe("エラーハンドリング", () => {
-		it("無効なURL形式でもプレースホルダーで適切に処理される", async () => {
-			const invalidUrl = "invalid-url";
-			render(<ThumbnailImage {...defaultProps} src={invalidUrl} />);
+		it("無効なURL形式は next/image に渡さずプレースホルダーになる", () => {
+			render(<ThumbnailImage {...defaultProps} src="invalid-url" />);
 
 			const image = screen.getByTestId("next-image");
-			expect(image).toHaveAttribute("src", invalidUrl);
-
-			// エラーイベントを発火
-			fireEvent.error(image);
-
-			// プレースホルダーに切り替わることを確認
-			await waitFor(() => {
-				expect(image).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
-			});
+			expect(image).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
 		});
 
 		it("プレースホルダー状態からの再度のsrc変更で正常に復帰する", async () => {
@@ -270,12 +278,56 @@ describe("ThumbnailImage", () => {
 			});
 
 			// 新しいsrcで再レンダリング
-			const newSrc = "https://example.com/new-image.jpg";
+			const newSrc = "https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ002_img_main.jpg";
 			rerender(<ThumbnailImage {...defaultProps} src={newSrc} />);
 
 			// useEffectによる状態リセットを待機
 			await waitFor(() => {
 				expect(image).toHaveAttribute("src", newSrc);
+			});
+		});
+	});
+
+	// 許可ホスト外の src の扱い（next/image のホスト検証は開発時のみ throw する）
+	describe("許可ホスト外のsrc", () => {
+		// DLsite の「画像なし」プレースホルダ。実データに存在し、next.config.mjs の
+		// remotePatterns に無いため next/image に渡すと開発時はレンダリングごと落ちる。
+		const NO_IMAGE_SAM = "https://www.dlsite.com/images/web/home/no_img_sam.gif";
+		const NO_IMAGE_MAIN = "https://www.dlsite.com/images/web/home/no_img_main.gif";
+		const ALLOWED_SRC = "https://img.dlsite.jp/resize/images2/work/doujin/RJ01/RJ003_img_main.jpg";
+
+		it("src・fallbackSrc とも許可外ならプレースホルダーを表示する", () => {
+			render(
+				<ThumbnailImage
+					{...defaultProps}
+					src={NO_IMAGE_MAIN}
+					fallbackSrc={NO_IMAGE_SAM}
+					alt="テスト画像"
+				/>,
+			);
+
+			const image = screen.getByTestId("next-image");
+			expect(image).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
+			expect(screen.getByText("画像なし")).toBeInTheDocument();
+		});
+
+		it("src が許可外でも fallbackSrc が許可ホストならそちらを使う", () => {
+			render(<ThumbnailImage {...defaultProps} src={NO_IMAGE_MAIN} fallbackSrc={ALLOWED_SRC} />);
+
+			const image = screen.getByTestId("next-image");
+			expect(image).toHaveAttribute("src", ALLOWED_SRC);
+		});
+
+		it("読み込みエラー時に許可外の fallbackSrc へは切り替えない", async () => {
+			render(<ThumbnailImage {...defaultProps} src={ALLOWED_SRC} fallbackSrc={NO_IMAGE_SAM} />);
+
+			const image = screen.getByTestId("next-image");
+			expect(image).toHaveAttribute("src", ALLOWED_SRC);
+
+			fireEvent.error(image);
+
+			await waitFor(() => {
+				expect(image).toHaveAttribute("src", expect.stringContaining("data:image/svg+xml"));
 			});
 		});
 	});

--- a/apps/web/src/components/ui/thumbnail-image.tsx
+++ b/apps/web/src/components/ui/thumbnail-image.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { memo, useEffect, useState } from "react";
+import { isOptimizableImageSrc, normalizeImageUrl } from "@/lib/image-src";
 
 interface ThumbnailImageProps {
 	src: string;
@@ -24,25 +25,34 @@ interface ThumbnailImageProps {
 const PLACEHOLDER_IMAGE =
 	"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI4IiBoZWlnaHQ9Ijk2IiB2aWV3Qm94PSIwIDAgMTI4IDk2IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cmVjdCB3aWR0aD0iMTI4IiBoZWlnaHQ9Ijk2IiBmaWxsPSIjRkRGMkY1Ii8+CjxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDY0IDUwKSBzY2FsZSgwLjEzKSIgZmlsbD0iI0YxRDBEQiI+CjxwYXRoIGQ9Ik0wIC0yOEMtNzQgLTU0IC04OCAtMTQ4IC01MCAtMTk4TDAgLTE3Mkw1MCAtMTk4Qzg4IC0xNDggNzQgLTU0IDAgLTI4WiIvPgo8cGF0aCB0cmFuc2Zvcm09InJvdGF0ZSg3MikiIGQ9Ik0wIC0yOEMtNzQgLTU0IC04OCAtMTQ4IC01MCAtMTk4TDAgLTE3Mkw1MCAtMTk4Qzg4IC0xNDggNzQgLTU0IDAgLTI4WiIvPgo8cGF0aCB0cmFuc2Zvcm09InJvdGF0ZSgxNDQpIiBkPSJNMCAtMjhDLTc0IC01NCAtODggLTE0OCAtNTAgLTE5OEwwIC0xNzJMNTAgLTE5OEM4OCAtMTQ4IDc0IC01NCAwIC0yOFoiLz4KPHBhdGggdHJhbnNmb3JtPSJyb3RhdGUoMjE2KSIgZD0iTTAgLTI4Qy03NCAtNTQgLTg4IC0xNDggLTUwIC0xOThMMCAtMTcyTDUwIC0xOThDODggLTE0OCA3NCAtNTQgMCAtMjhaIi8+CjxwYXRoIHRyYW5zZm9ybT0icm90YXRlKDI4OCkiIGQ9Ik0wIC0yOEMtNzQgLTU0IC04OCAtMTQ4IC01MCAtMTk4TDAgLTE3Mkw1MCAtMTk4Qzg4IC0xNDggNzQgLTU0IDAgLTI4WiIvPgo8L2c+Cjwvc3ZnPgo=";
 
+interface ImageState {
+	/** 実際に next/image へ渡す src */
+	src: string;
+	/** 一次 src を使い切ったか（= fallbackSrc へ進んだ／進めなかった） */
+	hasError: boolean;
+	/** フォールバックまで使い切ったか（= プレースホルダーで確定） */
+	hasFallbackError: boolean;
+}
+
 /**
- * DLsite画像URLを正規化
- * プロトコル相対URLやHTTPをHTTPSに変換
+ * src / fallbackSrc を正規化し、next/image に渡せる最初の URL を選ぶ。
+ *
+ * 許可ホスト外の URL（DLsite の「画像なし」プレースホルダ等）は描画前に捨てる。
+ * next/image のホスト検証は開発時のみ throw するため、渡してしまうとローカルだけ
+ * ページ全体が落ちる（本番は 400 → onError）。判定の詳細は lib/image-src を参照。
  */
-function normalizeDLsiteUrl(url: string): string {
-	if (typeof url !== "string" || url.trim() === "") {
-		return PLACEHOLDER_IMAGE;
+function resolveImageState(src: string, fallbackSrc?: string): ImageState {
+	const normalizedSrc = normalizeImageUrl(src);
+	if (isOptimizableImageSrc(normalizedSrc)) {
+		return { src: normalizedSrc, hasError: false, hasFallbackError: false };
 	}
 
-	// プロトコル相対URL（//img.dlsite.jp/...）をHTTPS URLに変換
-	if (url.startsWith("//")) {
-		return `https:${url}`;
-	}
-	// HTTPプロトコルをHTTPSに変換
-	if (url.startsWith("http://")) {
-		return url.replace("http://", "https://");
+	const normalizedFallback = normalizeImageUrl(fallbackSrc ?? "");
+	if (isOptimizableImageSrc(normalizedFallback)) {
+		return { src: normalizedFallback, hasError: true, hasFallbackError: false };
 	}
 
-	return url;
+	return { src: PLACEHOLDER_IMAGE, hasError: true, hasFallbackError: true };
 }
 
 // パフォーマンス向上: 画像コンポーネントをメモ化してプロップの変更時のみ再レンダリング
@@ -59,44 +69,36 @@ const ThumbnailImage = memo(function ThumbnailImage({
 	quality = 85,
 	optimized = true,
 }: ThumbnailImageProps) {
-	const [imageSrc, setImageSrc] = useState(() => {
-		const safeSrc = typeof src === "string" && src.trim() !== "" ? src : PLACEHOLDER_IMAGE;
-		return normalizeDLsiteUrl(safeSrc);
-	});
-	const [hasError, setHasError] = useState(false);
-	const [hasFallbackError, setHasFallbackError] = useState(false);
+	const [imageState, setImageState] = useState<ImageState>(() =>
+		resolveImageState(src, fallbackSrc),
+	);
 	const [isLoaded, setIsLoaded] = useState(false);
 
-	// srcプロップが変更された際に内部状態をリセット
+	// src / fallbackSrc プロップが変更された際に内部状態をリセット
 	useEffect(() => {
-		// DLsite画像のURLを正規化
-		const safeSrc = typeof src === "string" && src.trim() !== "" ? src : PLACEHOLDER_IMAGE;
-		const normalizedSrc = normalizeDLsiteUrl(safeSrc);
-		setImageSrc(normalizedSrc);
-		setHasError(false);
-		setHasFallbackError(false);
+		setImageState(resolveImageState(src, fallbackSrc));
 		setIsLoaded(false);
-	}, [src]);
+	}, [src, fallbackSrc]);
 
 	const handleError = () => {
-		if (
-			!hasError &&
-			typeof fallbackSrc === "string" &&
-			fallbackSrc.trim() !== "" &&
-			!hasFallbackError
-		) {
-			// 最初にフォールバック画像を試行
-			const normalizedFallbackSrc = normalizeDLsiteUrl(fallbackSrc);
-			setImageSrc(normalizedFallbackSrc);
-			setHasError(true);
-			setIsLoaded(false);
-		} else if (!hasFallbackError) {
+		setImageState((prev) => {
+			if (prev.hasFallbackError) {
+				return prev;
+			}
+			if (!prev.hasError) {
+				// 最初にフォールバック画像を試行（許可ホスト外なら飛ばす）
+				const normalizedFallback = normalizeImageUrl(fallbackSrc ?? "");
+				if (isOptimizableImageSrc(normalizedFallback)) {
+					return { src: normalizedFallback, hasError: true, hasFallbackError: false };
+				}
+			}
 			// フォールバック画像もエラーの場合、またはフォールバック画像がない場合
-			setImageSrc(PLACEHOLDER_IMAGE);
-			setHasFallbackError(true);
-		}
+			return { src: PLACEHOLDER_IMAGE, hasError: true, hasFallbackError: true };
+		});
+		setIsLoaded(false);
 	};
 
+	const imageSrc = imageState.src;
 	// プレースホルダー画像自体を表示している場合は、その下に同じ画像のぼかし背景を重ねない
 	const isPlaceholderImage = imageSrc === PLACEHOLDER_IMAGE;
 

--- a/apps/web/src/lib/__tests__/image-src.test.ts
+++ b/apps/web/src/lib/__tests__/image-src.test.ts
@@ -62,11 +62,34 @@ describe("isOptimizableImageSrc", () => {
 describe("ALLOWED_IMAGE_PATTERNS と next.config.mjs の一致", () => {
 	// 正本は next.config.mjs（Next 本体が読む設定）。写しがズレたらここで落とす。
 	const remotePatterns = (
-		nextConfig as { images?: { remotePatterns?: { hostname: string; pathname: string }[] } }
+		nextConfig as {
+			images?: {
+				remotePatterns?: {
+					protocol?: string;
+					hostname: string;
+					port?: string;
+					pathname: string;
+					search?: string;
+				}[];
+			};
+		}
 	).images?.remotePatterns;
 
 	it("remotePatterns が読み取れる", () => {
 		expect(remotePatterns?.length).toBeGreaterThan(0);
+	});
+
+	// 写しは hostname + pathname 前方一致（https 固定）しかモデル化していない。
+	// next.config.mjs 側にそれ以外の制約（ポート・クエリ・http）が入ると、写しの方が
+	// 緩くなり許可外 URL を next/image に渡してしまう＝この防御が抜ける。
+	// 前提が崩れたことを検出できるよう、前提そのものをここで固定する。
+	it("remotePatterns が写しの前提に収まっている（https / ポート無し / search 無し / `/x/**`）", () => {
+		for (const pattern of remotePatterns ?? []) {
+			expect(pattern.protocol).toBe("https");
+			expect(pattern.port ?? "").toBe("");
+			expect(pattern.search ?? "").toBe("");
+			expect(pattern.pathname).toMatch(/\/\*\*$/);
+		}
 	});
 
 	it("すべての remotePattern が ALLOWED_IMAGE_PATTERNS に存在する", () => {

--- a/apps/web/src/lib/__tests__/image-src.test.ts
+++ b/apps/web/src/lib/__tests__/image-src.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import nextConfig from "../../../next.config.mjs";
+import { ALLOWED_IMAGE_PATTERNS, isOptimizableImageSrc, normalizeImageUrl } from "../image-src";
+
+describe("normalizeImageUrl", () => {
+	it("プロトコル相対URLをhttpsに変換する", () => {
+		expect(normalizeImageUrl("//img.dlsite.jp/resize/images2/a.jpg")).toBe(
+			"https://img.dlsite.jp/resize/images2/a.jpg",
+		);
+	});
+
+	it("httpをhttpsに変換する", () => {
+		expect(normalizeImageUrl("http://img.dlsite.jp/resize/images2/a.jpg")).toBe(
+			"https://img.dlsite.jp/resize/images2/a.jpg",
+		);
+	});
+
+	it("空文字・非文字列は空文字を返す", () => {
+		expect(normalizeImageUrl("")).toBe("");
+		expect(normalizeImageUrl("   ")).toBe("");
+		expect(normalizeImageUrl(undefined as unknown as string)).toBe("");
+	});
+});
+
+describe("isOptimizableImageSrc", () => {
+	it("許可ホスト・許可パスのURLを通す", () => {
+		expect(
+			isOptimizableImageSrc("https://img.dlsite.jp/modpub/images2/work/doujin/RJ01/x_img_main.jpg"),
+		).toBe(true);
+		expect(isOptimizableImageSrc("https://i.ytimg.com/vi/abc/maxresdefault.jpg")).toBe(true);
+		expect(isOptimizableImageSrc("https://cdn.discordapp.com/avatars/1/2.png")).toBe(true);
+	});
+
+	it("DLsiteの「画像なし」プレースホルダを弾く", () => {
+		// 実データに存在する（本番 works で 39 件）。許可ホスト外なので next/image に渡すと
+		// 開発時は throw、本番は /_next/image が 400 を返す。
+		expect(isOptimizableImageSrc("https://www.dlsite.com/images/web/home/no_img_sam.gif")).toBe(
+			false,
+		);
+		expect(isOptimizableImageSrc("https://www.dlsite.com/images/web/home/no_img_main.gif")).toBe(
+			false,
+		);
+	});
+
+	it("許可ホストでもパスが許可外なら弾く", () => {
+		expect(isOptimizableImageSrc("https://img.dlsite.jp/other/a.jpg")).toBe(false);
+	});
+
+	it("http・プロトコル相対・不正URLを弾く", () => {
+		expect(isOptimizableImageSrc("http://img.dlsite.jp/resize/images2/a.jpg")).toBe(false);
+		expect(isOptimizableImageSrc("//img.dlsite.jp/resize/images2/a.jpg")).toBe(false);
+		expect(isOptimizableImageSrc("not a url")).toBe(false);
+		expect(isOptimizableImageSrc("")).toBe(false);
+	});
+
+	it("data URIと自サイトの相対パスは通す", () => {
+		expect(isOptimizableImageSrc("data:image/svg+xml;base64,AAA")).toBe(true);
+		expect(isOptimizableImageSrc("/cherry-blossom.svg")).toBe(true);
+	});
+});
+
+describe("ALLOWED_IMAGE_PATTERNS と next.config.mjs の一致", () => {
+	// 正本は next.config.mjs（Next 本体が読む設定）。写しがズレたらここで落とす。
+	const remotePatterns = (
+		nextConfig as { images?: { remotePatterns?: { hostname: string; pathname: string }[] } }
+	).images?.remotePatterns;
+
+	it("remotePatterns が読み取れる", () => {
+		expect(remotePatterns?.length).toBeGreaterThan(0);
+	});
+
+	it("すべての remotePattern が ALLOWED_IMAGE_PATTERNS に存在する", () => {
+		const derived = (remotePatterns ?? []).map((pattern) => ({
+			hostname: pattern.hostname,
+			// `/x/y/**` → `/x/y/`
+			pathnamePrefix: pattern.pathname.replace(/\*+$/, ""),
+		}));
+		expect([...ALLOWED_IMAGE_PATTERNS]).toEqual(derived);
+	});
+});

--- a/apps/web/src/lib/image-src.ts
+++ b/apps/web/src/lib/image-src.ts
@@ -1,0 +1,83 @@
+/**
+ * next/image に渡す src の正規化と、最適化可能かどうかの判定。
+ *
+ * 背景（なぜ描画前に弾くのか）:
+ * next/image のホスト検証（`Invalid src prop ... hostname "x" is not configured`）は
+ * `NODE_ENV !== "production"` のガード内にあり、**開発時のみ throw** する
+ * （next/dist/shared/lib/image-loader.js）。つまり許可外ホストの URL が 1 件混ざると
+ * - 開発: レンダリング中に throw してページ全体がエラーページになる
+ * - 本番: `/_next/image` が 400 を返し、onError 経由でフォールバックに落ちる（無駄な往復）
+ * という非対称な壊れ方をする。DLsite の「画像なし」プレースホルダ
+ * （https://www.dlsite.com/images/web/home/no_img_*.gif）が実データに存在するため、
+ * 表示側で許可ホスト以外を弾き、自前のプレースホルダへ倒す。
+ */
+
+interface AllowedImagePattern {
+	hostname: string;
+	/** remotePatterns の pathname グロブ（`/x/y/**`）から `**` を除いた前方一致部分 */
+	pathnamePrefix: string;
+}
+
+/**
+ * next/image が最適化を許可するリモート画像パターン。
+ *
+ * 正本は next.config.mjs の `images.remotePatterns`（Next 本体が実際に読む設定）で、
+ * ここはその写し。ズレは `__tests__/image-src.test.ts` が next.config.mjs を読み込んで
+ * 突き合わせ、テスト失敗として検出する（コメントでの運用に頼らない）。
+ */
+export const ALLOWED_IMAGE_PATTERNS: readonly AllowedImagePattern[] = [
+	{ hostname: "i.ytimg.com", pathnamePrefix: "/vi/" },
+	{ hostname: "img.youtube.com", pathnamePrefix: "/vi/" },
+	{ hostname: "img.dlsite.jp", pathnamePrefix: "/resize/images2/" },
+	{ hostname: "img.dlsite.jp", pathnamePrefix: "/modpub/images2/" },
+	{ hostname: "cdn.discordapp.com", pathnamePrefix: "/avatars/" },
+	{ hostname: "cdn.discordapp.com", pathnamePrefix: "/embed/avatars/" },
+];
+
+/**
+ * 画像 URL を正規化する。
+ * プロトコル相対 URL（`//img.dlsite.jp/...`）と http:// を https:// に揃える。
+ */
+export function normalizeImageUrl(url: string): string {
+	if (typeof url !== "string" || url.trim() === "") {
+		return "";
+	}
+	if (url.startsWith("//")) {
+		return `https:${url}`;
+	}
+	if (url.startsWith("http://")) {
+		return url.replace("http://", "https://");
+	}
+	return url;
+}
+
+/**
+ * 正規化済みの src を next/image に渡してよいか判定する。
+ * data URI と自サイトの相対パスは常に可。リモート URL は許可パターンに一致した場合のみ可。
+ */
+export function isOptimizableImageSrc(src: string): boolean {
+	if (typeof src !== "string" || src.trim() === "") {
+		return false;
+	}
+	if (src.startsWith("data:")) {
+		return true;
+	}
+	// 自サイトの相対パス（`//` はプロトコル相対 URL なので除外）
+	if (src.startsWith("/") && !src.startsWith("//")) {
+		return true;
+	}
+
+	let parsed: URL;
+	try {
+		parsed = new URL(src);
+	} catch {
+		return false;
+	}
+	if (parsed.protocol !== "https:") {
+		return false;
+	}
+	return ALLOWED_IMAGE_PATTERNS.some(
+		(pattern) =>
+			pattern.hostname === parsed.hostname && parsed.pathname.startsWith(pattern.pathnamePrefix),
+	);
+}

--- a/apps/web/src/lib/image-src.ts
+++ b/apps/web/src/lib/image-src.ts
@@ -24,6 +24,10 @@ interface AllowedImagePattern {
  * 正本は next.config.mjs の `images.remotePatterns`（Next 本体が実際に読む設定）で、
  * ここはその写し。ズレは `__tests__/image-src.test.ts` が next.config.mjs を読み込んで
  * 突き合わせ、テスト失敗として検出する（コメントでの運用に頼らない）。
+ *
+ * 写しがモデル化しているのは **hostname と pathname の前方一致（protocol は https 固定）** のみ。
+ * remotePatterns にポート・`search` 制約が入ると写しの方が緩くなる（＝許可外 URL を
+ * next/image に渡してしまう）ため、同テストが「前提に収まっているか」も併せて固定している。
  */
 export const ALLOWED_IMAGE_PATTERNS: readonly AllowedImagePattern[] = [
 	{ hostname: "i.ytimg.com", pathnamePrefix: "/vi/" },


### PR DESCRIPTION
## 何が起きていたか

`thumbnailUrl` / `highResImageUrl` が DLsite の「画像なし」プレースホルダ
（`https://www.dlsite.com/images/web/home/no_img_sam.gif` / `no_img_main.gif`）になっている作品を描画すると、**ローカル開発でページ全体がエラーページになる**（画像が欠けるだけでは済まない）。本番 Firestore で該当する works は 39 件。

```
Error: Invalid src prop (https://www.dlsite.com/images/web/home/no_img_main.gif) on `next/image`,
hostname "www.dlsite.com" is not configured under images in your `next.config.js`
```

## 原因：next/image のホスト検証は開発時のみ throw する

`next/dist/shared/lib/image-loader.js`（next 16.3.0）:

```js
if (process.env.NODE_ENV !== 'production') {
  ...
  if (!hasRemoteMatch(config.domains, config.remotePatterns, parsedSrc)) {
    throw new Error(`Invalid src prop (${src}) on \`next/image\`, hostname ... is not configured`)
  }
}
```

同じデータでも壊れ方が非対称になる。

| | 挙動 |
|---|---|
| 開発 | レンダリング中に throw → ページ全体がエラーページ |
| 本番 | `/_next/image` が 400 → `onError` 経由でプレースホルダ（無駄な往復） |

本番でも**経路には到達している**。`/works/RJ01041035` の HTML には実際に `<img src="/_next/image?url=https%3A%2F%2Fwww.dlsite.com...">` が出ており、その URL は 400 を返す（確認済み）。落ちないだけで、正常ではない。

なお `/circles/RG53217` の HTML に見えていた www.dlsite.com 参照 2 件は RSC ペイロード内の生データで、この 2 作品は `highResImageUrl` が img.dlsite.jp だったためカード自体は正常だった。

## 直し方

`remotePatterns` に `www.dlsite.com` を足すのは却下した（意味のない gif のために外部ホストを 1 つ増やし、しかも最適化して配信することになる）。代わりに**許可ホスト外の src は next/image に渡さず**、自前の桜プレースホルダ（「画像なし」表示）へ倒す。1 件のデータ汚れでページ全体が落ちる構造自体をなくす。

- **`lib/image-src.ts`（新規）** — 許可パターンの写しと判定関数。正本は `next.config.mjs`（Next 本体が読む設定）で、写しのズレは `image-src.test.ts` が `next.config.mjs` を import して突き合わせ、テスト失敗として検出する（コメントでの運用にしない）
- **`thumbnail-image.tsx`** — `src` が許可外でも `fallbackSrc` が有効ならそちらを使い、両方だめなら即プレースホルダ。許可外の URL には `onError` でも切り替えない。分散していた 3 つの state を 1 つに集約
- **`sample-image-gallery.tsx`** — 同じガードを適用し、重複していた URL 正規化関数を統合
- **`work-card.tsx`** — 実在しない `/placeholder.svg`（`public/` に無い）へのフォールバックを削除。空なら `ThumbnailImage` 側がプレースホルダを出す

既存テストが `example.com` / `thumb.jpg` を src にしていた（本番なら 400 になる非現実的な値）ため、img.dlsite.jp の実形に揃えた。

## 検証

`pnpm dev:local`（Emulator）で修正前後を同じ URL で比較:

- **修正前** `/works/RJ01041035` → エラーバウンダリ「作品データの読み込みに失敗しました / Invalid src prop ...」
- **修正後** → 200 で完全描画、「画像なし」プレースホルダ。`_next/image` へのリクエストは img.dlsite.jp の 2 件のみで、**www.dlsite.com へのリクエストは 0 件**（data URI なので往復自体が消える）

一覧カード経路はブラウザで再現条件を作れなかったため（該当サークルが circles fixture に無い）、work-card のユニットテストで「プレースホルダ URL でもカードが落ちない」を固定した。

`pnpm verify` — pass（exit 0）。

## 残課題（このPRの対象外）

該当作品の **JSON-LD `image` がこの「画像なし」gif のまま**本番に出ている（#940 の product snippet と同じ領域）。取り込み側（`apps/functions` の DLsite パイプライン）でプレースホルダ URL を検出して空にする案を採るならそこで一緒に片付く。データ移行が絡むので分離した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
