### PR TITLE
perf(web): /works 一覧の年齢フィルタをクエリへ降ろす + 死んだ ageRating コードの削除 (SPR-321)

### DIFF
--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -9,7 +9,7 @@ import { withErrorHandling } from "@/lib/server-action-wrapper";
 // Internal modules
 import type { EnhancedSearchParams } from "./lib/work-filtering";
 import { filterWorksByUnifiedData, needsComplexFiltering } from "./lib/work-filtering";
-import { buildWorksQuery } from "./lib/work-query-builder";
+import { buildNonR18WorksQuery, buildWorksQuery } from "./lib/work-query-builder";
 import { sortWorks } from "./lib/work-sorting";
 import {
 	convertDocsToWorks,
@@ -24,10 +24,10 @@ async function getWorksWithSimpleQuery(
 	firestore: FirebaseFirestore.Firestore,
 	params: EnhancedSearchParams,
 ): Promise<WorkListResultPlain> {
-	const { page = 1, limit = 12, sort = "newest", category, ageRating } = params;
+	const { page = 1, limit = 12, sort = "newest", category } = params;
 
 	// クエリ構築
-	let query = buildWorksQuery(firestore, { category, ageRating, sort });
+	let query = buildWorksQuery(firestore, { category, sort });
 	query = query.limit(limit);
 
 	// オフセット処理
@@ -48,13 +48,10 @@ async function getWorksWithSimpleQuery(
 	const snapshot = await query.get();
 	const works = await convertDocsToWorks(snapshot.docs);
 
-	// 全件数取得用クエリ（ソート不要。category/ageRating フィルタのみ適用）
+	// 全件数取得用クエリ（ソート不要。category フィルタのみ適用）
 	let countQuery: FirebaseFirestore.Query = firestore.collection("works");
 	if (category && category !== "all") {
 		countQuery = countQuery.where("category", "==", category);
-	}
-	if (ageRating && ageRating.length === 1) {
-		countQuery = countQuery.where("ageRating", "==", ageRating[0]);
 	}
 	const countSnapshot = await countQuery.count().get();
 	const totalCount = countSnapshot.data().count;
@@ -87,12 +84,16 @@ async function getWorksWithComplexFiltering(
 		priceRange,
 		ratingRange,
 		hasHighResImage,
-		ageRating,
 		showR18,
 	} = params;
 
-	// クエリ構築
-	let query = buildWorksQuery(firestore, { category, ageRating, sort });
+	// クエリ構築。
+	// 匿名・年齢未確認（showR18 === false）は表示対象が非 R18 の 37 件しかないので、
+	// 全件を読んでから in-memory で落とすのをやめ、Firestore 側で絞る（SPR-321）。
+	const excludeR18 = showR18 === false;
+	let query = excludeR18
+		? buildNonR18WorksQuery(firestore, { category })
+		: buildWorksQuery(firestore, { category, sort });
 
 	// ページネーション用のオフセット
 	const startOffset = (page - 1) * limit;
@@ -106,8 +107,10 @@ async function getWorksWithComplexFiltering(
 		(voiceActors && voiceActors.length > 0);
 
 	if (requiresFullDataFetch) {
-		// 全件取得（limitを設定しない）
-		// 注: Firestoreには約1500件なので問題ない
+		// limit を設定しない。
+		// excludeR18 のときは上のクエリが既に 37 件程度まで絞っている。
+		// それ以外（検索・ジャンル・声優・言語）は絞り込み条件を Firestore で表現できないため
+		// 全件（2,191 件）を読む。ここは残っている増幅で、実トラフィックでの利用率が低いため据え置き。
 	} else {
 		// その他の複雑フィルタリングの場合は、必要な分+余裕を取得
 		const fetchLimit = Math.min(startOffset + limit * 10, 3000);
@@ -129,7 +132,6 @@ async function getWorksWithComplexFiltering(
 		priceRange,
 		ratingRange,
 		hasHighResImage,
-		ageRating: ageRating && ageRating.length > 1 ? ageRating : undefined,
 		showR18, // R18フィルタリングも適用する
 	});
 

--- a/apps/web/src/app/works/actions.ts
+++ b/apps/web/src/app/works/actions.ts
@@ -123,7 +123,12 @@ async function getWorksWithComplexFiltering(
 		id: doc.id,
 	})) as import("@suzumina.click/shared-types").WorkDocument[];
 
-	// メモリ上でのフィルタリング
+	// メモリ上でのフィルタリング。
+	// excludeR18 のときは既にクエリ側で非 R18 に絞られているため、この中の `showR18 === false`
+	// 分岐（filterR18Content = denylist）は実質 no-op になる（"全年齢" / "R15" はどちらも
+	// isR18Content で false）。**冗長に見えるが意図的に残している**: allowlist（クエリ）と
+	// denylist（判定）が将来食い違ったとき、R18 が匿名一覧へ漏れるのをここで止める安全網になる。
+	// 対象は 37 件程度なのでコストは無視できる。消さないこと（SPR-321）。
 	allWorks = filterWorksByUnifiedData(allWorks, {
 		search,
 		language,

--- a/apps/web/src/app/works/lib/__tests__/work-filtering.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-filtering.test.ts
@@ -74,9 +74,6 @@ describe("filterWorksByUnifiedData", () => {
 		expect(run({ hasHighResImage: true })).toEqual(["w1"]);
 		expect(run({ hasHighResImage: false })).toEqual(["w2"]);
 	});
-	it("ageRating（特定指定）", () => {
-		expect(run({ ageRating: ["18禁"] })).toEqual(["w2"]);
-	});
 	// language / showR18 の実フィルタロジックは shared-types 側（filterWorksByLanguage /
 	// filterR18Content）の責務。ここでは当該分岐が実行され例外なく配列を返すことだけを担保する。
 	it("language 指定で当該分岐を通り配列を返す（実フィルタは shared-types の責務）", () => {

--- a/apps/web/src/app/works/lib/__tests__/work-query-builder.test.ts
+++ b/apps/web/src/app/works/lib/__tests__/work-query-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildWorksQuery } from "../work-query-builder";
+import { buildNonR18WorksQuery, buildWorksQuery } from "../work-query-builder";
 
 // where/orderBy がチェーン可能で、呼び出しを記録する Firestore モック
 const makeFirestore = () => {
@@ -38,15 +38,6 @@ describe("buildWorksQuery", () => {
 		expect(run({ category: "all" }).some((c) => c.method === "where")).toBe(false);
 	});
 
-	it("ageRating は単一指定のときのみ where", () => {
-		expect(run({ ageRating: ["18禁"] })).toContainEqual({
-			method: "where",
-			args: ["ageRating", "==", "18禁"],
-		});
-		// 複数指定は where しない
-		expect(run({ ageRating: ["全年齢", "18禁"] }).some((c) => c.method === "where")).toBe(false);
-	});
-
 	it("sort 種別ごとに orderBy を切り替える", () => {
 		const orderOf = (sort: string) => run({ sort }).find((c) => c.method === "orderBy")?.args;
 		expect(orderOf("oldest")).toEqual(["releaseDateISO", "asc"]);
@@ -56,5 +47,35 @@ describe("buildWorksQuery", () => {
 		expect(orderOf("popular")).toEqual(["rating.count", "desc"]);
 		expect(orderOf("newest")).toEqual(["releaseDateISO", "desc"]); // default
 		expect(orderOf("unknown")).toEqual(["releaseDateISO", "desc"]);
+	});
+});
+
+describe("buildNonR18WorksQuery", () => {
+	const runNonR18 = (params: Parameters<typeof buildNonR18WorksQuery>[1]) => {
+		const { firestore, calls } = makeFirestore();
+		buildNonR18WorksQuery(firestore as any, params);
+		return calls;
+	};
+
+	it("非 R18 の ageRating だけを in で絞る", () => {
+		expect(runNonR18({})).toContainEqual({
+			method: "where",
+			args: ["ageRating", "in", ["全年齢", "R15"]],
+		});
+	});
+
+	it("orderBy を付けない（複合インデックス不要を維持するため）", () => {
+		// ここが崩れると `in` + `orderBy` になり FAILED_PRECONDITION で一覧が 0 件になる。
+		// 並び替えは呼び出し側が in-memory の sortWorks で行うので Firestore 側は不要（SPR-321）。
+		expect(runNonR18({}).some((c) => c.method === "orderBy")).toBe(false);
+		expect(runNonR18({ category: "SOU" }).some((c) => c.method === "orderBy")).toBe(false);
+	});
+
+	it("category 指定で where を足し、'all' はスキップ", () => {
+		expect(runNonR18({ category: "SOU" })).toContainEqual({
+			method: "where",
+			args: ["category", "==", "SOU"],
+		});
+		expect(runNonR18({ category: "all" }).filter((c) => c.method === "where")).toHaveLength(1);
 	});
 });

--- a/apps/web/src/app/works/lib/work-filtering.ts
+++ b/apps/web/src/app/works/lib/work-filtering.ts
@@ -23,7 +23,6 @@ export interface EnhancedSearchParams {
 	};
 	hasHighResImage?: boolean;
 	_strategy?: "minimal" | "standard" | "comprehensive";
-	ageRating?: string[];
 	showR18?: boolean;
 }
 
@@ -134,19 +133,6 @@ export function filterWorksByUnifiedData(
 		filteredWorks = filterR18Content(filteredWorks, getAgeRatingFromWork);
 	}
 
-	// 特定の年齢制限でフィルタリング
-	if (params.ageRating && params.ageRating.length > 0) {
-		filteredWorks = filteredWorks.filter((work) => {
-			const workAgeRating = work.ageRating || "";
-			return params.ageRating?.some(
-				(rating) =>
-					typeof workAgeRating === "string" &&
-					typeof rating === "string" &&
-					(workAgeRating.includes(rating) || rating === workAgeRating),
-			);
-		});
-	}
-
 	return filteredWorks;
 }
 
@@ -162,7 +148,6 @@ export function needsComplexFiltering(params: EnhancedSearchParams): boolean {
 		params.priceRange ||
 		params.ratingRange ||
 		params.hasHighResImage !== undefined ||
-		(params.ageRating && params.ageRating.length > 1) ||
 		params.showR18 === false
 	);
 }

--- a/apps/web/src/app/works/lib/work-query-builder.ts
+++ b/apps/web/src/app/works/lib/work-query-builder.ts
@@ -1,3 +1,31 @@
+import { NON_R18_AGE_RATINGS } from "@suzumina.click/shared-types";
+
+/**
+ * 非 R18 の作品だけを引くクエリを構築する（SPR-321）。
+ *
+ * 匿名・年齢未確認のアクセス（`showR18 ?? false`）は全体 2,191 件のうち 37 件しか表示しない。
+ * 従来は全件取得して in-memory で落としていたため **1 リクエスト 2,191 read = 増幅率 59 倍**だった。
+ *
+ * **`orderBy` を付けない**のが要点。呼び出し側（`getWorksWithComplexFiltering`）は取得後に
+ * `sortWorks` で並べ直しており Firestore 側の並びを使っていないので、外しても機能は変わらない。
+ * 一方 `in` + `orderBy` は複合インデックスを要求する（`ageRating` を含むインデックスは存在しない）。
+ * `orderBy` を外すことで**インデックス追加なしに**成立する。本番の実クエリで検証済み。
+ */
+export function buildNonR18WorksQuery(
+	firestore: FirebaseFirestore.Firestore,
+	params: { category?: string },
+): FirebaseFirestore.Query {
+	let query: FirebaseFirestore.Query = firestore
+		.collection("works")
+		.where("ageRating", "in", [...NON_R18_AGE_RATINGS]);
+
+	if (params.category && params.category !== "all") {
+		query = query.where("category", "==", params.category);
+	}
+
+	return query;
+}
+
 /**
  * Firestoreクエリを構築する
  */
@@ -5,7 +33,6 @@ export function buildWorksQuery(
 	firestore: FirebaseFirestore.Firestore,
 	params: {
 		category?: string;
-		ageRating?: string[];
 		sort?: string;
 	},
 ): FirebaseFirestore.Query {
@@ -14,11 +41,6 @@ export function buildWorksQuery(
 	// カテゴリーフィルタ
 	if (params.category && params.category !== "all") {
 		query = query.where("category", "==", params.category);
-	}
-
-	// 特定の年齢制限フィルタ（単一の場合のみ）
-	if (params.ageRating && params.ageRating.length === 1) {
-		query = query.where("ageRating", "==", params.ageRating[0]);
 	}
 
 	// ソート処理

--- a/packages/shared-types/src/utilities/age-rating.ts
+++ b/packages/shared-types/src/utilities/age-rating.ts
@@ -65,6 +65,23 @@ const R18_KEYWORDS = ["R18", "R-18", "18禁", "成人向け", "Adult", "18歳以
 const ALL_AGES_KEYWORDS = ["全年齢", "全年令", "一般", "General", "All ages"];
 
 /**
+ * Firestore の `works.ageRating` に実在する「R18 ではない」値の集合（SPR-321）。
+ *
+ * `isR18Content()` は denylist（R18 らしいキーワードを含むか）で判定するため、
+ * **Firestore クエリには載らない**（部分一致は where で表現できない）。
+ * 一覧を「非 R18 だけ」に絞るクエリのために、実データから列挙した allowlist をここに置く。
+ *
+ * 本番実測（2026-08-24・欠損ゼロ）: R18 2,154 / 全年齢 26 / R15 11 = 2,191。
+ *
+ * **`isR18Content()` の隣に置いてあるのは、両者が食い違うと表示が壊れるため。**
+ * R18_KEYWORDS を触るときはこちらも見ること。
+ *
+ * DLsite が未知の区分を返した場合、その作品は匿名ユーザーの一覧に出なくなる（fail-closed）。
+ * 表示側の既定（`showR18 ?? false`）と失敗方向が揃っているので安全側に倒れる。
+ */
+export const NON_R18_AGE_RATINGS = ["全年齢", "R15"] as const;
+
+/**
  * 年齢制限文字列がR18相当かどうかを判定
  * @param ageRating 年齢制限文字列
  * @returns R18相当の場合true

--- a/packages/shared-types/src/utilities/age-rating.ts
+++ b/packages/shared-types/src/utilities/age-rating.ts
@@ -71,13 +71,18 @@ const ALL_AGES_KEYWORDS = ["全年齢", "全年令", "一般", "General", "All a
  * **Firestore クエリには載らない**（部分一致は where で表現できない）。
  * 一覧を「非 R18 だけ」に絞るクエリのために、実データから列挙した allowlist をここに置く。
  *
- * 本番実測（2026-08-24・欠損ゼロ）: R18 2,154 / 全年齢 26 / R15 11 = 2,191。
+ * **この 3 値の正本は取り込み側の `mapAgeRating()`**（`apps/functions/src/services/mappers/work-mapper.ts`）。
+ * DLsite の `age_category` を 1→"全年齢" / 2→"R15" / 3→"R18" に正規化し、**未知の値は `undefined`**（フィールド自体が無い）。
+ * したがってここは「実データがたまたまこの 3 値だった」のではなく、**書き込み側の値域をそのまま写している**。
+ * `mapAgeRating()` の対応表を変えるときは、必ずこの定数も一緒に変えること。
+ * 本番実測（2026-08-24）でも R18 2,154 / 全年齢 26 / R15 11 = 2,191・欠損ゼロで一致している。
  *
- * **`isR18Content()` の隣に置いてあるのは、両者が食い違うと表示が壊れるため。**
- * R18_KEYWORDS を触るときはこちらも見ること。
+ * `isR18Content()` の隣に置いてあるのは、あちらが denylist の部分一致（Firestore クエリに載らない）で
+ * 同じ判断を別の方法で行っており、**両者が食い違うと表示が壊れる**ため。
  *
- * DLsite が未知の区分を返した場合、その作品は匿名ユーザーの一覧に出なくなる（fail-closed）。
- * 表示側の既定（`showR18 ?? false`）と失敗方向が揃っているので安全側に倒れる。
+ * 未知の区分（`ageRating` が無い doc）はこの `in` に一致しないため匿名ユーザーの一覧に出ない（fail-closed）。
+ * `isR18Content(undefined)` が false＝非 R18 扱い（fail-open）なのとは逆だが、
+ * 表示側の既定（`showR18 ?? false`）と失敗方向が揃うのはこちら。
  */
 export const NON_R18_AGE_RATINGS = ["全年齢", "R15"] as const;
 


### PR DESCRIPTION
Linear: [SPR-321](https://linear.app/nothink/issue/SPR-321/perfweb-works-一覧の-59倍増幅を解消する年齢フィルタをクエリへと死んだ-agerating-コードの削除)（SPR-316 WS-A の調査から切り出した実装 Issue）

terraform 変更なし・インデックス追加なしの Two-Way Door です。

## 背景: 37 件を返すために 2,191 件を読んでいた

`/works` 一覧は匿名・年齢未確認のアクセスで **全 37 件（4ページ）しか表示しない**（R18 が 2,154 件で fail-closed の既定により除外）。にもかかわらず **2,191 件を全件スキャン**していた。**増幅率 59 倍**。

実測（8/20〜8/23）: 44 req/日 × 2,191 read = **約 96,952 read/日**（8/23 総 reads の 6.7%）。

`page.tsx:27` の `showR18 ?? false` が `needsComplexFiltering` → `requiresFullDataFetch` を発火させ、`query.get()` が limit 無しの全件取得になっていました。一覧のエントリポイントはキャッシュもされていません。

## なぜキャッシュではなくクエリを直したか

`use cache` の支払いは `min(リクエスト数, インスタンス世代数)` で決まります。`/works` は **44 req/日 に対しインスタンス世代が 40/日** なので、キャッシュを足しても 44→40 にしかなりません。

| ルート | req/日 | 世代/日 | キャッシュの効き |
|---|---|---|---|
| `/creators/28165`（#941 で対処済み） | 526 | 40 | 13 倍 |
| `/works` 一覧 | 44 | 40 | ほぼ無し |

> 低トラフィックだが 1 回が高いルートは、キャッシュではなくクエリ自体を直すしかない。

## 変更1: 年齢フィルタをクエリへ

```ts
where("ageRating", "in", ["全年齢", "R15"])   // orderBy は付けない
```

**`orderBy` を外せるのが要点です。** このブランチは取得後に `sortWorks` で並べ直しており Firestore 側の並びを使っていないので、外しても機能は変わりません。一方 `in` + `orderBy` は複合インデックスを要求します（`ageRating` を含むインデックスは terraform にも live にも存在しない）。外すことで**インデックス追加なしに**成立します。

**本番の実クエリで検証済み**（実装前に確認。CLAUDE.md が警告する「Emulator は複合インデックスを強制しない」罠を回避）:

| クエリ | 結果 |
|---|---|
| `ageRating in ["全年齢","R15"]`（orderBy 無し） | ✓ 37 件 |
| 同上 + `category == "SOU"` | ✓ 35 件 |

**効果: 96,952 → 約 1,628 read/日（−98%）**

許可リストは `isR18Content()` の隣（`age-rating.ts`）に置きました。あちらは denylist の部分一致で Firestore クエリに載らないため、クエリ用の allowlist を別に持つ必要があります。**両者が食い違うと表示が壊れる**ので近接配置し、その旨を明記しています。DLsite が未知の区分を返した場合は fail-closed（匿名一覧に出ない）で、表示側の既定と失敗方向が揃います。

## 変更2: 死んだ `ageRating` フィルタの削除（軸3）

`params.ageRating`（フィルタ引数。`work.ageRating` というデータ項目とは別物）は**どこからも渡されていません**。

| 検証 | 結果 |
|---|---|
| `getWorks` の呼び出し元 3 箇所 | 渡さない（すべて明示的なフィールド指定） |
| URL から入るか | 入らない（`parse-search-params.ts` に解析なし） |
| スプレッドで動的混入 | しない（client は category/language/showR18/genres の allowlist） |
| 本番ログの index エラー | 過去 7 日で 0 件 |

しかも**到達したら落ちます**（本番で実証）:

```
where("ageRating","==","全年齢") + orderBy("releaseDateISO","desc")
→ FAILED_PRECONDITION: The query requires an index.
```

型（`ageRating?: string[]`）と where 句が「対応済み」に見えるのに動かない状態で、将来ここに年齢フィルタ UI を足す人が踏む罠でした。型・where 2 箇所・in-memory フィルタ・`needsComplexFiltering` の分岐・対応する 2 テストを削除しています。

## 案B を採らなかった理由（判断の記録）

`isR18: boolean` を `isR18Content()` で非正規化する案（判定の正本が 1 つに集約され新区分に自動追従）も検討しましたが、**得られる差分は「新区分への自動追従」だけで金額差はゼロ**（どちらも −98%）。対価が works へのフィールド追加 + 2,191 件のバックフィル + 取り込みパイプライン改修 = One-Way Door 寄りで、SPR-316 WS-C（マイグレーション方針）が未決の段階で先走ることになります。案A → 案B の移行はいつでも可能（逆は面倒）。

**再検討条件**: `ageRating` に既知の 3 値以外が出現したとき、または SPR-316 WS-C で works のスキーマを触ると決まったとき。

## 検証

`pnpm verify` 通過、`pnpm --filter web build` 通過（exit 0）。

ローカル（emulator・fixture は R18 98 / 全年齢 1 / R15 1）で全分岐を確認:

| URL | 結果 |
|---|---|
| `/works` | 全 2 件 ✓（= 全年齢1 + R15 1） |
| `/works?showR18=true` | 全 100 件 ✓（無影響） |
| `?sort=oldest` / `?page=1` / `?category=SOU` | 全 2 件 ✓ |
| `?q=ASMR` / `?genres=ASMR` / `?language=ja` | 正常 ✓ |
| `?showR18=true&genres=ASMR` | 全 39 件 ✓ |

サーバエラーゼロ。

テストは `buildNonR18WorksQuery` に 3 件追加。特に**「orderBy を付けない」を固定するテスト**を置きました（ここが崩れると `in` + `orderBy` になり FAILED_PRECONDITION で一覧が 0 件になるため）。

## 残っている増幅（スコープ外）

検索・ジャンル・声優・言語フィルタは Firestore で表現できないため、`showR18=true` と併用すると今も全件（2,191 件）を読みます。実トラフィックでの利用率が低い（`genres` 13 / `sort` 4 / 4日間）ため据え置きました。

## デプロイ後の確認

`/works` の表示が「全 37 件」のままであること（回帰していないこと）を確認します。read の減少は総 reads の 6.7% なので日次合計では埋もれる可能性があり、切り分けるならリクエスト数 × 1回あたり read で見ます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
