### PR TITLE
fix(functions): translation_info を正しく読み、翻訳版の親子関係まで取り込む

### DIFF
--- a/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
@@ -337,7 +337,6 @@ describe("WorkMapper", () => {
 				parentWorkno: undefined,
 				childWorknos: ["RJ01113567"],
 				lang: "CHI_HANS",
-				productionTradePriceRate: undefined,
 			});
 		});
 

--- a/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
+++ b/apps/functions/src/services/mappers/__tests__/work-mapper.test.ts
@@ -307,6 +307,88 @@ describe("WorkMapper", () => {
 		});
 	});
 
+	// SPR-313: API の実フィールド名は translation_info。旧実装は raw.translation を見ており
+	// 全作品で translationInfo が欠落していた（本番 works で 0 件）。
+	describe("translationInfo（翻訳版の親子関係）", () => {
+		it("親作品は is_parent と child_worknos まで取り込む", () => {
+			// 実データ: RJ01113566（CHI_HANS 版・親） → 原作 RJ01098758 / 子 RJ01113567
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				translation_info: {
+					is_translation_agree: false,
+					is_volunteer: false,
+					is_original: false,
+					is_parent: true,
+					is_child: false,
+					original_workno: "RJ01098758",
+					parent_workno: null,
+					child_worknos: ["RJ01113567"],
+					lang: "CHI_HANS",
+				},
+			} as DLsiteApiResponse);
+
+			expect(work.translationInfo).toEqual({
+				isTranslationAgree: false,
+				isVolunteer: false,
+				isOriginal: false,
+				isParent: true,
+				isChild: false,
+				originalWorkno: "RJ01098758",
+				parentWorkno: undefined,
+				childWorknos: ["RJ01113567"],
+				lang: "CHI_HANS",
+				productionTradePriceRate: undefined,
+			});
+		});
+
+		it("子作品は parent_workno を取り込む", () => {
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				translation_info: {
+					is_original: false,
+					is_parent: false,
+					is_child: true,
+					original_workno: "RJ01098758",
+					parent_workno: "RJ01113566",
+					child_worknos: [],
+					lang: "CHI_HANS",
+				},
+			} as DLsiteApiResponse);
+
+			expect(work.translationInfo?.isChild).toBe(true);
+			expect(work.translationInfo?.parentWorkno).toBe("RJ01113566");
+			expect(work.translationInfo?.childWorknos).toEqual([]);
+		});
+
+		it("非翻訳作品の null は undefined に落とす", () => {
+			// API は非翻訳作品で original_workno / parent_workno / lang を null で返す
+			const work = WorkMapper.toWork({
+				...mockRawApiData,
+				translation_info: {
+					is_translation_agree: true,
+					is_original: true,
+					is_parent: false,
+					is_child: false,
+					original_workno: null,
+					parent_workno: null,
+					child_worknos: [],
+					lang: null,
+				},
+			} as DLsiteApiResponse);
+
+			expect(work.translationInfo?.isOriginal).toBe(true);
+			expect(work.translationInfo?.originalWorkno).toBeUndefined();
+			expect(work.translationInfo?.parentWorkno).toBeUndefined();
+			expect(work.translationInfo?.lang).toBeUndefined();
+		});
+
+		it("translation_info が無ければ undefined", () => {
+			const work = WorkMapper.toWork(mockRawApiData);
+
+			expect(work.translationInfo).toBeUndefined();
+		});
+	});
+
 	// SPR-312: DLsite API は画像未登録の作品で no_img プレースホルダを返す。
 	// これを保存すると web の remotePatterns 外のホストになり、JSON-LD / OG 画像も壊れる。
 	describe("「画像なし」プレースホルダの正規化", () => {

--- a/apps/functions/src/services/mappers/work-mapper.ts
+++ b/apps/functions/src/services/mappers/work-mapper.ts
@@ -420,7 +420,9 @@ function toTranslationInfo(raw: DLsiteApiResponse): TranslationInfo | undefined 
 		parentWorkno: translation.parent_workno ?? undefined,
 		childWorknos: translation.child_worknos ?? undefined,
 		lang: translation.lang ?? undefined,
-		productionTradePriceRate: translation.production_trade_price_rate ?? undefined,
+		// production_trade_price_rate は TranslationInfoSchema に定義はあるが、
+		// 実 API では翻訳親/子・原作・非翻訳のいずれでもキー自体が返らない（8件で確認）。
+		// 常に undefined になるだけなので取り込まない。
 	};
 }
 

--- a/apps/functions/src/services/mappers/work-mapper.ts
+++ b/apps/functions/src/services/mappers/work-mapper.ts
@@ -401,15 +401,26 @@ function extractSampleImages(
 
 /**
  * 翻訳情報の変換
+ *
+ * 親子関係（isParent / isChild / parentWorkno / childWorknos）まで取り込む。
+ * 同じ作品の各言語版を1つにまとめる導線は、この関係が無いと復元できない（SPR-313）。
  */
 function toTranslationInfo(raw: DLsiteApiResponse): TranslationInfo | undefined {
-	if (!raw.translation) return undefined;
+	const translation = raw.translation_info;
+	if (!translation) return undefined;
+	// API は非翻訳作品で original_workno / parent_workno / lang を null で返す。
+	// 保存側は `string | undefined` なので null は「不在」に倒す。
 	return {
-		isTranslationAgree: raw.translation.is_translation_agree,
-		isVolunteer: raw.translation.is_volunteer,
-		isOriginal: raw.translation.is_original,
-		originalWorkno: raw.translation.original_workno,
-		lang: raw.translation.lang,
+		isTranslationAgree: translation.is_translation_agree,
+		isVolunteer: translation.is_volunteer,
+		isOriginal: translation.is_original,
+		isParent: translation.is_parent,
+		isChild: translation.is_child,
+		originalWorkno: translation.original_workno ?? undefined,
+		parentWorkno: translation.parent_workno ?? undefined,
+		childWorknos: translation.child_worknos ?? undefined,
+		lang: translation.lang ?? undefined,
+		productionTradePriceRate: translation.production_trade_price_rate ?? undefined,
 	};
 }
 

--- a/packages/shared-types/src/api-schemas/dlsite-raw.ts
+++ b/packages/shared-types/src/api-schemas/dlsite-raw.ts
@@ -102,17 +102,19 @@ export const DLsiteRawCampaign = z.object({
 });
 
 // === 翻訳情報 ===
+// 非翻訳作品では original_workno / parent_workno / lang が **null** で返る（実 API で確認）。
+// 保存側の TranslationInfo は `string | undefined` なので、マッパーで null を落とすこと。
 export const DLsiteRawTranslation = z.object({
 	is_translation_agree: z.boolean().optional(),
 	is_volunteer: z.boolean().optional(),
 	is_original: z.boolean().optional(),
 	is_parent: z.boolean().optional(),
 	is_child: z.boolean().optional(),
-	original_workno: z.string().optional(),
-	parent_workno: z.string().optional(),
-	child_worknos: z.array(z.string()).optional(),
-	lang: z.string().optional(),
-	production_trade_price_rate: z.number().optional(),
+	original_workno: z.string().nullish(),
+	parent_workno: z.string().nullish(),
+	child_worknos: z.array(z.string()).nullish(),
+	lang: z.string().nullish(),
+	production_trade_price_rate: z.number().nullish(),
 });
 
 // === 言語版情報 ===
@@ -166,8 +168,9 @@ export const DLsiteApiResponse = z.object({
 	title: DLsiteRawSeries.optional(),
 	// キャンペーン
 	campaign: DLsiteRawCampaign.optional(),
-	// 翻訳
-	translation: DLsiteRawTranslation.optional(),
+	// 翻訳（API の実フィールド名は `translation_info`。SPR-313 まで `translation` を見ており
+	// 全作品で欠落していた）
+	translation_info: DLsiteRawTranslation.optional(),
 	// 言語版
 	language_editions: DLsiteRawLanguageEditions.optional(),
 	// ランキング

--- a/packages/shared-types/src/plain-objects/work-plain.ts
+++ b/packages/shared-types/src/plain-objects/work-plain.ts
@@ -190,7 +190,13 @@ export interface WorkPlainObject {
 	translationInfo?: {
 		isTranslationAgree: boolean;
 		isOriginal: boolean;
+		/** 翻訳版の親（この作品の下に各言語版がぶら下がる） */
+		isParent: boolean;
+		/** 翻訳版の子（parentWorkno に親がいる） */
+		isChild: boolean;
 		originalWorkno?: string;
+		parentWorkno?: string;
+		childWorknos?: string[];
 		lang?: string;
 	};
 	languageDownloads?: Array<{

--- a/packages/shared-types/src/transformers/__tests__/work-firestore.test.ts
+++ b/packages/shared-types/src/transformers/__tests__/work-firestore.test.ts
@@ -68,3 +68,56 @@ describe("work-firestore fromFirestore の言語判定（detectWorkLanguage へ�
 		expect(fromFirestore(doc)._computed.primaryLanguage).toBe("ko");
 	});
 });
+
+// SPR-313: translationInfo の親子関係（isParent / isChild / parentWorkno / childWorknos）は
+// PlainObject まで通す必要がある。ここで落ちると Firestore にデータがあっても web からは
+// 見えず、「翻訳版を1つにまとめる」導線が組めない（フィールド名バグと同じ静かな欠落）。
+describe("work-firestore fromFirestore の translationInfo", () => {
+	it("親子関係を PlainObject まで落とさず渡す", () => {
+		const work = fromFirestore(
+			createWorkDocument({
+				translationInfo: {
+					isTranslationAgree: false,
+					isOriginal: false,
+					isParent: true,
+					isChild: false,
+					originalWorkno: "RJ01098758",
+					childWorknos: ["RJ01113567"],
+					lang: "CHI_HANS",
+				},
+			}),
+		);
+
+		expect(work.translationInfo).toEqual({
+			isTranslationAgree: false,
+			isOriginal: false,
+			isParent: true,
+			isChild: false,
+			originalWorkno: "RJ01098758",
+			parentWorkno: undefined,
+			childWorknos: ["RJ01113567"],
+			lang: "CHI_HANS",
+		});
+	});
+
+	it("子作品の parentWorkno を渡す", () => {
+		const work = fromFirestore(
+			createWorkDocument({
+				translationInfo: {
+					isOriginal: false,
+					isParent: false,
+					isChild: true,
+					parentWorkno: "RJ01113566",
+					childWorknos: [],
+				},
+			}),
+		);
+
+		expect(work.translationInfo?.isChild).toBe(true);
+		expect(work.translationInfo?.parentWorkno).toBe("RJ01113566");
+	});
+
+	it("translationInfo が無ければ undefined", () => {
+		expect(fromFirestore(createWorkDocument()).translationInfo).toBeUndefined();
+	});
+});

--- a/packages/shared-types/src/transformers/work-firestore.ts
+++ b/packages/shared-types/src/transformers/work-firestore.ts
@@ -226,7 +226,11 @@ export function fromFirestore(doc: WorkDocument): WorkPlainObject {
 			? {
 					isTranslationAgree: doc.translationInfo.isTranslationAgree || false,
 					isOriginal: doc.translationInfo.isOriginal || false,
+					isParent: doc.translationInfo.isParent || false,
+					isChild: doc.translationInfo.isChild || false,
 					originalWorkno: doc.translationInfo.originalWorkno,
+					parentWorkno: doc.translationInfo.parentWorkno,
+					childWorknos: doc.translationInfo.childWorknos,
 					lang: doc.translationInfo.lang,
 				}
 			: undefined,


### PR DESCRIPTION
[SPR-313](https://linear.app/nothink/issue/SPR-313/fixfunctions-translation-info-を読めておらず全作品で-translationinfo-が欠落している)

## 事象

本番 `works` で **`translationInfo` を持つドキュメントは 0件**だった。

```
db.collection("works").orderBy("translationInfo").limit(5) → 0件
```

エラーも警告も出ないため、誰も気付かないまま欠落し続けていた。

## 原因

API の実フィールドは `translation_info` だが、raw スキーマとマッパーが揃って `translation` を見ており、早期 return で常に undefined になっていた。

| 場所 | 修正前 | |
|---|---|---|
| `api-schemas/dlsite-raw.ts:170` | `translation:` | ❌ |
| `mappers/work-mapper.ts:406` | `if (!raw.translation) return undefined;` | ❌ |
| `dlsite/dlsite-known-api-fields.ts:246` | `"translation_info"` | ✅ こちらだけ正しかった |

## 変更

**フィールド名を直すだけでは足りない。** `toTranslationInfo` は元々 5 フィールドしかマップしておらず、親子関係が入らなかった。

- `dlsite-raw.ts` — `translation` → `translation_info` にリネーム
- `work-mapper.ts` — `isParent` / `isChild` / `parentWorkno` / `childWorknos` を追加でマップ
- 非翻訳作品では `original_workno` / `parent_workno` / `lang` が **null** で返るため（実 API で確認）、raw スキーマを `.nullish()` にし、マッパーで null を「不在」に倒す
- `work-plain.ts` / `work-firestore.ts` — PlainObject が親子関係を落としていたので通す

最後の1点は当初スコープ外だったが、Firestore に入れても web から見えないままでは**同じ静かな欠落**になるため含めた。追加はすべて optional なフィールドで破壊的変更ではない。保存側の `TranslationInfoSchema` は元から全フィールドを持つのでスキーマ変更は不要。

### `productionTradePriceRate` は取り込まない（レビュー指摘への対応）

初版は `TranslationInfoSchema` にあるのに合わせてこのフィールドもマップしていたが、PlainObject には通しておらず、AI レビューに「Firestore にはあるが web から見えない ＝ この PR が是正している欠落と同型」と指摘された（major × 2、同一内容）。指摘は事実として正しい。

PlainObject へ通す方向ではなく、**マッパーから外す**方を選んだ。実 API を 8 件で確認したところ、`production_trade_price_rate` は**どの作品でもキー自体が返らない**ため。

| 確認した作品 | 種別 | 結果 |
|---|---|---|
| RJ01113566 / RJ01113567 | 翻訳の親 / 子 | キー無し |
| RJ01098758 | 原作（`is_translation_agree: true`・翻訳実績あり） | キー無し |
| RJ01037463 / RJ01041035 / RJ252366 / RJ440045 / RJ01133519 | 非翻訳ほか | キー無し |

取り込んでも常に undefined で、Firestore にも web にも意味のある値は流れない。用途の無いフィールドを PlainObject まで広げるより、取り込まない方が意図と挙動が一致する。raw スキーマと `TranslationInfoSchema` の定義は API の形を記述するものとして残した。

これにより「実値が未確認」という初版の確認事項も消えた（値が存在しないため）。

## 検証：実 API で親子チェーンが復元できること

live のレスポンスを `WorkMapper.toWork` に通した結果:

```
RJ01098758（原作）: isOriginal=true, childWorknos=[]
RJ01113566（親）  : isParent=true,  originalWorkno=RJ01098758, childWorknos=["RJ01113567"]
RJ01113567（子）  : isChild=true,   originalWorkno=RJ01098758, parentWorkno=RJ01113566
RJ01037463（非翻訳）: isOriginal=true（null の originalWorkno / lang はキーごと落ちる）
```

原作 → 親 → 子のチェーンが辿れる。「同じ作品の各言語版を1つにまとめる」導線の前提データが揃う。

テストは mapper 側4件（親 / 子 / null 落とし / フィールド不在）、transformer 側3件（PlainObject まで通ること）を追加。**transformer 側のテストが無いと、Firestore にデータがあるのに web から見えないという今回と同じクラスのバグが再発する**ため明示的に固定した。

`pnpm verify` — pass（exit 0）。

## バックフィル

**不要。** 週次フルスイープ（SPR-229）が全件を merge 書き込みするため、デプロイ後最大1週間で全作品に `translationInfo` が入る。

## 確認事項

- 全作品に nested object が1つ増える（非翻訳作品でも `isOriginal` などのフラグは意味を持つため一律に保存する）
- `isVolunteer` は本 PR 以前から PlainObject に無く、今回も用途が無いためスコープ外のままとした

## Door 判定

apps/functions の**本番パイプライン変更**。スキーマ変更なし・既存フィールドの書き換えなし（欠落フィールドの充填のみ）だが、CLAUDE.md のセルフマージ・ポリシーに従い**自己レビュー前提**で扱ってください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
