### PR TITLE
fix(functions): image_thum が no_img の works で thumbnailUrl を image_main から正規化する

### DIFF
--- a/apps/functions/src/services/dlsite/__tests__/dlsite-firestore.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/dlsite-firestore.test.ts
@@ -123,6 +123,37 @@ describe("dlsite-firestore", () => {
 			expect(payload.price.current).toBe(1650);
 		});
 
+		it("highResImageUrl が不在なら FieldValue.delete() で旧値を消す", async () => {
+			// SPR-312: API が「画像なし」プレースホルダを返す作品では mapper が undefined を返す。
+			// delete しないと過去に保存した no_img gif の URL が残り続ける（sticky）。
+			const workWithoutHighRes: WorkDocument = {
+				...sampleWork,
+				highResImageUrl: undefined,
+			};
+			mockQuery.get.mockResolvedValue({ empty: true, docs: [] });
+
+			await saveWorksToFirestore([workWithoutHighRes]);
+
+			const payload = mockBatch.set.mock.calls[0]![1] as Record<string, unknown>;
+			expect((payload.highResImageUrl as any).isEqual(FieldValue.delete())).toBe(true);
+		});
+
+		it("highResImageUrl があればその値を保持する", async () => {
+			const workWithHighRes: WorkDocument = {
+				...sampleWork,
+				highResImageUrl:
+					"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01099000/RJ01098758_img_main.jpg",
+			};
+			mockQuery.get.mockResolvedValue({ empty: true, docs: [] });
+
+			await saveWorksToFirestore([workWithHighRes]);
+
+			const payload = mockBatch.set.mock.calls[0]![1] as Record<string, unknown>;
+			expect(payload.highResImageUrl).toBe(
+				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01099000/RJ01098758_img_main.jpg",
+			);
+		});
+
 		it("セール中（discount/original あり）はその値を保持する", async () => {
 			const workOnSale: WorkDocument = {
 				...sampleWork,

--- a/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
@@ -162,9 +162,11 @@ describe("URL正規化機能", () => {
 
 		const result = WorkMapper.toWork(mockApiData);
 
-		// デフォルトURLが設定されることを確認
+		// デフォルトURLが設定されることを確認。
+		// SPR-312: 旧フォールバック（.../doujin/RJ01037463_img_main.jpg）は千番台ディレクトリを
+		// 欠いており実際には 404 だった。次の千番台配下の resize 形式へ是正している。
 		expect(result.thumbnailUrl).toBe(
-			"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01037463_img_main.jpg",
+			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01038000/RJ01037463_img_main_240x240.jpg",
 		);
 		expect(result.highResImageUrl).toBeUndefined();
 	});

--- a/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/url-normalization.test.ts
@@ -163,10 +163,9 @@ describe("URL正規化機能", () => {
 		const result = WorkMapper.toWork(mockApiData);
 
 		// デフォルトURLが設定されることを確認。
-		// SPR-312: 旧フォールバック（.../doujin/RJ01037463_img_main.jpg）は千番台ディレクトリを
-		// 欠いており実際には 404 だった。次の千番台配下の resize 形式へ是正している。
+		// SPR-312: 旧フォールバックは千番台ディレクトリを欠いており実際には 404 だった。
 		expect(result.thumbnailUrl).toBe(
-			"https://img.dlsite.jp/resize/images2/work/doujin/RJ01038000/RJ01037463_img_main_240x240.jpg",
+			"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01038000/RJ01037463_img_main.jpg",
 		);
 		expect(result.highResImageUrl).toBeUndefined();
 	});

--- a/apps/functions/src/services/dlsite/dlsite-firestore.ts
+++ b/apps/functions/src/services/dlsite/dlsite-firestore.ts
@@ -27,6 +27,10 @@ const DLSITE_WORKS_COLLECTION = "works";
  *
  * price の任意フィールド（original / discount / point）は不在時に FieldValue.delete() を
  * 明示し、セール終了などの状態遷移を Firestore 上の正本へ確実に反映する。
+ *
+ * highResImageUrl も同様。API が「画像なし」プレースホルダを返す作品では
+ * mapper が undefined を返すため（SPR-312）、delete しないと過去に保存した
+ * no_img gif の URL が残り続ける。
  */
 function toWorkWriteData(work: WorkDocument): WorkDocument {
 	const { original, discount, point } = work.price;
@@ -40,6 +44,7 @@ function toWorkWriteData(work: WorkDocument): WorkDocument {
 			discount: discount ?? del,
 			point: point ?? del,
 		},
+		highResImageUrl: work.highResImageUrl ?? del,
 	};
 }
 

--- a/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
@@ -307,6 +307,82 @@ describe("WorkMapper", () => {
 		});
 	});
 
+	// SPR-312: DLsite API は画像未登録の作品で no_img プレースホルダを返す。
+	// これを保存すると web の remotePatterns 外のホストになり、JSON-LD / OG 画像も壊れる。
+	describe("「画像なし」プレースホルダの正規化", () => {
+		const NO_IMG_SAM = "//www.dlsite.com/images/web/home/no_img_sam.gif";
+		const NO_IMG_MAIN = "//www.dlsite.com/images/web/home/no_img_main.gif";
+
+		it("image_thum が no_img なら image_main の URL を使う", () => {
+			// 翻訳版は image_main が元作品の画像を指す（実データ: RJ01113566 → RJ01098758）
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				image_thum: { url: NO_IMG_SAM },
+				image_main: {
+					url: "//img.dlsite.jp/modpub/images2/work/doujin/RJ01099000/RJ01098758_img_main.jpg",
+				},
+			} as DLsiteApiResponse);
+
+			expect(work.thumbnailUrl).toBe(
+				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01099000/RJ01098758_img_main.jpg",
+			);
+		});
+
+		it("image_main が no_img なら highResImageUrl は undefined になる", () => {
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				image_main: { url: NO_IMG_MAIN },
+			} as DLsiteApiResponse);
+
+			expect(work.highResImageUrl).toBeUndefined();
+		});
+
+		it("image_thum / image_main とも no_img なら次の千番台のフォールバックURLになる", () => {
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				workno: "RJ01041035",
+				image_thum: { url: NO_IMG_SAM },
+				image_main: { url: NO_IMG_MAIN },
+			} as DLsiteApiResponse);
+
+			expect(work.thumbnailUrl).toBe(
+				"https://img.dlsite.jp/resize/images2/work/doujin/RJ01042000/RJ01041035_img_main_240x240.jpg",
+			);
+			expect(work.highResImageUrl).toBeUndefined();
+		});
+
+		it("フォールバックURLは元IDの桁数を保ち、千番台ちょうどでも次の千番台へ繰り上げる", () => {
+			const sixDigits = WorkMapper.toWork({
+				...mockRawApiData,
+				workno: "RJ252366",
+				image_thum: { url: NO_IMG_SAM },
+				image_main: { url: NO_IMG_MAIN },
+			} as DLsiteApiResponse);
+			expect(sixDigits.thumbnailUrl).toContain("/doujin/RJ253000/RJ252366_img_main_240x240.jpg");
+
+			const onBoundary = WorkMapper.toWork({
+				...mockRawApiData,
+				workno: "RJ01042000",
+				image_thum: { url: NO_IMG_SAM },
+				image_main: { url: NO_IMG_MAIN },
+			} as DLsiteApiResponse);
+			expect(onBoundary.thumbnailUrl).toContain(
+				"/doujin/RJ01043000/RJ01042000_img_main_240x240.jpg",
+			);
+		});
+
+		it("正常な画像URLの作品は挙動が変わらない", () => {
+			const work = WorkMapper.toWork(mockRawApiData);
+
+			expect(work.thumbnailUrl).toBe(
+				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ12345678_img_thum.jpg",
+			);
+			expect(work.highResImageUrl).toBe(
+				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ12345678_img_main.jpg",
+			);
+		});
+	});
+
 	describe("プロトコル相対URLの正規化", () => {
 		it("プロトコル相対URLをHTTPSに変換する", () => {
 			const work = WorkMapper.toWork(mockRawApiData);

--- a/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
@@ -346,7 +346,7 @@ describe("WorkMapper", () => {
 			} as DLsiteApiResponse);
 
 			expect(work.thumbnailUrl).toBe(
-				"https://img.dlsite.jp/resize/images2/work/doujin/RJ01042000/RJ01041035_img_main_240x240.jpg",
+				"https://img.dlsite.jp/modpub/images2/work/doujin/RJ01042000/RJ01041035_img_main.jpg",
 			);
 			expect(work.highResImageUrl).toBeUndefined();
 		});
@@ -358,7 +358,7 @@ describe("WorkMapper", () => {
 				image_thum: { url: NO_IMG_SAM },
 				image_main: { url: NO_IMG_MAIN },
 			} as DLsiteApiResponse);
-			expect(sixDigits.thumbnailUrl).toContain("/doujin/RJ253000/RJ252366_img_main_240x240.jpg");
+			expect(sixDigits.thumbnailUrl).toContain("/doujin/RJ253000/RJ252366_img_main.jpg");
 
 			const onBoundary = WorkMapper.toWork({
 				...mockRawApiData,
@@ -366,9 +366,7 @@ describe("WorkMapper", () => {
 				image_thum: { url: NO_IMG_SAM },
 				image_main: { url: NO_IMG_MAIN },
 			} as DLsiteApiResponse);
-			expect(onBoundary.thumbnailUrl).toContain(
-				"/doujin/RJ01043000/RJ01042000_img_main_240x240.jpg",
-			);
+			expect(onBoundary.thumbnailUrl).toContain("/doujin/RJ01043000/RJ01042000_img_main.jpg");
 		});
 
 		it("正常な画像URLの作品は挙動が変わらない", () => {

--- a/apps/functions/src/services/mappers/work-mapper.ts
+++ b/apps/functions/src/services/mappers/work-mapper.ts
@@ -222,25 +222,73 @@ function mapAgeCategoryString(ageCategory?: number): string | undefined {
 }
 
 /**
+ * DLsite の「画像なし」プレースホルダ URL かどうか。
+ *
+ * API は画像が未登録の作品で `image_thum` / `image_main` に
+ * `//www.dlsite.com/images/web/home/no_img_sam.gif`（`no_img_main.gif`）を返す。
+ * これを URL として保存すると、web の `remotePatterns` 外のホストになるため画像を出せず、
+ * JSON-LD・OG 画像も壊れた URL を指す（SPR-312）。保存前にここで弾く。
+ */
+function isNoImagePlaceholder(url: string | undefined): boolean {
+	return url?.includes("/images/web/home/no_img_") ?? false;
+}
+
+/**
+ * API から画像 URL が一切得られなかった場合の最終フォールバック。
+ *
+ * DLsite の画像は「次の千番台」ディレクトリ配下に置かれる（RJ01098758 → RJ01099000）。
+ * ただしこれは**推測**であり、API 由来の値が取れるときは必ずそちらを優先すること。
+ * SPR-312 の実測では productId からの導出は 39件中 7件で外れた
+ * （翻訳版の画像は元作品 ID の配下にあり、productId からは辿れない）。
+ *
+ * 原寸（modpub）が無い作品でも解決することがある resize 形式を使う。
+ */
+function buildFallbackThumbnailUrl(productId: string): string {
+	const match = productId.match(/^([A-Z]+)(\d+)$/);
+	if (!match?.[1] || !match[2]) {
+		return `https://img.dlsite.jp/modpub/images2/work/doujin/${productId}_img_main.jpg`;
+	}
+	const [, prefix, digits] = match;
+	const bucket = (Math.floor(Number(digits) / 1000) + 1) * 1000;
+	const dir = `${prefix}${String(bucket).padStart(digits.length, "0")}`;
+	return `https://img.dlsite.jp/resize/images2/work/doujin/${dir}/${productId}_img_main_240x240.jpg`;
+}
+
+/**
  * サムネイルURLの抽出
+ *
+ * `image_thum` が「画像なし」プレースホルダのときは `image_main` を使う。
+ * 翻訳版は `image_main` が元作品の画像を指しており、API 側が正しい URL を持っている
+ * （例: RJ01113566 の image_main は RJ01098758 の画像）。
  */
 function extractThumbnailUrl(raw: DLsiteApiResponse, productId: string): string {
-	const url = extractUrlFromImageField(raw.image_thum);
+	const thumbUrl = extractUrlFromImageField(raw.image_thum);
+	if (thumbUrl && !isNoImagePlaceholder(thumbUrl)) {
+		return thumbUrl;
+	}
 
-	// URLが取得できた場合はそれを返す、できなかった場合はデフォルトURL
-	return url || `https://img.dlsite.jp/modpub/images2/work/doujin/${productId}_img_main.jpg`;
+	const mainUrl = extractHighResImageUrl(raw);
+	if (mainUrl) {
+		return mainUrl;
+	}
+
+	return buildFallbackThumbnailUrl(productId);
 }
 
 /**
  * 高解像度画像URLの抽出
+ *
+ * 「画像なし」プレースホルダは URL として無価値なため undefined を返す
+ * （= フィールド不在。書き込み側で FieldValue.delete() に変換される）。
  */
 function extractHighResImageUrl(raw: DLsiteApiResponse): string | undefined {
 	// image_mainから抽出
 	const mainUrl = extractUrlFromImageField(raw.image_main);
-	if (mainUrl) return mainUrl;
+	if (mainUrl && !isNoImagePlaceholder(mainUrl)) return mainUrl;
 
 	// srcsetから抽出
-	return extractUrlFromSrcset(raw.srcset);
+	const srcsetUrl = extractUrlFromSrcset(raw.srcset);
+	return isNoImagePlaceholder(srcsetUrl) ? undefined : srcsetUrl;
 }
 
 /**

--- a/apps/functions/src/services/mappers/work-mapper.ts
+++ b/apps/functions/src/services/mappers/work-mapper.ts
@@ -237,11 +237,14 @@ function isNoImagePlaceholder(url: string | undefined): boolean {
  * API から画像 URL が一切得られなかった場合の最終フォールバック。
  *
  * DLsite の画像は「次の千番台」ディレクトリ配下に置かれる（RJ01098758 → RJ01099000）。
- * ただしこれは**推測**であり、API 由来の値が取れるときは必ずそちらを優先すること。
+ * 従来この関数はそのディレクトリを欠いた URL を返しており、実際には常に 404 だった。
+ *
+ * ただし**推測**であることに変わりはなく、API 由来の値が取れるときは必ずそちらを優先する。
  * SPR-312 の実測では productId からの導出は 39件中 7件で外れた
  * （翻訳版の画像は元作品 ID の配下にあり、productId からは辿れない）。
- *
- * 原寸（modpub）が無い作品でも解決することがある resize 形式を使う。
+ * そもそもカバー画像が存在しない作品もあり、その場合はどう組み立てても 404 になる
+ * （web 側は #943 の「画像なし」プレースホルダで受ける）。resize 形式の派生ファイルが
+ * 残っていて 200 を返すことがあるが、原本が消えた作品では失効し得るので採用しない。
  */
 function buildFallbackThumbnailUrl(productId: string): string {
 	const match = productId.match(/^([A-Z]+)(\d+)$/);
@@ -251,7 +254,7 @@ function buildFallbackThumbnailUrl(productId: string): string {
 	const [, prefix, digits] = match;
 	const bucket = (Math.floor(Number(digits) / 1000) + 1) * 1000;
 	const dir = `${prefix}${String(bucket).padStart(digits.length, "0")}`;
-	return `https://img.dlsite.jp/resize/images2/work/doujin/${dir}/${productId}_img_main_240x240.jpg`;
+	return `https://img.dlsite.jp/modpub/images2/work/doujin/${dir}/${productId}_img_main.jpg`;
 }
 
 /**


### PR DESCRIPTION
[SPR-312](https://linear.app/nothink/issue/SPR-312/fixfunctions-image-thum-が-no-img-の-works-で-thumbnailurl-を-image-main)

## 事象

DLsite の Individual Info API は画像未登録の作品で `image_thum` / `image_main` に「画像なし」プレースホルダ（`//www.dlsite.com/images/web/home/no_img_*.gif`）を返す。これがそのまま `thumbnailUrl` に保存されており、本番に **39件**ある。

`www.dlsite.com` は web の `remotePatterns` 外のため `/_next/image` で 400 になり、JSON-LD の `image` や OG 画像も壊れた URL を指す。表示側は #943 で自前プレースホルダに倒してあるので画面は既に正常。

## 直し方：API 自身が正解を持っている

no_img なのは `image_thum` だけで、`image_main` には正しい URL が入っている。翻訳版は元作品の画像を指す。

```
RJ01113566:
  image_thum: {"url": "//www.dlsite.com/images/web/home/no_img_sam.gif"}
  image_main: {"workno": "RJ01098758", ...
               "url": "//img.dlsite.jp/modpub/images2/work/doujin/RJ01099000/RJ01098758_img_main.jpg"}
```

これを使うことで**推測を一切せずに**解決する。

- `isNoImagePlaceholder` — no_img プレースホルダを判定
- `extractThumbnailUrl` — `image_thum` が no_img なら `image_main` を使う
- `extractHighResImageUrl` — no_img は `undefined`（フィールド不在）にする
- `toWorkWriteData` — `highResImageUrl` の不在を `FieldValue.delete()` で明示（merge + `ignoreUndefinedProperties` では undefined はスキップされ旧値が残るため）

### productId からの URL 導出は実測で却下した

39件で試した結果:

| 形式 | 200 の件数 |
|---|---|
| `modpub/{bucket}/{id}_img_sam.jpg`（正常系と同じ形） | **0/39** |
| `modpub/{bucket}/{id}_img_main.jpg` | 31/39 |

404 だった7件は**翻訳版で、画像が元作品ID配下にある**（RJ01113566 → RJ01098758 など）。URL は productId から機械的に導出できない。

### 併せて、壊れていた最終フォールバックを是正

API から画像 URL が一切取れない場合のフォールバック `.../doujin/${productId}_img_main.jpg`（work-mapper.ts:231）は千番台ディレクトリを欠いており**実際には 404** だった（実測）。`.../doujin/{次の千番台}/${productId}_img_main.jpg` に是正する。これは推測なので、API 由来の値が取れるときは必ずそちらを優先する旨をコメントに明記している。

## 検証：実 API + 実 URL

live の API レスポンスに対して実際に `WorkMapper.toWork` を通し、出力された URL を取得して確認した。

| 作品 | 結果 |
|---|---|
| RJ01113566 / RJ01310517 / RJ421964（翻訳版） | 200・元作品の実画像（189KB / 170KB / 155KB） |
| RJ01008336 / RJ01133519 / RJ252366 / RJ440045 | 200・実画像 |
| RJ01041035 | 404（下記） |

`pnpm verify` — pass（exit 0）。

## 直らないケース：RJ01041035（1件）

**この作品は DLsite 側にカバー画像が存在しない。** 作品ページは `_img_smp1〜10` と parts しか参照せず `_img_main` を持たない。原本（modpub の .jpg / .webp）も 560x420 の resize も 404。API が `image_thum` / `image_main` とも no_img を返すのはそれが実態だから。

このため本 PR でも `thumbnailUrl` は 404 の URL になる。web は #943 の「画像なし」プレースホルダで受けるので表示は正常。JSON-LD の `image` は 404 URL を指したままになる。

<details>
<summary>初版で「解決した」と書いた経緯（撤回済み）</summary>

初版はフォールバックに resize の 240x240 派生を使い、この作品で 200 が返ることを根拠に「RJ01041035 も解決した」と書いていた。しかし調べ直すと、200 を返していたのは **原本が消えた後に CDN に取り残された派生ファイル**（`last-modified: 2026-02-11` / `max-age=259200`）で、原本が無い以上キャッシュ失効後に再生成されない。依存すべきでないと判断し、フォールバックを正規の modpub 形式へ戻した（コミット cb338522）。

</details>

## バックフィル

**不要。** 週次フルスイープ（SPR-229）がティア差分を無視して全件処理し、`saveWorksToFirestore` が merge:true で無条件に書くため、デプロイ後最大1週間で38件が自動修復される。

## Door 判定

apps/functions の**本番パイプライン変更**。スキーマ変更なし・適用条件は「no_img 検出時のみ」でブラスト半径は39件だが、CLAUDE.md のセルフマージ・ポリシーに従い**自己レビュー前提**で扱ってください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
