### PR TITLE
fix(web): consent カテゴリと gtag パラメータの対応のねじれを直す (SPR-280)

### DIFF
--- a/apps/web/src/components/consent/__tests__/consent-mode-script.test.tsx
+++ b/apps/web/src/components/consent/__tests__/consent-mode-script.test.tsx
@@ -1,0 +1,72 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ConsentModeScript } from "../consent-mode-script";
+
+type ConsentUpdate = ["consent", "update", Record<string, unknown>];
+
+function consentUpdates(): ConsentUpdate[] {
+	return (window.dataLayer ?? []).filter(
+		(entry): entry is ConsentUpdate =>
+			Array.isArray(entry) && entry[0] === "consent" && entry[1] === "update",
+	);
+}
+
+function saveConsent(data: Record<string, boolean>, date = new Date()) {
+	localStorage.setItem("consent-state", JSON.stringify(data));
+	localStorage.setItem("consent-state-date", date.toISOString());
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	// gtag 未ロード（lazyOnload の前）の状態を再現する
+	(window as unknown as { dataLayer?: unknown; gtag?: unknown }).dataLayer = undefined;
+	(window as unknown as { dataLayer?: unknown; gtag?: unknown }).gtag = undefined;
+});
+
+afterEach(() => {
+	localStorage.clear();
+});
+
+describe("ConsentModeScript", () => {
+	it("保存済み同意を default の後に復元する（gtag.js ロード前でも dataLayer に積む）", () => {
+		saveConsent({ analytics: true, advertising: false, functional: true, personalization: true });
+
+		render(<ConsentModeScript />);
+
+		// SPR-280: マッピングは google-consent-mode.ts が正本。ad_* は advertising 駆動で、
+		// functionality_storage は保存値（以前は復元側だけ "granted" 決め打ちだった）
+		expect(consentUpdates()).toEqual([
+			[
+				"consent",
+				"update",
+				{
+					ad_storage: "denied",
+					ad_user_data: "denied",
+					ad_personalization: "denied",
+					analytics_storage: "granted",
+					functionality_storage: "granted",
+					personalization_storage: "granted",
+				},
+			],
+		]);
+	});
+
+	it("1年より古い同意は復元しない", () => {
+		const twoYearsAgo = new Date();
+		twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2);
+		saveConsent({ analytics: true, advertising: false, functional: true }, twoYearsAgo);
+
+		render(<ConsentModeScript />);
+
+		expect(consentUpdates()).toEqual([]);
+	});
+
+	it("保存が無ければ default だけを積む", () => {
+		render(<ConsentModeScript />);
+
+		expect(consentUpdates()).toEqual([]);
+		expect(window.dataLayer.filter((entry) => (entry as unknown[])[1] === "default")).toHaveLength(
+			2,
+		);
+	});
+});

--- a/apps/web/src/components/consent/__tests__/cookie-consent-banner.test.tsx
+++ b/apps/web/src/components/consent/__tests__/cookie-consent-banner.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgeVerificationProvider } from "@/contexts/age-verification-context";
+import { CookieConsentBanner } from "../cookie-consent-banner";
+
+const gtag = vi.fn();
+
+function consentUpdateCalls() {
+	return gtag.mock.calls.filter(
+		([command, action]) => command === "consent" && action === "update",
+	);
+}
+
+function saveConsent(data: Record<string, boolean>, savedAt: Date) {
+	localStorage.setItem("consent-state", JSON.stringify(data));
+	localStorage.setItem("consent-state-date", savedAt.toISOString());
+}
+
+function yearsAgo(years: number) {
+	const date = new Date();
+	date.setFullYear(date.getFullYear() - years);
+	return date;
+}
+
+function renderBanner() {
+	return render(
+		<AgeVerificationProvider>
+			<CookieConsentBanner />
+		</AgeVerificationProvider>,
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	localStorage.clear();
+	(window as unknown as { gtag: typeof gtag }).gtag = gtag;
+});
+
+describe("CookieConsentBanner", () => {
+	it("同意が無ければバナーを出す", () => {
+		renderBanner();
+		expect(screen.getByRole("button", { name: "許可" })).toBeInTheDocument();
+	});
+
+	// SPR-280: 復元の gtag 反映は ConsentModeScript の役割。ここで再 push すると
+	// 二重 push・ユーザー操作でない consent_update イベント・consent-state-date の
+	// 更新（＝1年の再確認が永久に来ない）が起きていた
+	it("有効な同意が保存済みなら、バナーを出さず gtag も保存も触らない", async () => {
+		const savedAt = yearsAgo(0);
+		saveConsent({ analytics: true, advertising: false, functional: true }, savedAt);
+		const listener = vi.fn();
+		window.addEventListener("consentUpdate", listener);
+
+		renderBanner();
+
+		expect(screen.queryByRole("button", { name: "許可" })).not.toBeInTheDocument();
+		expect(consentUpdateCalls()).toHaveLength(0);
+		expect(gtag).not.toHaveBeenCalledWith("event", "consent_update", expect.anything());
+		expect(localStorage.getItem("consent-state-date")).toBe(savedAt.toISOString());
+		// page_view 再送の契機としての通知だけは残す（page-view-tracker.tsx）
+		expect(listener).toHaveBeenCalledTimes(1);
+		window.removeEventListener("consentUpdate", listener);
+	});
+
+	// クッキー設定パネルの「設定は1年間保存され、期限後に再確認をお願いします」を実際に効かせる
+	it("1年より古い同意は未同意扱いでバナーを出し直す", () => {
+		saveConsent({ analytics: true, advertising: false, functional: true }, yearsAgo(2));
+
+		renderBanner();
+
+		expect(screen.getByRole("button", { name: "許可" })).toBeInTheDocument();
+	});
+
+	it("「許可」は保存し、広告系は denied のまま gtag に反映する", async () => {
+		renderBanner();
+
+		await userEvent.click(screen.getByRole("button", { name: "許可" }));
+
+		expect(JSON.parse(localStorage.getItem("consent-state") || "{}")).toEqual({
+			functional: true,
+			analytics: true,
+			advertising: false,
+			personalization: true,
+		});
+		expect(consentUpdateCalls()).toHaveLength(1);
+		expect(gtag).toHaveBeenCalledWith(
+			"consent",
+			"update",
+			expect.objectContaining({
+				ad_storage: "denied",
+				ad_user_data: "denied",
+				ad_personalization: "denied",
+				analytics_storage: "granted",
+				personalization_storage: "granted",
+			}),
+		);
+	});
+});

--- a/apps/web/src/components/consent/consent-mode-script.tsx
+++ b/apps/web/src/components/consent/consent-mode-script.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { applyGoogleConsent, getCurrentConsentState } from "@/lib/consent/google-consent-mode";
 
 // EU/GDPR countries list
 const GDPR_COUNTRIES = [
@@ -113,74 +114,17 @@ function setDefaultConsent() {
 
 /**
  * Apply saved consent preferences if valid
+ *
+ * SPR-280: 保存値の読み取り・期限判定・gtag へのマッピングはすべて
+ * google-consent-mode.ts が正本。ここは gtag.js ロード前だが、setupDataLayer の
+ * polyfill が window.gtag を用意済みなので同じ関数を通せる。
+ * 復元は「ユーザー操作」ではないので consent_update イベントは送らない。
+ *
+ * 保存済み同意を gtag に反映するのはこの経路だけ（バナー側は再 push しない）。
  */
 function applySavedConsent() {
-	try {
-		const savedConsent = getSavedConsent();
-		if (!savedConsent) return;
-
-		const { data, date } = savedConsent;
-		if (isConsentValid(date)) {
-			updateConsent(data);
-			logConsentInDevelopment(data);
-		}
-	} catch {
-		// Silent fail for normal operation
-	}
-}
-
-/**
- * Get saved consent from localStorage
- */
-function getSavedConsent() {
-	const consentState = localStorage.getItem("consent-state");
-	const consentDate = localStorage.getItem("consent-state-date");
-
-	if (!consentState || !consentDate) return null;
-
-	return {
-		data: JSON.parse(consentState),
-		date: new Date(consentDate),
-	};
-}
-
-/**
- * Check if consent is still valid (less than 1 year old)
- */
-function isConsentValid(consentDate: Date): boolean {
-	const oneYearAgo = new Date();
-	oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-	return consentDate > oneYearAgo;
-}
-
-interface ConsentData {
-	advertising: boolean;
-	analytics: boolean;
-	personalization: boolean;
-}
-
-/**
- * Update consent based on saved preferences
- */
-function updateConsent(consentData: ConsentData) {
-	function gtag(...args: unknown[]) {
-		window.dataLayer.push(args);
-	}
-
-	gtag("consent", "update", {
-		ad_storage: consentData.advertising ? "granted" : "denied",
-		ad_user_data: consentData.advertising ? "granted" : "denied",
-		ad_personalization: consentData.personalization ? "granted" : "denied",
-		analytics_storage: consentData.analytics ? "granted" : "denied",
-		functionality_storage: "granted",
-		personalization_storage: consentData.personalization ? "granted" : "denied",
-	});
-}
-
-/**
- * Log consent application in development environment
- */
-function logConsentInDevelopment(_consentData: ConsentData) {
-	if (window.location.hostname === "localhost") {
+	const savedConsent = getCurrentConsentState();
+	if (savedConsent) {
+		applyGoogleConsent(savedConsent);
 	}
 }

--- a/apps/web/src/components/consent/cookie-consent-banner.tsx
+++ b/apps/web/src/components/consent/cookie-consent-banner.tsx
@@ -3,7 +3,7 @@
 import { DockedPanel } from "@suzumina.click/ui/components/custom";
 import { Button } from "@suzumina.click/ui/components/ui/button";
 import { Cookie } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useAgeVerification } from "@/contexts/age-verification-context";
 import { useIsClient } from "@/hooks/use-is-client";
 import {
@@ -22,6 +22,11 @@ const DEFAULT_CONSENT: ConsentState = {
 };
 
 const NARROW_VIEWPORT_QUERY = "(max-width: 639px)";
+
+/** 同意の確定を他のクライアント機能へ通知する（page_view の再送契機など） */
+function notifyConsentUpdate(choices: ConsentState) {
+	window.dispatchEvent(new CustomEvent("consentUpdate", { detail: choices }));
+}
 
 /**
  * 案A: 左下に独立して浮く非モーダルなピル型バー（年齢確認カードは右下・重ならない）。
@@ -46,20 +51,9 @@ export function CookieConsentBanner() {
 		return () => mediaQuery.removeEventListener("change", update);
 	}, []);
 
-	// Apply consent choices using unified system
-	const applyConsentChoices = useCallback((choices: ConsentState) => {
-		updateConsent(choices);
-
-		// Trigger custom event for other services to listen
-		window.dispatchEvent(
-			new CustomEvent("consentUpdate", {
-				detail: choices,
-			}),
-		);
-	}, []);
-
 	const saveConsent = (choices: ConsentState) => {
-		applyConsentChoices(choices);
+		updateConsent(choices);
+		notifyConsentUpdate(choices);
 		setShowBanner(false);
 		setShowPreferences(false);
 	};
@@ -85,12 +79,16 @@ export function CookieConsentBanner() {
 		// Only run on client side
 		if (!isClient) return;
 
-		// Check if user has already made consent choices using unified system
+		// 有効な同意が保存済みか（期限切れは null＝未同意扱いで再確認へ）
 		const savedConsent = getCurrentConsentState();
 
 		if (savedConsent) {
-			// User has already made consent choices
-			applyConsentChoices(savedConsent);
+			// SPR-280: 保存済み同意の gtag への反映は ConsentModeScript（layout に常設）が
+			// 済ませている。ここで updateConsent を呼ぶと (1) 同じ consent update の二重 push、
+			// (2) ユーザー操作でないのに consent_update イベントの送信、
+			// (3) consent-state-date の更新で1年の再確認が永久に来ない、の3つが起きていた。
+			// 残すのは DOM イベントの通知だけ（page_view 再送の契機・page-view-tracker.tsx）。
+			notifyConsentUpdate(savedConsent);
 			setShowBanner(false);
 		} else {
 			// No consent yet, show banner
@@ -98,7 +96,7 @@ export function CookieConsentBanner() {
 		}
 
 		setIsLoading(false);
-	}, [isClient, applyConsentChoices]);
+	}, [isClient]);
 
 	// 狭い画面では年齢確認カードのドック占有中（ask/toast）は出さず、決着後に表示する（順次表示）
 	const deferredForMobileAgeGate = isNarrowViewport && isAgeCardDocked;

--- a/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
+++ b/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	applyGoogleConsent,
 	getCurrentConsentState,
+	normalizeConsentState,
 	resetAllConsent,
 	sendGoogleAnalyticsEvent,
 	sendGoogleAnalyticsPageView,
@@ -29,13 +31,24 @@ const grantAnalytics = {
 	personalization: false,
 };
 
+function saveConsent(data: Record<string, boolean>, savedAt = new Date()) {
+	localStorage.setItem("consent-state", JSON.stringify(data));
+	localStorage.setItem("consent-state-date", savedAt.toISOString());
+}
+
+function yearsAgo(years: number) {
+	const date = new Date();
+	date.setFullYear(date.getFullYear() - years);
+	return date;
+}
+
 describe("getCurrentConsentState", () => {
 	it("保存が無ければ null", () => {
 		expect(getCurrentConsentState()).toBeNull();
 	});
 
 	it("保存値を ConsentState に正規化する（functional は既定 true）", () => {
-		localStorage.setItem("consent-state", JSON.stringify({ analytics: true }));
+		saveConsent({ analytics: true });
 		expect(getCurrentConsentState()).toEqual({
 			analytics: true,
 			advertising: false,
@@ -45,8 +58,84 @@ describe("getCurrentConsentState", () => {
 	});
 
 	it("不正 JSON は null（catch）", () => {
+		saveConsent({});
 		localStorage.setItem("consent-state", "{壊れた");
 		expect(getCurrentConsentState()).toBeNull();
+	});
+
+	// SPR-280: 期限判定は consent-mode-script.tsx 側にしか無く、バナーが参照する
+	// この関数は日付を見ていなかったため「1年で再確認」が実際には起きなかった
+	it("保存から1年を超えた同意は null（＝未同意扱いで再確認へ）", () => {
+		saveConsent({ analytics: true }, yearsAgo(2));
+		expect(getCurrentConsentState()).toBeNull();
+	});
+
+	it("保存日時が無い（壊れた保存）場合も null", () => {
+		localStorage.setItem("consent-state", JSON.stringify({ analytics: true }));
+		expect(getCurrentConsentState()).toBeNull();
+	});
+});
+
+describe("normalizeConsentState", () => {
+	it("欠けた項目は既定に落とす（functional のみ true）", () => {
+		expect(normalizeConsentState({})).toEqual({
+			analytics: false,
+			advertising: false,
+			functional: true,
+			personalization: false,
+		});
+		expect(normalizeConsentState(null)).toEqual({
+			analytics: false,
+			advertising: false,
+			functional: true,
+			personalization: false,
+		});
+	});
+});
+
+describe("applyGoogleConsent", () => {
+	// SPR-280: ad_personalization は「広告のパーソナライズ」なので advertising 駆動。
+	// personalization カテゴリが駆動するのは personalization_storage だけ。
+	// 以前は personalization 駆動で、バナーの「許可」が
+	// ad_storage: denied なのに ad_personalization: granted を生んでいた。
+	it("ad_* は advertising 駆動・personalization_storage だけが personalization 駆動", () => {
+		applyGoogleConsent({
+			analytics: true,
+			advertising: false,
+			functional: true,
+			personalization: true,
+		});
+		expect(gtag).toHaveBeenCalledWith("consent", "update", {
+			ad_storage: "denied",
+			ad_user_data: "denied",
+			ad_personalization: "denied",
+			analytics_storage: "granted",
+			functionality_storage: "granted",
+			personalization_storage: "granted",
+		});
+	});
+
+	it("advertising 同意時は ad_* が揃って granted", () => {
+		applyGoogleConsent({
+			analytics: false,
+			advertising: true,
+			functional: true,
+			personalization: false,
+		});
+		expect(gtag).toHaveBeenCalledWith(
+			"consent",
+			"update",
+			expect.objectContaining({
+				ad_storage: "granted",
+				ad_user_data: "granted",
+				ad_personalization: "granted",
+			}),
+		);
+	});
+
+	it("consent_update イベントは送らない（復元時に使うため）", () => {
+		applyGoogleConsent(grantAnalytics);
+		expect(gtag).not.toHaveBeenCalledWith("event", "consent_update", expect.anything());
 	});
 });
 
@@ -78,6 +167,17 @@ describe("updateConsent", () => {
 		expect(JSON.parse(localStorage.getItem("consent-state") || "{}")).toEqual(grantAnalytics);
 		expect(localStorage.getItem("consent-state-date")).toBeTruthy();
 	});
+
+	// SPR-280: 以前は updateConsent 自身が4フィールドだけの consent update を push した
+	// 直後に updateGoogleConsent が6フィールドを push しており、ad_user_data /
+	// ad_personalization を欠いた中間状態が一瞬存在した
+	it("consent update は1回だけ push する", () => {
+		updateConsent(grantAnalytics);
+		const consentUpdates = gtag.mock.calls.filter(
+			([command, action]) => command === "consent" && action === "update",
+		);
+		expect(consentUpdates).toHaveLength(1);
+	});
 });
 
 describe("resetAllConsent", () => {
@@ -101,7 +201,7 @@ describe("sendGoogleAnalyticsPageView / Event", () => {
 	// 同意は「識別子を保存するか」だけを意味する。ゲートしていた頃は同意率 3.3% のため
 	// カスタムイベントが本番0件・landingPage の 63% が (not set) になっていた。
 	it("analytics 同意が無くても送信する（可否は consent mode に委ねる）", () => {
-		localStorage.setItem("consent-state", JSON.stringify({ analytics: false }));
+		saveConsent({ analytics: false });
 		expect(sendGoogleAnalyticsPageView("/x", "G-TEST")).toBe(true);
 		sendGoogleAnalyticsEvent("evt");
 		expect(gtag).toHaveBeenCalledWith(

--- a/apps/web/src/lib/consent/google-consent-mode.ts
+++ b/apps/web/src/lib/consent/google-consent-mode.ts
@@ -40,20 +40,61 @@ export interface ConsentState {
 }
 
 /**
+ * 保存済みの任意値を ConsentState に正規化する（`functional` の既定は true）
+ *
+ * localStorage から読む経路が複数あるため（このファイルの getCurrentConsentState と、
+ * hydration 前に走る consent-mode-script.tsx）、解釈のズレを避けて正本をここに置く。
+ */
+export function normalizeConsentState(saved: unknown): ConsentState {
+	const source = (saved ?? {}) as Partial<Record<keyof ConsentState, unknown>>;
+	return {
+		analytics: source.analytics === true,
+		advertising: source.advertising === true,
+		functional: source.functional !== false,
+		personalization: source.personalization === true,
+	};
+}
+
+/**
+ * ConsentState → Google Consent Mode v2 パラメータの対応（正本）
+ *
+ * SPR-280: `ad_personalization` は「広告のパーソナライズ」なので advertising 駆動にする。
+ * personalization カテゴリが駆動するのは GA のコンテンツ・パーソナライズ
+ * （`personalization_storage`）だけで、両者は別物。以前は ad_personalization を
+ * personalization で駆動していたため、「広告を拒否したのに ad_personalization: granted」
+ * という、カテゴリ名から予測できない状態になっていた。
+ */
+function toGoogleConsentParams(consentState: ConsentState): ConsentParams {
+	const advertising = consentState.advertising ? "granted" : "denied";
+	return {
+		ad_storage: advertising,
+		ad_user_data: advertising,
+		ad_personalization: advertising,
+		analytics_storage: consentState.analytics ? "granted" : "denied",
+		functionality_storage: consentState.functional ? "granted" : "denied",
+		personalization_storage: consentState.personalization ? "granted" : "denied",
+	};
+}
+
+/**
+ * 同意状態を gtag に反映する（`consent update` の push のみ・イベントは送らない）
+ *
+ * 保存済み同意の復元時にも使うため、ユーザー操作を表す `consent_update` イベントは
+ * 含めない（そちらは updateGoogleConsent の責務）。
+ */
+export function applyGoogleConsent(consentState: ConsentState) {
+	if (typeof window === "undefined" || !window.gtag) return;
+
+	window.gtag("consent", "update", toGoogleConsentParams(consentState));
+}
+
+/**
  * Update consent choices and notify Google services
  */
 export function updateGoogleConsent(consentState: ConsentState) {
 	if (typeof window === "undefined" || !window.gtag) return;
 
-	// Update consent mode with user choices
-	window.gtag("consent", "update", {
-		ad_storage: consentState.advertising ? "granted" : "denied",
-		ad_user_data: consentState.advertising ? "granted" : "denied",
-		ad_personalization: consentState.personalization ? "granted" : "denied",
-		analytics_storage: consentState.analytics ? "granted" : "denied",
-		functionality_storage: consentState.functional ? "granted" : "denied",
-		personalization_storage: consentState.personalization ? "granted" : "denied",
-	});
+	applyGoogleConsent(consentState);
 
 	// Send custom event for tracking consent changes
 	window.gtag("event", "consent_update", {
@@ -64,22 +105,31 @@ export function updateGoogleConsent(consentState: ConsentState) {
 }
 
 /**
+ * 保存済み同意の有効期間（1年）。クッキー設定パネルの「設定は1年間保存され、
+ * 期限後に再確認をお願いします」という記述がこの値の対外的な約束にあたる。
+ */
+function isConsentValid(savedAt: Date): boolean {
+	const oneYearAgo = new Date();
+	oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+	return savedAt > oneYearAgo;
+}
+
+/**
  * Check current consent state from localStorage
+ *
+ * SPR-280: 期限切れ（保存から1年超・日付が無い・壊れている）は null を返す＝
+ * 「同意していない」と同じ扱いにして再確認へ倒す。以前は期限判定が
+ * consent-mode-script.tsx 側にしか無く、バナーはこの関数が値を返す限り
+ * 表示されないため、**期限を過ぎても再確認が出ない**状態だった。
  */
 export function getCurrentConsentState(): ConsentState | null {
 	if (typeof window === "undefined") return null;
 
 	try {
 		const saved = localStorage.getItem("consent-state");
-		if (saved) {
-			const parsed = JSON.parse(saved);
-			// Ensure functional property exists with default value
-			return {
-				analytics: parsed.analytics === true,
-				advertising: parsed.advertising === true,
-				functional: parsed.functional !== false,
-				personalization: parsed.personalization === true,
-			};
+		const savedAt = localStorage.getItem("consent-state-date");
+		if (saved && savedAt && isConsentValid(new Date(savedAt))) {
+			return normalizeConsentState(JSON.parse(saved));
 		}
 	} catch (_error) {
 		// Silently handle parsing errors for consent state
@@ -94,14 +144,6 @@ export function getCurrentConsentState(): ConsentState | null {
 export function updateConsent(consentState: ConsentState) {
 	if (typeof window === "undefined") return;
 
-	// Update Google Consent Mode
-	window.gtag("consent", "update", {
-		analytics_storage: consentState.analytics ? "granted" : "denied",
-		ad_storage: consentState.advertising ? "granted" : "denied",
-		functionality_storage: consentState.functional ? "granted" : "denied",
-		personalization_storage: consentState.personalization ? "granted" : "denied",
-	});
-
 	// Save to localStorage
 	try {
 		localStorage.setItem("consent-state", JSON.stringify(consentState));
@@ -111,6 +153,9 @@ export function updateConsent(consentState: ConsentState) {
 	}
 
 	// Apply consent based on updated state
+	// SPR-280: gtag への push は updateGoogleConsent に一本化（以前はここでも
+	// 4フィールドだけの consent update を先に push しており、二重 push かつ
+	// 一瞬だけ ad_user_data / ad_personalization を欠いた中間状態が存在した）
 	updateGoogleConsent(consentState);
 }
 

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -260,6 +260,7 @@ vi.mock("lucide-react", () => {
 		ChevronUpIcon: createMockIcon("ChevronUpIcon"),
 		CheckIcon: createMockIcon("CheckIcon"),
 		// Icons for Cookie Settings
+		Cookie: createMockIcon("Cookie"),
 		Shield: createMockIcon("Shield"),
 		BarChart3: createMockIcon("BarChart3"),
 		Target: createMockIcon("Target"),


### PR DESCRIPTION
[SPR-280](https://linear.app/nothink/issue/SPR-280) の 3 点を修正し、consent カテゴリ → Google Consent Mode v2 パラメータのマッピングと同意の期限判定の正本を `apps/web/src/lib/consent/google-consent-mode.ts` に一本化しました。

## 1. `ad_personalization` を advertising 駆動に変更

`ad_personalization`（広告のパーソナライズ）だけが `personalization` カテゴリ（＝ GA のコンテンツ・パーソナライズ）で駆動されており、**バナーの「許可」を押した全ユーザーが `ad_storage: denied` かつ `ad_personalization: granted`** になっていました。`ad_storage` / `ad_user_data` / `ad_personalization` を揃って `advertising` 駆動にし、`personalization` が駆動するのは `personalization_storage` だけにしています。

## 2. `consent update` の二重 push を解消

`updateConsent` 自身の 4 フィールド push を撤去し `updateGoogleConsent` に一本化（`ad_user_data` / `ad_personalization` を欠いた中間状態が消えます）。

## 3. マッピングの重複を解消

`consent-mode-script.tsx` の private な `updateConsent`（`functionality_storage: "granted"` 決め打ち）を撤去し、hydration 前の復元経路も同じ `applyGoogleConsent` を通します。`setupDataLayer` の polyfill が先に `window.gtag` を用意するため、gtag.js ロード前でも同じ関数で push できます。

## あわせて修正: バナー mount 時の再 push と「1年で再確認」の不発

同意済みユーザーのページ読み込みごとに、バナーの mount effect が `updateConsent` を呼んでいました。これにより (1) 同じ `consent update` の再 push、(2) ユーザー操作でないのに `consent_update` イベント送信、(3) `consent-state-date` の更新、が起きていました。mount 経路は `consentUpdate` の DOM イベント通知だけに縮小しています（page_view 再送の契機として維持）。

さらに期限判定が `consent-mode-script.tsx` 側にしか無く、バナーが参照する `getCurrentConsentState()` は日付を見ていなかったため、**クッキー設定パネルの「設定は1年間保存され、期限後に再確認をお願いします」が実際には効いていませんでした**。期限判定を同関数へ移し、期限切れ・日付欠落・破損は `null`（未同意扱い）を返すようにしています。

## 実機確認（Firestore Emulator + preview）

| 状況 | consent update | consent_update イベント | consent-state-date | バナー |
|---|---|---|---|---|
| 「許可」押下 | 1回（`ad_personalization: denied`） | 送信 | 更新 | 閉じる |
| 再読み込み（有効な同意） | 1回（復元のみ） | 送信されない | 不変 | 出ない |
| 再読み込み（2年前の同意） | 0回 | 送信されない | 不変 | 再表示 |

※ dev の実測では `default` / `update` が各 2 セット出ますが、React StrictMode の effect 二重実行によるもので本番ビルドでは各 1 回です。

## 本番反映後に起きる変化（想定内）

- **1年以上前に同意したユーザーにバナーが再表示されます**。UI の記述どおりの挙動になります
- **GA4 の `consent_update` イベント数が落ちます**。従来はページ読み込みごとに送られていたため、過去の件数は「同意操作の回数」ではなく「同意済みセッションのページ表示数」に近い値でした。ここで過去データとの接続性は切れます

現状の実効影響はありません（Google シグナルは 2026-07-25 に無効化済み・`googleAdsLinks` も空）。プライバシーポリシー（「当サイトは広告を掲載しておらず…連携も行っていません」）とも矛盾せず、むしろ記述に近づくため文言変更は不要と判断しました。保存済み同意はカテゴリの意味を変えていない（`advertising` は元から常に false）ため、同意の再取得も不要です。

## テスト

- `applyGoogleConsent` のマッピング（ad_* は advertising 駆動）と「`consent update` は 1 回だけ」の回帰テストを追加
- `consent-mode-script.test.tsx` を新規追加（gtag 未ロード状態からの復元 push・1年超は復元しない）。今回の refactor で load-bearing になった「polyfill が先に立つ」前提を固定
- `cookie-consent-banner.test.tsx` を新規追加（mount 時に gtag も保存も触らない / 1年超は再表示 / 「許可」は ad_* denied）
- `vitest.setup.ts` の lucide mock に `Cookie` を追加

`pnpm verify` パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
