### PR TITLE
fix(analytics): page_view を gtag('config') 完了後に送る (SPR-317)

### DIFF
--- a/apps/web/src/components/analytics/__tests__/page-view-tracker.test.tsx
+++ b/apps/web/src/components/analytics/__tests__/page-view-tracker.test.tsx
@@ -13,7 +13,7 @@ function setRoute(pathname: string, query = "") {
 
 /**
  * 送信の成否を模す。SPR-299 で同意ゲートを撤廃したため、戻り値の意味は
- * 「同意されたか」ではなく「gtag がロード済みで実際に送れたか」。
+ * 「同意されたか」ではなく「gtag が config 済みで実際に送れたか」（SPR-317）。
  */
 function mockPageView(sent: boolean) {
 	return vi.spyOn(consent, "sendGoogleAnalyticsPageView").mockReturnValue(sent);
@@ -22,6 +22,13 @@ function mockPageView(sent: boolean) {
 function dispatchConsentUpdate() {
 	act(() => {
 		window.dispatchEvent(new CustomEvent("consentUpdate", { detail: { analytics: true } }));
+	});
+}
+
+/** GA ブートストラップの `gtag('config', ...)` 完了通知（SPR-317） */
+function dispatchGaConfigured() {
+	act(() => {
+		window.dispatchEvent(new Event("gaConfigured"));
 	});
 }
 
@@ -59,6 +66,34 @@ describe("PageViewTracker", () => {
 		render(<PageViewTracker measurementId="G-TEST" />);
 
 		expect(spy).toHaveBeenCalledExactlyOnceWith("/buttons", "G-TEST");
+	});
+
+	// SPR-317 の回帰テスト。GA は lazyOnload（window `load` 後）で config するのに対し
+	// この effect は hydration 直後に走るため、初回送信は空振りするのが常態。
+	// これを再送できないと、遷移も同意操作もしないセッション＝直帰の page_view が
+	// 丸ごと失われ、landingPage が「速いセッションだけ」に偏る。
+	it("config 未完了で送れなかった場合、gaConfigured を契機に再送する", () => {
+		const spy = mockPageView(false);
+
+		render(<PageViewTracker />);
+		expect(spy).toHaveBeenCalledTimes(1); // 呼びはするが config 前なので送信されない
+
+		spy.mockReturnValue(true);
+		dispatchGaConfigured();
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		expect(spy).toHaveBeenLastCalledWith("/buttons", undefined);
+	});
+
+	it("gaConfigured で再送済みなら、後続の consentUpdate で二重に送らない", () => {
+		const spy = mockPageView(false);
+		render(<PageViewTracker />);
+
+		spy.mockReturnValue(true);
+		dispatchGaConfigured();
+		dispatchConsentUpdate();
+
+		expect(spy).toHaveBeenCalledTimes(2); // 初回ロード分 + 再送分のみ
 	});
 
 	it("gtag 未ロードで送れなかった場合、consentUpdate を契機に再送する", () => {

--- a/apps/web/src/components/analytics/google-analytics-script.tsx
+++ b/apps/web/src/components/analytics/google-analytics-script.tsx
@@ -19,8 +19,12 @@ export function GoogleAnalyticsScript() {
 			 * lazyOnload で `load` 後にロードし、Mobile LCP への影響を抑える (SPR-9)。
 			 * Consent Mode の default は ConsentModeScript の useEffect で hydration 直後に
 			 * dataLayer に push 済み。GA 本体は send_page_view: false で、page view は
-			 * PageViewTracker から手動送信するため、ロード順序の遅延は
-			 * 計測結果の整合性に影響しない。 */}
+			 * PageViewTracker から手動送信する。
+			 *
+			 * SPR-317: この `config` は hydration より後に走る（lazyOnload = window `load` 後）。
+			 * 一方 PageViewTracker は hydration 直後に送るため、放置すると page_view が
+			 * `config` より前に dataLayer へ積まれる＝送信先未設定のまま捨てられる。
+			 * 下の `gaConfigured` はその順序を送信側に伝えるための印。 */}
 			<Script
 				strategy="lazyOnload"
 				src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
@@ -39,6 +43,10 @@ export function GoogleAnalyticsScript() {
 							page_location: window.location.href,
 							send_page_view: false  // We'll manually control page views based on consent
 						});
+						// SPR-317: config 完了を送信側へ伝える。window.gtag は ConsentModeScript の
+						// polyfill が hydration 時に定義済みなので、gtag の有無では順序を判別できない。
+						window.gaConfigured = true;
+						window.dispatchEvent(new Event('gaConfigured'));
 						// Debug: Log GA initialization in development only
 						if (window.location.hostname === 'localhost') {
 							console.log('Google Analytics initialized with ID:', '${measurementId}');

--- a/apps/web/src/components/analytics/page-view-tracker.tsx
+++ b/apps/web/src/components/analytics/page-view-tracker.tsx
@@ -15,9 +15,11 @@ import { sendGoogleAnalyticsPageView } from "@/lib/consent/google-consent-mode";
  * ON のままだと App Router の client 遷移で page_view が二重に飛ぶ。
  *
  * SPR-299 で同意ゲートを外したので、送信可否は同意状態に依存しなくなった
- * （非同意時も cookieless ping として送られる）。残る失敗要因は gtag の未ロードだけで、
- * consentUpdate の再送はその取りこぼしに対する保険として残している
- * （同意バナーの操作は gtag が動いている証拠になるため、再試行の契機として有効）。
+ * （非同意時も cookieless ping として送られる）。
+ *
+ * SPR-317: 残る失敗要因は「gtag の未ロード」ではなく「`gtag('config', ...)` の未完了」。
+ * GA は lazyOnload（window `load` 後）で config するのに対しこの effect は hydration 直後に
+ * 走るため、**初回送信は空振りするのが常態**で、再送は gaConfigured 通知が担う。
  * 送信できたときだけ印を付ける設計は、未送信を「送信済み」と誤認して
  * landingPage を欠落させないために引き続き必要。
  *
@@ -49,12 +51,22 @@ export function PageViewTracker({ measurementId }: { measurementId?: string }) {
 		if (!url) return;
 		if (sendOnce(url)) return;
 
-		// gtag が未ロードだった。同意操作は gtag が動いている証拠になるので再送の契機に使う
-		const handleConsentUpdate = () => {
+		// まだ送れていない（gtag 未ロード、または config 未完了）。再送の契機は2つ。
+		//
+		// - gaConfigured: `gtag('config', ...)` の完了通知（SPR-317）。lazyOnload の GA は
+		//   hydration より後に config するため、初回送信はここで空振りするのが常態。
+		//   これが主たる再送契機で、consentUpdate だけだった頃は同意操作をしない訪問
+		//   （＝ほぼ全部）の page_view が永久に失われていた。
+		// - consentUpdate: 同意操作は gtag が動いている証拠なので保険として残す
+		const retry = () => {
 			sendOnce(url);
 		};
-		window.addEventListener("consentUpdate", handleConsentUpdate);
-		return () => window.removeEventListener("consentUpdate", handleConsentUpdate);
+		window.addEventListener("gaConfigured", retry);
+		window.addEventListener("consentUpdate", retry);
+		return () => {
+			window.removeEventListener("gaConfigured", retry);
+			window.removeEventListener("consentUpdate", retry);
+		};
 	}, [url, sendOnce]);
 
 	// This component doesn't render anything

--- a/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
+++ b/apps/web/src/lib/consent/__tests__/google-consent-mode.test.ts
@@ -15,10 +15,13 @@ const gtag = vi.fn();
 beforeEach(() => {
 	vi.clearAllMocks();
 	(window as unknown as { gtag: typeof gtag }).gtag = gtag;
+	// SPR-317: page view は `gtag('config', ...)` 完了後にしか送らない
+	window.gaConfigured = true;
 	localStorage.clear();
 });
 
 afterEach(() => {
+	window.gaConfigured = undefined;
 	localStorage.clear();
 	// 文字列 "undefined" が残らないよう削除（テスト間の漏れ防止）
 	delete process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
@@ -222,6 +225,16 @@ describe("sendGoogleAnalyticsPageView / Event", () => {
 			"page_view",
 			expect.not.objectContaining({ send_to: expect.anything() }),
 		);
+	});
+
+	// SPR-317 の回帰テスト。window.gtag は ConsentModeScript の polyfill が hydration 時に
+	// 定義するため「gtag がある＝送れる」ではない。config 前に積むと送信先が未設定のまま
+	// 捨てられるうえ、true を返すと呼び出し側が「送信済み」と誤認して再送の機会を失う。
+	it("config が未完了なら page view を送らず false を返す", () => {
+		window.gaConfigured = undefined;
+
+		expect(sendGoogleAnalyticsPageView("/x", "G-TEST")).toBe(false);
+		expect(gtag).not.toHaveBeenCalledWith("event", "page_view", expect.anything());
 	});
 
 	it("クエリつきの URL をそのまま page_location に載せる", () => {

--- a/apps/web/src/lib/consent/google-consent-mode.ts
+++ b/apps/web/src/lib/consent/google-consent-mode.ts
@@ -204,10 +204,6 @@ export function resetAllConsent() {
  * 同じ理由で黙って全滅する構造ではなくなる。SPA で推奨されている形でもある
  * （同一測定IDへの 2 回目の `config` は設定更新として扱われ、page_view 送信は保証されない）。
  *
- * @param url 送信するパス（クエリ込み）。省略時は現在地
- * @param measurementId 送信先の GA4 プロパティ。**Server Component から prop で渡す**
- * （[ga-measurement-id.ts](../analytics/ga-measurement-id.ts) 参照）。省略すると
- * 設定済みの全ターゲットに送られる。GTM 併用時に送信先を絞るためだけに使う
  * SPR-317: 送信可否の条件を「gtag があるか」から「`config` が済んでいるか」に変えた。
  * `gtag/js` は lazyOnload（window `load` 後・SPR-9）でロードされる一方、PageViewTracker は
  * hydration 直後に送るため、`window.gtag`（ConsentModeScript の polyfill）だけを見ていると
@@ -216,6 +212,10 @@ export function resetAllConsent() {
  * ページほど hydration が先行するため、**初期表示が遅い訪問ほど欠測する**偏りが出ていた
  * （landingPage の (not set) 30%・そのセッション群の page_view は0件）。
  *
+ * @param url 送信するパス（クエリ込み）。省略時は現在地
+ * @param measurementId 送信先の GA4 プロパティ。**Server Component から prop で渡す**
+ * （[ga-measurement-id.ts](../analytics/ga-measurement-id.ts) 参照）。省略すると
+ * 設定済みの全ターゲットに送られる。GTM 併用時に送信先を絞るためだけに使う
  * @returns 実際に送信したか。config 未完了では false を返すため、呼び出し側は再送を
  * 判断できる（未送信を「送信済み」と誤認すると landing page が欠ける）
  */

--- a/apps/web/src/lib/consent/google-consent-mode.ts
+++ b/apps/web/src/lib/consent/google-consent-mode.ts
@@ -28,6 +28,12 @@ declare global {
 	interface Window {
 		gtag: (command: GtagCommand, ...args: unknown[]) => void;
 		dataLayer: DataLayerEvent[];
+		/**
+		 * `gtag('config', ...)` が済んだか（正本は google-analytics-script.tsx のブートストラップ）。
+		 * `window.gtag` は ConsentModeScript の polyfill が hydration 時に定義するため、
+		 * gtag の有無は config 完了を意味しない（SPR-317）。
+		 */
+		gaConfigured?: boolean;
 	}
 }
 
@@ -202,11 +208,19 @@ export function resetAllConsent() {
  * @param measurementId 送信先の GA4 プロパティ。**Server Component から prop で渡す**
  * （[ga-measurement-id.ts](../analytics/ga-measurement-id.ts) 参照）。省略すると
  * 設定済みの全ターゲットに送られる。GTM 併用時に送信先を絞るためだけに使う
- * @returns 実際に送信したか。gtag 未ロードでは false を返すため、呼び出し側は再送を
+ * SPR-317: 送信可否の条件を「gtag があるか」から「`config` が済んでいるか」に変えた。
+ * `gtag/js` は lazyOnload（window `load` 後・SPR-9）でロードされる一方、PageViewTracker は
+ * hydration 直後に送るため、`window.gtag`（ConsentModeScript の polyfill）だけを見ていると
+ * **`config` より前の dataLayer に積んで true を返す**＝送信先が未設定のまま捨てられ、
+ * 呼び出し側は「送信済み」と誤認して再送の機会を失っていた。画像が多く `load` が遅い
+ * ページほど hydration が先行するため、**初期表示が遅い訪問ほど欠測する**偏りが出ていた
+ * （landingPage の (not set) 30%・そのセッション群の page_view は0件）。
+ *
+ * @returns 実際に送信したか。config 未完了では false を返すため、呼び出し側は再送を
  * 判断できる（未送信を「送信済み」と誤認すると landing page が欠ける）
  */
 export function sendGoogleAnalyticsPageView(url?: string, measurementId?: string): boolean {
-	if (typeof window === "undefined" || !window.gtag) return false;
+	if (typeof window === "undefined" || !window.gtag || !window.gaConfigured) return false;
 
 	const path = url || `${window.location.pathname}${window.location.search}`;
 


### PR DESCRIPTION
## 何を直すか

`page_view` の送信可否を「`window.gtag` があるか」から「`gtag('config')` が済んでいるか」に変える。

Linear: [SPR-317](https://linear.app/nothink/issue/SPR-317)

## 背景（SPR-284 の再確認で判明）

GA は `lazyOnload`（window `load` 後・SPR-9 の Mobile LCP 対策）で config する一方、`PageViewTracker` は hydration 直後に送る。`window.gtag` は `ConsentModeScript` の polyfill が hydration 時に定義するため、**gtag の有無では順序を判別できない**。結果 `sendGoogleAnalyticsPageView` は `config` より前の dataLayer に積んで `true` を返しており、送信先が未設定のまま捨てられたうえ、呼び出し側は「送信済み」と誤認して再送の機会を失っていた。

再送の契機は `consentUpdate` しか無く、これは同意バナーを操作したときだけ発火する。したがって**遷移も同意操作もしないセッション＝直帰の page_view が丸ごと失われていた**。画像が多く `load` が遅いページほど hydration が先行するため、**初期表示が遅い訪問ほど欠測する**という偏り方をする。

これは SPR-307 の積み残し。SPR-307 は「測定IDが client バンドルに無い」ことを直したが、送信順序は保証されないままだった。

## 本番での実測（2026-08-06〜08-22）

|  | `landingPage=(not set)` 27セッション | 着地ページ判明 61セッション |
| -- | -- | -- |
| `page_view` | **0件** | 114件 |
| `web_vitals` | 24件（0.89/セッション） | 139件（2.28/セッション） |
| `session_start` | 27 | 61 |

`(not set)` 層も `web_vitals` を送っている＝ hydration は完了しており、「JS が動かないボット」では説明できない。`page_view`（1回しか発火しない）が全損、`web_vitals`（TTFB → LCP/CLS/INP と複数回）が後半だけ生存する、という「早いイベントが落ちる」パターンと整合する。

本番の `window.dataLayer` でも順序が入れ替わることを確認した:

- **cold load**: `consent default` ×2 → **`page_view`** → `web_vitals` → `js` → **`config`**
- **warm load**（`loadEvent` 104ms）: `consent default` ×2 → `js` → **`config`** → **`page_view`** → `web_vitals`

## なぜ重要か

単なる件数の欠落ではなく、**欠測が初期表示の遅さと相関する**点が問題。SPR-284 は「判明分は全件 engagementRate 1.0＝生存バイアスで結論が出せない」として止まっていたが、その構造がこの経路で再生産されている。速いセッションだけが観測される限り、「モバイルの初期表示が重いか」という問い自体が GA4 では測れない。`landingPage` / `sessionDefaultChannelGroup` 由来の分析すべてに効く。

## 変更内容

- `google-analytics-script.tsx`: `gtag('config', ...)` の直後に `window.gaConfigured = true` を立て、`gaConfigured` イベントを dispatch
- `google-consent-mode.ts`: `sendGoogleAnalyticsPageView` の guard に `window.gaConfigured` を追加（未完了なら `false` を返す＝再送できる。戻り値の契約は変えない）+ `Window` の型宣言を追加
- `page-view-tracker.tsx`: 再送契機に `gaConfigured` を追加（既存の `consentUpdate` は保険として維持）
- テスト: 順序 guard の回帰テストと `gaConfigured` 再送の回帰テストを追加

これで `consent default` → `config` → `event` という gtag / Consent Mode の要求順序を満たす。

## 検証

`pnpm verify` exit 0（157ファイル / 1321テスト通過）。

ローカルで失敗ケースを再現して確認した（`load` に48秒かかる重いページ）:

1. 修正後は初回送信が正しく `false` を返して待機し、dataLayer に `page_view` が積まれない（修正前はここで積まれて捨てられていた）
2. `gaConfigured` 通知後に `config` の後ろへ `page_view` が再送される

本番 GA4 プロパティを汚さないよう、検証中はダミー測定IDを使用（`.env.local` は復元済み）。

**本番での確認はデプロイ後**。判定基準は `landingPage` の `(not set)` 率が 30% から下がること（`node scripts/report-ga4.mjs`）。

## スコープ外

- `sendGoogleAnalyticsEvent` の早期発火（`web_vitals` の TTFB 等）も同じ理由で `config` 前に積まれうるが、戻り値を持たず再送の口が無いためキュー設計の判断が要る。今回は触らない
- `load` 前に離脱するセッションはこの修正でも救えない。`gtag/js` 自体が `lazyOnload` である以上、`load` 前には送信できない。ここを埋めるには `afterInteractive` へ戻す＝**LCP と計測完全性のトレードオフ**になるので別途判断

## 判定

Two-Way Door（計測コードのみ・戻せる）。プライバシー方針・同意の意味には触れていない（送信可否の条件は変えず、順序だけを正す）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
