### PR TITLE
fix(functions): DLsite run の実行時間計測を起動時点基準にし timeout を 540s に広げる (SPR-318)

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -219,6 +219,10 @@ jobs:
           deploy_pids["fetchYouTubeVideos"]=$!
           
           # fetchDLsiteUnifiedData
+          # timeout 540s の理由（SPR-318）: 旧 300s では run が構造的に上限を超え、
+          # 超過後のリクエスト外実行（CPU スロットリング下）で Individual Info API が
+          # 15 秒タイムアウトを連発していた（失敗率アラートの実発火要因）。
+          # アプリ側の打ち切りは MAX_EXECUTION_TIME=480s（process-batch.ts・run 起動時点基準）。
           gcloud functions deploy fetchDLsiteUnifiedData \
             --gen2 \
             --source ${{ env.DEPLOYMENT_SOURCE }} \
@@ -229,7 +233,7 @@ jobs:
             --project ${{ secrets.GCP_PROJECT_ID }} \
             --set-env-vars NODE_ENV=production,FUNCTION_SIGNATURE_TYPE=cloudevent,FUNCTION_TARGET=fetchDLsiteUnifiedData,INDIVIDUAL_INFO_API_ENABLED=true,API_ONLY_MODE=true,MAX_CONCURRENT_API_REQUESTS=5,API_REQUEST_DELAY_MS=500,ENABLE_DATA_VALIDATION=true,MINIMUM_QUALITY_SCORE=80,ENABLE_TIMESERIES_INTEGRATION=true,LOG_LEVEL=info \
             --memory 512Mi \
-            --timeout 300s \
+            --timeout 540s \
             --max-instances 1 \
             --service-account fetch-dlsite-individual-api-sa@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --quiet &

--- a/apps/functions/src/endpoints/dlsite/process-batch.ts
+++ b/apps/functions/src/endpoints/dlsite/process-batch.ts
@@ -18,7 +18,14 @@ import * as logger from "../../shared/logger";
 const MAX_CONCURRENT_API_REQUESTS = 5; // 6 → 3 → 5（バッチ処理を効率化: 50件を10回の並列処理で実行）
 const API_REQUEST_DELAY = 400;
 export const BATCH_SIZE = 50; // 100 → 50に削減（エラー率低下とタイムアウト回避）
-export const MAX_EXECUTION_TIME = 270000; // 4.5分（Cloud Functions 5分タイムアウトより短く設定）
+// 実行時間制限（SPR-318）。関数の timeout は 540 秒（deploy-functions.yml が正本）で、
+// この 480 秒は **run 起動時点** からの経過で測る（準備処理＝作品ID収集の約35秒を含む）。
+// 旧 270 秒は準備処理の後にタイマーを開始していたため、起動から見ると約305秒でしか
+// break できず、当時の timeout 300 秒を構造的に超えていた。超過後もコンテナの JS は
+// 走り続けるがリクエスト外＝CPU が絞られ、平常 0.1〜0.4 秒で返る Individual Info API が
+// 15 秒のタイムアウトに掛かる（失敗率アラートの実発火要因）。
+// 残り 60 秒は「判定を通過した1バッチが走り切る」ぶんの余白（平常 約7秒/バッチ）。
+export const MAX_EXECUTION_TIME = 480000;
 
 /**
  * 統合処理結果の型定義

--- a/apps/functions/src/endpoints/dlsite/run-unified-data-collection.ts
+++ b/apps/functions/src/endpoints/dlsite/run-unified-data-collection.ts
@@ -398,6 +398,11 @@ export async function runUnifiedDataCollection(
 	// SPR-225 Stage 1: 変更 creator の recompute キューを run 開始でクリアする。
 	resetCreatorRecomputeQueue();
 
+	// 実行時間の計測は run 起動時点から始める（SPR-318）。準備処理（メタデータ読み・
+	// 作品ID収集）に約35秒かかるため、準備完了後に測ると MAX_EXECUTION_TIME が
+	// そのまま関数 timeout との差になってくれない。
+	const startTime = Date.now();
+
 	try {
 		// メタデータから処理状態を確認
 		const metadata = await getOrCreateUnifiedMetadata();
@@ -427,9 +432,6 @@ export async function runUnifiedDataCollection(
 		logger.info(
 			`既存作品マップ取得完了: ${existingWorksMap.size}件（対象: ${remainingWorkIds.length}件）`,
 		);
-
-		// 準備完了後にタイマー開始（バッチ処理の実際の開始時点）
-		const startTime = Date.now();
 
 		// デバッグ: バッチ処理の状態を確認
 		logger.info(`バッチ処理開始: batches.length=${batches.length}, startBatch=${startBatch}`);

--- a/terraform/function_dlsite_individual_info_api.tf
+++ b/terraform/function_dlsite_individual_info_api.tf
@@ -14,7 +14,7 @@ locals {
 # Terraform では google_cloudfunctions2_function リソースを管理しない（ADR-009 / SPR-92）。
 #
 # spec の正本（deploy-functions.yml の gcloud functions deploy）:
-#   runtime=nodejs24 / memory=512Mi / timeout=300s / max-instances=1
+#   runtime=nodejs24 / memory=512Mi / timeout=540s / max-instances=1
 #   entry-point=fetchDLsiteUnifiedData / trigger-topic=dlsite-individual-api-trigger
 #
 # デプロイ手順:

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -509,7 +509,10 @@ resource "google_monitoring_alert_policy" "dlsite_api_failure_rate_high" {
     1. ログ確認: "API取得失敗が多数" / "Individual Info API サーバーエラー" を Cloud Logging で検索
        （エラー内訳が timeout ばかりなら上記の実行時間超過、HTTP 4xx/5xx なら DLsite 側）
     2. DLsite の稼働状況を手動確認
-    3. 失敗した作品は次サイクルで自動再試行される（手動介入は原則不要）
+    3. 失敗した作品は **そのサイクル内では再試行されない**（取得失敗の有無に関わらずバッチは
+       完了扱いになるため、次 run はサイクルの続き＝次バッチから始まる）。次サイクルの開始時に
+       due として拾われる＝通常は2時間後、サイクルが2 runにまたがった場合は4時間後（2026-08 実測）。
+       手動介入は原則不要。
     EOT
     mime_type = "text/markdown"
   }

--- a/terraform/monitoring_dlsite.tf
+++ b/terraform/monitoring_dlsite.tf
@@ -435,7 +435,12 @@ resource "google_monitoring_alert_policy" "dlsite_run_absent" {
 # バッチ取得で失敗が 10% を超えるとクライアントが集約 WARN「API取得失敗が多数」を出す
 # （individual-info-api-client.ts）。per-work 一時エラー（常態・除外済み）と「全滅」
 # （dlsite_api_batch_all_failed）の中間帯＝部分劣化を検知する（SPR-234 分類 B2）。
-# 頻度実績は月1〜3回（直近30日で3回・失敗率12〜18%）＝低ノイズ。
+# 頻度実績は月1〜3回（2026-08 実測で 12%/20%/22%）＝低ノイズ。
+# ただし SPR-318 まで、実際の発火要因は DLsite 側ではなく自前の実行時間超過だった
+# （run が関数 timeout を超えて走り、リクエスト外＝CPU スロットリング下で API 取得が
+# 15 秒タイムアウトする）。観測した4回とも timeout 到達後に発生している。
+# timeout 540s + MAX_EXECUTION_TIME 480s（run 起動時点基準）で解消済みのため、
+# 以後の発火は DLsite 側の劣化として読んでよい（再発時はまず run の latency を見る）。
 # 単一文字列 warn のため textPayload に出る点に注意（両フィールド張り）。
 resource "google_logging_metric" "dlsite_api_failure_rate_high" {
   name    = "dlsite_api_failure_rate_high"
@@ -485,15 +490,26 @@ resource "google_monitoring_alert_policy" "dlsite_api_failure_rate_high" {
     content   = <<-EOT
     # DLsite API 取得失敗率の上昇（部分劣化）
 
-    バッチ取得の失敗率が 10% を超えました（実績: 月1〜3回・12〜18%）。DLsite 側の
-    部分障害・レート制限・ネットワーク不調の兆候です。単発は自己回復することが
-    多いですが、短時間に連続する場合は全面停止（DLsite API Batch All Failed）へ
+    バッチ取得の失敗率が 10% を超えました（実績: 月1〜3回・12〜22%）。単発は自己回復する
+    ことが多いですが、短時間に連続する場合は全面停止（DLsite API Batch All Failed）へ
     進行する可能性があるため要調査です。
 
-    ## 確認事項
+    ## まず確認すること（SPR-318）
+    2026-08 までの発火4回はすべて DLsite 側ではなく **自前の実行時間超過** が原因だった。
+    run が関数 timeout に達すると、以降はリクエスト外＝CPU スロットリング下で実行され、
+    平常 0.1〜0.4 秒で返る API 呼び出しが 15 秒のタイムアウトに掛かる。まず run が
+    timeout に張り付いていないかを見る（張り付いていれば DLsite は無実）:
+    ```bash
+    gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="fetchdlsiteunifieddata" AND logName:"run.googleapis.com%2Frequests"' --limit=20 --format="value(timestamp,httpRequest.status,httpRequest.latency)" --order=desc
+    ```
+    latency が上限（540s）に張り付いている場合は MAX_EXECUTION_TIME（process-batch.ts）と
+    timeout（deploy-functions.yml）の関係を見直す。
+
+    ## DLsite 側を疑う場合の確認事項
     1. ログ確認: "API取得失敗が多数" / "Individual Info API サーバーエラー" を Cloud Logging で検索
+       （エラー内訳が timeout ばかりなら上記の実行時間超過、HTTP 4xx/5xx なら DLsite 側）
     2. DLsite の稼働状況を手動確認
-    3. 失敗した作品は次 run（2h後）で自動再試行される（手動介入は原則不要）
+    3. 失敗した作品は次サイクルで自動再試行される（手動介入は原則不要）
     EOT
     mime_type = "text/markdown"
   }


### PR DESCRIPTION
## 背景

「DLsite API High Failure Rate Alert」（バッチ取得の失敗率10%超）が 2026-08-22 15:11 UTC に発火した。調査の結果、**DLsite 側の劣化ではなく、run が関数 timeout を超えて走り続けることが原因**と判明した（[SPR-318](https://linear.app/nothink/issue/SPR-318/dlsite-取り込み-run-が-300秒のリクエスト上限を超過し超過後の実行で-api-取得が-15秒タイムアウトする)）。

- 失敗 11 件はすべて `The operation was aborted due to timeout`。**HTTP 4xx/5xx は 0 件**＝DLsite からのエラー応答は一切ない
- 失敗はちょうど 5 件ずつ同時に発生（= `MAX_CONCURRENT_API_REQUESTS`）。個別作品の遅延ではなくサブバッチ丸ごとの停止
- Cloud Run のリクエストログが決定打で、latency が **ちょうど 300.000s** ＝上限で打ち切り。最初のタイムアウト試行はその到達後

超過後もコンテナの JS は走り続けるが、リクエスト外＝CPU が絞られるため、平常 0.1〜0.4 秒で返る Individual Info API が 15 秒の `AbortSignal.timeout` に掛かる。

観測した失敗バーストは全て timeout 到達後に発生している。

| 発生 (UTC) | run 開始 | 上限到達 | 失敗率 |
| -- | -- | -- | -- |
| 08-14 15:11 | 15:03 | 15:08 | 12.0% |
| 08-19 17:09 | 17:03 | 17:08 | 6%（閾値未満で未発火） |
| 08-21 19:23 | 19:15 | 19:20 | 20.0% |
| 08-22 15:11 | 15:03 | 15:08 | 22.0% |

上限ちょうどで終わった run は 08-14〜08-22 の 8 日間で 20 回＝**全 run の約2割が恒常的に超過**していた。

## 変更内容

真因は値ではなく**計測起点**。`MAX_EXECUTION_TIME` のタイマーを準備処理（作品ID収集・約35秒）の後に開始していたため、起動から見ると約305秒でしか break できず、timeout 300 秒を構造的に超えていた。

- `run-unified-data-collection.ts`: `startTime` の取得を **run 起動直後**へ移動（本質はここ）
- `process-batch.ts`: `MAX_EXECUTION_TIME` 270000 → 480000
- `deploy-functions.yml`: fetchDLsiteUnifiedData の `--timeout` 300s → 540s（他の functions と同値）
- `function_dlsite_individual_info_api.tf`: spec 転記コメントの timeout を同期（版ズレ防止）
- `monitoring_dlsite.tf`: 失敗率アラートの実績値と原因説明を実態に合わせ、「まず run の latency が上限に張り付いていないか見る」手順を追加

540 − 480 = 60 秒は「判定を通過した1バッチが走り切る」ぶんの余白（平常 約7秒/バッチ）。

## 確認した制約

Eventarc の push subscription `eventarc-asia-northeast1-fetchdlsiteunifieddata-011083-sub-900` の **ackDeadlineSeconds は 600**。540s はその内側で、ack 期限切れによる再配信（＝run の重複実行）は発生しない。将来さらに伸ばす場合は 600 秒が天井。

## テスト

- `pnpm verify` パス
- 挙動変更はランタイム側のため、本番反映後に次の観点で確認する:
  - リクエスト latency が上限（540s）に張り付かないこと（従来は 300.000s 固定）
  - `API取得失敗が多数` の warn が出ないこと（数日観測）
  - 1 run あたりの処理バッチ数が増えること（従来は 44 バッチ中 38 前後で中断）

## レビュー観点

`.github/workflows` と本番 Cloud Function の挙動変更を含むため、CLAUDE.md のセルフマージ・ポリシー上は **One-Way Door 扱い**（AI レビュー任せにせず要自己レビュー）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
