### PR TITLE
perf(web): creator/circle のエッジ TTL を 60秒から 6時間に広げる (SPR-315)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -236,17 +236,25 @@ const nextConfig = {
 			// 最悪 18 時間ぶん古い内容を返しうるが、元データの鮮度（最大1日）を下回らない範囲。
 			//
 			// Cloudflare 側は Cache Rule #5 が respect_origin なのでここの値がそのまま効く（terraform 無変更）。
+			//
+			// 一覧と詳細で TTL を分ける。オリジンの鮮度契約が違うため:
+			//   詳細 = cacheLife("days") → エッジも時間〜日オーダーでよい
+			//   一覧 = cacheLife("hours") → 新着クリエイター/サークルの反映を時間オーダーに保つ意図（SPR-311）
+			// 一覧にも詳細と同じ 6+12 時間を当てると、**エッジがオリジンの鮮度契約を追い越して古くなる**。
+			// 一覧側の実測（8/20・creators 720 req / circles 237 req）では 6時間と 2時間の差は
+			// オリジン到達 +270 件/日＝概ね ¥100〜140/月 で、鮮度の一貫性に対して十分小さい。
 			{
-				source: "/creators/:path*",
+				source: "/(creators|circles)",
 				headers: [
 					{
 						key: "Cache-Control",
-						value: "public, s-maxage=21600, stale-while-revalidate=43200",
+						// 2時間 fresh + 2時間 swr（最悪4時間）。DLsite 取り込みの間隔（2h）に合わせる。
+						value: "public, s-maxage=7200, stale-while-revalidate=7200",
 					},
 				],
 			},
 			{
-				source: "/circles/:path*",
+				source: "/(creators|circles)/:path+",
 				headers: [
 					{
 						key: "Cache-Control",

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -222,14 +222,26 @@ const nextConfig = {
 					},
 				],
 			},
-			// 動的ページのstale-while-revalidate（LCP改善）
-			// force-dynamicページでもブラウザキャッシュを活用
+			// creators / circles はクローラの巡回先で、同じ URL が何度も来る（SPR-315）。
+			// 8/20 の実測（/creators/* + /circles/* の詳細 4,372 リクエスト・異なり 1,223 URL）で
+			// TTL ごとのオリジン到達数を出すと、**60 秒は何も吸収していなかった**:
+			//
+			//    60秒 → 4,370 件（削減 0.0%）   1時間 → 3,484（20.3%）
+			//    6時間 → 2,162 件（50.5%）      12時間 → 1,668（61.8%）   24時間 → 1,223（72.0%）
+			//
+			// クローラは同じ URL を平均 7.35 回叩く（86.4% が再訪）が、再訪の間隔が数時間オーダーなので
+			// 60 秒では全部すり抜けていた。オリジン側の `use cache` は creator/circle 詳細が
+			// cacheLife("days")・一覧が ("hours") で、データはもともと時間〜日オーダーで陳腐化する。
+			// エッジをそれより短く保つ意味が無いため 6 時間 fresh + 12 時間 swr に広げる。
+			// 最悪 18 時間ぶん古い内容を返しうるが、元データの鮮度（最大1日）を下回らない範囲。
+			//
+			// Cloudflare 側は Cache Rule #5 が respect_origin なのでここの値がそのまま効く（terraform 無変更）。
 			{
 				source: "/creators/:path*",
 				headers: [
 					{
 						key: "Cache-Control",
-						value: "public, s-maxage=60, stale-while-revalidate=300",
+						value: "public, s-maxage=21600, stale-while-revalidate=43200",
 					},
 				],
 			},
@@ -238,7 +250,7 @@ const nextConfig = {
 				headers: [
 					{
 						key: "Cache-Control",
-						value: "public, s-maxage=60, stale-while-revalidate=300",
+						value: "public, s-maxage=21600, stale-while-revalidate=43200",
 					},
 				],
 			},


### PR DESCRIPTION
Linear: [SPR-315](https://linear.app/nothink/issue/SPR-315/spr-311-後も予算超過が続いている-残-read-の帰属は取り込みパイプラインではなく今も-creatorsid)

SPR-315 の「やること 2」。1 行相当の変更で、terraform には触れません（Cloudflare Cache Rule #5 が `/creators/` `/circles/` を `respect_origin` で扱うため、origin のヘッダ変更だけで効く）。

## 現行の `s-maxage=60` は何も吸収していなかった

「エッジで吸収できているはず」を仮定せず、8/20 の Cloud Logging 全件（`/creators/*` + `/circles/*` 詳細 **4,372 リクエスト・異なり 1,223 URL**）で TTL ごとのオリジン到達数を再生しました。

| TTL | オリジン到達 | 削減率 |
|---|---|---|
| **60秒（現行）** | **4,370** | **0.0%** |
| 1時間 | 3,484 | 20.3% |
| **6時間（本PR）** | **2,162** | **50.5%** |
| 12時間 | 1,668 | 61.8% |
| 24時間 | 1,223 | 72.0% |

クローラは**同じ URL を平均 7.35 回**叩いており（86.4% が再訪、1回だけの URL は 11 件）、吸収の余地は大きい。にもかかわらず 60 秒では再訪間隔（数時間オーダー）に届かず、全部すり抜けていました。

creator `28165` 単体で見ると 1,389 リクエストがわずか 189 URL に集中しています。

## なぜ 6 時間か

オリジン側の `use cache` は詳細が `cacheLife("days")`・一覧が `("hours")` で、**データはもともと時間〜日オーダーで陳腐化します**。エッジをそれより短く保つ意味がありません。

`s-maxage=21600`（6時間 fresh）+ `stale-while-revalidate=43200`（その後 12 時間は stale を返しつつ背景再検証）としました。最悪 18 時間ぶん古い内容を返しうるので、そこがトレードオフです。元データの鮮度（最大 1 日）を大きく下回らない範囲に収めたつもりですが、**24 時間まで伸ばせば削減率は 72% まで上がる**ので、鮮度をどこまで許容するかは判断していただく余地があります。

なお `stale-while-revalidate` は Cache Rule #5（`respect_origin`）では解釈されます（`/` の rule は `override_origin` なので効かない、という既存コメントとは条件が違います）。

## 検証

`pnpm verify` 通過、`pnpm --filter web build` 通過（exit 0）。

**デプロイ後に機構レベルで検証します**: 同一 URL への 2 回目のリクエストで `cf-cache-status: HIT` になること、および `age` ヘッダが伸びることを確認します。日次メトリクスを待たずに判定できます。

## スコープ外

SPR-315 の #1（`creators/{id}/works` の cursor ページング）は本命ですが、任意ソートと全文検索を Firestore 側にどう降ろすかという設計論点があり、SPR-316（データモデル棚卸し）と関係するため分離しています。本 PR で予算内に収まるかを先に測ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
