### PR TITLE
fix(infra): priceHistory の index 変更にタイムアウトを明示する (SPR-323)

### DIFF
--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -337,7 +337,6 @@ resource "google_firestore_field" "price_history_date" {
     }
   }
 
-
   # 既定のタイムアウトは 20 分で、この規模には足りない（SPR-323 実測）。
   # date の索引変更（array-contains の削除 1 種のみ）で **720,022 doc を 21.2 分**かけて走査し、
   # terraform が 20 分で諦めた 53 秒後にサーバ側は SUCCESSFUL になっていた。

--- a/terraform/firestore_indexes.tf
+++ b/terraform/firestore_indexes.tf
@@ -303,6 +303,17 @@ resource "google_firestore_field" "price_history_disable_default_indexes" {
   # その窓で orderBy("date") が FAILED_PRECONDITION になる（価格チャートが落ちる）。
   # date を先に明示しておけば、この窓が生じない。
   depends_on = [google_firestore_field.price_history_date]
+
+  # 既定のタイムアウトは 20 分で、この規模には足りない（SPR-323 実測）。
+  # date の索引変更（array-contains の削除 1 種のみ）で **720,022 doc を 21.2 分**かけて走査し、
+  # terraform が 20 分で諦めた 53 秒後にサーバ側は SUCCESSFUL になっていた。
+  # ワイルドカード側は削除する索引が約 66 種と桁違いに多いので、さらに長くなる想定。
+  # GitHub Actions のジョブ上限は既定 360 分なので、その内側に収まる値にしてある。
+  timeouts {
+    create = "4h"
+    update = "4h"
+    delete = "4h"
+  }
 }
 
 # 唯一のクエリ（orderBy("date") + 範囲 where）を維持するため date だけ索引を戻す。
@@ -326,6 +337,17 @@ resource "google_firestore_field" "price_history_date" {
     }
   }
 
+
+  # 既定のタイムアウトは 20 分で、この規模には足りない（SPR-323 実測）。
+  # date の索引変更（array-contains の削除 1 種のみ）で **720,022 doc を 21.2 分**かけて走査し、
+  # terraform が 20 分で諦めた 53 秒後にサーバ側は SUCCESSFUL になっていた。
+  # ワイルドカード側は削除する索引が約 66 種と桁違いに多いので、さらに長くなる想定。
+  # GitHub Actions のジョブ上限は既定 360 分なので、その内側に収まる値にしてある。
+  timeouts {
+    create = "4h"
+    update = "4h"
+    delete = "4h"
+  }
 }
 
 # （将来用・複合インデックスの例）役割と作品IDの組み合わせ検索用。


### PR DESCRIPTION
Linear: [SPR-323](https://linear.app/nothink/issue/SPR-323/perfinfra-pricehistory-の未使用な単一フィールドインデックスを除外するストレージ-833約105-gib)

#956 の apply が失敗したので、その修正です。terraform 変更のみ。

## 何が起きたか

**プロバイダの既定タイムアウト 20 分**で失敗しました。GitHub Actions のジョブ上限（既定 360 分）ではありません。

```
Error: Error waiting to create Field: Error waiting for Creating Field:
timeout while waiting for state to become 'done: true' (last state: 'done: false', timeout: 20m0s)
```

**しかもサーバ側は成功していました。**

| | 時刻 |
|---|---|
| FieldOperation 開始 | 15:14:46 |
| terraform が諦めた | 15:34:47（20m01s） |
| **サーバ側の操作完了（SUCCESSFUL）** | **15:35:40** |

**53 秒足りませんでした。** 実測で 720,022 doc の走査に **21.2 分**かかっています。

## 本番影響は無し（確認済み）

- `/works/RJ01084276` は HTTP 200・エラーページ無し・価格推移セクション描画あり
- `date` の索引は **ASC / DESC が READY**（削除された delta は `array-contains` の 1 種のみ）で `orderBy("date")` は生存
- レビュー指摘を受けて依存順を `date` → ワイルドカードに直しておいたため、**索引が消える窓も生じませんでした**

ただし**ワイルドカード側は未適用**なので、本命の索引削除（8.33 GiB → 約 1.05 GiB）はまだ起きていません。

## 修正

両リソースに `timeouts` を明示します。

```hcl
timeouts {
  create = "4h"
  update = "4h"
  delete = "4h"
}
```

`date`（削除する索引 **1 種**）で 21.2 分かかった以上、ワイルドカード（**約 66 種**）はさらに長くなる想定です。線形なら数時間規模なので 4h を確保しました。Actions の既定 360 分の内側に収まります。

## 補足: apply が長時間ジョブを占有します

ワイルドカードの適用は最悪数時間かかる可能性があり、その間 apply ジョブが走り続けます。承認ゲート付きの環境を長く占有する点は許容いただく前提です。

代替として「out-of-band で API を叩いてから `terraform import`」も考えましたが、ADR-010 の「CI の plan → 承認 → apply が正」に反するので採りませんでした。

## CI plan で確認したいこと

前回の失敗で terraform state に何が残ったかによって、plan が **2 to add** か **1 to add** かが変わります。どちらでも動作しますが、`price_history_date` が state に無ければ再度 PATCH されます（設定は既に適用済みなので no-op になり短時間で終わる想定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
