### PR TITLE
fix(functions): DLsite API のタイムアウトをリトライ対象にする

### DIFF
--- a/apps/functions/src/services/dlsite/__tests__/individual-info-api-client.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/individual-info-api-client.test.ts
@@ -232,7 +232,7 @@ describe("Individual Info API Client", () => {
 
 			await expect(fetchIndividualWorkInfo("RJ123456")).rejects.toThrow();
 
-			// タイムアウトは1回あたり30秒を消費するためリトライ上限は1回（初回+1回=2回）
+			// タイムアウトは1回あたり15秒を消費するためリトライ上限は1回（初回+1回=2回）
 			expect(mockFetch).toHaveBeenCalledTimes(2);
 		});
 

--- a/apps/functions/src/services/dlsite/__tests__/individual-info-api-client.test.ts
+++ b/apps/functions/src/services/dlsite/__tests__/individual-info-api-client.test.ts
@@ -188,10 +188,13 @@ describe("Individual Info API Client", () => {
 			expect(result).toBeNull();
 		});
 
-		it("ネットワークエラーの場合例外を投げる", async () => {
+		it("ネットワークエラーの場合リトライせず例外を投げる", async () => {
 			mockFetch.mockRejectedValue(new Error("Network error"));
 
 			await expect(fetchIndividualWorkInfo("RJ123456")).rejects.toThrow();
+
+			// 一過性と判定できないエラーはリトライ対象外（初回のみ）
+			expect(mockFetch).toHaveBeenCalledTimes(1);
 		});
 
 		it("リトライが成功した場合データを返す", async () => {
@@ -218,6 +221,46 @@ describe("Individual Info API Client", () => {
 
 			expect(result).toEqual(mockWorkData);
 			expect(mockFetch).toHaveBeenCalledTimes(2); // 初回失敗 + リトライ成功
+		});
+
+		// AbortSignal.timeout() が投げるのは "TimeoutError"。以前は "retry needed" を含む
+		// エラー（429/5xx）しかリトライ対象でなく、一過性の遅延がそのまま失敗計上されていた。
+		it("タイムアウト（TimeoutError）はリトライしてから例外を投げる", async () => {
+			mockFetch.mockRejectedValue(
+				new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+			);
+
+			await expect(fetchIndividualWorkInfo("RJ123456")).rejects.toThrow();
+
+			// タイムアウトは1回あたり30秒を消費するためリトライ上限は1回（初回+1回=2回）
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+		});
+
+		it("AbortError もリトライ対象になる", async () => {
+			mockFetch.mockRejectedValue(new DOMException("The operation was aborted", "AbortError"));
+
+			await expect(fetchIndividualWorkInfo("RJ123456")).rejects.toThrow();
+
+			expect(mockFetch).toHaveBeenCalledTimes(2);
+		});
+
+		it("タイムアウト後のリトライが成功した場合データを返す", async () => {
+			mockFetch
+				.mockRejectedValueOnce(
+					new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+				)
+				.mockResolvedValueOnce({
+					ok: true,
+					status: 200,
+					statusText: "OK",
+					text: vi.fn().mockResolvedValue(JSON.stringify([mockWorkData])),
+					headers: new Headers({ "content-type": "application/json" }),
+				});
+
+			const result = await fetchIndividualWorkInfo("RJ123456");
+
+			expect(result).toEqual(mockWorkData);
+			expect(mockFetch).toHaveBeenCalledTimes(2);
 		});
 	});
 

--- a/apps/functions/src/services/dlsite/individual-info-api-client.ts
+++ b/apps/functions/src/services/dlsite/individual-info-api-client.ts
@@ -12,6 +12,18 @@ import { recordSchemaDriftForBatch } from "./schema-drift";
 
 // API設定
 const INDIVIDUAL_INFO_API_BASE_URL = "https://www.dlsite.com/maniax/api/=/product.json";
+// タイムアウトを 30 秒から詰めているのは、リトライ1回分を足しても1作品あたりの
+// 最悪待ち時間（15s + backoff 1s + 15s = 31s）が従来の 30s から増えないようにするため。
+// バッチは Cloud Functions の 300 秒上限の中で 10 サブバッチ（BATCH_SIZE=50 /
+// maxConcurrent=5）を直列に回すので、1作品の最悪値がそのまま run の生死に効く。
+// 実測レイテンシは 0.08〜0.37 秒（2026-08-22・タイムアウトした作品で計測）＝15 秒でも 40 倍以上の余裕がある。
+const REQUEST_TIMEOUT_MS = 15000;
+
+// リトライ上限はエラーの「1回あたりのコスト」で分ける。
+// 429/5xx は即座にレスポンスが返るため2回まで許容できるが、タイムアウトは1回で
+// REQUEST_TIMEOUT_MS を丸ごと消費するため1回に抑える。
+const MAX_RETRIES_HTTP = 2;
+const MAX_RETRIES_TIMEOUT = 1;
 
 /**
  * Individual Info API リクエストオプション
@@ -127,6 +139,30 @@ function validateResponseFormat(
 }
 
 /**
+ * エラー種別ごとのリトライ上限を返す（0 = リトライしない）
+ *
+ * タイムアウトは一過性のネットワーク遅延が主因でリトライが最も効くクラス。
+ * fetch は AbortSignal.timeout() 由来だと "TimeoutError" を投げる（"AbortError" は
+ * AbortController.abort() 由来）ので、dlsite-ajax-fetcher と同じく両方を見る。
+ */
+function getMaxRetries(error: unknown): number {
+	if (!(error instanceof Error)) {
+		return 0;
+	}
+
+	// 429 / 5xx は handleHttpError が "retry needed" を付けて投げる
+	if (error.message.includes("retry needed")) {
+		return MAX_RETRIES_HTTP;
+	}
+
+	if (error.name === "TimeoutError" || error.name === "AbortError") {
+		return MAX_RETRIES_TIMEOUT;
+	}
+
+	return 0;
+}
+
+/**
  * Individual Info APIから単一作品データを取得
  * 詳細エラーハンドリング付き（リトライ機能付き）
  *
@@ -139,7 +175,6 @@ export async function fetchIndividualWorkInfo(
 	options: IndividualInfoAPIOptions & { retryCount?: number } = {},
 ): Promise<DLsiteApiResponse | null> {
 	const { enableDetailedLogging = false, retryCount = 0 } = options;
-	const MAX_RETRIES = 2;
 
 	try {
 		const url = `${INDIVIDUAL_INFO_API_BASE_URL}?workno=${workId}`;
@@ -150,7 +185,7 @@ export async function fetchIndividualWorkInfo(
 		const response = await fetch(url, {
 			method: "GET",
 			headers,
-			signal: AbortSignal.timeout(30000), // 30秒タイムアウト
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 		});
 
 		if (!response.ok) {
@@ -189,12 +224,9 @@ export async function fetchIndividualWorkInfo(
 		return validatedData;
 	} catch (error) {
 		// リトライ可能なエラーかチェック
-		if (
-			error instanceof Error &&
-			error.message.includes("retry needed") &&
-			retryCount < MAX_RETRIES
-		) {
-			logger.warn(`リトライ実行 (${retryCount + 1}/${MAX_RETRIES}): ${workId}`);
+		const maxRetries = getMaxRetries(error);
+		if (maxRetries > 0 && retryCount < maxRetries) {
+			logger.warn(`リトライ実行 (${retryCount + 1}/${maxRetries}): ${workId}`);
 			// エクスポネンシャルバックオフ
 			await new Promise((resolve) => setTimeout(resolve, (retryCount + 1) * 1000));
 			return fetchIndividualWorkInfo(workId, {


### PR DESCRIPTION
## 背景

2026-08-21 19:27 UTC に `Cloud Run Revision - DLsite API Failure Rate High` が発火した件の対応。

調査したところ、発火の実体はログ 1 件（バッチ41で 10/50 = 失敗率20.0%）で、**失敗10件すべてが `TimeoutError: The operation was aborted due to timeout`**。403/429/5xx は 1 件も無く、DLsite 側のレート制限でもサーバーエラーでもなく応答遅延だった。

run 自体は完走し、後続 run（21:03 / 23:03 UTC）は API エラー 0 件。失敗した作品も後続 run で再取得済み（`priceHistory/2026-08-22` の存在を本番 Firestore で確認）。つまり事象自体は自己回復しているが、調査の過程でリトライの穴が見つかった。

## 問題

`fetchIndividualWorkInfo` のリトライ条件が `error.message.includes("retry needed")` になっていた。この文字列を付けているのは `handleHttpError` の 429 と 5xx だけなので、**タイムアウトは 1 回もリトライされずに失敗計上される**。一過性のネットワーク遅延こそリトライが最も効くクラスなのに素通りしていた。

## 変更

- リトライ判定を `getMaxRetries()` に切り出し、`TimeoutError` / `AbortError` を対象に追加。判定は同じ罠を踏んで修正済みの `dlsite-ajax-fetcher.ts` に合わせた（`AbortSignal.timeout()` が投げるのは `AbortError` ではなく `TimeoutError`）
- リトライ上限をエラーの「1回あたりのコスト」で分けた。429/5xx は即座にレスポンスが返るため従来どおり 2 回、タイムアウトは 1 回
- リクエストタイムアウトを 30s → 15s

### タイムアウト短縮はリトライ追加の副作用対策

リトライを足すと 1 作品あたりの最悪待ち時間が倍になる。バッチは Cloud Functions の 300 秒上限の中で 10 サブバッチ（`BATCH_SIZE=50` / `maxConcurrent=5`）を直列に回すため、これは実害がある：**サブバッチの半数がタイムアウトすると、従来は完走していた run が関数タイムアウトで殺され、そのバッチの書き込みを丸ごと失う**（`DLsite Function Platform Failure (5xx)` が鳴る側に倒れる）。

`15s + backoff 1s + 15s = 31s` なら従来の 30s から最悪値が増えない。15s の妥当性は実測で確認した — タイムアウトした 5 作品を 2026-08-22 に計測したところ全て正常応答で、レイテンシは 0.08〜0.37 秒（15s でも 40 倍以上の余裕）。

```
RJ01643492  http=200 ttfb=0.374s
RJ01622742  http=200 ttfb=0.082s
RJ01639238  http=200 ttfb=0.127s
RJ01664409  http=200 ttfb=0.079s
RJ01620216  http=200 ttfb=0.087s
```

## テスト

- `TimeoutError` / `AbortError` がそれぞれ 1 回リトライされること
- タイムアウト後のリトライ成功でデータが返ること
- 既存の「ネットワークエラー」テストに `toHaveBeenCalledTimes(1)` を追加し、**リトライ対象を広げた際に無関係なエラーまで巻き込まない**境界を固定

`pnpm verify` 全通過。

## 検知能力への影響

DLsite が実際に落ちている場合はリトライ後も失敗するため、アラートの検知能力は落ちない。今回のような一過性の部分劣化（terraform のコメントいわく実績は月1〜3回）が吸収されて鳴らなくなるのが期待される効果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
