### PR TITLE
perf(infra): priceHistory の未使用な単一フィールド index を除外する (SPR-323)

### DIFF
--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -267,6 +267,62 @@ resource "google_firestore_field" "works_workid_collection_group" {
   }
 }
 
+# ===================================================================
+# priceHistory: 未使用な単一フィールド index の除外（SPR-323）
+# ===================================================================
+# works/{id}/priceHistory は 717,833 docs で DB の doc 数の約 98%。
+# doc の実体は 1.24 KB だが**ストレージ上は 1 doc 12.2 KB**を占めていた。差は索引。
+#
+# 原因は map のサブフィールドが個別に索引されること:
+#   capturedAt / date / discountRate / officialPrice / price / workId
+#   localePrice        : map（14 ロケール）
+#   localeOfficialPrice: map（14 ロケール）
+# → リーフ 34 フィールド × (ASC + DESC + array-contains) ≒ 1 doc 68 索引エントリ。
+#   実体 0.83 GiB に対し索引が約 7.50 GiB（DB 全体 8.33 GiB の 90%）。
+#
+# だが priceHistory を索引で引くクエリは `orderBy("date", ...)` の 3 箇所だけ
+# （web の actions/price-history.ts、functions の debug/check ツール）。
+# 書き込みは .doc(today) の直接参照で索引不要。collectionGroup("priceHistory") も無い。
+# **33/34 のリーフフィールドは索引を持ちながら一度も検索されていない。**
+#
+# データは一切消さない。索引だけを外す（可逆・戻せば再構築される）。
+resource "google_firestore_field" "price_history_disable_default_indexes" {
+  project    = var.gcp_project_id
+  database   = "(default)"
+  collection = "priceHistory"
+  field      = "*"
+
+  # ワイルドカードの index_config を空にすると、そのコレクショングループの
+  # 自動単一フィールド index が全停止する。**map のサブフィールドもまとめて効く**ので
+  # localePrice.* の 14 ロケールを個別に書く必要はない（Admin API で確認済み）。
+  index_config {}
+}
+
+# 唯一のクエリ（orderBy("date") + 範囲 where）を維持するため date だけ索引を戻す。
+# 上のワイルドカードで既定が「索引なし」になるため、ここは明示しないと date も引けなくなる。
+resource "google_firestore_field" "price_history_date" {
+  project    = var.gcp_project_id
+  database   = "(default)"
+  collection = "priceHistory"
+  field      = "date"
+
+  # index_config は当該フィールドの index 構成を「全置換」する（works_workid_collection_group と同じ注意）。
+  # orderBy("date","desc") と where("date", "<=" / ">=") の両方を賄うため ASC/DESC の両方が要る。
+  index_config {
+    indexes {
+      query_scope = "COLLECTION"
+      order       = "ASCENDING"
+    }
+    indexes {
+      query_scope = "COLLECTION"
+      order       = "DESCENDING"
+    }
+  }
+
+  # ワイルドカード側の既定が先に適用されるよう順序を固定する。
+  depends_on = [google_firestore_field.price_history_disable_default_indexes]
+}
+
 # （将来用・複合インデックスの例）役割と作品IDの組み合わせ検索用。
 # 現在のクエリでは不要。必要になったら有効化する。
 # resource "google_firestore_index" "creators_works_collection_group_roles_workid" {
@@ -462,6 +518,10 @@ resource "google_firestore_index" "videos_livebroadcastcontent_lastfetchedat_asc
 # - works.workId COLLECTION_GROUP（google_firestore_field・SPR-204）: creator-firestore.ts
 # - videos_livebroadcastcontent_lastfetchedat_asc（1・2026-07-06 SPR-230回帰対応で追加）:
 #   getStaleLiveVideoIds()（youtube-firestore.ts）の配信中/配信予定固着動画の再取得
+# - priceHistory の単一フィールド index 設定（google_firestore_field ×2・SPR-323）:
+#   ワイルドカード `*` で自動 index を全停止し、実際に引く `date` だけ ASC/DESC を戻す。
+#   複合 index の「追加」ではなく**既定 index の除外**なので、上の query-backed 判定とは向きが逆。
+#   索引が DB ストレージの 90%（8.33 GiB 中 7.50 GiB）を占めていたのを解消する目的
 # - ※ audioButtons の creatorId / stats.* / videoId 系は firestore_indexes_audiobuttons_update.tf が管理
 #
 # 【SPR-213 で本ファイルから撤去した managed-unused（13）】

--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -296,6 +296,13 @@ resource "google_firestore_field" "price_history_disable_default_indexes" {
   # 自動単一フィールド index が全停止する。**map のサブフィールドもまとめて効く**ので
   # localePrice.* の 14 ロケールを個別に書く必要はない（Admin API で確認済み）。
   index_config {}
+
+  # **date より後に適用する**。最終状態は順序に依らない（明示設定を持つフィールドは
+  # usesAncestorConfig=false になりワイルドカードの影響を受けない）が、apply 中の
+  # 過渡状態は順序で変わる。先にこちらを適用すると date の index が一時的に消え、
+  # その窓で orderBy("date") が FAILED_PRECONDITION になる（価格チャートが落ちる）。
+  # date を先に明示しておけば、この窓が生じない。
+  depends_on = [google_firestore_field.price_history_date]
 }
 
 # 唯一のクエリ（orderBy("date") + 範囲 where）を維持するため date だけ索引を戻す。
@@ -319,8 +326,6 @@ resource "google_firestore_field" "price_history_date" {
     }
   }
 
-  # ワイルドカード側の既定が先に適用されるよう順序を固定する。
-  depends_on = [google_firestore_field.price_history_disable_default_indexes]
 }
 
 # （将来用・複合インデックスの例）役割と作品IDの組み合わせ検索用。


### PR DESCRIPTION
Linear: [SPR-323](https://linear.app/nothink/issue/SPR-323/perfinfra-pricehistory-の未使用な単一フィールドインデックスを除外するストレージ-833約105-gib)（SPR-316 WS-C の調査から切り出した実装 Issue）

> [!IMPORTANT]
> **terraform 変更のみ。CLAUDE.md のセルフマージ・ポリシー上 One-Way Door 扱い**なので、AI レビュー任せにせず CI の plan を目視してください。期待は **追加 2・変更 0・削除 0** です。

## 何が起きていたか

DB 全体のストレージは **8.33 GiB = 月 ¥157**、増加 **約 27 MB/日**（年 9.9 GB）。その大半が `works/{id}/priceHistory`（**717,833 docs**、全 doc の約 98%）で、**1 doc あたり 12.2 KB**。

しかし **doc の JSON 実体は 1.24 KB**。差の約 11 KB は**索引**でした。

### 原因: map のサブフィールドが個別に索引される

```
capturedAt / date / discountRate / officialPrice / price / workId
localePrice        : map（14 ロケール）
localeOfficialPrice: map（14 ロケール）
```

リーフは **34 フィールド**。ASC + DESC + array-contains で **1 doc あたり約 68 索引エントリ**。実体 0.83 GiB に対し **索引が約 7.50 GiB（DB 全体の 90%）**。

### 決定的: `date` 以外は一度も検索されていない

リポジトリ全体を走査した結果、priceHistory を索引で引くクエリは 3 箇所だけで、すべて `orderBy("date", ...)`：

| 箇所 | クエリ |
|---|---|
| `apps/web/src/actions/price-history.ts:29` | `orderBy("date","desc")` + `where("date","<=")` + `where("date",">=")` + `limit(500)` |
| `apps/functions/src/tools/debug-price-history.ts:93` | `orderBy("date","desc")` |
| `apps/functions/src/tools/check-price-history.ts:59` | `orderBy("date","desc")` |

書き込み（`price-history-saver.ts:187`）は `.doc(today)` の直接参照で索引不要。`collectionGroup("priceHistory")` は存在しません。

**33/34 のリーフフィールドが、索引を持ちながら検索対象になったことがありません。**

## 変更

`google_firestore_field` を 2 つ追加するだけです。

1. **`priceHistory` の `*`** → `index_config {}`（空）で自動索引を全停止
2. **`priceHistory` の `date`** → COLLECTION ASC + DESC を明示して復活

**14 ロケールを個別に書く必要はありません。** ワイルドカードが map のサブフィールドまでまとめて効くことを Firestore Admin API で事前確認しました（`priceHistory/fields/*` が既定 3 索引・`usesAncestorConfig: true` で存在）。

`date` 側で ASC/DESC を明示しているのは、既存の `works_workid_collection_group`（SPR-204）のコメントにあるとおり **`index_config` が全置換**だからです。

## 効果（推定）

| | 現状 | 適用後 |
|---|---|---|
| ストレージ | 8.33 GiB | **約 1.05 GiB** |
| 月額 | ¥157 | **約 ¥20** |
| 増加ペース | 27 MB/日 | 約 3.3 MB/日 |

推定は「索引 7.50 GiB のうち 66/68 エントリが消える」計算です。**実測は apply 後**に `firestore.googleapis.com/storage/data_and_index_storage_bytes` で行います（索引削除は背景処理なので反映に時間がかかります）。

## 破壊性

**データは一切消えません。索引だけを外します。** 可逆（索引を戻せば再構築される）。terraform カテゴリとしては One-Way Door 扱いです。

## apply 後の検証

- **本番で価格チャートが従来どおり描画されること**（`/works/RJ01084276` など価格変動のある作品）
- `orderBy("date")` が `FAILED_PRECONDITION` にならないこと。**Emulator は単一フィールド索引の除外を再現しないので本番で確認**します（CLAUDE.md が警告する罠と同型）
- ストレージ実測（適用直後ではなく数時間〜1日後）

## スコープ外

- **変化時のみ書く** — サンプル 15 作品で変化率は中央値 4.6%（1 年間まったく変化なしが 4 作品）＝約 96% が重複。増加を止める効果はありますが、チャートの欠測日対応が必要なので本 PR の効果測定後に判断します
- **TTL による削除** — ①の後では節約が月 ¥15 程度で、対価が取り返しのつかないデータ消失（DLsite から過去価格は再取得不可）。**採らない**判断済み。再評価条件は「ストレージが月 ¥300 超」

🤖 Generated with [Claude Code](https://claude.com/claude-code)
